### PR TITLE
Add rpm & deb build script with nfpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,11 +73,18 @@ build-arm64:
 	CGO_ENABLED=${CGO_ENABLED} GOOS=${OS} GOARCH=arm64 go build ${LDFLAGS} -o $(shell pwd)/bin/${OS}_arm64/sealos -tags "containers_image_openpgp" cmd/sealos/main.go
 	CGO_ENABLED=0 GOOS=${OS} GOARCH=arm64 go build ${LDFLAGS} -o $(shell pwd)/bin/${OS}_arm64/seactl -tags "containers_image_openpgp" cmd/sealctl/main.go
 
+# upx is required for this
+upx: upx-amd64 upx-arm64
+upx-amd64:
+	cd bin/linux_amd64/ ; upx sealos ; upx seactl
+upx-arm64:
+	cd bin/linux_arm64/ ; upx sealos ; upx seactl
+
+# nfpm is required for making rpm & deb
 package: package-amd64 package-arm64
 package-amd64:
 	nfpm package -p rpm -f amd64.yaml -t bin/linux_amd64/
 	nfpm package -p deb -f amd64.yaml -t bin/linux_amd64/
-
 package-arm64:
 	nfpm package -p rpm -f arm64.yaml -t bin/linux_arm64/
 	nfpm package -p deb -f arm64.yaml -t bin/linux_arm64/

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,15 @@ build-arm64:
 	CGO_ENABLED=${CGO_ENABLED} GOOS=${OS} GOARCH=arm64 go build ${LDFLAGS} -o $(shell pwd)/bin/${OS}_arm64/sealos -tags "containers_image_openpgp" cmd/sealos/main.go
 	CGO_ENABLED=0 GOOS=${OS} GOARCH=arm64 go build ${LDFLAGS} -o $(shell pwd)/bin/${OS}_arm64/seactl -tags "containers_image_openpgp" cmd/sealctl/main.go
 
+package: package-amd64 package-arm64
+package-amd64:
+	nfpm package -p rpm -f amd64.yaml -t bin/linux_amd64/
+	nfpm package -p deb -f amd64.yaml -t bin/linux_amd64/
+
+package-arm64:
+	nfpm package -p rpm -f arm64.yaml -t bin/linux_arm64/
+	nfpm package -p deb -f arm64.yaml -t bin/linux_arm64/
+
 import:
 	goimports -l -w cmd
 	goimports -l -w pkg

--- a/amd64.yaml
+++ b/amd64.yaml
@@ -1,0 +1,21 @@
+# nfpm example config file
+#
+# check https://nfpm.goreleaser.com/configuration for detailed usage
+#
+name: "sealos"
+arch: "amd64"
+platform: "linux"
+version: "v4.0.0"
+version_schema: semver
+maintainer: fanux(https://github.com/fanux)
+description: Cloud OS distribution with Kubernetes as kernel
+vendor: "https://github.com/fanux"
+homepage: "https://github.com/labring/sealos"
+license: "Apache-2.0 License"
+
+contents:
+- src: ./bin/linux_amd64/seactl
+  dst: /usr/bin/sealos
+
+- src: ./bin/linux_amd64/
+  dst: /usr/bin/sealos

--- a/amd64.yaml
+++ b/amd64.yaml
@@ -1,7 +1,16 @@
-# nfpm example config file
-#
-# check https://nfpm.goreleaser.com/configuration for detailed usage
-#
+#// Copyright © 2021 sealos.
+#//
+#// Licensed under the Apache License, Version 2.0 (the "License");
+#// you may not use this file except in compliance with the License.
+#// You may obtain a copy of the License at
+#//
+#//     http://www.apache.org/licenses/LICENSE-2.0
+#//
+#// Unless required by applicable law or agreed to in writing, software
+#// distributed under the License is distributed on an "AS IS" BASIS,
+#// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#// See the License for the specific language governing permissions and
+#// limitations under the License.
 name: "sealos"
 arch: "amd64"
 platform: "linux"

--- a/arm64.yaml
+++ b/arm64.yaml
@@ -1,0 +1,21 @@
+# nfpm example config file
+#
+# check https://nfpm.goreleaser.com/configuration for detailed usage
+#
+name: "sealos"
+arch: "arm64"
+platform: "linux"
+version: "v4.0.0"
+version_schema: semver
+maintainer: fanux(https://github.com/fanux)
+description: Cloud OS distribution with Kubernetes as kernel
+vendor: "https://github.com/fanux"
+homepage: "https://github.com/labring/sealos"
+license: "Apache-2.0 License"
+
+contents:
+- src: ./bin/linux_arm64/seactl
+  dst: /usr/bin/sealos
+
+- src: ./bin/linux_arm64/
+  dst: /usr/bin/sealos

--- a/arm64.yaml
+++ b/arm64.yaml
@@ -1,7 +1,16 @@
-# nfpm example config file
+# Copyright © 2021 sealos.
 #
-# check https://nfpm.goreleaser.com/configuration for detailed usage
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 name: "sealos"
 arch: "arm64"
 platform: "linux"


### PR DESCRIPTION
[SKIP CI]seaols: Add rpm & deb build script for sealos with nfpm


```bash
brew install nfpm
```

```bash
make build
make package
```

```bash
$ md5sum bin/linux_amd64/*
MD5 (bin/linux_amd64/seactl) = 108e8a42b748c0e9be3ba941656a00c5
MD5 (bin/linux_amd64/sealos) = 9521d81960d1905b6f1d12595b9731be
MD5 (bin/linux_amd64/sealos-4.0.0.x86_64.rpm) = 24b06f6d44ac5e3c6099f048cc2a037f
MD5 (bin/linux_amd64/sealos_4.0.0_amd64.deb) = 92143841ab8af926b11bda454e55ad49

$ md5sum bin/linux_arm64/*
MD5 (bin/linux_arm64/seactl) = 002894239bcc7fd507444a30bed47720
MD5 (bin/linux_arm64/sealos) = f6ae4d21075c3aa475545295890ce860
MD5 (bin/linux_arm64/sealos-4.0.0.aarch64.rpm) = fa40dce776dd4107b13568f07c030f7e
MD5 (bin/linux_arm64/sealos_4.0.0_arm64.deb) = 15078e4b70ffcac44d5b1cd5430e2552
```
