### PR TITLE
fix: unexpected config merge

### DIFF
--- a/pkg/apply/processor/create.go
+++ b/pkg/apply/processor/create.go
@@ -145,7 +145,7 @@ func (c *CreateProcessor) RunConfig(cluster *v2.Cluster) error {
 	for _, cManifest := range cluster.Status.Mounts {
 		manifest := cManifest
 		eg.Go(func() error {
-			cfg := config.NewConfiguration(manifest.MountPoint, c.ClusterFile.GetConfigs())
+			cfg := config.NewConfiguration(manifest.ImageName, manifest.MountPoint, c.ClusterFile.GetConfigs())
 			return cfg.Dump()
 		})
 	}

--- a/pkg/apply/processor/install.go
+++ b/pkg/apply/processor/install.go
@@ -166,7 +166,7 @@ func (c *InstallProcessor) RunConfig(cluster *v2.Cluster) error {
 	for _, cManifest := range c.NewMounts {
 		manifest := cManifest
 		eg.Go(func() error {
-			cfg := config.NewConfiguration(manifest.MountPoint, c.ClusterFile.GetConfigs())
+			cfg := config.NewConfiguration(manifest.ImageName, manifest.MountPoint, c.ClusterFile.GetConfigs())
 			return cfg.Dump()
 		})
 	}

--- a/pkg/apply/processor/scale.go
+++ b/pkg/apply/processor/scale.go
@@ -201,7 +201,7 @@ func (c *ScaleProcessor) RunConfig(cluster *v2.Cluster) error {
 	for _, cManifest := range cluster.Status.Mounts {
 		manifest := cManifest
 		eg.Go(func() error {
-			cfg := config.NewConfiguration(manifest.MountPoint, c.ClusterFile.GetConfigs())
+			cfg := config.NewConfiguration(manifest.ImageName, manifest.MountPoint, c.ClusterFile.GetConfigs())
 			return cfg.Dump()
 		})
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,15 +52,18 @@ type Interface interface {
 
 type Dumper struct {
 	Configs  []v1beta1.Config
+	name     string
 	RootPath string
 }
 
-func NewConfiguration(rootPath string, configs []v1beta1.Config) Interface {
+func NewConfiguration(name, rootPath string, configs []v1beta1.Config) Interface {
 	return &Dumper{
 		RootPath: rootPath,
+		name:     name,
 		Configs:  configs,
 	}
 }
+
 func NewDefaultConfiguration(clusterName string) Interface {
 	return &Dumper{
 		RootPath: constants.NewData(clusterName).RootFSPath(),
@@ -72,13 +75,6 @@ func (c *Dumper) Dump() error {
 		logger.Debug("clusterfile config is empty!")
 		return nil
 	}
-	//if len(c.Configs) == 0 {
-	//	configs, err := decode.Configs(clusterfile)
-	//	if err != nil {
-	//		return fmt.Errorf("failed to dump config %v", err)
-	//	}
-	//	c.Configs = configs
-	//}
 
 	if err := c.WriteFiles(); err != nil {
 		return fmt.Errorf("failed to write config files %v", err)
@@ -87,11 +83,10 @@ func (c *Dumper) Dump() error {
 }
 
 func (c *Dumper) WriteFiles() (err error) {
-	if c.Configs == nil {
-		logger.Debug("empty config found")
-		return nil
-	}
 	for _, config := range c.Configs {
+		if config.Spec.Match != "" && config.Spec.Match != c.name {
+			continue
+		}
 		configData := []byte(config.Spec.Data)
 		configPath := filepath.Join(c.RootPath, config.Spec.Path)
 		//only the YAML format is supported
@@ -129,7 +124,7 @@ func (c *Dumper) WriteFiles() (err error) {
 func getAppendOrInsertConfigData(path string, data []byte, insert bool) ([]byte, error) {
 	var configs [][]byte
 	context, err := os.ReadFile(filepath.Clean(path))
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
 	if insert {
@@ -146,7 +141,7 @@ func getAppendOrInsertConfigData(path string, data []byte, insert bool) ([]byte,
 func getMergeConfigData(path string, data []byte) ([]byte, error) {
 	var configs [][]byte
 	context, err := os.ReadFile(filepath.Clean(path))
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
 	mergeConfigMap := make(map[string]interface{})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -155,6 +155,7 @@ func getMergeConfigData(path string, data []byte) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to unmarshal config: %v", err)
 		}
+		// todo: should we allow merge into a non-exists file?
 		if len(configMap) == 0 {
 			continue
 		}

--- a/pkg/config/test_clusterfile.yaml
+++ b/pkg/config/test_clusterfile.yaml
@@ -17,7 +17,8 @@ kind: Cluster
 metadata:
   name: my-cluster
 spec:
-  image: registry.cn-qingdao.aliyuncs.com/sealer-app/my-SAAS-all-inone:latest
+  image:
+    - registry.cn-qingdao.aliyuncs.com/sealer-app/my-SAAS-all-inone:latest
   provider: BAREMETAL
 ---
 apiVersion: apps.sealos.io/v1beta1
@@ -27,7 +28,7 @@ metadata:
 spec:
   path: etc/mysql.yaml
   data: |
-     test
+    test
 ---
 apiVersion: apps.sealos.io/v1beta1
 kind: Config

--- a/pkg/types/v1beta1/config.go
+++ b/pkg/types/v1beta1/config.go
@@ -73,6 +73,7 @@ const (
 
 // ConfigSpec defines the desired state of Config
 type ConfigSpec struct {
+	Match    string       `json:"match,omitempty"`
 	Strategy StrategyType `json:"strategy,omitempty"`
 	Data     string       `json:"data,omitempty"`
 	Path     string       `json:"path,omitempty"`


### PR DESCRIPTION
Signed-off-by: fengxsong <fengxsong@outlook.com>

Merge config into file in specified application image. defaults is overwriting all configs into all images(works but not necessary), when `Config.spec.strategy` is `merge`, modified files will be overwritten with null values again in later for-loop processing.