### PR TITLE
fix: merge go.build.%.sealctl/sealos

### DIFF
--- a/scripts/make-rules/golang.mk
+++ b/scripts/make-rules/golang.mk
@@ -42,21 +42,9 @@ ifneq ($(shell $(GO) version | grep -q 'go version go' && echo 0 || echo 1), 0)
 	$(error Go binary is not found. Please install Go first.')
 endif
 
-# TODO: merge go.build.%.sealos and go.build.%.sealctl
-.PHONY: go.build.%.sealos
-go.build.%.sealos:
-	$(eval COMMAND := sealos)
-	$(eval PLATFORM := $(word 1,$(subst ., ,$*)))
-	$(eval OS := $(word 1,$(subst _, ,$(PLATFORM))))
-	$(eval ARCH := $(word 2,$(subst _, ,$(PLATFORM))))
-
-	@echo "===========> Building binary $(COMMAND) for $(PLATFORM)"
-	@mkdir -p $(BIN_DIR)/$(PLATFORM)
-	CGO_ENABLED=1 GOOS=$(OS) GOARCH=$(ARCH) $(GO) build $(GO_BUILD_FLAGS) -o $(BIN_DIR)/$(PLATFORM)/$(COMMAND) $(ROOT_PACKAGE)/cmd/$(COMMAND)
-
-.PHONY: go.build.%.sealctl
-go.build.%.sealctl:
-	$(eval COMMAND := sealctl)
+.PHONY: go.build.%
+go.build.%:
+	$(eval COMMAND := $(word 2,$(subst ., ,$*)))
 	$(eval PLATFORM := $(word 1,$(subst ., ,$*)))
 	$(eval OS := $(word 1,$(subst _, ,$(PLATFORM))))
 	$(eval ARCH := $(word 2,$(subst _, ,$(PLATFORM))))


### PR DESCRIPTION
Now sealos will be built with `CGO_ENABLED=0` too, which makes cross-platform building possible.