### PR TITLE
fix(auth): retain mysql pv when delete pvc

### DIFF
--- a/service/auth/deploy/manifests/casdoor.yaml
+++ b/service/auth/deploy/manifests/casdoor.yaml
@@ -1,0 +1,208 @@
+# Copyright © 2022 sealos.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sealos
+  annotations:
+  labels:
+    name: sealos
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-root-credentials
+  namespace: sealos
+type: Opaque
+data:
+  # base64 encoded string
+  password: MTIzNDU2Cg==
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: casdoor-config
+  namespace: sealos
+data:
+  app.conf: |-
+    appname = casdoor
+    httpport = 8000
+    runmode = dev
+    SessionOn = true
+    copyrequestbody = true
+    driverName = mysql
+    dataSourceName = ${DATA_SOURCE_NAME}
+    dbName = casdoor
+    tableNamePrefix =
+    showSql = false
+    redisEndpoint =
+    defaultStorageProvider =
+    isCloudIntranet = false
+    authState = "casdoor"
+    socks5Proxy = "127.0.0.1:10808"
+    verificationCodeTimeout = 10
+    initScore = 2000
+    logPostOnly = true
+    origin =
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: casdoor-svc
+  namespace: sealos
+  labels:
+    app: casdoor
+spec:
+  ports:
+    - protocol: TCP
+      port: 8000
+  selector:
+    app: casdoor
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: casdoor
+  namespace: sealos
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: casdoor
+  template:
+    metadata:
+      labels:
+        app: casdoor
+    spec:
+      containers:
+        - name: casdoor-server
+          image: casbin/casdoor:latest
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh"]
+          args: ["-c", "./server --createDatabase=true"]
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+          volumeMounts:
+            - name: casdoor-conf-volume
+              mountPath: /conf/app.conf
+              subPath: app.conf
+          env:
+            - name: RUNNING_IN_DOCKER
+              value: "true"
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-root-credentials
+                  key: password
+            - name: DATA_SOURCE_NAME
+              value: root:$(MYSQL_ROOT_PASSWORD)@tcp(mysql.sealos.svc.cluster.local:3306)/
+      volumes:
+        - name: casdoor-conf-volume
+          configMap:
+            name: casdoor-config
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  namespace: sealos
+spec:
+  ports:
+    - port: 3306
+  selector:
+    app: mysql
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+  namespace: sealos
+spec:
+  selector:
+    matchLabels:
+      app: mysql
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+        - image: mysql:8.0.25
+          name: mysql
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-root-credentials
+                  key: password
+          ports:
+            - containerPort: 3306
+              name: mysql
+          volumeMounts:
+            - name: mysql-persistent-storage
+              mountPath: /var/lib/mysql
+      volumes:
+        - name: mysql-persistent-storage
+          persistentVolumeClaim:
+            claimName: mysql-pv-claim
+
+---
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: service-auth-storage-class
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+    openebs.io/cas-type: local
+    cas.openebs.io/config: |
+      - name: StorageType
+        value: hostpath
+      - name: BasePath
+        value: /service-auth
+provisioner: openebs.io/local
+reclaimPolicy: Retain
+volumeBindingMode: WaitForFirstConsumer
+
+---
+
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: mysql-pv-claim
+  namespace: sealos
+  annotations:
+    volume.beta.kubernetes.io/storage-class: service-auth-storage-class
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5G


### PR DESCRIPTION
Signed-off-by: abingcbc <abingcbc626@gmail.com>

The default reclaim policy of storage class created by Openebs is `Delete`. 
https://github.com/labring/cluster-image/blob/46dfc576d274e7422e35852a1938c8a13f8a44cb/applications/openebs/v1.9.0/manifests/host-path-sc.yaml#L14

So I add a new storage class for MySQL whose reclaim policy is `Retain` to protect users' data.