### PR TITLE
fix: copy binary with execute permission

### DIFF
--- a/docker/sealos/Dockerfile
+++ b/docker/sealos/Dockerfile
@@ -6,6 +6,7 @@ ENTRYPOINT ["/usr/bin/sealos"]
 
 WORKDIR /usr/bin/
 
-RUN --mount=target=/build tar xf /build/dist/sealos_*_$(echo ${TARGETPLATFORM} | tr '/' '_' | sed -e 's/arm_/arm/').tar.gz sealos
+RUN --mount=target=/build tar xf /build/dist/sealos_*_$(echo ${TARGETPLATFORM} | tr '/' '_' | sed -e 's/arm_/arm/').tar.gz sealos && \
+    chmod +x sealos
 
 CMD ["--help"]

--- a/docker/sealos/Dockerfile.main
+++ b/docker/sealos/Dockerfile.main
@@ -6,4 +6,4 @@ ENTRYPOINT ["/usr/bin/sealos"]
 
 WORKDIR /usr/bin/
 
-COPY /bin/sealos-$TARGETARCH/sealos .
+COPY --chmod=0755 /bin/sealos-$TARGETARCH/sealos .


### PR DESCRIPTION
Signed-off-by: fengxsong <fengxsong@outlook.com>

When trying to run `sealos` tasks with the dev container, error `bash: /usr/local/sealos: Permission denied` occured. this PR sets default permission of the binary to `755`