### PR TITLE
fix: release binary segfault on centos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,9 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          sudo apt install -y gcc-aarch64-linux-gnu upx \
+          sudo apt install -y gcc-aarch64-linux-gnu \
             libbtrfs-dev libgpgme-dev libdevmapper-dev
+          make tools.install.upx
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,7 +24,7 @@ builds:
     main: ./cmd/sealos
     binary: sealos
     hooks:
-      post: upx "{{ .Path }}"
+      post: ./tools/upx "{{ .Path }}"
     goos:
       - linux
     goarch:
@@ -59,7 +59,7 @@ builds:
       - CGO_ENABLED=0
     main: ./cmd/sealctl
     hooks:
-      post: upx "{{ .Path }}"
+      post: ./tools/upx "{{ .Path }}"
     binary: sealctl
     goos:
       - linux
@@ -79,7 +79,7 @@ builds:
       - CGO_ENABLED=0
     main: ./cmd/lvscare
     hooks:
-      post: upx "{{ .Path }}"
+      post: ./tools/upx "{{ .Path }}"
     binary: lvscare
     goos:
       - linux
@@ -99,7 +99,7 @@ builds:
       - CGO_ENABLED=0
     main: ./cmd/image-cri-shim
     hooks:
-      post: upx "{{ .Path }}"
+      post: ./tools/upx "{{ .Path }}"
     binary: image-cri-shim
     goos:
       - linux


### PR DESCRIPTION
Signed-off-by: Mercurio <signormercurio@gmail.com>

Use `make tools.install.upx` to install upx for the release workflow.