### PR TITLE
modify help

### DIFF
--- a/cmd/sealos/cmd/add.go
+++ b/cmd/sealos/cmd/add.go
@@ -30,6 +30,9 @@ func newAddCmd() *cobra.Command {
 		Short: "add some node",
 		Args:  cobra.NoArgs,
 		Example: `
+add to nodes :
+	sealos add --nodes x.x.x.x
+
 add to default cluster: 
 	sealos add --masters x.x.x.x --nodes x.x.x.x
 	sealos add --masters x.x.x.x-x.x.x.y --nodes x.x.x.x-x.x.x.y

--- a/cmd/sealos/cmd/delete.go
+++ b/cmd/sealos/cmd/delete.go
@@ -25,17 +25,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// deleteCmd represents the delete command
-func newDeleteCmd() *cobra.Command {
-	var deleteCmd = &cobra.Command{
-		Use:   "delete",
-		Short: "delete some node",
-		Args:  cobra.NoArgs,
-		Example: `
+var exampledelete = `
+delete to nodes:
+	sealos delete --nodes x.x.x.x
+		if accidentally deleted; 
+		Use 'sealos add' to recover:
+			sealos add --nodes x.x.x.x
+
 delete to default cluster: 
 	sealos delete --masters x.x.x.x --nodes x.x.x.x
 	sealos delete --masters x.x.x.x-x.x.x.y --nodes x.x.x.x-x.x.x.y
-`,
+`
+
+// deleteCmd represents the delete command
+func newDeleteCmd() *cobra.Command {
+	var deleteCmd = &cobra.Command{
+		Use:     "delete",
+		Short:   "delete some node",
+		Args:    cobra.NoArgs,
+		Example: exampledelete,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := processor.ConfirmDeleteNodes(); err != nil {
 				return err


### PR DESCRIPTION
sealos delete can not only delect cluster ,but also delete a single node,while sealos add is supported to add new one.