### PR TITLE
feat: support test mode for lvscare

### DIFF
--- a/cmd/lvscare/cmd/care.go
+++ b/cmd/lvscare/cmd/care.go
@@ -24,8 +24,8 @@ import (
 var careCmd = &cobra.Command{
 	Use:   "care",
 	Short: "A lightweight LVS baby care, support ipvs health check.",
-	Run: func(cmd *cobra.Command, args []string) {
-		care.LVS.VsAndRsCare()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return care.LVS.VsAndRsCare()
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if err := care.SetTargetIP(); err != nil {
@@ -63,6 +63,7 @@ func init() {
 	careCmd.Flags().StringSliceVar(&care.LVS.RealServer, "rs", []string{}, "real server like 192.168.0.2:6443")
 	careCmd.Flags().StringVar(&care.LVS.Logger, "logger", "INFO", "logger level: DEBG/INFO")
 	careCmd.Flags().BoolVar(&care.LVS.Clean, "clean", false, "before run clean ipvs rules")
+	careCmd.Flags().BoolVarP(&care.LVS.Test, "test", "t", false, "test mode")
 
 	careCmd.Flags().StringVar(&care.LVS.HealthPath, "health-path", "/healthz", "health check path")
 	careCmd.Flags().StringVar(&care.LVS.HealthSchem, "health-schem", "https", "health check schem")

--- a/cmd/lvscare/cmd/care.go
+++ b/cmd/lvscare/cmd/care.go
@@ -51,24 +51,6 @@ func init() {
 			logger.CfgConsoleLogger(false, false)
 		}
 	})
+	care.LVS.RegisterFlags(careCmd.Flags())
 	rootCmd.AddCommand(careCmd)
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// careCmd.PersistentFlags().String("foo", "", "A help for foo")
-	careCmd.Flags().IPVar(&care.LVS.TargetIP, "ip", nil, "target ip")
-	careCmd.Flags().BoolVar(&care.LVS.RunOnce, "run-once", false, "is run once mode")
-	careCmd.Flags().StringVar(&care.LVS.VirtualServer, "vs", "", "virtual server like 10.54.0.2:6443")
-	careCmd.Flags().StringSliceVar(&care.LVS.RealServer, "rs", []string{}, "real server like 192.168.0.2:6443")
-	careCmd.Flags().StringVar(&care.LVS.Logger, "logger", "INFO", "logger level: DEBG/INFO")
-	careCmd.Flags().BoolVar(&care.LVS.Clean, "clean", false, "before run clean ipvs rules")
-	careCmd.Flags().BoolVarP(&care.LVS.Test, "test", "t", false, "test mode")
-
-	careCmd.Flags().StringVar(&care.LVS.HealthPath, "health-path", "/healthz", "health check path")
-	careCmd.Flags().StringVar(&care.LVS.HealthSchem, "health-schem", "https", "health check schem")
-	careCmd.Flags().Int32Var(&care.LVS.Interval, "interval", 5, "health check interval, unit is sec.")
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// careCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/staging/src/github.com/labring/lvscare/care/care.go
+++ b/staging/src/github.com/labring/lvscare/care/care.go
@@ -16,6 +16,7 @@ package care
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"os/signal"
@@ -27,25 +28,40 @@ import (
 	"github.com/labring/sealos/pkg/utils/logger"
 )
 
-//VsAndRsCare is
-func (care *LvsCare) VsAndRsCare() {
-	lvs := BuildLvscare()
-	//set inner lvs
-	care.lvs = lvs
-	if care.Clean {
+// VsAndRsCare is
+func (care *LvsCare) VsAndRsCare() error {
+	if care.lvs == nil {
+		care.lvs = BuildLvscare()
+	}
+
+	cleanVirtualServer := func() error {
 		logger.Info("lvscare deleteVirtualServer")
-		err := lvs.DeleteVirtualServer(care.VirtualServer, false)
+		err := care.lvs.DeleteVirtualServer(care.VirtualServer, false)
 		if err != nil {
-			logger.Info("virtualServer is not exist skip...: %v", err)
+			logger.Warn("virtualServer is not exist skip...: %v", err)
 		}
+		return nil
 	}
-	care.createVsAndRs()
+
+	if care.Clean {
+		cleanVirtualServer()
+		care.cleanupFuncs = append(care.cleanupFuncs, cleanVirtualServer)
+	}
+	if err := care.test(); err != nil {
+		return err
+	}
+	if err := care.createVsAndRs(); err != nil {
+		return err
+	}
 	if care.RunOnce {
-		return
+		return nil
 	}
+
 	t := time.NewTicker(time.Duration(care.Interval) * time.Second)
+	defer t.Stop()
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+
 	for {
 		select {
 		case <-t.C:
@@ -53,44 +69,84 @@ func (care *LvsCare) VsAndRsCare() {
 			isAvailable := care.lvs.IsVirtualServerAvailable(care.VirtualServer)
 			if !isAvailable {
 				err := care.lvs.CreateVirtualServer(care.VirtualServer, true)
-				//virtual server is exists
+				// virtual server is exists
 				if err != nil {
 					logger.Error("failed to create virtual server: %v", err)
-
-					return
+					return err
 				}
 			}
-			//check real server
-			lvs.CheckRealServers(care.HealthPath, care.HealthSchem)
+			// check real server
+			care.lvs.CheckRealServers(care.HealthPath, care.HealthSchem)
 		case signa := <-sig:
 			logger.Info("receive kill signal: %+v", signa)
-			_ = LVS.Route.DelRoute()
-			return
+			for _, fn := range care.cleanupFuncs {
+				if err := fn(); err != nil {
+					return err
+				}
+			}
+			return nil
 		}
 	}
 }
-func (care *LvsCare) SyncRouter() error {
-	if len(LVS.VirtualServer) == 0 {
-		return errors.New("virtual server can't empty")
-	}
-	if LVS.TargetIP != nil {
-		var ipv4 bool
-		vIP, _, err := net.SplitHostPort(LVS.VirtualServer)
+
+func (care *LvsCare) test() error {
+	if care.Test {
+		ips, err := ipAddrsFromNetworkAddrs(care.RealServer...)
 		if err != nil {
 			return err
 		}
-		if utils.IsIPv6(LVS.TargetIP) {
+		hasLocal, err := isAnyLocalHostAddr(ips...)
+		if err != nil {
+			return err
+		}
+		if !hasLocal {
+			return nil
+		}
+		virIP, virPort := SplitServer(care.VirtualServer)
+		if virIP == "" || virPort == 0 {
+			return fmt.Errorf("virtual server ip and port is empty")
+		}
+		logger.Info("create dummy interface with name %s", dummyIfaceName)
+		link, err := utils.GetOrCreateDummyLink(dummyIfaceName)
+		if err != nil {
+			return err
+		}
+		care.cleanupFuncs = append(care.cleanupFuncs, func() error {
+			logger.Info("remove dummy interface %s", dummyIfaceName)
+			return utils.DeleteLinkByName(dummyIfaceName)
+		})
+		logger.Info("assign IP %s/32 to interface", virIP)
+		return utils.AssignIPToLink(virIP+"/32", link)
+	}
+	return nil
+}
+
+func (care *LvsCare) SyncRouter() error {
+	if len(care.VirtualServer) == 0 {
+		return errors.New("virtual server can't empty")
+	}
+	if care.TargetIP != nil {
+		var ipv4 bool
+		vIP, _, err := net.SplitHostPort(care.VirtualServer)
+		if err != nil {
+			return err
+		}
+		if utils.IsIPv6(care.TargetIP) {
 			ipv4 = false
 		} else {
 			ipv4 = true
 		}
 		if !ipv4 {
-			logger.Info("tip: %s is not ipv4", LVS.TargetIP.String())
+			logger.Info("tip: %s is not ipv4", care.TargetIP.String())
 			return nil
 		}
-		logger.Info("tip: %s,vip: %s", LVS.TargetIP.String(), vIP)
-		LVS.Route = route.NewRoute(vIP, LVS.TargetIP.String())
-		return LVS.Route.SetRoute()
+		logger.Info("tip: %s,vip: %s", care.TargetIP.String(), vIP)
+		care.Route = route.NewRoute(vIP, care.TargetIP.String())
+		if err = care.Route.SetRoute(); err != nil {
+			return err
+		}
+		care.cleanupFuncs = append(care.cleanupFuncs, care.Route.DelRoute)
+		return nil
 	}
 	return nil
 }

--- a/staging/src/github.com/labring/lvscare/care/care.go
+++ b/staging/src/github.com/labring/lvscare/care/care.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 

--- a/staging/src/github.com/labring/lvscare/care/create.go
+++ b/staging/src/github.com/labring/lvscare/care/create.go
@@ -15,22 +15,21 @@
 package care
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/labring/sealos/pkg/utils/logger"
 )
 
-//createVsAndRs is
-func (care *LvsCare) createVsAndRs() {
-	//ip, _ := utils.SplitServer(vs)
-	if care.lvs == nil {
-		care.lvs = BuildLvscare()
-	}
+// createVsAndRs is
+func (care *LvsCare) createVsAndRs() error {
 	var errs []string
 	isAvailable := care.lvs.IsVirtualServerAvailable(care.VirtualServer)
 	if !isAvailable {
 		err := care.lvs.CreateVirtualServer(care.VirtualServer, true)
-		//virtual server is exists
+		// virtual server is exists
 		if err != nil {
-			//can't return
+			// can't return
 			errs = append(errs, err.Error())
 		}
 	}
@@ -42,5 +41,7 @@ func (care *LvsCare) createVsAndRs() {
 	}
 	if len(errs) != 0 {
 		logger.Error("createVsAndRs error: %v", errs)
+		return fmt.Errorf(strings.Join(errs, ","))
 	}
+	return nil
 }

--- a/staging/src/github.com/labring/lvscare/care/vars.go
+++ b/staging/src/github.com/labring/lvscare/care/vars.go
@@ -27,12 +27,16 @@ type LvsCare struct {
 	RealServer    []string
 	RunOnce       bool
 	Clean         bool
+	Test          bool
 	Interval      int32
 	Logger        string
 	TargetIP      net.IP
-	//
-	lvs   Lvser
-	Route *route.Route
+	// runtime
+	cleanupFuncs []func() error
+	lvs          Lvser
+	Route        *route.Route
 }
 
 var LVS LvsCare
+
+const dummyIfaceName = "lvscare"

--- a/staging/src/github.com/labring/lvscare/care/vars.go
+++ b/staging/src/github.com/labring/lvscare/care/vars.go
@@ -18,6 +18,7 @@ import (
 	"net"
 
 	"github.com/labring/lvscare/pkg/route"
+	"github.com/spf13/pflag"
 )
 
 type LvsCare struct {
@@ -29,6 +30,7 @@ type LvsCare struct {
 	Clean         bool
 	Test          bool
 	Interval      int32
+	IfaceName     string
 	Logger        string
 	TargetIP      net.IP
 	// runtime
@@ -37,6 +39,20 @@ type LvsCare struct {
 	Route        *route.Route
 }
 
-var LVS LvsCare
+func (l *LvsCare) RegisterFlags(fs *pflag.FlagSet) {
+	fs.IPVar(&l.TargetIP, "ip", nil, "target ip")
+	fs.BoolVar(&l.RunOnce, "run-once", false, "is run once mode")
+	fs.StringVar(&l.VirtualServer, "vs", "", "virtual server like 10.54.0.2:6443")
+	fs.StringSliceVar(&l.RealServer, "rs", []string{}, "real server like 192.168.0.2:6443")
+	fs.StringVar(&l.Logger, "logger", "INFO", "logger level: DEBG/INFO")
+	fs.BoolVarP(&l.Clean, "clean", "C", false, "before run clean ipvs rules")
+	fs.BoolVarP(&l.Test, "test", "t", false, "use when any of real server is listening on the same host, "+
+		"enable test mode will automatically create a dummy type interface and bind virtual IP to it")
+	fs.StringVar(&l.IfaceName, "iface", "lvscare", "name of dummy network interface to setup")
 
-const dummyIfaceName = "lvscare"
+	fs.StringVar(&l.HealthPath, "health-path", "/healthz", "health check path")
+	fs.StringVar(&l.HealthSchem, "health-schem", "https", "health check schem")
+	fs.Int32Var(&l.Interval, "interval", 5, "health check interval, unit is sec.")
+}
+
+var LVS LvsCare

--- a/staging/src/github.com/labring/lvscare/pkg/utils/iputils.go
+++ b/staging/src/github.com/labring/lvscare/pkg/utils/iputils.go
@@ -71,7 +71,7 @@ func GetOrCreateDummyLink(name string) (netlink.Link, error) {
 }
 
 func AssignIPToLink(s string, link netlink.Link) error {
-	if strings.Index(s, "/") < 0 {
+	if !strings.Contains(s, "/") {
 		s = s + "/32"
 	}
 	addr, err := netlink.ParseAddr(s)


### PR DESCRIPTION
In some scenario, we want that lvscare can automatically bind virtual IP address to a dummy interface, this PR does
1. check if any of realservers is at the same lvscare host, then create dummy interface and assign virtual IP to it, otherwise do nothing.
2. test mode flag is disabled by default
3. adjust a few logger level