### PR TITLE
feat: support pulling in sealos save and loading in sealos run

### DIFF
--- a/pkg/image/binary/image.go
+++ b/pkg/image/binary/image.go
@@ -56,11 +56,18 @@ func (d *ImageService) Save(imageName, archiveName string) error {
 	return exec.Cmd("bash", "-c", fmt.Sprintf("buildah push %s %s:%s:%s", imageName, types.DefaultTransport, archiveName, imageName))
 }
 
-func (d *ImageService) Load(archiveName string) error {
+func (d *ImageService) Load(archiveName string) (string, error) {
 	if !fileutil.IsExist(archiveName) {
-		return errors.New("archive file is not exist")
+		return "", errors.New("archive file is not exist")
 	}
-	return exec.Cmd("bash", "-c", fmt.Sprintf("buildah pull %s:%s", types.DefaultTransport, archiveName))
+	output, err := exec.Output("bash", "-c", fmt.Sprintf("buildah pull %s:%s", types.DefaultTransport, archiveName))
+	if err != nil {
+		return "", err
+	}
+	l := len(output)
+	id := string(output[l-65 : l-1])
+	logger.Info("load image %s", id)
+	return id, nil
 }
 
 func (d *ImageService) Remove(force bool, images ...string) error {

--- a/pkg/image/buildah/registry/pull.go
+++ b/pkg/image/buildah/registry/pull.go
@@ -93,7 +93,7 @@ func (*Service) Pull(platform v1.Platform, images ...string) error {
 	systemContext.OSChoice = platform.OS
 	systemContext.ArchitectureChoice = platform.Architecture
 	systemContext.VariantChoice = platform.Variant
-	logger.Info("pull images %v for platform is %s", images, fmt.Sprintf("%s/%s", systemContext.OSChoice, systemContext.ArchitectureChoice))
+	logger.Info("pulling images %v for platform %s", images, fmt.Sprintf("%s/%s", systemContext.OSChoice, systemContext.ArchitectureChoice))
 	opts := buildah.PullOptions{
 		SignaturePolicyPath: opt.signaturePolicy,
 		Store:               store,

--- a/pkg/image/cmd/load.go
+++ b/pkg/image/cmd/load.go
@@ -33,11 +33,12 @@ func NewLoadCmd() *cobra.Command {
 		Example: `sealos load -i kubernetes.tar`,
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			registrySvc, err := image.NewImageService()
+			imageSvc, err := image.NewImageService()
 			if err != nil {
 				return err
 			}
-			return registrySvc.Load(archiveName)
+			_, err = imageSvc.Load(archiveName)
+			return err
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if !strings.In(types.DefaultTransport, []string{types.OCIArchive, types.DockerArchive}) {

--- a/pkg/image/types/interface.go
+++ b/pkg/image/types/interface.go
@@ -26,7 +26,7 @@ type RegistryService interface {
 type ImageService interface {
 	Tag(src, dst string) error
 	Save(imageName, archiveName string) error
-	Load(archiveName string) error
+	Load(archiveName string) (string, error)
 	Remove(force bool, images ...string) error
 	Inspect(images ...string) (ImageListOCIV1, error) //oci image
 	Build(options *BuildOptions, contextDir, imageName string) error


### PR DESCRIPTION
Fix #1770 

Now `sealos save` supports pulling image if there's no image locally, and `sealos run` supports loading image from archive if the command line argument ends with `.tar` or `.gz`.

## Expected behavior after this PR

### Save images online

```shell
$ sealos save -o kubernetes-v1.24.0.tar.gz labring/kubernetes:v1.24.0
```

There's no need to `sealos pull` in advance.

### Run cluster offline

```shell
$ sealos run kubernetes-v1.24.0.tar.gz --single
```

There's no need to `sealos load` in advance.