### PR TITLE
fix(auth): connect to casdoor

### DIFF
--- a/pkg/auth/sso/client.go
+++ b/pkg/auth/sso/client.go
@@ -28,7 +28,7 @@ type User struct {
 
 type Client interface {
 	GetRedirectURL() (string, error)
-	GetUserInfo(state string, code string) (User, error)
+	GetUserInfo(state, code string) (User, error)
 }
 
 type ClientType string

--- a/pkg/auth/utils/config.go
+++ b/pkg/auth/utils/config.go
@@ -43,7 +43,7 @@ func RandomHexStr(n int) (string, error) {
 	return hex.EncodeToString(b), nil
 }
 
-func CreateJWTPublicAndPrivateKey() (string, string, error) {
+func CreateJWTCertificateAndPrivateKey() (string, string, error) {
 	// Generate RSA key.
 	key, err := rsa.GenerateKey(rand.Reader, 4096)
 	if err != nil {


### PR DESCRIPTION
Fix:
1. Each time restarting service-auth, load the existing Casdoor init data instead of creating a new one.
2. Redirect URL to Casdoor (ssoEndpoint in config.yaml)
3. Wrap all errors with `errors.Wrap`
4. Parsing OAuth token error. 
    The root cause is that Casdoor raised a breaking change. In PR https://github.com/casdoor/casdoor/pull/894, `PublicKey` is renamed to `Certificate`. Therefore, the jwt publickey we created is ignored by Casdoor.