### PR TITLE
feature(main): support cache http registry #1022

### DIFF
--- a/cmd/sealctl/cmd/registry.go
+++ b/cmd/sealctl/cmd/registry.go
@@ -40,6 +40,7 @@ var (
 	registryPullAuths        []string
 	registryPullArch         string
 	registryPullMaxPullProcs int
+	registryPullAuthBasic    bool
 )
 
 func NewRegistryImageCmd() *cobra.Command {
@@ -66,6 +67,7 @@ func NewRegistryImagePullCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&registryPullRegistryDir, "data-dir", "/var/lib/registry", "registry data dir path")
 	cmd.PersistentFlags().StringSliceVar(&registryPullAuths, "auths", []string{}, "auths data for login mirror registry, format example is \"address=docker.io&&auth=YWRtaW46YWRtaW4=\".")
 	cmd.PersistentFlags().IntVar(&registryPullMaxPullProcs, "max-pull-procs", 5, "maximum number of goroutines for pulling")
+	cmd.PersistentFlags().BoolVar(&registryPullAuthBasic, "basic-auth", false, "pull image auth policy,default is token auth")
 	cmd.AddCommand(NewRegistryImagePullRawCmd())
 	cmd.AddCommand(NewRegistryImagePullYamlCmd())
 	cmd.AddCommand(NewRegistryImagePullDefaultCmd())
@@ -85,7 +87,7 @@ func NewRegistryImagePullRawCmd() *cobra.Command {
 				logger.Error("ImageFile convert images is error: %s", err.Error())
 				os.Exit(1)
 			}
