### PR TITLE
feat(auth): deploy for service auth

### DIFF
--- a/cloud/deploy/manifests/ingress-nginx-with-cert.yaml
+++ b/cloud/deploy/manifests/ingress-nginx-with-cert.yaml
@@ -64,14 +64,42 @@ spec:
             name: service-auth
             port:
               number: 8080
-      - pathType: Prefix
-        path: /casdoor/
-        backend:
-          service:
-            name: casdoor
-            port:
-              number: 8000
   tls: # < placing a host in the TLS config will determine what ends up in the cert's subjectAltNames
   - hosts:
     - cloud.sealos.io
     secretName: cloud-sealos-io-cert # < cert-manager will store the created certificate in this secret.
+
+---
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    # add an annotation indicating the issuer to use.
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/common-name: login.cloud.sealos.io
+    cert-manager.io/duration: "2160h"
+    cert-manager.io/renew-before: "360h"
+    kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+  name: nginx-casdoor
+  namespace: sealos
+spec:
+  rules:
+    - host: login.cloud.sealos.io
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: casdoor
+                port:
+                  number: 8000
+  tls: # < placing a host in the TLS config will determine what ends up in the cert's subjectAltNames
+    - hosts:
+        - login.cloud.sealos.io
+      secretName: login-cloud-sealos-io-cert # < cert-manager will store the created certificate in this secret.

--- a/pkg/auth/conf/casdoor.yaml
+++ b/pkg/auth/conf/casdoor.yaml
@@ -56,7 +56,7 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: casdoor-svc
+  name: casdoor
   namespace: sealos
   labels:
     app: casdoor

--- a/service/auth/Dockerfile
+++ b/service/auth/Dockerfile
@@ -16,7 +16,12 @@
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 
 # FROM gcr.io/distroless/static:nonroot
-FROM scratch
+FROM alpine:latest
+
+RUN sed -i 's/https/http/' /etc/apk/repositories
+RUN apk add curl
+RUN apk add ca-certificates && update-ca-certificates
+
 WORKDIR /
 COPY /service-auth .
 USER 65532:65532


### PR DESCRIPTION
1. Ingress for Casdoor
2. Fix HTTPS certificate of Golang OAuth client in the docker image. A same problem: https://github.com/casdoor/casdoor/pull/491

FYI: Image size becomes 32MB to 44MB after using `alphine` as the base image instead of `scratch`.