### PR TITLE
feat: deploy terminal in terminal-app ns

### DIFF
--- a/controllers/terminal/api/v1/terminal_types.go
+++ b/controllers/terminal/api/v1/terminal_types.go
@@ -40,6 +40,8 @@ type TerminalSpec struct {
 	Keepalived string `json:"keepalived"`
 	//+kubebuilder:validation:Optional
 	APIServer string `json:"apiServer"`
+	//+kubebuilder:validation:Optional
+	Namespace string `json:"namespace"`
 }
 
 // TerminalStatus defines the observed state of Terminal

--- a/controllers/terminal/config/crd/bases/terminal.sealos.io_terminals.yaml
+++ b/controllers/terminal/config/crd/bases/terminal.sealos.io_terminals.yaml
@@ -60,6 +60,8 @@ spec:
                 type: string
               keepalived:
                 type: string
+              namespace:
+                type: string
               replicas:
                 format: int32
                 type: integer

--- a/controllers/terminal/config/rbac/role.yaml
+++ b/controllers/terminal/config/rbac/role.yaml
@@ -54,6 +54,30 @@ rules:
   - update
   - watch
 - apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - terminal.sealos.io
   resources:
   - terminals

--- a/controllers/terminal/controllers/ingress.go
+++ b/controllers/terminal/controllers/ingress.go
@@ -33,8 +33,10 @@ func createIngress(terminal *terminalv1.Terminal, host string) *networkingv1.Ing
 		Name:      terminal.Name,
 		Namespace: terminal.Namespace,
 		Annotations: map[string]string{
-			"kubernetes.io/ingress.class":                "nginx",
-			"nginx.ingress.kubernetes.io/rewrite-target": "/",
+			"kubernetes.io/ingress.class":                    "nginx",
+			"nginx.ingress.kubernetes.io/rewrite-target":     "/",
+			"nginx.ingress.kubernetes.io/proxy-send-timeout": "86400",
+			"nginx.ingress.kubernetes.io/proxy-read-timeout": "86400",
 		},
 		Labels: map[string]string{
 			"k8s-app": "terminal",

--- a/controllers/terminal/controllers/terminal_controller.go
+++ b/controllers/terminal/controllers/terminal_controller.go
@@ -195,9 +195,9 @@ func (r *TerminalReconciler) syncRoleBinding(ctx context.Context, terminal *term
 		}
 		roleBinding.Subjects = []rbacv1.Subject{
 			{
-				Kind:     "User",
-				Name:     terminal.Spec.User,
-				APIGroup: "rbac.authorization.k8s.io",
+				Kind:      "ServiceAccount",
+				Name:      terminal.Spec.User,
+				Namespace: "user-system",
 			},
 		}
 
@@ -324,7 +324,7 @@ func (r *TerminalReconciler) syncDeployment(ctx context.Context, terminal *termi
 	envs = []corev1.EnvVar{
 		{Name: "APISERVER", Value: terminal.Spec.APIServer},
 		{Name: "USER_TOKEN", Value: terminal.Spec.Token},
-		{Name: "NAMESPACE", Value: terminal.Namespace},
+		{Name: "NAMESPACE", Value: terminal.Spec.Namespace},
 		{Name: "USER_NAME", Value: terminal.Spec.User},
 	}
 
@@ -388,6 +388,11 @@ func (r *TerminalReconciler) fillDefaultValue(ctx context.Context, terminal *ter
 	hasUpdate := false
 	if terminal.Spec.APIServer == "" {
 		terminal.Spec.APIServer = r.Config.Host
+		hasUpdate = true
+	}
+
+	if terminal.Spec.Namespace == "" {
+		terminal.Spec.Namespace = terminal.Namespace
 		hasUpdate = true
 	}
 

--- a/controllers/terminal/deploy/Dockerfile
+++ b/controllers/terminal/deploy/Dockerfile
@@ -1,3 +1,3 @@
 FROM scratch
 COPY manifests ./terminal-controller
-CMD ["kubectl apply -f terminal-controller/clusterissuer.yaml", "kubectl apply -f terminal-controller/deploy.yaml"]
+CMD ["kubectl apply -f terminal-controller/deploy.yaml"]

--- a/controllers/terminal/deploy/manifests/deploy.yaml
+++ b/controllers/terminal/deploy/manifests/deploy.yaml
@@ -195,6 +195,30 @@ rules:
   - update
   - watch
 - apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - terminal.sealos.io
   resources:
   - terminals

--- a/controllers/terminal/deploy/manifests/deploy.yaml
+++ b/controllers/terminal/deploy/manifests/deploy.yaml
@@ -62,6 +62,8 @@ spec:
                 type: string
               keepalived:
                 type: string
+              namespace:
+                type: string
               replicas:
                 format: int32
                 type: integer


### PR DESCRIPTION
Signed-off-by: gitccl <chenchuanle6@gmail.com>
In order to make the ingress work normally, deploy the terminal in terminal-app namespace. And granting the read permissions of terminal-app namespace to the user. Thus the front can apply the yaml in user's namespace, and get terminal domain in terminal-app namespace.
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note
-->