### PR TITLE
feat: customize maximum goroutines for pulling

### DIFF
--- a/cmd/sealos/cmd/build.go
+++ b/cmd/sealos/cmd/build.go
@@ -55,6 +55,7 @@ func newBuildCmd() *cobra.Command {
 	buildCmd.Flags().StringVarP(&options.File, "kubefile", "f", "Kubefile", "kubefile filepath")
 	buildCmd.Flags().StringVarP(&options.Tag, "tag", "t", "", "tagged name to apply to the built image")
 	buildCmd.Flags().StringVar(&options.Platform, "platform", fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH), "set the OS/ARCH/VARIANT of the image to the provided value instead of the current operating system and architecture of the host (for example linux/arm)")
+	buildCmd.Flags().IntVarP(&options.MaxPullProcs, "max-pull-procs", "m", 5, "maximum number of goroutines for pulling")
 	if err := buildCmd.MarkFlagRequired("tag"); err != nil {
 		logger.Error("failed to init flag: %v", err)
 		os.Exit(1)

--- a/pkg/image/binary/image.go
+++ b/pkg/image/binary/image.go
@@ -126,7 +126,7 @@ func (d *ImageService) Build(options *types.BuildOptions, contextDir, imageName 
 	if err != nil {
 		return err
 	}
-	is := registry.NewImageSaver(context.Background(), auths)
+	is := registry.NewImageSaver(context.Background(), options.MaxPullProcs, auths)
 	platform := strings.Split(options.Platform, "/")
 	var platformVar v1.Platform
 	if len(platform) > 2 {

--- a/pkg/image/buildah/image/build.go
+++ b/pkg/image/buildah/image/build.go
@@ -63,7 +63,7 @@ func (d *ImageService) Build(options *types.BuildOptions, contextDir, imageName 
 	if err != nil {
 		return err
 	}
-	is := registry.NewImageSaver(context.Background(), auths)
+	is := registry.NewImageSaver(context.Background(), options.MaxPullProcs, auths)
 	platform := strings.Split(options.Platform, "/")
 	var platformVar v1.Platform
 	if len(platform) > 2 {

--- a/pkg/image/types/types.go
+++ b/pkg/image/types/types.go
@@ -47,6 +47,7 @@ type BuildOptions struct {
 	Remove             bool     //--rm true
 	Platform           string   //--platform linux/amd64
 	Pull               PullType //--pull string[="true"] true  (true,always,never)
+	MaxPullProcs       int      //--max-pull-procs
 	Tag                string
 }
 
@@ -78,6 +79,9 @@ func (opts *BuildOptions) String() string {
 	}
 	if len(opts.Pull) > 0 {
 		sb.WriteString(fmt.Sprintf(" --pull=%s ", string(opts.Pull)))
+	}
+	if opts.MaxPullProcs > 0 {
+		sb.WriteString(fmt.Sprintf(" --max-pull-procs %d ", opts.MaxPullProcs))
 	}
 	if len(opts.Tag) > 0 {
 		sb.WriteString(fmt.Sprintf(" -t %s ", opts.Tag))

--- a/pkg/registry/interface.go
+++ b/pkg/registry/interface.go
@@ -33,10 +33,11 @@ type DefaultImageSaver struct {
 	ctx            context.Context
 	domainToImages map[string][]Named
 	progressOut    progress.Output
+	maxPullProcs   int
 	auths          map[string]types.AuthConfig
 }
 
-func NewImageSaver(ctx context.Context, auths map[string]types.AuthConfig) Save {
+func NewImageSaver(ctx context.Context, maxPullProcs int, auths map[string]types.AuthConfig) Save {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -46,6 +47,7 @@ func NewImageSaver(ctx context.Context, auths map[string]types.AuthConfig) Save 
 	return &DefaultImageSaver{
 		ctx:            ctx,
 		domainToImages: make(map[string][]Named),
+		maxPullProcs:   maxPullProcs,
 		auths:          auths,
 	}
 }

--- a/pkg/registry/save.go
+++ b/pkg/registry/save.go
@@ -47,11 +47,10 @@ import (
 )
 
 const (
-	HTTPS               = "https://"
-	HTTP                = "http://"
-	defaultProxyURL     = "https://registry-1.docker.io"
-	configRootDir       = "rootdirectory"
-	maxPullGoroutineNum = 5
+	HTTPS           = "https://"
+	HTTP            = "http://"
+	defaultProxyURL = "https://registry-1.docker.io"
+	configRootDir   = "rootdirectory"
 
 	manifestV2       = "application/vnd.docker.distribution.manifest.v2+json"
 	manifestOCI      = "application/vnd.oci.image.manifest.v1+json"
@@ -87,7 +86,7 @@ func (is *DefaultImageSaver) SaveImages(images []string, dir string, platform v1
 
 	//perform image save ability
 	eg, _ := errgroup.WithContext(context.Background())
-	numCh := make(chan struct{}, maxPullGoroutineNum)
+	numCh := make(chan struct{}, is.maxPullProcs)
 	var outImages []string
 	var mu sync.Mutex
 	for _, nameds := range is.domainToImages {
@@ -216,7 +215,7 @@ func (is *DefaultImageSaver) saveManifestAndGetDigest(nameds []Named, repo distr
 		return nil, fmt.Errorf("get manifest service error: %v", err)
 	}
 	eg, _ := errgroup.WithContext(context.Background())
-	numCh := make(chan struct{}, maxPullGoroutineNum)
+	numCh := make(chan struct{}, is.maxPullProcs)
 	imageDigests := make([]digest.Digest, 0)
 	for _, named := range nameds {
 		tmpnamed := named
@@ -285,7 +284,7 @@ func (is *DefaultImageSaver) saveBlobs(imageDigests []digest.Digest, repo distri
 		return fmt.Errorf("get blob service error: %v", err)
 	}
 	eg, _ := errgroup.WithContext(context.Background())
-	numCh := make(chan struct{}, maxPullGoroutineNum)
+	numCh := make(chan struct{}, is.maxPullProcs)
 	blobLists := make([]digest.Digest, 0)
 
 	//get blob list

--- a/pkg/registry/save_test.go
+++ b/pkg/registry/save_test.go
@@ -28,7 +28,7 @@ import (
 func TestSaveImages(t *testing.T) {
 	//tests := []string{"quay.io/tigera/operator:v1.25.3"}
 	tests := []string{"registry.cn-beijing.aliyuncs.com/private-test/nginx"}
-	is := NewImageSaver(context.Background(), nil)
+	is := NewImageSaver(context.Background(), 5, nil)
 	images, err := is.SaveImages(tests, "/Users/cuisongliu/DockerImages/registry", v1.Platform{OS: "linux", Architecture: "amd64"})
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
Fix #994 

Affected commands: `sealos build`, `seactl registry pull`. Add a flag `--max-pull-procs` for both.