### PR TITLE
fix: can't specify dockerfile 

### DIFF
--- a/pkg/image/buildah/image/build.go
+++ b/pkg/image/buildah/image/build.go
@@ -135,7 +135,7 @@ func (d *Service) Build(options *types.BuildOptions, contextDir, imageName strin
 			}
 		}
 	}
-	containerfiles := getContainerfiles(iopts.File)
+	containerfiles := getContainerfiles([]string{options.File})
 	format, err := getFormat(iopts.Format)
 	if err != nil {
 		return err


### PR DESCRIPTION
sealos default build file is  kubefile , the same as binary method build, and can specified by cli args.
fix: https://github.com/labring/sealos/issues/1150