### PR TITLE
fix: no longer explicitly specify cgo_enabled

### DIFF
--- a/DEVELOPGUIDE.md
+++ b/DEVELOPGUIDE.md
@@ -12,11 +12,24 @@ cd sealos
 make build
 ```
 
-You can scp the bin file to your linux host. 
+You can scp the bin file to your linux host.
 
 If you use multipaas, you can mount the bin dir to the vm:
+
 ```shell script
 multipass mount /your-bin-dir <name>[:<path>]
 ```
+
+## Notice About build and cross build
+
+Since Golang CGO_ENABLED is enabled by default if it is not specified, if you compile the sealos binary of linuxos on
+macos, it is cross-compiled, and since CGO_ENABLED is not explicitly specified, go will close CGO_ENABLED by default,
+that is, CGO_ENABLED=0, and compile at this time Some functions of sealos will not be supported, such as
+'images' subcommand depends on cgo for overlay. At this time, sealos does not support overlay driver by default, and
+will report "driver not supported" error. Therefore, if you are developing or debugging images storage related
+functions, it is best to compile sealos in a linux environment such as ubuntu.
+
+In addition, the final release build of sealos is based on the ubuntu environment of Github Action. The built binary
+defaults to open CGO and supports overlay driver.
 
 Then test it locally.

--- a/scripts/make-rules/golang.mk
+++ b/scripts/make-rules/golang.mk
@@ -42,16 +42,28 @@ ifneq ($(shell $(GO) version | grep -q 'go version go' && echo 0 || echo 1), 0)
 	$(error Go binary is not found. Please install Go first.')
 endif
 
-.PHONY: go.build.%
-go.build.%:
-	$(eval COMMAND := $(word 2,$(subst ., ,$*)))
+.PHONY: go.build.%.sealos
+go.build.%.sealos:
+	$(eval COMMAND := sealos)
 	$(eval PLATFORM := $(word 1,$(subst ., ,$*)))
 	$(eval OS := $(word 1,$(subst _, ,$(PLATFORM))))
 	$(eval ARCH := $(word 2,$(subst _, ,$(PLATFORM))))
+	$(eval GO_LDFLAGS += "")
 
 	@echo "===========> Building binary $(COMMAND) for $(PLATFORM)"
 	@mkdir -p $(BIN_DIR)/$(PLATFORM)
-	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) $(GO) build $(GO_BUILD_FLAGS) -o $(BIN_DIR)/$(PLATFORM)/$(COMMAND) $(ROOT_PACKAGE)/cmd/$(COMMAND)
+	GOOS=$(OS) GOARCH=$(ARCH) $(GO) build $(GO_BUILD_FLAGS) -o $(BIN_DIR)/$(PLATFORM)/$(COMMAND) $(ROOT_PACKAGE)/cmd/$(COMMAND)
+
+.PHONY: go.build.%.sealctl
+go.build.%.sealctl:
+	$(eval COMMAND := sealctl)
+	$(eval PLATFORM := $(word 1,$(subst ., ,$*)))
+	$(eval OS := $(word 1,$(subst _, ,$(PLATFORM))))
+	$(eval ARCH := $(word 2,$(subst _, ,$(PLATFORM))))
+	@echo "===========> Building binary $(COMMAND) for $(PLATFORM)"
+	@mkdir -p $(BIN_DIR)/$(PLATFORM)
+	GOOS=$(OS) GOARCH=$(ARCH) $(GO) build $(GO_BUILD_FLAGS) -o $(BIN_DIR)/$(PLATFORM)/$(COMMAND) $(ROOT_PACKAGE)/cmd/$(COMMAND)
+
 
 .PHONY: go.build
 go.build: go.build.verify $(addprefix go.build., $(addprefix $(PLATFORM)., $(BINS)))


### PR DESCRIPTION
Signed-off-by: maybaby <ybyang7@iflytek.com>


[SKIP CI]sealos:  no longer explicitly specify cgo_enabled . and i think we should close the https://github.com/labring/sealos/pull/1244. 