### PR TITLE
fix: use bufio.reader to avoid token too long error

### DIFF
--- a/pkg/buildimage/chart.go
+++ b/pkg/buildimage/chart.go
@@ -49,7 +49,10 @@ func ParseChartImages(chartPath string) ([]string, error) {
 		c := Chart{
 			Path: chartPath + "/" + subChartPath,
 		}
-		images, _ := c.GetImages()
+		images, err := c.GetImages()
+		if err != nil {
+			return nil, err
+		}
 		if len(images) > 0 {
 			allImages = allImages.Insert(images...)
 		}


### PR DESCRIPTION
Signed-off-by: fengxsong <fengxsong@outlook.com>

bufio.Scanner will return error when length of line is far more large than MaxScanTokenSize, use bufio.Reader instead.