### PR TITLE
fix: validate vip before initialization

### DIFF
--- a/pkg/runtime/kubeadm.go
+++ b/pkg/runtime/kubeadm.go
@@ -122,6 +122,20 @@ func (k *KubeadmRuntime) MergeKubeadmConfig() error {
 		return fmt.Errorf("failed to merge kubeadm config: %v", err)
 	}
 	k.setKubeadmAPIVersion()
+	return k.validateVIP(k.getVip())
+}
+
+func (k *KubeadmRuntime) validateVIP(ip string) error {
+	for k, sub := range map[string]string{
+		"podSubnet":     k.KubeadmConfig.Networking.PodSubnet,
+		"serviceSubnet": k.KubeadmConfig.Networking.ServiceSubnet,
+	} {
+		if contains, err := iputils.Contains(sub, ip); err != nil {
+			return err
+		} else if contains {
+			return fmt.Errorf("ensure IP %s is not in %s range", ip, k)
+		}
+	}
 	return nil
 }
 
@@ -133,6 +147,7 @@ func (k *KubeadmRuntime) getClusterName() string {
 	return k.Cluster.Name
 }
 
+// todo: maybe make this virtual IP configurable?
 func (k *KubeadmRuntime) getVip() string {
 	return DefaultVIP
 }

--- a/pkg/utils/iputils/iputils_v2.go
+++ b/pkg/utils/iputils/iputils_v2.go
@@ -205,4 +205,3 @@ func Contains(sub, s string) (bool, error) {
 	}
 	return ipNet.Contains(ip), nil
 }
-

--- a/pkg/utils/iputils/iputils_v2.go
+++ b/pkg/utils/iputils/iputils_v2.go
@@ -193,3 +193,16 @@ func NextIP(ip string) net.IP {
 	i := IPToInt(ip)
 	return i.Add(i, big.NewInt(1)).Bytes()
 }
+
+func Contains(sub, s string) (bool, error) {
+	_, ipNet, err := net.ParseCIDR(sub)
+	if err != nil {
+		return false, err
+	}
+	ip := net.ParseIP(s)
+	if ip == nil {
+		return false, fmt.Errorf("%s is not a valid IP address", s)
+	}
+	return ipNet.Contains(ip), nil
+}
+


### PR DESCRIPTION
[SKIP CI]sealos: validate virtual IP for masters

virtual IP address of masters MUST NOT in podSubnet and serviceSubnet range, otherwise, when the same IP address is allocated in cluster, unexpected network connectivity from components to APIServer may failed.

or, even we can make the constant `DefaultVIP` configurable?
