### PR TITLE
fix(auth): get ca cert from kubeconfig

### DIFF
--- a/pkg/auth/conf/config.go
+++ b/pkg/auth/conf/config.go
@@ -24,7 +24,6 @@ type Config struct {
 	// Empty if in InCluster mode
 	Kubeconfig  string `yaml:"kubeconfig"`
 	SSOEndpoint string `yaml:"ssoEndpoint"`
-	CaCert      string `yaml:"caCert"`
 }
 
 type Provider struct {

--- a/pkg/auth/utils/config.go
+++ b/pkg/auth/utils/config.go
@@ -23,7 +23,6 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"time"
 
@@ -115,7 +114,6 @@ func GenerateKubeConfig(username string) (string, error) {
 	}
 
 	ctx := fmt.Sprintf("%s@%s", username, "kubernetes")
-	cert, err := GetCaCert()
 	if err != nil {
 		return "", err
 	}
@@ -123,7 +121,7 @@ func GenerateKubeConfig(username string) (string, error) {
 		Clusters: map[string]*api.Cluster{
 			"kubernetes": {
 				Server:                   "https://apiserver.cluster.local:6443",
-				CertificateAuthorityData: []byte(cert),
+				CertificateAuthorityData: client.Config().TLSClientConfig.CAData,
 			},
 		},
 		Contexts: map[string]*api.Context{
@@ -146,18 +144,4 @@ func GenerateKubeConfig(username string) (string, error) {
 	}
 
 	return string(content), nil
-}
-
-func GetCaCert() (string, error) {
-	if conf.GlobalConfig.Kubeconfig == "" {
-		caCert, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
-		if err != nil {
-			return "", err
-		}
-		return string(caCert), nil
-	}
-	if conf.GlobalConfig.CaCert == "" {
-		return "", fmt.Errorf("ca cert is empty")
-	}
-	return conf.GlobalConfig.CaCert, nil
 }

--- a/service/auth/deploy/manifests/auth.yaml
+++ b/service/auth/deploy/manifests/auth.yaml
@@ -68,7 +68,6 @@ data:
         clientSecret: ""
     kubeconfig: ""
     ssoEndpoint: "cloud.sealos.io/casdoor"
-    caCert: ""
 
 ---
 


### PR DESCRIPTION
Get CA Cert from kubeconfig instead of :
1. From `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` for in cluster mode
2. From config.CaCert for out of cluster mode