### PR TITLE
fix: chart deps rendering

### DIFF
--- a/pkg/buildimage/chart.go
+++ b/pkg/buildimage/chart.go
@@ -88,6 +88,9 @@ func (c Chart) getRenderContent() (map[string]string, error) {
 			return nil, err
 		}
 	}
+	if err := chartutil.ProcessDependencies(ccc, values); err != nil {
+		return nil, err
+	}
 
 	options := chartutil.ReleaseOptions{
 		Name: "dryrun",


### PR DESCRIPTION
Signed-off-by: fengxsong <fengxsong@outlook.com>

fix chart‘s dependencies rendering are not affected by `dependencies[].condition` and `dependencies[].alias`