### PR TITLE
feat: auto create dummy link if needed

### DIFF
--- a/staging/src/github.com/labring/lvscare/care/vars.go
+++ b/staging/src/github.com/labring/lvscare/care/vars.go
@@ -29,6 +29,7 @@ type LvsCare struct {
 	RunOnce       bool
 	Clean         bool
 	Interval      int32
+	IfaceName     string
 	Logger        string
 	TargetIP      net.IP
 	// runtime
@@ -42,6 +43,9 @@ func (care *LvsCare) RegisterFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&care.RunOnce, "run-once", false, "run once mode, creating ipvs rules and routes and exit")
 	fs.StringVar(&care.VirtualServer, "vs", "", "virtual server like 10.54.0.2:6443")
 	fs.StringSliceVar(&care.RealServer, "rs", []string{}, "real server like 192.168.0.2:6443")
+	fs.StringVar(&care.IfaceName, "iface", "lvscare", "name of interface to created if needed, "+
+		"use when any of real server is listening locally, this command will create a dummy network interface "+
+		"and bind virtual ip to it automatically, setting this parameter to null will skip this behaviour")
 	fs.StringVar(&care.Logger, "logger", "INFO", "logger level: DEBG/INFO")
 	fs.BoolVarP(&care.Clean, "clean", "C", false, "clean existing ipvs rules and routes and then exit")
 	fs.StringVar(&care.HealthPath, "health-path", "/healthz", "health check path")

--- a/staging/src/github.com/labring/lvscare/care/vars.go
+++ b/staging/src/github.com/labring/lvscare/care/vars.go
@@ -43,7 +43,7 @@ func (care *LvsCare) RegisterFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&care.RunOnce, "run-once", false, "run once mode, creating ipvs rules and routes and exit")
 	fs.StringVar(&care.VirtualServer, "vs", "", "virtual server like 10.54.0.2:6443")
 	fs.StringSliceVar(&care.RealServer, "rs", []string{}, "real server like 192.168.0.2:6443")
-	fs.StringVar(&care.IfaceName, "iface", "lvscare", "name of interface to created if needed, "+
+	fs.StringVar(&care.IfaceName, "iface", "", "name of interface to created when specified if needed, "+
 		"use when any of real server is listening locally, this command will create a dummy network interface "+
 		"and bind virtual ip to it automatically, setting this parameter to null will skip this behaviour")
 	fs.StringVar(&care.Logger, "logger", "INFO", "logger level: DEBG/INFO")

--- a/staging/src/github.com/labring/lvscare/pkg/utils/netlink.go
+++ b/staging/src/github.com/labring/lvscare/pkg/utils/netlink.go
@@ -1,0 +1,59 @@
+// Copyright © 2022 sealos.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"strings"
+
+	"github.com/vishvananda/netlink"
+)
+
+// GetOrCreateDummyLink get link by name or create dummy link if not exists
+func GetOrCreateDummyLink(name string) (netlink.Link, error) {
+	link, _ := netlink.LinkByName(name)
+	if link != nil {
+		return link, nil
+	}
+	link = &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: name,
+		},
+	}
+	return link, netlink.LinkAdd(link)
+}
+
+// AssignIPToLink bind IP to link
+func AssignIPToLink(s string, link netlink.Link) error {
+	if !strings.Contains(s, "/") {
+		s = s + "/32"
+	}
+	addr, err := netlink.ParseAddr(s)
+	if err != nil {
+		return err
+	}
+	return netlink.AddrAdd(link, addr)
+}
+
+// DeleteLinkByName delete link if exists
+func DeleteLinkByName(name string) error {
+	l, err := netlink.LinkByName(name)
+	if err != nil {
+		if err, ok := err.(netlink.LinkNotFoundError); !ok {
+			return err
+		}
+		return nil
+	}
+	return netlink.LinkDel(l)
+}


### PR DESCRIPTION
automatic create a dummy network interface and bind virtual IP to it when any of real server is listening locally(by automatic dectection), setting this parameter to null will skip this behaviour.

Signed-off-by: fengxsong <fengxsong@outlook.com>