-			is := registry.NewImageSaver(context.Background(), registryPullMaxPullProcs, auth)
+			is := registry.NewImageSaver(context.Background(), registryPullMaxPullProcs, auth, registryPullAuthBasic)
 			_, err = is.SaveImages(images, registryPullRegistryDir, v1.Platform{OS: "linux", Architecture: registryPullArch})
 			if err != nil {
 				logger.Error("pull registry images is error: %s", err.Error())
@@ -118,7 +120,7 @@ func NewRegistryImagePullYamlCmd() *cobra.Command {
 				logger.Error("yaml path convert images is error: %s", err.Error())
 				os.Exit(1)
 			}
-			is := registry.NewImageSaver(context.Background(), registryPullMaxPullProcs, auth)
+			is := registry.NewImageSaver(context.Background(), registryPullMaxPullProcs, auth, registryPullAuthBasic)
 			_, err = is.SaveImages(images, registryPullRegistryDir, v1.Platform{OS: "linux", Architecture: registryPullArch})
 			if err != nil {
 				logger.Error("pull registry images is error: %s", err.Error())
@@ -146,7 +148,7 @@ func NewRegistryImagePullDefaultCmd() *cobra.Command {
 		Short: "registry images manager pull to local dir by default type",
 		Run: func(cmd *cobra.Command, args []string) {
 			flags.PrintFlags(cmd.Flags())
-			is := registry.NewImageSaver(context.Background(), registryPullMaxPullProcs, auth)
+			is := registry.NewImageSaver(context.Background(), registryPullMaxPullProcs, auth, registryPullAuthBasic)
 			_, err := is.SaveImages(images, registryPullRegistryDir, v1.Platform{OS: "linux", Architecture: registryPullArch})
 			if err != nil {
 				logger.Error("pull registry images is error: %s", err.Error())

--- a/cmd/sealos/cmd/build.go
+++ b/cmd/sealos/cmd/build.go
@@ -56,6 +56,8 @@ func newBuildCmd() *cobra.Command {
 	buildCmd.Flags().StringVarP(&options.Tag, "tag", "t", "", "tagged name to apply to the built image")
 	buildCmd.Flags().StringVar(&options.Platform, "platform", fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH), "set the OS/ARCH/VARIANT of the image to the provided value instead of the current operating system and architecture of the host (for example linux/arm)")
 	buildCmd.Flags().IntVarP(&options.MaxPullProcs, "max-pull-procs", "m", 5, "maximum number of goroutines for pulling")
+	buildCmd.Flags().BoolVar(&options.BasicAuth, "basic-auth", false, "pull image auth policy,default is token auth")
+
 	if err := buildCmd.MarkFlagRequired("tag"); err != nil {
 		logger.Error("failed to init flag: %v", err)
 		os.Exit(1)

--- a/pkg/image/binary/image.go
+++ b/pkg/image/binary/image.go
@@ -126,7 +126,7 @@ func (d *ImageService) Build(options *types.BuildOptions, contextDir, imageName 
 	if err != nil {
 		return err
 	}
-	is := registry.NewImageSaver(context.Background(), options.MaxPullProcs, auths)
+	is := registry.NewImageSaver(context.Background(), options.MaxPullProcs, auths, options.BasicAuth)
 	platform := strings.Split(options.Platform, "/")
 	var platformVar v1.Platform
 	if len(platform) > 2 {

--- a/pkg/image/buildah/image/build.go
+++ b/pkg/image/buildah/image/build.go
@@ -63,7 +63,7 @@ func (d *ImageService) Build(options *types.BuildOptions, contextDir, imageName 
 	if err != nil {
 		return err
 	}
-	is := registry.NewImageSaver(context.Background(), options.MaxPullProcs, auths)
+	is := registry.NewImageSaver(context.Background(), options.MaxPullProcs, auths, options.BasicAuth)
 	platform := strings.Split(options.Platform, "/")
 	var platformVar v1.Platform
 	if len(platform) > 2 {

--- a/pkg/image/types/types.go
+++ b/pkg/image/types/types.go
@@ -48,6 +48,7 @@ type BuildOptions struct {
 	Platform           string   //--platform linux/amd64
 	Pull               PullType //--pull string[="true"] true  (true,always,never)
 	MaxPullProcs       int      //--max-pull-procs
+	BasicAuth          bool
 	Tag                string
 }
 

--- a/pkg/registry/distributionpkg/client/auth/api_version.go
+++ b/pkg/registry/distributionpkg/client/auth/api_version.go
@@ -1,0 +1,72 @@
+// Copyright © 2022 https://github.com/distribution/distribution
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"net/http"
+	"strings"
+)
+
+// APIVersion represents a version of an API including its
+// type and version number.
+type APIVersion struct {
+	// Type refers to the name of a specific API specification
+	// such as "registry"
+	Type string
+
+	// Version is the version of the API specification implemented,
+	// This may omit the revision number and only include
+	// the major and minor version, such as "2.0"
+	Version string
+}
+
+// String returns the string formatted API Version
+func (v APIVersion) String() string {
+	return v.Type + "/" + v.Version
+}
+
+// APIVersions gets the API versions out of an HTTP response using the provided
+// version header as the key for the HTTP header.
+func APIVersions(resp *http.Response, versionHeader string) []APIVersion {
+	versions := []APIVersion{}
+	if versionHeader != "" {
+		for _, supportedVersions := range resp.Header[http.CanonicalHeaderKey(versionHeader)] {
+			for _, version := range strings.Fields(supportedVersions) {
+				versions = append(versions, ParseAPIVersion(version))
+			}
+		}
+	}
+	return versions
+}
+
+// ParseAPIVersion parses an API version string into an APIVersion
+// Format (Expected, not enforced):
+// API version string = <API type> '/' <API version>
+// API type = [a-z][a-z0-9]*
+// API version = [0-9]+(\.[0-9]+)?
+// TODO(dmcgowan): Enforce format, add error condition, remove unknown type
+func ParseAPIVersion(versionStr string) APIVersion {
+	idx := strings.IndexRune(versionStr, '/')
+	if idx == -1 {
+		return APIVersion{
+			Type:    "unknown",
+			Version: versionStr,
+		}
+	}
+	return APIVersion{
+		Type:    strings.ToLower(versionStr[:idx]),
+		Version: versionStr[idx+1:],
+	}
+}

--- a/pkg/registry/distributionpkg/client/auth/challenge/addr.go
+++ b/pkg/registry/distributionpkg/client/auth/challenge/addr.go
@@ -1,0 +1,41 @@
+// Copyright © 2022 https://github.com/distribution/distribution
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package challenge
+
+import (
+	"net/url"
+	"strings"
+)
+
+// FROM: https://golang.org/src/net/http/http.go
+// Given a string of the form "host", "host:port", or "[ipv6::address]:port",
+// return true if the string includes a port.
+func hasPort(s string) bool { return strings.LastIndex(s, ":") > strings.LastIndex(s, "]") }
+
+// FROM: http://golang.org/src/net/http/transport.go
+var portMap = map[string]string{
+	"http":  "80",
+	"https": "443",
+}
+
+// canonicalAddr returns url.Host but always with a ":port" suffix
+// FROM: http://golang.org/src/net/http/transport.go
+func canonicalAddr(url *url.URL) string {
+	addr := url.Host
+	if !hasPort(addr) {
+		return addr + ":" + portMap[url.Scheme]
+	}
+	return addr
+}

--- a/pkg/registry/distributionpkg/client/auth/challenge/authchallenge.go
+++ b/pkg/registry/distributionpkg/client/auth/challenge/authchallenge.go
@@ -1,0 +1,251 @@
+// Copyright © 2022 https://github.com/distribution/distribution
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package challenge
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+)
+
+// Challenge carries information from a WWW-Authenticate response header.
+// See RFC 2617.
+type Challenge struct {
+	// Scheme is the auth-scheme according to RFC 2617
+	Scheme string
+
+	// Parameters are the auth-params according to RFC 2617
+	Parameters map[string]string
+}
+
+// Manager manages the challenges for endpoints.
+// The challenges are pulled out of HTTP responses. Only
+// responses which expect challenges should be added to
+// the manager, since a non-unauthorized request will be
+// viewed as not requiring challenges.
+type Manager interface {
+	// GetChallenges returns the challenges for the given
+	// endpoint URL.
+	GetChallenges(endpoint url.URL) ([]Challenge, error)
+
+	// AddResponse adds the response to the challenge
+	// manager. The challenges will be parsed out of
+	// the WWW-Authenicate headers and added to the
+	// URL which was produced the response. If the
+	// response was authorized, any challenges for the
+	// endpoint will be cleared.
+	AddResponse(resp *http.Response) error
+}
+
+// NewSimpleManager returns an instance of
+// Manager which only maps endpoints to challenges
+// based on the responses which have been added the
+// manager. The simple manager will make no attempt to
+// perform requests on the endpoints or cache the responses
+// to a backend.
+func NewSimpleManager() Manager {
+	return &simpleManager{
+		Challenges: make(map[string][]Challenge),
+	}
+}
+
+type simpleManager struct {
+	sync.RWMutex
+	Challenges map[string][]Challenge
+}
+
+func normalizeURL(endpoint *url.URL) {
+	endpoint.Host = strings.ToLower(endpoint.Host)
+	endpoint.Host = canonicalAddr(endpoint)
+}
+
+func (m *simpleManager) GetChallenges(endpoint url.URL) ([]Challenge, error) {
+	normalizeURL(&endpoint)
+
+	m.RLock()
+	defer m.RUnlock()
+	challenges := m.Challenges[endpoint.String()]
+	return challenges, nil
+}
+
+func (m *simpleManager) AddResponse(resp *http.Response) error {
+	challenges := ResponseChallenges(resp)
+	if resp.Request == nil {
+		return fmt.Errorf("missing request reference")
+	}
+	urlCopy := url.URL{
+		Path:   resp.Request.URL.Path,
+		Host:   resp.Request.URL.Host,
+		Scheme: resp.Request.URL.Scheme,
+	}
+	normalizeURL(&urlCopy)
+
+	m.Lock()
+	defer m.Unlock()
+	m.Challenges[urlCopy.String()] = challenges
+	return nil
+}
+
+// Octet types from RFC 2616.
+type octetType byte
+
+var octetTypes [256]octetType
+
+const (
+	isToken octetType = 1 << iota
+	isSpace
+)
+
+func init() {
+	// OCTET      = <any 8-bit sequence of data>
+	// CHAR       = <any US-ASCII character (octets 0 - 127)>
+	// CTL        = <any US-ASCII control character (octets 0 - 31) and DEL (127)>
+	// CR         = <US-ASCII CR, carriage return (13)>
+	// LF         = <US-ASCII LF, linefeed (10)>
+	// SP         = <US-ASCII SP, space (32)>
+	// HT         = <US-ASCII HT, horizontal-tab (9)>
+	// <">        = <US-ASCII double-quote mark (34)>
+	// CRLF       = CR LF
+	// LWS        = [CRLF] 1*( SP | HT )
+	// TEXT       = <any OCTET except CTLs, but including LWS>
+	// separators = "(" | ")" | "<" | ">" | "@" | "," | ";" | ":" | "\" | <">
+	//              | "/" | "[" | "]" | "?" | "=" | "{" | "}" | SP | HT
+	// token      = 1*<any CHAR except CTLs or separators>
+	// qdtext     = <any TEXT except <">>
+
+	for c := 0; c < 256; c++ {
+		var t octetType
+		isCtl := c <= 31 || c == 127
+		isChar := 0 <= c && c <= 127
+		isSeparator := strings.ContainsRune(" \t\"(),/:;<=>?@[]\\{}", rune(c))
+		if strings.ContainsRune(" \t\r\n", rune(c)) {
+			t |= isSpace
+		}
+		if isChar && !isCtl && !isSeparator {
+			t |= isToken
+		}
+		octetTypes[c] = t
+	}
+}
+
+// ResponseChallenges returns a list of authorization challenges
+// for the given http Response. Challenges are only checked if
+// the response status code was a 401.
+func ResponseChallenges(resp *http.Response) []Challenge {
+	if resp.StatusCode == http.StatusUnauthorized {
+		// Parse the WWW-Authenticate Header and store the challenges
+		// on this endpoint object.
+		return parseAuthHeader(resp.Header)
+	}
+
+	return nil
+}
+
+func parseAuthHeader(header http.Header) []Challenge {
+	challenges := []Challenge{}
+	for _, h := range header[http.CanonicalHeaderKey("WWW-Authenticate")] {
+		v, p := parseValueAndParams(h)
+		if v != "" {
+			challenges = append(challenges, Challenge{Scheme: v, Parameters: p})
+		}
+	}
+	return challenges
+}
+
+func parseValueAndParams(header string) (value string, params map[string]string) {
+	params = make(map[string]string)
+	value, s := expectToken(header)
+	if value == "" {
+		return
+	}
+	value = strings.ToLower(value)
+	s = "," + skipSpace(s)
+	for strings.HasPrefix(s, ",") {
+		var pkey string
+		pkey, s = expectToken(skipSpace(s[1:]))
+		if pkey == "" {
+			return
+		}
+		if !strings.HasPrefix(s, "=") {
+			return
+		}
+		var pvalue string
+		pvalue, s = expectTokenOrQuoted(s[1:])
+		if pvalue == "" {
+			return
+		}
+		pkey = strings.ToLower(pkey)
+		params[pkey] = pvalue
+		s = skipSpace(s)
+	}
+	return
+}
+
+func skipSpace(s string) (rest string) {
+	i := 0
+	for ; i < len(s); i++ {
+		if octetTypes[s[i]]&isSpace == 0 {
+			break
+		}
+	}
+	return s[i:]
+}
+
+func expectToken(s string) (token, rest string) {
+	i := 0
+	for ; i < len(s); i++ {
+		if octetTypes[s[i]]&isToken == 0 {
+			break
+		}
+	}
+	return s[:i], s[i:]
+}
+
+func expectTokenOrQuoted(s string) (value string, rest string) {
+	if !strings.HasPrefix(s, "\"") {
+		return expectToken(s)
+	}
+	s = s[1:]
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '"':
+			return s[:i], s[i+1:]
+		case '\\':
+			p := make([]byte, len(s)-1)
+			j := copy(p, s[:i])
+			escape := true
+			for i = i + 1; i < len(s); i++ {
+				b := s[i]
+				switch {
+				case escape:
+					escape = false
+					p[j] = b
+					j++
+				case b == '\\':
+					escape = true
+				case b == '"':
+					return string(p[:j]), s[i+1:]
+				default:
+					p[j] = b
+					j++
+				}
+			}
+			return "", ""
+		}
+	}
+	return "", ""
+}

--- a/pkg/registry/distributionpkg/client/auth/session.go
+++ b/pkg/registry/distributionpkg/client/auth/session.go
@@ -1,0 +1,549 @@
+// Copyright © 2022 https://github.com/distribution/distribution
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/labring/sealos/pkg/registry/distributionpkg/client"
+	"github.com/labring/sealos/pkg/registry/distributionpkg/client/auth/challenge"
+	"github.com/labring/sealos/pkg/registry/distributionpkg/client/transport"
+)
+
+var (
+	// ErrNoBasicAuthCredentials is returned if a request can't be authorized with
+	// basic auth due to lack of credentials.
+	ErrNoBasicAuthCredentials = errors.New("no basic auth credentials")
+
+	// ErrNoToken is returned if a request is successful but the body does not
+	// contain an authorization token.
+	ErrNoToken = errors.New("authorization server did not include a token in the response")
+)
+
+const defaultClientID = "registry-client"
+
+// AuthenticationHandler is an interface for authorizing a request from
+// params from a "WWW-Authenicate" header for a single scheme.
+type AuthenticationHandler interface {
+	// Scheme returns the scheme as expected from the "WWW-Authenicate" header.
+	Scheme() string
+
+	// AuthorizeRequest adds the authorization header to a request (if needed)
+	// using the parameters from "WWW-Authenticate" method. The parameters
+	// values depend on the scheme.
+	AuthorizeRequest(req *http.Request, params map[string]string) error
+}
+
+// CredentialStore is an interface for getting credentials for
+// a given URL
+type CredentialStore interface {
+	// Basic returns basic auth for the given URL
+	Basic(*url.URL) (string, string)
+
+	// RefreshToken returns a refresh token for the
+	// given URL and service
+	RefreshToken(*url.URL, string) string
+
+	// SetRefreshToken sets the refresh token if none
+	// is provided for the given url and service
+	SetRefreshToken(realm *url.URL, service, token string)
+}
+
+// NewAuthorizer creates an authorizer which can handle multiple authentication
+// schemes. The handlers are tried in order, the higher priority authentication
+// methods should be first. The challengeMap holds a list of challenges for
+// a given root API endpoint (for example "https://registry-1.docker.io/v2/").
+func NewAuthorizer(manager challenge.Manager, handlers ...AuthenticationHandler) transport.RequestModifier {
+	return &endpointAuthorizer{
+		challenges: manager,
+		handlers:   handlers,
+	}
+}
+
+type endpointAuthorizer struct {
+	challenges challenge.Manager
+	handlers   []AuthenticationHandler
+}
+
+func (ea *endpointAuthorizer) ModifyRequest(req *http.Request) error {
+	pingPath := req.URL.Path
+	if v2Root := strings.Index(req.URL.Path, "/v2/"); v2Root != -1 {
+		pingPath = pingPath[:v2Root+4]
+	} else if v1Root := strings.Index(req.URL.Path, "/v1/"); v1Root != -1 {
+		pingPath = pingPath[:v1Root] + "/v2/"
+	} else {
+		return nil
+	}
+
+	ping := url.URL{
+		Host:   req.URL.Host,
+		Scheme: req.URL.Scheme,
+		Path:   pingPath,
+	}
+
+	challenges, err := ea.challenges.GetChallenges(ping)
+	if err != nil {
+		return err
+	}
+
+	if len(challenges) > 0 {
+		for _, handler := range ea.handlers {
+			for _, c := range challenges {
+				if c.Scheme != handler.Scheme() {
+					continue
+				}
+				if err := handler.AuthorizeRequest(req, c.Parameters); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// This is the minimum duration a token can last (in seconds).
+// A token must not live less than 60 seconds because older versions
+// of the Docker client didn't read their expiration from the token
+// response and assumed 60 seconds.  So to remain compatible with
+// those implementations, a token must live at least this long.
+const minimumTokenLifetimeSeconds = 60
+
+// Private interface for time used by this package to enable tests to provide their own implementation.
+type clock interface {
+	Now() time.Time
+}
+
+type tokenHandler struct {
+	creds     CredentialStore
+	transport http.RoundTripper
+	clock     clock
+
+	offlineAccess bool
+	forceOAuth    bool
+	clientID      string
+	scopes        []Scope
+
+	tokenLock       sync.Mutex
+	tokenCache      string
+	tokenExpiration time.Time
+
+	logger Logger
+}
+
+// Scope is a type which is serializable to a string
+// using the allow scope grammar.
+type Scope interface {
+	String() string
+}
+
+// RepositoryScope represents a token scope for access
+// to a repository.
+type RepositoryScope struct {
+	Repository string
+	Class      string
+	Actions    []string
+}
+
+// String returns the string representation of the repository
+// using the scope grammar
+func (rs RepositoryScope) String() string {
+	repoType := "repository"
+	// Keep existing format for image class to maintain backwards compatibility
+	// with authorization servers which do not support the expanded grammar.
+	if rs.Class != "" && rs.Class != "image" {
+		repoType = fmt.Sprintf("%s(%s)", repoType, rs.Class)
+	}
+	return fmt.Sprintf("%s:%s:%s", repoType, rs.Repository, strings.Join(rs.Actions, ","))
+}
+
+// RegistryScope represents a token scope for access
+// to resources in the registry.
+type RegistryScope struct {
+	Name    string
+	Actions []string
+}
+
+// String returns the string representation of the user
+// using the scope grammar
+func (rs RegistryScope) String() string {
+	return fmt.Sprintf("registry:%s:%s", rs.Name, strings.Join(rs.Actions, ","))
+}
+
+// Logger defines the injectable logging interface, used on TokenHandlers.
+type Logger interface {
+	Debugf(format string, args ...interface{})
+}
+
+func logDebugf(logger Logger, format string, args ...interface{}) {
+	if logger == nil {
+		return
+	}
+	logger.Debugf(format, args...)
+}
+
+// TokenHandlerOptions is used to configure a new token handler
+type TokenHandlerOptions struct {
+	Transport   http.RoundTripper
+	Credentials CredentialStore
+
+	OfflineAccess bool
+	ForceOAuth    bool
+	ClientID      string
+	Scopes        []Scope
+	Logger        Logger
+}
+
+// An implementation of clock for providing real time data.
+type realClock struct{}
+
+// Now implements clock
+func (realClock) Now() time.Time { return time.Now() }
+
+// NewTokenHandler creates a new AuthenicationHandler which supports
+// fetching tokens from a remote token server.
+func NewTokenHandler(transport http.RoundTripper, creds CredentialStore, scope string, actions ...string) AuthenticationHandler {
+	// Create options...
+	return NewTokenHandlerWithOptions(TokenHandlerOptions{
+		Transport:   transport,
+		Credentials: creds,
+		Scopes: []Scope{
+			RepositoryScope{
+				Repository: scope,
+				Actions:    actions,
+			},
+		},
+	})
+}
+
+// NewTokenHandlerWithOptions creates a new token handler using the provided
+// options structure.
+func NewTokenHandlerWithOptions(options TokenHandlerOptions) AuthenticationHandler {
+	handler := &tokenHandler{
+		transport:     options.Transport,
+		creds:         options.Credentials,
+		offlineAccess: options.OfflineAccess,
+		forceOAuth:    options.ForceOAuth,
+		clientID:      options.ClientID,
+		scopes:        options.Scopes,
+		clock:         realClock{},
+		logger:        options.Logger,
+	}
+
+	return handler
+}
+
+func (th *tokenHandler) client() *http.Client {
+	return &http.Client{
+		Transport: th.transport,
+		Timeout:   15 * time.Second,
+	}
+}
+
+func (th *tokenHandler) Scheme() string {
+	return "bearer"
+}
+
+func (th *tokenHandler) AuthorizeRequest(req *http.Request, params map[string]string) error {
+	var additionalScopes []string
+	if fromParam := req.URL.Query().Get("from"); fromParam != "" {
+		additionalScopes = append(additionalScopes, RepositoryScope{
+			Repository: fromParam,
+			Actions:    []string{"pull"},
+		}.String())
+	}
+
+	token, err := th.getToken(params, additionalScopes...)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	return nil
+}
+
+func (th *tokenHandler) getToken(params map[string]string, additionalScopes ...string) (string, error) {
+	th.tokenLock.Lock()
+	defer th.tokenLock.Unlock()
+	scopes := make([]string, 0, len(th.scopes)+len(additionalScopes))
+	for _, scope := range th.scopes {
+		scopes = append(scopes, scope.String())
+	}
+	var addedScopes bool
+	for _, scope := range additionalScopes {
+		if hasScope(scopes, scope) {
+			continue
+		}
+		scopes = append(scopes, scope)
+		addedScopes = true
+	}
+
+	now := th.clock.Now()
+	if now.After(th.tokenExpiration) || addedScopes {
+		token, expiration, err := th.fetchToken(params, scopes)
+		if err != nil {
+			return "", err
+		}
+
+		// do not update cache for added scope tokens
+		if !addedScopes {
+			th.tokenCache = token
+			th.tokenExpiration = expiration
+		}
+
+		return token, nil
+	}
+
+	return th.tokenCache, nil
+}
+
+func hasScope(scopes []string, scope string) bool {
+	for _, s := range scopes {
+		if s == scope {
+			return true
+		}
+	}
+	return false
+}
+
+type postTokenResponse struct {
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token"`
+	ExpiresIn    int       `json:"expires_in"`
+	IssuedAt     time.Time `json:"issued_at"`
+	Scope        string    `json:"scope"`
+}
+
+func (th *tokenHandler) fetchTokenWithOAuth(realm *url.URL, refreshToken, service string, scopes []string) (token string, expiration time.Time, err error) {
+	form := url.Values{}
+	form.Set("scope", strings.Join(scopes, " "))
+	form.Set("service", service)
+
+	clientID := th.clientID
+	if clientID == "" {
+		// Use default client, this is a required field
+		clientID = defaultClientID
+	}
+	form.Set("client_id", clientID)
+
+	if refreshToken != "" {
+		form.Set("grant_type", "refresh_token")
+		form.Set("refresh_token", refreshToken)
+	} else if th.creds != nil {
+		form.Set("grant_type", "password")
+		username, password := th.creds.Basic(realm)
+		form.Set("username", username)
+		form.Set("password", password)
+
+		// attempt to get a refresh token
+		form.Set("access_type", "offline")
+	} else {
+		// refuse to do oauth without a grant type
+		return "", time.Time{}, fmt.Errorf("no supported grant type")
+	}
+
+	resp, err := th.client().PostForm(realm.String(), form)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	defer resp.Body.Close()
+
+	if !client.SuccessStatus(resp.StatusCode) {
+		err := client.HandleErrorResponse(resp)
+		return "", time.Time{}, err
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+
+	var tr postTokenResponse
+	if err = decoder.Decode(&tr); err != nil {
+		return "", time.Time{}, fmt.Errorf("unable to decode token response: %s", err)
+	}
+
+	if tr.AccessToken == "" {
+		return "", time.Time{}, ErrNoToken
+	}
+
+	if tr.RefreshToken != "" && tr.RefreshToken != refreshToken {
+		th.creds.SetRefreshToken(realm, service, tr.RefreshToken)
+	}
+
+	if tr.ExpiresIn < minimumTokenLifetimeSeconds {
+		// The default/minimum lifetime.
+		tr.ExpiresIn = minimumTokenLifetimeSeconds
+		logDebugf(th.logger, "Increasing token expiration to: %d seconds", tr.ExpiresIn)
+	}
+
+	if tr.IssuedAt.IsZero() {
+		// issued_at is optional in the token response.
+		tr.IssuedAt = th.clock.Now().UTC()
+	}
+
+	return tr.AccessToken, tr.IssuedAt.Add(time.Duration(tr.ExpiresIn) * time.Second), nil
+}
+
+type getTokenResponse struct {
+	Token        string    `json:"token"`
+	AccessToken  string    `json:"access_token"`
+	ExpiresIn    int       `json:"expires_in"`
+	IssuedAt     time.Time `json:"issued_at"`
+	RefreshToken string    `json:"refresh_token"`
+}
+
+func (th *tokenHandler) fetchTokenWithBasicAuth(realm *url.URL, service string, scopes []string) (token string, expiration time.Time, err error) {
+	req, err := http.NewRequest("GET", realm.String(), nil)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+
+	reqParams := req.URL.Query()
+
+	if service != "" {
+		reqParams.Add("service", service)
+	}
+
+	for _, scope := range scopes {
+		reqParams.Add("scope", scope)
+	}
+
+	if th.offlineAccess {
+		reqParams.Add("offline_token", "true")
+		clientID := th.clientID
+		if clientID == "" {
+			clientID = defaultClientID
+		}
+		reqParams.Add("client_id", clientID)
+	}
+
+	if th.creds != nil {
+		username, password := th.creds.Basic(realm)
+		if username != "" && password != "" {
+			reqParams.Add("account", username)
+			req.SetBasicAuth(username, password)
+		}
+	}
+
+	req.URL.RawQuery = reqParams.Encode()
+
+	resp, err := th.client().Do(req)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	defer resp.Body.Close()
+
+	if !client.SuccessStatus(resp.StatusCode) {
+		err := client.HandleErrorResponse(resp)
+		return "", time.Time{}, err
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+
+	var tr getTokenResponse
+	if err = decoder.Decode(&tr); err != nil {
+		return "", time.Time{}, fmt.Errorf("unable to decode token response: %s", err)
+	}
+
+	if tr.RefreshToken != "" && th.creds != nil {
+		th.creds.SetRefreshToken(realm, service, tr.RefreshToken)
+	}
+
+	// `access_token` is equivalent to `token` and if both are specified
+	// the choice is undefined.  Canonicalize `access_token` by sticking
+	// things in `token`.
+	if tr.AccessToken != "" {
+		tr.Token = tr.AccessToken
+	}
+
+	if tr.Token == "" {
+		return "", time.Time{}, ErrNoToken
+	}
+
+	if tr.ExpiresIn < minimumTokenLifetimeSeconds {
+		// The default/minimum lifetime.
+		tr.ExpiresIn = minimumTokenLifetimeSeconds
+		logDebugf(th.logger, "Increasing token expiration to: %d seconds", tr.ExpiresIn)
+	}
+
+	if tr.IssuedAt.IsZero() {
+		// issued_at is optional in the token response.
+		tr.IssuedAt = th.clock.Now().UTC()
+	}
+
+	return tr.Token, tr.IssuedAt.Add(time.Duration(tr.ExpiresIn) * time.Second), nil
+}
+
+func (th *tokenHandler) fetchToken(params map[string]string, scopes []string) (token string, expiration time.Time, err error) {
+	realm, ok := params["realm"]
+	if !ok {
+		return "", time.Time{}, errors.New("no realm specified for token auth challenge")
+	}
+
+	// TODO(dmcgowan): Handle empty scheme and relative realm
+	realmURL, err := url.Parse(realm)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("invalid token auth challenge realm: %s", err)
+	}
+
+	service := params["service"]
+
+	var refreshToken string
+
+	if th.creds != nil {
+		refreshToken = th.creds.RefreshToken(realmURL, service)
+	}
+
+	if refreshToken != "" || th.forceOAuth {
+		return th.fetchTokenWithOAuth(realmURL, refreshToken, service, scopes)
+	}
+
+	return th.fetchTokenWithBasicAuth(realmURL, service, scopes)
+}
+
+type basicHandler struct {
+	creds     CredentialStore
+	remoteURL *url.URL
+}
+
+// NewBasicHandler creaters a new authentiation handler which adds
+// basic authentication credentials to a request.
+func NewBasicHandler(creds CredentialStore, remoteURL *url.URL) AuthenticationHandler {
+	return &basicHandler{
+		creds:     creds,
+		remoteURL: remoteURL,
+	}
+}
+
+func (*basicHandler) Scheme() string {
+	return "basic"
+}
+
+func (bh *basicHandler) AuthorizeRequest(req *http.Request, params map[string]string) error {
+	if bh.creds != nil {
+		username, password := bh.creds.Basic(bh.remoteURL)
+		if username != "" && password != "" {
+			req.SetBasicAuth(username, password)
+			return nil
+		}
+	}
+	return ErrNoBasicAuthCredentials
+}

--- a/pkg/registry/distributionpkg/client/blob_writer.go
+++ b/pkg/registry/distributionpkg/client/blob_writer.go
@@ -1,0 +1,176 @@
+// Copyright © 2022 https://github.com/distribution/distribution
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/distribution/distribution/v3"
+)
+
+type httpBlobUpload struct {
+	statter distribution.BlobStatter
+	client  *http.Client
+
+	uuid      string
+	startedAt time.Time
+
+	location string // always the last value of the location header.
+	offset   int64
+	closed   bool
+}
+
+func (hbu *httpBlobUpload) Reader() (io.ReadCloser, error) {
+	panic("Not implemented")
+}
+
+func (hbu *httpBlobUpload) handleErrorResponse(resp *http.Response) error {
+	if resp.StatusCode == http.StatusNotFound {
+		return distribution.ErrBlobUploadUnknown
+	}
+	return HandleErrorResponse(resp)
+}
+
+func (hbu *httpBlobUpload) ReadFrom(r io.Reader) (n int64, err error) {
+	req, err := http.NewRequest("PATCH", hbu.location, ioutil.NopCloser(r))
+	if err != nil {
+		return 0, err
+	}
+	defer req.Body.Close()
+
+	resp, err := hbu.client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+
+	if !SuccessStatus(resp.StatusCode) {
+		return 0, hbu.handleErrorResponse(resp)
+	}
+
+	hbu.uuid = resp.Header.Get("Docker-Upload-UUID")
+	hbu.location, err = sanitizeLocation(resp.Header.Get("Location"), hbu.location)
+	if err != nil {
+		return 0, err
+	}
+	rng := resp.Header.Get("Range")
+	var start, end int64
+	if n, err := fmt.Sscanf(rng, "%d-%d", &start, &end); err != nil {
+		return 0, err
+	} else if n != 2 || end < start {
+		return 0, fmt.Errorf("bad range format: %s", rng)
+	}
+
+	hbu.offset += end - start + 1
+	return (end - start + 1), nil
+}
+
+func (hbu *httpBlobUpload) Write(p []byte) (n int, err error) {
+	req, err := http.NewRequest("PATCH", hbu.location, bytes.NewReader(p))
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Content-Range", fmt.Sprintf("%d-%d", hbu.offset, hbu.offset+int64(len(p)-1)))
+	req.Header.Set("Content-Length", fmt.Sprintf("%d", len(p)))
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	resp, err := hbu.client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+
+	if !SuccessStatus(resp.StatusCode) {
+		return 0, hbu.handleErrorResponse(resp)
+	}
+
+	hbu.uuid = resp.Header.Get("Docker-Upload-UUID")
+	hbu.location, err = sanitizeLocation(resp.Header.Get("Location"), hbu.location)
+	if err != nil {
+		return 0, err
+	}
+	rng := resp.Header.Get("Range")
+	var start, end int
+	if n, err := fmt.Sscanf(rng, "%d-%d", &start, &end); err != nil {
+		return 0, err
+	} else if n != 2 || end < start {
+		return 0, fmt.Errorf("bad range format: %s", rng)
+	}
+
+	hbu.offset += int64(end - start + 1)
+	return (end - start + 1), nil
+}
+
+func (hbu *httpBlobUpload) Size() int64 {
+	return hbu.offset
+}
+
+func (hbu *httpBlobUpload) ID() string {
+	return hbu.uuid
+}
+
+func (hbu *httpBlobUpload) StartedAt() time.Time {
+	return hbu.startedAt
+}
+
+func (hbu *httpBlobUpload) Commit(ctx context.Context, desc distribution.Descriptor) (distribution.Descriptor, error) {
+	// TODO(dmcgowan): Check if already finished, if so just fetch
+	req, err := http.NewRequest("PUT", hbu.location, nil)
+	if err != nil {
+		return distribution.Descriptor{}, err
+	}
+
+	values := req.URL.Query()
+	values.Set("digest", desc.Digest.String())
+	req.URL.RawQuery = values.Encode()
+
+	resp, err := hbu.client.Do(req)
+	if err != nil {
+		return distribution.Descriptor{}, err
+	}
+	defer resp.Body.Close()
+
+	if !SuccessStatus(resp.StatusCode) {
+		return distribution.Descriptor{}, hbu.handleErrorResponse(resp)
+	}
+
+	return hbu.statter.Stat(ctx, desc.Digest)
+}
+
+func (hbu *httpBlobUpload) Cancel(ctx context.Context) error {
+	req, err := http.NewRequest("DELETE", hbu.location, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := hbu.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound || SuccessStatus(resp.StatusCode) {
+		return nil
+	}
+	return hbu.handleErrorResponse(resp)
+}
+
+func (hbu *httpBlobUpload) Close() error {
+	hbu.closed = true
+	return nil
+}

--- a/pkg/registry/distributionpkg/client/errors.go
+++ b/pkg/registry/distributionpkg/client/errors.go
@@ -1,0 +1,154 @@
+// Copyright © 2022 https://github.com/distribution/distribution
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/labring/sealos/pkg/registry/distributionpkg/client/auth/challenge"
+
+	"github.com/distribution/distribution/v3/registry/api/errcode"
+)
+
+// ErrNoErrorsInBody is returned when an HTTP response body parses to an empty
+// errcode.Errors slice.
+var ErrNoErrorsInBody = errors.New("no error details found in HTTP response body")
+
+// UnexpectedHTTPStatusError is returned when an unexpected HTTP status is
+// returned when making a registry api call.
+type UnexpectedHTTPStatusError struct {
+	Status string
+}
+
+func (e *UnexpectedHTTPStatusError) Error() string {
+	return fmt.Sprintf("received unexpected HTTP status: %s", e.Status)
+}
+
+// UnexpectedHTTPResponseError is returned when an expected HTTP status code
+// is returned, but the content was unexpected and failed to be parsed.
+type UnexpectedHTTPResponseError struct {
+	ParseErr   error
+	StatusCode int
+	Response   []byte
+}
+
+func (e *UnexpectedHTTPResponseError) Error() string {
+	return fmt.Sprintf("error parsing HTTP %d response body: %s: %q", e.StatusCode, e.ParseErr.Error(), string(e.Response))
+}
+
+func parseHTTPErrorResponse(statusCode int, r io.Reader) error {
+	var errors errcode.Errors
+	body, err := ioutil.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	// For backward compatibility, handle irregularly formatted
+	// messages that contain a "details" field.
+	var detailsErr struct {
+		Details string `json:"details"`
+	}
+	err = json.Unmarshal(body, &detailsErr)
+	if err == nil && detailsErr.Details != "" {
+		switch statusCode {
+		case http.StatusUnauthorized:
+			return errcode.ErrorCodeUnauthorized.WithMessage(detailsErr.Details)
+		case http.StatusTooManyRequests:
+			return errcode.ErrorCodeTooManyRequests.WithMessage(detailsErr.Details)
+		default:
+			return errcode.ErrorCodeUnknown.WithMessage(detailsErr.Details)
+		}
+	}
+
+	if err := json.Unmarshal(body, &errors); err != nil {
+		return &UnexpectedHTTPResponseError{
+			ParseErr:   err,
+			StatusCode: statusCode,
+			Response:   body,
+		}
+	}
+
+	if len(errors) == 0 {
+		// If there was no error specified in the body, return
+		// UnexpectedHTTPResponseError.
+		return &UnexpectedHTTPResponseError{
+			ParseErr:   ErrNoErrorsInBody,
+			StatusCode: statusCode,
+			Response:   body,
+		}
+	}
+
+	return errors
+}
+
+func makeErrorList(err error) []error {
+	if errL, ok := err.(errcode.Errors); ok {
+		return []error(errL)
+	}
+	return []error{err}
+}
+
+func mergeErrors(err1, err2 error) error {
+	return errcode.Errors(append(makeErrorList(err1), makeErrorList(err2)...))
+}
+
+// HandleErrorResponse returns error parsed from HTTP response for an
+// unsuccessful HTTP response code (in the range 400 - 499 inclusive). An
+// UnexpectedHTTPStatusError returned for response code outside of expected
+// range.
+func HandleErrorResponse(resp *http.Response) error {
+	if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+		// Check for OAuth errors within the `WWW-Authenticate` header first
+		// See https://tools.ietf.org/html/rfc6750#section-3
+		for _, c := range challenge.ResponseChallenges(resp) {
+			if c.Scheme == "bearer" {
+				var err errcode.Error
+				// codes defined at https://tools.ietf.org/html/rfc6750#section-3.1
+				switch c.Parameters["error"] {
+				case "invalid_token":
+					err.Code = errcode.ErrorCodeUnauthorized
+				case "insufficient_scope":
+					err.Code = errcode.ErrorCodeDenied
+				default:
+					continue
+				}
+				if description := c.Parameters["error_description"]; description != "" {
+					err.Message = description
+				} else {
+					err.Message = err.Code.Message()
+				}
+
+				return mergeErrors(err, parseHTTPErrorResponse(resp.StatusCode, resp.Body))
+			}
+		}
+		err := parseHTTPErrorResponse(resp.StatusCode, resp.Body)
+		if uErr, ok := err.(*UnexpectedHTTPResponseError); ok && resp.StatusCode == 401 {
+			return errcode.ErrorCodeUnauthorized.WithDetail(uErr.Response)
+		}
+		return err
+	}
+	return &UnexpectedHTTPStatusError{Status: resp.Status}
+}
+
+// SuccessStatus returns true if the argument is a successful HTTP response
+// code (in the range 200 - 399 inclusive).
+func SuccessStatus(status int) bool {
+	return status >= 200 && status <= 399
+}

--- a/pkg/registry/distributionpkg/client/repository.go
+++ b/pkg/registry/distributionpkg/client/repository.go
@@ -1,0 +1,964 @@
+// Copyright © 2022 https://github.com/distribution/distribution
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/labring/sealos/pkg/registry/distributionpkg/client/transport"
+
+	"github.com/distribution/distribution/v3"
+	"github.com/distribution/distribution/v3/reference"
+	v2 "github.com/distribution/distribution/v3/registry/api/v2"
+	"github.com/distribution/distribution/v3/registry/storage/cache"
+	"github.com/distribution/distribution/v3/registry/storage/cache/memory"
+	"github.com/opencontainers/go-digest"
+)
+
+// Registry provides an interface for calling Repositories, which returns a catalog of repositories.
+type Registry interface {
+	Repositories(ctx context.Context, repos []string, last string) (n int, err error)
+}
+
+// checkHTTPRedirect is a callback that can manipulate redirected HTTP
+// requests. It is used to preserve Accept and Range headers.
+func checkHTTPRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return errors.New("stopped after 10 redirects")
+	}
+
+	if len(via) > 0 {
+		for headerName, headerVals := range via[0].Header {
+			if headerName != "Accept" && headerName != "Range" {
+				continue
+			}
+			for _, val := range headerVals {
+				// Don't add to redirected request if redirected
+				// request already has a header with the same
+				// name and value.
+				hasValue := false
+				for _, existingVal := range req.Header[headerName] {
+					if existingVal == val {
+						hasValue = true
+						break
+					}
+				}
+				if !hasValue {
+					req.Header.Add(headerName, val)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// NewRegistry creates a registry namespace which can be used to get a listing of repositories
+func NewRegistry(baseURL string, transport http.RoundTripper) (Registry, error) {
+	ub, err := v2.NewURLBuilderFromString(baseURL, false)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{
+		Transport:     transport,
+		Timeout:       1 * time.Minute,
+		CheckRedirect: checkHTTPRedirect,
+	}
+
+	return &registry{
+		client: client,
+		ub:     ub,
+	}, nil
+}
+
+type registry struct {
+	client *http.Client
+	ub     *v2.URLBuilder
+}
+
+// Repositories returns a lexigraphically sorted catalog given a base URL.  The 'entries' slice will be filled up to the size
+// of the slice, starting at the value provided in 'last'.  The number of entries will be returned along with io.EOF if there
+// are no more entries
+func (r *registry) Repositories(ctx context.Context, entries []string, last string) (int, error) {
+	var numFilled int
+	var returnErr error
+
+	values := buildCatalogValues(len(entries), last)
+	u, err := r.ub.BuildCatalogURL(values)
+	if err != nil {
+		return 0, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
+	if err != nil {
+		return 0, err
+	}
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	if SuccessStatus(resp.StatusCode) {
+		var ctlg struct {
+			Repositories []string `json:"repositories"`
+		}
+		decoder := json.NewDecoder(resp.Body)
+
+		if err := decoder.Decode(&ctlg); err != nil {
+			return 0, err
+		}
+
+		for cnt := range ctlg.Repositories {
+			entries[cnt] = ctlg.Repositories[cnt]
+		}
+		numFilled = len(ctlg.Repositories)
+
+		link := resp.Header.Get("Link")
+		if link == "" {
+			returnErr = io.EOF
+		}
+	} else {
+		return 0, HandleErrorResponse(resp)
+	}
+
+	return numFilled, returnErr
+}
+
+// NewRepository creates a new Repository for the given repository name and base URL.
+func NewRepository(name reference.Named, baseURL string, transport http.RoundTripper) (distribution.Repository, error) {
+	ub, err := v2.NewURLBuilderFromString(baseURL, false)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{
+		Transport:     transport,
+		CheckRedirect: checkHTTPRedirect,
+		// TODO(dmcgowan): create cookie jar
+	}
+
+	return &repository{
+		client: client,
+		ub:     ub,
+		name:   name,
+	}, nil
+}
+
+type repository struct {
+	client *http.Client
+	ub     *v2.URLBuilder
+	name   reference.Named
+}
+
+func (r *repository) Named() reference.Named {
+	return r.name
+}
+
+func (r *repository) Blobs(ctx context.Context) distribution.BlobStore {
+	statter := &blobStatter{
+		name:   r.name,
+		ub:     r.ub,
+		client: r.client,
+	}
+	return &blobs{
+		name:    r.name,
+		ub:      r.ub,
+		client:  r.client,
+		statter: cache.NewCachedBlobStatter(memory.NewInMemoryBlobDescriptorCacheProvider(), statter),
+	}
+}
+
+func (r *repository) Manifests(ctx context.Context, options ...distribution.ManifestServiceOption) (distribution.ManifestService, error) {
+	// todo(richardscothern): options should be sent over the wire
+	return &manifests{
+		name:   r.name,
+		ub:     r.ub,
+		client: r.client,
+		etags:  make(map[string]string),
+	}, nil
+}
+
+func (r *repository) Tags(ctx context.Context) distribution.TagService {
+	return &tags{
+		client: r.client,
+		ub:     r.ub,
+		name:   r.Named(),
+	}
+}
+
+// tags implements remote tagging operations.
+type tags struct {
+	client *http.Client
+	ub     *v2.URLBuilder
+	name   reference.Named
+}
+
+// All returns all tags
+func (t *tags) All(ctx context.Context) ([]string, error) {
+	var tags []string
+
+	listURLStr, err := t.ub.BuildTagsURL(t.name)
+	if err != nil {
+		return tags, err
+	}
+
+	listURL, err := url.Parse(listURLStr)
+	if err != nil {
+		return tags, err
+	}
+
+	for {
+		req, err := http.NewRequestWithContext(ctx, "GET", listURL.String(), nil)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := t.client.Do(req)
+		if err != nil {
+			return tags, err
+		}
+		defer resp.Body.Close()
+
+		if SuccessStatus(resp.StatusCode) {
+			b, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return tags, err
+			}
+
+			tagsResponse := struct {
+				Tags []string `json:"tags"`
+			}{}
+			if err := json.Unmarshal(b, &tagsResponse); err != nil {
+				return tags, err
+			}
+			tags = append(tags, tagsResponse.Tags...)
+			if link := resp.Header.Get("Link"); link != "" {
+				linkURLStr := strings.Trim(strings.Split(link, ";")[0], "<>")
+				linkURL, err := url.Parse(linkURLStr)
+				if err != nil {
+					return tags, err
+				}
+
+				listURL = listURL.ResolveReference(linkURL)
+			} else {
+				return tags, nil
+			}
+		} else {
+			return tags, HandleErrorResponse(resp)
+		}
+	}
+}
+
+func descriptorFromResponse(response *http.Response) (distribution.Descriptor, error) {
+	desc := distribution.Descriptor{}
+	headers := response.Header
+
+	ctHeader := headers.Get("Content-Type")
+	if ctHeader == "" {
+		return distribution.Descriptor{}, errors.New("missing or empty Content-Type header")
+	}
+	desc.MediaType = ctHeader
+
+	digestHeader := headers.Get("Docker-Content-Digest")
+	if digestHeader == "" {
+		bytes, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			return distribution.Descriptor{}, err
+		}
+		_, desc, err := distribution.UnmarshalManifest(ctHeader, bytes)
+		if err != nil {
+			return distribution.Descriptor{}, err
+		}
+		return desc, nil
+	}
+
+	dgst, err := digest.Parse(digestHeader)
+	if err != nil {
+		return distribution.Descriptor{}, err
+	}
+	desc.Digest = dgst
+
+	lengthHeader := headers.Get("Content-Length")
+	if lengthHeader == "" {
+		return distribution.Descriptor{}, errors.New("missing or empty Content-Length header")
+	}
+	length, err := strconv.ParseInt(lengthHeader, 10, 64)
+	if err != nil {
+		return distribution.Descriptor{}, err
+	}
+	desc.Size = length
+
+	return desc, nil
+}
+
+// Get issues a HEAD request for a Manifest against its named endpoint in order
+// to construct a descriptor for the tag.  If the registry doesn't support HEADing
+// a manifest, fallback to GET.
+func (t *tags) Get(ctx context.Context, tag string) (distribution.Descriptor, error) {
+	ref, err := reference.WithTag(t.name, tag)
+	if err != nil {
+		return distribution.Descriptor{}, err
+	}
+	u, err := t.ub.BuildManifestURL(ref)
+	if err != nil {
+		return distribution.Descriptor{}, err
+	}
+
+	newRequest := func(method string) (*http.Response, error) {
+		req, err := http.NewRequestWithContext(ctx, method, u, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, t := range distribution.ManifestMediaTypes() {
+			req.Header.Add("Accept", t)
+		}
+		resp, err := t.client.Do(req)
+		return resp, err
+	}
+
+	resp, err := newRequest("HEAD")
+	if err != nil {
+		return distribution.Descriptor{}, err
+	}
+	defer resp.Body.Close()
+
+	switch {
+	case resp.StatusCode >= 200 && resp.StatusCode < 400 && len(resp.Header.Get("Docker-Content-Digest")) > 0:
+		// if the response is a success AND a Docker-Content-Digest can be retrieved from the headers
+		return descriptorFromResponse(resp)
+	default:
+		// if the response is an error - there will be no body to decode.
+		// Issue a GET request:
+		//   - for data from a server that does not handle HEAD
+		//   - to get error details in case of a failure
+		resp, err = newRequest("GET")
+		if err != nil {
+			return distribution.Descriptor{}, err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+			return descriptorFromResponse(resp)
+		}
+		return distribution.Descriptor{}, HandleErrorResponse(resp)
+	}
+}
+
+func (t *tags) Lookup(ctx context.Context, digest distribution.Descriptor) ([]string, error) {
+	panic("not implemented")
+}
+
+func (t *tags) Tag(ctx context.Context, tag string, desc distribution.Descriptor) error {
+	panic("not implemented")
+}
+
+func (t *tags) Untag(ctx context.Context, tag string) error {
+	ref, err := reference.WithTag(t.name, tag)
+	if err != nil {
+		return err
+	}
+	u, err := t.ub.BuildManifestURL(ref)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if SuccessStatus(resp.StatusCode) {
+		return nil
+	}
+	return HandleErrorResponse(resp)
+}
+
+type manifests struct {
+	name   reference.Named
+	ub     *v2.URLBuilder
+	client *http.Client
+	etags  map[string]string
+}
+
+func (ms *manifests) Exists(ctx context.Context, dgst digest.Digest) (bool, error) {
+	ref, err := reference.WithDigest(ms.name, dgst)
+	if err != nil {
+		return false, err
+	}
+	u, err := ms.ub.BuildManifestURL(ref)
+	if err != nil {
+		return false, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "HEAD", u, nil)
+	if err != nil {
+		return false, err
+	}
+	resp, err := ms.client.Do(req)
+	if err != nil {
+		return false, err
+	}
+
+	if SuccessStatus(resp.StatusCode) {
+		return true, nil
+	} else if resp.StatusCode == http.StatusNotFound {
+		return false, nil
+	}
+	return false, HandleErrorResponse(resp)
+}
+
+// AddEtagToTag allows a client to supply an eTag to Get which will be
+// used for a conditional HTTP request.  If the eTag matches, a nil manifest
+// and ErrManifestNotModified error will be returned. etag is automatically
+// quoted when added to this map.
+func AddEtagToTag(tag, etag string) distribution.ManifestServiceOption {
+	return etagOption{tag, etag}
+}
+
+type etagOption struct{ tag, etag string }
+
+func (o etagOption) Apply(ms distribution.ManifestService) error {
+	if ms, ok := ms.(*manifests); ok {
+		ms.etags[o.tag] = fmt.Sprintf(`"%s"`, o.etag)
+		return nil
+	}
+	return fmt.Errorf("etag options is a client-only option")
+}
+
+// ReturnContentDigest allows a client to set a the content digest on
+// a successful request from the 'Docker-Content-Digest' header. This
+// returned digest is represents the digest which the registry uses
+// to refer to the content and can be used to delete the content.
+func ReturnContentDigest(dgst *digest.Digest) distribution.ManifestServiceOption {
+	return contentDigestOption{dgst}
+}
+
+type contentDigestOption struct{ digest *digest.Digest }
+
+func (o contentDigestOption) Apply(ms distribution.ManifestService) error {
+	return nil
+}
+
+func (ms *manifests) Get(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
+	var (
+		digestOrTag string
+		ref         reference.Named
+		err         error
+		contentDgst *digest.Digest
+		mediaTypes  []string
+	)
+
+	for _, option := range options {
+		switch opt := option.(type) {
+		case distribution.WithTagOption:
+			digestOrTag = opt.Tag
+			ref, err = reference.WithTag(ms.name, opt.Tag)
+			if err != nil {
+				return nil, err
+			}
+		case contentDigestOption:
+			contentDgst = opt.digest
+		case distribution.WithManifestMediaTypesOption:
+			mediaTypes = opt.MediaTypes
+		default:
+			err := option.Apply(ms)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if digestOrTag == "" {
+		digestOrTag = dgst.String()
+		ref, err = reference.WithDigest(ms.name, dgst)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if len(mediaTypes) == 0 {
+		mediaTypes = distribution.ManifestMediaTypes()
+	}
+
+	u, err := ms.ub.BuildManifestURL(ref)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, t := range mediaTypes {
+		req.Header.Add("Accept", t)
+	}
+
+	if _, ok := ms.etags[digestOrTag]; ok {
+		req.Header.Set("If-None-Match", ms.etags[digestOrTag])
+	}
+
+	resp, err := ms.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotModified {
+		return nil, distribution.ErrManifestNotModified
+	} else if SuccessStatus(resp.StatusCode) {
+		if contentDgst != nil {
+			dgst, err := digest.Parse(resp.Header.Get("Docker-Content-Digest"))
+			if err == nil {
+				*contentDgst = dgst
+			}
+		}
+		mt := resp.Header.Get("Content-Type")
+		body, err := ioutil.ReadAll(resp.Body)
+
+		if err != nil {
+			return nil, err
+		}
+		m, _, err := distribution.UnmarshalManifest(mt, body)
+		if err != nil {
+			return nil, err
+		}
+		return m, nil
+	}
+	return nil, HandleErrorResponse(resp)
+}
+
+// Put puts a manifest.  A tag can be specified using an options parameter which uses some shared state to hold the
+// tag name in order to build the correct upload URL.
+func (ms *manifests) Put(ctx context.Context, m distribution.Manifest, options ...distribution.ManifestServiceOption) (digest.Digest, error) {
+	ref := ms.name
+	var tagged bool
+
+	for _, option := range options {
+		if opt, ok := option.(distribution.WithTagOption); ok {
+			var err error
+			ref, err = reference.WithTag(ref, opt.Tag)
+			if err != nil {
+				return "", err
+			}
+			tagged = true
+		} else {
+			err := option.Apply(ms)
+			if err != nil {
+				return "", err
+			}
+		}
+	}
+	mediaType, p, err := m.Payload()
+	if err != nil {
+		return "", err
+	}
+
+	if !tagged {
+		// generate a canonical digest and Put by digest
+		_, d, err := distribution.UnmarshalManifest(mediaType, p)
+		if err != nil {
+			return "", err
+		}
+		ref, err = reference.WithDigest(ref, d.Digest)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	manifestURL, err := ms.ub.BuildManifestURL(ref)
+	if err != nil {
+		return "", err
+	}
+
+	putRequest, err := http.NewRequestWithContext(ctx, "PUT", manifestURL, bytes.NewReader(p))
+	if err != nil {
+		return "", err
+	}
+
+	putRequest.Header.Set("Content-Type", mediaType)
+
+	resp, err := ms.client.Do(putRequest)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if SuccessStatus(resp.StatusCode) {
+		dgstHeader := resp.Header.Get("Docker-Content-Digest")
+		dgst, err := digest.Parse(dgstHeader)
+		if err != nil {
+			return "", err
+		}
+
+		return dgst, nil
+	}
+
+	return "", HandleErrorResponse(resp)
+}
+
+func (ms *manifests) Delete(ctx context.Context, dgst digest.Digest) error {
+	ref, err := reference.WithDigest(ms.name, dgst)
+	if err != nil {
+		return err
+	}
+	u, err := ms.ub.BuildManifestURL(ref)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, "DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := ms.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if SuccessStatus(resp.StatusCode) {
+		return nil
+	}
+	return HandleErrorResponse(resp)
+}
+
+// todo(richardscothern): Restore interface and implementation with merge of #1050
+/*func (ms *manifests) Enumerate(ctx context.Context, manifests []distribution.Manifest, last distribution.Manifest) (n int, err error) {
+	panic("not supported")
+}*/
+
+type blobs struct {
+	name   reference.Named
+	ub     *v2.URLBuilder
+	client *http.Client
+
+	statter distribution.BlobDescriptorService
+	distribution.BlobDeleter
+}
+
+func sanitizeLocation(location, base string) (string, error) {
+	baseURL, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+
+	locationURL, err := url.Parse(location)
+	if err != nil {
+		return "", err
+	}
+
+	return baseURL.ResolveReference(locationURL).String(), nil
+}
+
+func (bs *blobs) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
+	return bs.statter.Stat(ctx, dgst)
+}
+
+func (bs *blobs) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {
+	reader, err := bs.Open(ctx, dgst)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	return ioutil.ReadAll(reader)
+}
+
+func (bs *blobs) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
+	ref, err := reference.WithDigest(bs.name, dgst)
+	if err != nil {
+		return nil, err
+	}
+	blobURL, err := bs.ub.BuildBlobURL(ref)
+	if err != nil {
+		return nil, err
+	}
+
+	return transport.NewHTTPReadSeeker(ctx, bs.client, blobURL,
+		func(resp *http.Response) error {
+			if resp.StatusCode == http.StatusNotFound {
+				return distribution.ErrBlobUnknown
+			}
+			return HandleErrorResponse(resp)
+		}), nil
+}
+
+func (bs *blobs) ServeBlob(ctx context.Context, w http.ResponseWriter, r *http.Request, dgst digest.Digest) error {
+	desc, err := bs.statter.Stat(ctx, dgst)
+	if err != nil {
+		return err
+	}
+
+	w.Header().Set("Content-Length", strconv.FormatInt(desc.Size, 10))
+	w.Header().Set("Content-Type", desc.MediaType)
+	w.Header().Set("Docker-Content-Digest", dgst.String())
+	w.Header().Set("Etag", dgst.String())
+
+	if r.Method == http.MethodHead {
+		return nil
+	}
+
+	blob, err := bs.Open(ctx, dgst)
+	if err != nil {
+		return err
+	}
+	defer blob.Close()
+
+	_, err = io.CopyN(w, blob, desc.Size)
+	return err
+}
+
+func (bs *blobs) Put(ctx context.Context, mediaType string, p []byte) (distribution.Descriptor, error) {
+	writer, err := bs.Create(ctx)
+	if err != nil {
+		return distribution.Descriptor{}, err
+	}
+	dgstr := digest.Canonical.Digester()
+	n, err := io.Copy(writer, io.TeeReader(bytes.NewReader(p), dgstr.Hash()))
+	if err != nil {
+		return distribution.Descriptor{}, err
+	}
+	if n < int64(len(p)) {
+		return distribution.Descriptor{}, fmt.Errorf("short copy: wrote %d of %d", n, len(p))
+	}
+
+	desc := distribution.Descriptor{
+		MediaType: mediaType,
+		Size:      int64(len(p)),
+		Digest:    dgstr.Digest(),
+	}
+
+	return writer.Commit(ctx, desc)
+}
+
+type optionFunc func(interface{}) error
+
+func (f optionFunc) Apply(v interface{}) error {
+	return f(v)
+}
+
+// WithMountFrom returns a BlobCreateOption which designates that the blob should be
+// mounted from the given canonical reference.
+func WithMountFrom(ref reference.Canonical) distribution.BlobCreateOption {
+	return optionFunc(func(v interface{}) error {
+		opts, ok := v.(*distribution.CreateOptions)
+		if !ok {
+			return fmt.Errorf("unexpected options type: %T", v)
+		}
+
+		opts.Mount.ShouldMount = true
+		opts.Mount.From = ref
+
+		return nil
+	})
+}
+
+func (bs *blobs) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
+	var opts distribution.CreateOptions
+
+	for _, option := range options {
+		err := option.Apply(&opts)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var values []url.Values
+
+	if opts.Mount.ShouldMount {
+		values = append(values, url.Values{"from": {opts.Mount.From.Name()}, "mount": {opts.Mount.From.Digest().String()}})
+	}
+
+	u, err := bs.ub.BuildBlobUploadURL(bs.name, values...)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := bs.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusCreated:
+		desc, err := bs.statter.Stat(ctx, opts.Mount.From.Digest())
+		if err != nil {
+			return nil, err
+		}
+		return nil, distribution.ErrBlobMounted{From: opts.Mount.From, Descriptor: desc}
+	case http.StatusAccepted:
+		// TODO(dmcgowan): Check for invalid UUID
+		uuid := resp.Header.Get("Docker-Upload-UUID")
+		if uuid == "" {
+			parts := strings.Split(resp.Header.Get("Location"), "/")
+			uuid = parts[len(parts)-1]
+		}
+		if uuid == "" {
+			return nil, errors.New("cannot retrieve docker upload UUID")
+		}
+
+		location, err := sanitizeLocation(resp.Header.Get("Location"), u)
+		if err != nil {
+			return nil, err
+		}
+
+		return &httpBlobUpload{
+			statter:   bs.statter,
+			client:    bs.client,
+			uuid:      uuid,
+			startedAt: time.Now(),
+			location:  location,
+		}, nil
+	default:
+		return nil, HandleErrorResponse(resp)
+	}
+}
+
+func (bs *blobs) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
+	location, err := bs.ub.BuildBlobUploadChunkURL(bs.name, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return &httpBlobUpload{
+		statter:   bs.statter,
+		client:    bs.client,
+		uuid:      id,
+		startedAt: time.Now(),
+		location:  location,
+	}, nil
+}
+
+func (bs *blobs) Delete(ctx context.Context, dgst digest.Digest) error {
+	return bs.statter.Clear(ctx, dgst)
+}
+
+type blobStatter struct {
+	name   reference.Named
+	ub     *v2.URLBuilder
+	client *http.Client
+}
+
+func (bs *blobStatter) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
+	ref, err := reference.WithDigest(bs.name, dgst)
+	if err != nil {
+		return distribution.Descriptor{}, err
+	}
+	u, err := bs.ub.BuildBlobURL(ref)
+	if err != nil {
+		return distribution.Descriptor{}, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "HEAD", u, nil)
+	if err != nil {
+		return distribution.Descriptor{}, err
+	}
+	resp, err := bs.client.Do(req)
+	if err != nil {
+		return distribution.Descriptor{}, err
+	}
+	defer resp.Body.Close()
+
+	if SuccessStatus(resp.StatusCode) {
+		lengthHeader := resp.Header.Get("Content-Length")
+		if lengthHeader == "" {
+			return distribution.Descriptor{}, fmt.Errorf("missing content-length header for request: %s", u)
+		}
+
+		length, err := strconv.ParseInt(lengthHeader, 10, 64)
+		if err != nil {
+			return distribution.Descriptor{}, fmt.Errorf("error parsing content-length: %v", err)
+		}
+
+		return distribution.Descriptor{
+			MediaType: resp.Header.Get("Content-Type"),
+			Size:      length,
+			Digest:    dgst,
+		}, nil
+	} else if resp.StatusCode == http.StatusNotFound {
+		return distribution.Descriptor{}, distribution.ErrBlobUnknown
+	}
+	return distribution.Descriptor{}, HandleErrorResponse(resp)
+}
+
+func buildCatalogValues(maxEntries int, last string) url.Values {
+	values := url.Values{}
+
+	if maxEntries > 0 {
+		values.Add("n", strconv.Itoa(maxEntries))
+	}
+
+	if last != "" {
+		values.Add("last", last)
+	}
+
+	return values
+}
+
+func (bs *blobStatter) Clear(ctx context.Context, dgst digest.Digest) error {
+	ref, err := reference.WithDigest(bs.name, dgst)
+	if err != nil {
+		return err
+	}
+	blobURL, err := bs.ub.BuildBlobURL(ref)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "DELETE", blobURL, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := bs.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if SuccessStatus(resp.StatusCode) {
+		return nil
+	}
+	return HandleErrorResponse(resp)
+}
+
+func (bs *blobStatter) SetDescriptor(ctx context.Context, dgst digest.Digest, desc distribution.Descriptor) error {
+	return nil
+}

--- a/pkg/registry/distributionpkg/client/transport/http_reader.go
+++ b/pkg/registry/distributionpkg/client/transport/http_reader.go
@@ -1,0 +1,267 @@
+// Copyright © 2022 https://github.com/distribution/distribution
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+)
+
+var (
+	contentRangeRegexp = regexp.MustCompile(`bytes ([0-9]+)-([0-9]+)/([0-9]+|\\*)`)
+
+	// ErrWrongCodeForByteRange is returned if the client sends a request
+	// with a Range header but the server returns a 2xx or 3xx code other
+	// than 206 Partial Content.
+	ErrWrongCodeForByteRange = errors.New("expected HTTP 206 from byte range request")
+)
+
+// ReadSeekCloser combines io.ReadSeeker with io.Closer.
+type ReadSeekCloser interface {
+	io.ReadSeeker
+	io.Closer
+}
+
+// NewHTTPReadSeeker handles reading from an HTTP endpoint using a GET
+// request. When seeking and starting a read from a non-zero offset
+// the a "Range" header will be added which sets the offset.
+// TODO(dmcgowan): Move this into a separate utility package
+func NewHTTPReadSeeker(ctx context.Context, client *http.Client, url string, errorHandler func(*http.Response) error) ReadSeekCloser {
+	return &httpReadSeeker{
+		ctx:          ctx,
+		client:       client,
+		url:          url,
+		errorHandler: errorHandler,
+	}
+}
+
+type httpReadSeeker struct {
+	ctx    context.Context
+	client *http.Client
+	url    string
+
+	// errorHandler creates an error from an unsuccessful HTTP response.
+	// This allows the error to be created with the HTTP response body
+	// without leaking the body through a returned error.
+	errorHandler func(*http.Response) error
+
+	size int64
+
+	// rc is the remote read closer.
+	rc io.ReadCloser
+	// readerOffset tracks the offset as of the last read.
+	readerOffset int64
+	// seekOffset allows Seek to override the offset. Seek changes
+	// seekOffset instead of changing readOffset directly so that
+	// connection resets can be delayed and possibly avoided if the
+	// seek is undone (i.e. seeking to the end and then back to the
+	// beginning).
+	seekOffset int64
+	err        error
+}
+
+func (hrs *httpReadSeeker) Read(p []byte) (n int, err error) {
+	if hrs.err != nil {
+		return 0, hrs.err
+	}
+
+	// If we sought to a different position, we need to reset the
+	// connection. This logic is here instead of Seek so that if
+	// a seek is undone before the next read, the connection doesn't
+	// need to be closed and reopened. A common example of this is
+	// seeking to the end to determine the length, and then seeking
+	// back to the original position.
+	if hrs.readerOffset != hrs.seekOffset {
+		hrs.reset()
+	}
+
+	hrs.readerOffset = hrs.seekOffset
+
+	rd, err := hrs.reader()
+	if err != nil {
+		return 0, err
+	}
+
+	n, err = rd.Read(p)
+	hrs.seekOffset += int64(n)
+	hrs.readerOffset += int64(n)
+
+	return n, err
+}
+
+func (hrs *httpReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	if hrs.err != nil {
+		return 0, hrs.err
+	}
+
+	lastReaderOffset := hrs.readerOffset
+
+	if whence == io.SeekStart && hrs.rc == nil {
+		// If no request has been made yet, and we are seeking to an
+		// absolute position, set the read offset as well to avoid an
+		// unnecessary request.
+		hrs.readerOffset = offset
+	}
+
+	_, err := hrs.reader()
+	if err != nil {
+		hrs.readerOffset = lastReaderOffset
+		return 0, err
+	}
+	//nolint
+	newOffset := hrs.seekOffset
+
+	switch whence {
+	case io.SeekCurrent:
+		newOffset += offset
+	case io.SeekEnd:
+		if hrs.size < 0 {
+			return 0, errors.New("content length not known")
+		}
+		newOffset = hrs.size + offset
+	case io.SeekStart:
+		newOffset = offset
+	}
+
+	if newOffset < 0 {
+		err = errors.New("cannot seek to negative position")
+	} else {
+		hrs.seekOffset = newOffset
+	}
+
+	return hrs.seekOffset, err
+}
+
+func (hrs *httpReadSeeker) Close() error {
+	if hrs.err != nil {
+		return hrs.err
+	}
+
+	// close and release reader chain
+	if hrs.rc != nil {
+		hrs.rc.Close()
+	}
+
+	hrs.rc = nil
+
+	hrs.err = errors.New("httpLayer: closed")
+
+	return nil
+}
+
+func (hrs *httpReadSeeker) reset() {
+	if hrs.err != nil {
+		return
+	}
+	if hrs.rc != nil {
+		hrs.rc.Close()
+		hrs.rc = nil
+	}
+}
+
+func (hrs *httpReadSeeker) reader() (io.Reader, error) {
+	if hrs.err != nil {
+		return nil, hrs.err
+	}
+
+	if hrs.rc != nil {
+		return hrs.rc, nil
+	}
+
+	req, err := http.NewRequestWithContext(hrs.ctx, "GET", hrs.url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if hrs.readerOffset > 0 {
+		// If we are at different offset, issue a range request from there.
+		req.Header.Add("Range", fmt.Sprintf("bytes=%d-", hrs.readerOffset))
+		// TODO: get context in here
+		// context.GetLogger(hrs.context).Infof("Range: %s", req.Header.Get("Range"))
+	}
+
+	req.Header.Add("Accept-Encoding", "identity")
+	resp, err := hrs.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Normally would use client.SuccessStatus, but that would be a cyclic
+	// import
+	if resp.StatusCode >= 200 && resp.StatusCode <= 399 {
+		if hrs.readerOffset > 0 {
+			if resp.StatusCode != http.StatusPartialContent {
+				return nil, ErrWrongCodeForByteRange
+			}
+
+			contentRange := resp.Header.Get("Content-Range")
+			if contentRange == "" {
+				return nil, errors.New("no Content-Range header found in HTTP 206 response")
+			}
+
+			submatches := contentRangeRegexp.FindStringSubmatch(contentRange)
+			if len(submatches) < 4 {
+				return nil, fmt.Errorf("could not parse Content-Range header: %s", contentRange)
+			}
+
+			startByte, err := strconv.ParseUint(submatches[1], 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("could not parse start of range in Content-Range header: %s", contentRange)
+			}
+
+			if startByte != uint64(hrs.readerOffset) {
+				return nil, fmt.Errorf("received Content-Range starting at offset %d instead of requested %d", startByte, hrs.readerOffset)
+			}
+
+			endByte, err := strconv.ParseUint(submatches[2], 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("could not parse end of range in Content-Range header: %s", contentRange)
+			}
+
+			if submatches[3] == "*" {
+				hrs.size = -1
+			} else {
+				size, err := strconv.ParseUint(submatches[3], 10, 64)
+				if err != nil {
+					return nil, fmt.Errorf("could not parse total size in Content-Range header: %s", contentRange)
+				}
+
+				if endByte+1 != size {
+					return nil, fmt.Errorf("range in Content-Range stops before the end of the content: %s", contentRange)
+				}
+
+				hrs.size = int64(size)
+			}
+		} else if resp.StatusCode == http.StatusOK {
+			hrs.size = resp.ContentLength
+		} else {
+			hrs.size = -1
+		}
+		hrs.rc = resp.Body
+	} else {
+		defer resp.Body.Close()
+		if hrs.errorHandler != nil {
+			return nil, hrs.errorHandler(resp)
+		}
+		return nil, fmt.Errorf("unexpected status resolving reader: %v", resp.Status)
+	}
+
+	return hrs.rc, nil
+}

--- a/pkg/registry/distributionpkg/client/transport/transport.go
+++ b/pkg/registry/distributionpkg/client/transport/transport.go
@@ -1,0 +1,169 @@
+// Copyright © 2022 https://github.com/distribution/distribution
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport
+
+import (
+	"io"
+	"net/http"
+	"sync"
+)
+
+func identityTransportWrapper(rt http.RoundTripper) http.RoundTripper {
+	return rt
+}
+
+// DefaultTransportWrapper allows a user to wrap every generated transport
+var DefaultTransportWrapper = identityTransportWrapper
+
+// RequestModifier represents an object which will do an inplace
+// modification of an HTTP request.
+type RequestModifier interface {
+	ModifyRequest(*http.Request) error
+}
+
+type headerModifier http.Header
+
+// NewHeaderRequestModifier returns a new RequestModifier which will
+// add the given headers to a request.
+func NewHeaderRequestModifier(header http.Header) RequestModifier {
+	return headerModifier(header)
+}
+
+func (h headerModifier) ModifyRequest(req *http.Request) error {
+	for k, s := range http.Header(h) {
+		req.Header[k] = append(req.Header[k], s...)
+	}
+
+	return nil
+}
+
+// NewTransport creates a new transport which will apply modifiers to
+// the request on a RoundTrip call.
+func NewTransport(base http.RoundTripper, modifiers ...RequestModifier) http.RoundTripper {
+	return DefaultTransportWrapper(
+		&transport{
+			Modifiers: modifiers,
+			Base:      base,
+		})
+}
+
+// transport is an http.RoundTripper that makes HTTP requests after
+// copying and modifying the request
+type transport struct {
+	Modifiers []RequestModifier
+	Base      http.RoundTripper
+
+	mu     sync.Mutex                      // guards modReq
+	modReq map[*http.Request]*http.Request // original -> modified
+}
+
+// RoundTrip authorizes and authenticates the request with an
+// access token. If no token exists or token is expired,
+// tries to refresh/fetch a new token.
+func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req2 := cloneRequest(req)
+	for _, modifier := range t.Modifiers {
+		if err := modifier.ModifyRequest(req2); err != nil {
+			return nil, err
+		}
+	}
+
+	t.setModReq(req, req2)
+	res, err := t.base().RoundTrip(req2)
+	if err != nil {
+		t.setModReq(req, nil)
+		return nil, err
+	}
+	res.Body = &onEOFReader{
+		rc: res.Body,
+		fn: func() { t.setModReq(req, nil) },
+	}
+	return res, nil
+}
+
+// CancelRequest cancels an in-flight request by closing its connection.
+func (t *transport) CancelRequest(req *http.Request) {
+	type canceler interface {
+		CancelRequest(*http.Request)
+	}
+	if cr, ok := t.base().(canceler); ok {
+		t.mu.Lock()
+		modReq := t.modReq[req]
+		delete(t.modReq, req)
+		t.mu.Unlock()
+		cr.CancelRequest(modReq)
+	}
+}
+
+func (t *transport) base() http.RoundTripper {
+	if t.Base != nil {
+		return t.Base
+	}
+	return http.DefaultTransport
+}
+
+func (t *transport) setModReq(orig, mod *http.Request) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.modReq == nil {
+		t.modReq = make(map[*http.Request]*http.Request)
+	}
+	if mod == nil {
+		delete(t.modReq, orig)
+	} else {
+		t.modReq[orig] = mod
+	}
+}
+
+// cloneRequest returns a clone of the provided *http.Request.
+// The clone is a shallow copy of the struct and its Header map.
+func cloneRequest(r *http.Request) *http.Request {
+	// shallow copy of the struct
+	r2 := new(http.Request)
+	*r2 = *r
+	// deep copy of the Header
+	r2.Header = make(http.Header, len(r.Header))
+	for k, s := range r.Header {
+		r2.Header[k] = append([]string(nil), s...)
+	}
+
+	return r2
+}
+
+type onEOFReader struct {
+	rc io.ReadCloser
+	fn func()
+}
+
+func (r *onEOFReader) Read(p []byte) (n int, err error) {
+	n, err = r.rc.Read(p)
+	if err == io.EOF {
+		r.runFunc()
+	}
+	return
+}
+
+func (r *onEOFReader) Close() error {
+	err := r.rc.Close()
+	r.runFunc()
+	return err
+}
+
+func (r *onEOFReader) runFunc() {
+	if fn := r.fn; fn != nil {
+		fn()
+		r.fn = nil
+	}
+}

--- a/pkg/registry/distributionpkg/proxy/proxyauth.go
+++ b/pkg/registry/distributionpkg/proxy/proxyauth.go
@@ -20,10 +20,10 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/labring/sealos/pkg/utils/logger"
+	"github.com/labring/sealos/pkg/registry/distributionpkg/client/auth"
+	"github.com/labring/sealos/pkg/registry/distributionpkg/client/auth/challenge"
 
-	"github.com/distribution/distribution/v3/registry/client/auth"
-	"github.com/distribution/distribution/v3/registry/client/auth/challenge"
+	"github.com/labring/sealos/pkg/utils/logger"
 )
 
 // comment this const because not used
@@ -54,7 +54,7 @@ func (c credentials) SetRefreshToken(u *url.URL, service, token string) {
 }
 
 // configureAuth stores credentials for challenge responses
-func configureAuth(username, password, remoteURL string) (auth.CredentialStore, error) {
+func configureAuth(username, password, remoteURL string, basicAuth bool) (auth.CredentialStore, error) {
 	creds := map[string]userpass{}
 
 	authURLs, err := getAuthURLs(remoteURL)
@@ -69,7 +69,12 @@ func configureAuth(username, password, remoteURL string) (auth.CredentialStore, 
 			password: password,
 		}
 	}
-
+	if len(authURLs) == 0 && basicAuth {
+		creds[remoteURL] = userpass{
+			username: username,
+			password: password,
+		}
+	}
 	return credentials{creds: creds}, nil
 }
 

--- a/pkg/registry/distributionpkg/proxy/proxyblobstore.go
+++ b/pkg/registry/distributionpkg/proxy/proxyblobstore.go
@@ -21,10 +21,11 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/labring/sealos/pkg/registry/distributionpkg/proxy/scheduler"
+
 	"github.com/distribution/distribution/v3"
 	dcontext "github.com/distribution/distribution/v3/context"
 	"github.com/distribution/distribution/v3/reference"
-	"github.com/distribution/distribution/v3/registry/proxy/scheduler"
 	"github.com/opencontainers/go-digest"
 )
 

--- a/pkg/registry/distributionpkg/proxy/proxymanifeststore.go
+++ b/pkg/registry/distributionpkg/proxy/proxymanifeststore.go
@@ -18,9 +18,10 @@ import (
 	"context"
 	"time"
 
+	"github.com/labring/sealos/pkg/registry/distributionpkg/proxy/scheduler"
+
 	"github.com/distribution/distribution/v3"
 	"github.com/distribution/distribution/v3/reference"
-	"github.com/distribution/distribution/v3/registry/proxy/scheduler"
 	"github.com/opencontainers/go-digest"
 )
 

--- a/pkg/registry/interface.go
+++ b/pkg/registry/interface.go
@@ -34,10 +34,11 @@ type DefaultImageSaver struct {
 	domainToImages map[string][]Named
 	progressOut    progress.Output
 	maxPullProcs   int
+	basicAuth      bool
 	auths          map[string]types.AuthConfig
 }
 
-func NewImageSaver(ctx context.Context, maxPullProcs int, auths map[string]types.AuthConfig) Save {
+func NewImageSaver(ctx context.Context, maxPullProcs int, auths map[string]types.AuthConfig, basicAuth bool) Save {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -48,6 +49,7 @@ func NewImageSaver(ctx context.Context, maxPullProcs int, auths map[string]types
 		ctx:            ctx,
 		domainToImages: make(map[string][]Named),
 		maxPullProcs:   maxPullProcs,
+		basicAuth:      basicAuth,
 		auths:          auths,
 	}
 }

--- a/pkg/registry/save.go
+++ b/pkg/registry/save.go
@@ -97,7 +97,7 @@ func (is *DefaultImageSaver) SaveImages(images []string, dir string, platform v1
 			if auth.ServerAddress == "" {
 				auth.ServerAddress = tmpnameds[0].domain
 			}
-			registry, err := NewProxyRegistry(is.ctx, dir, auth)
+			registry, err := NewProxyRegistry(is.ctx, dir, auth, is.basicAuth)
 			if err != nil {
 				return fmt.Errorf("init registry error: %v", err)
 			}
@@ -148,7 +148,7 @@ func authConfigToProxy(auth types.AuthConfig) configuration.Proxy {
 	}
 }
 
-func NewProxyRegistry(ctx context.Context, rootdir string, auth types.AuthConfig) (distribution.Namespace, error) {
+func NewProxyRegistry(ctx context.Context, rootdir string, auth types.AuthConfig, basicAuth bool) (distribution.Namespace, error) {
 	config := configuration.Configuration{
 		Proxy: authConfigToProxy(auth),
 		Storage: configuration.Storage{
@@ -167,11 +167,11 @@ func NewProxyRegistry(ctx context.Context, rootdir string, auth types.AuthConfig
 		return nil, fmt.Errorf("create local registry error: %v", err)
 	}
 
-	proxyRegistry, err := proxy.NewRegistryPullThroughCache(ctx, registry, driver, config.Proxy)
+	proxyRegistry, err := proxy.NewRegistryPullThroughCache(ctx, registry, driver, config.Proxy, basicAuth)
 	if err != nil { // try http
 		logger.Warn("https error: %v, sealos try to use http", err)
 		config.Proxy.RemoteURL = strings.Replace(config.Proxy.RemoteURL, HTTPS, HTTP, 1)
-		proxyRegistry, err = proxy.NewRegistryPullThroughCache(ctx, registry, driver, config.Proxy)
+		proxyRegistry, err = proxy.NewRegistryPullThroughCache(ctx, registry, driver, config.Proxy, basicAuth)
 		if err != nil {
 			return nil, fmt.Errorf("create proxy registry error: %v", err)
 		}

--- a/pkg/registry/save_test.go
+++ b/pkg/registry/save_test.go
@@ -33,7 +33,7 @@ func TestSaveImages(t *testing.T) {
 			Username: "admin",
 			Password: "passw0rd",
 		},
-	})
+	}, true)
 	images, err := is.SaveImages(tests, "/Users/cuisongliu/DockerImages/registry", v1.Platform{OS: "linux", Architecture: "amd64"})
 	if err != nil {
 		t.Error(err)

--- a/pkg/registry/save_test.go
+++ b/pkg/registry/save_test.go
@@ -27,8 +27,13 @@ import (
 
 func TestSaveImages(t *testing.T) {
 	//tests := []string{"quay.io/tigera/operator:v1.25.3"}
-	tests := []string{"registry.cn-beijing.aliyuncs.com/private-test/nginx"}
-	is := NewImageSaver(context.Background(), 5, nil)
+	tests := []string{"47.94.15.171:5000/11c-code/11c-image-hook:0bb9121b"}
+	is := NewImageSaver(context.Background(), 5, map[string]types.AuthConfig{
+		"47.94.15.171:5000": {
+			Username: "admin",
+			Password: "passw0rd",
+		},
+	})
 	images, err := is.SaveImages(tests, "/Users/cuisongliu/DockerImages/registry", v1.Platform{OS: "linux", Architecture: "amd64"})
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
1. default only support token auth , add basic auth to cache registry
2. proxyauth.go (func configureAuth) if basicAuth and getAuthURLs is empty append remoteURL to default authURLs
3. proxyregistry.go (func Repository) default use tokenAuth ,if  basicAuth is true  use basicAuthHandler.
4. session.go (func AuthorizeRequest) bh.creds.Basic use remoteURL  to fetch authURLs  username password