### PR TITLE
feature(main): separate registry from master0

### DIFF
--- a/cmd/sealos/cmd/run.go
+++ b/cmd/sealos/cmd/run.go
@@ -45,7 +45,7 @@ create cluster to your baremetal server, appoint the iplist:
 	sealos run labring/kubernetes:v1.24.0 --masters 192.168.0.2,192.168.0.3:23,192.168.0.4:24 \
 	--nodes 192.168.0.5:25,192.168.0.6:25,192.168.0.7:27 --registry 192.168.0.8:28 --passwd xxx
   
-  Use the first master node as the registry for the cluster (omit the --registry param)
+  Use the first master node as the registry for the cluster (omit the --registry option)
     sealos run labring/kubernetes:v1.24.0 --masters 192.168.0.2,192.168.0.3,192.168.0.4 \
 	--nodes 192.168.0.5,192.168.0.6,192.168.0.7 --passwd xxx
 

--- a/cmd/sealos/cmd/run.go
+++ b/cmd/sealos/cmd/run.go
@@ -33,20 +33,20 @@ import (
 var exampleRun = `
 create cluster to your baremetal server, appoint the iplist:
 	sealos run labring/kubernetes:v1.24.0 --masters 192.168.0.2,192.168.0.3,192.168.0.4 \
-		--nodes 192.168.0.5,192.168.0.6,192.168.0.7 --registry 192.168.0.8 --passwd xxx
+		--nodes 192.168.0.5,192.168.0.6,192.168.0.7 --passwd xxx
   multi image:
     sealos run labring/kubernetes:v1.24.0 calico:v3.24.1 \
-        --masters 192.168.64.2,192.168.64.22,192.168.64.20 --nodes 192.168.64.21,192.168.64.19 --registry 192.168.64.18
+        --masters 192.168.64.2,192.168.64.22,192.168.64.20 --nodes 192.168.64.21,192.168.64.19 192.168.64.18
   Specify server InfraSSH port :
   All servers use the same InfraSSH port (default port: 22)：
 	sealos run labring/kubernetes:v1.24.0 --masters 192.168.0.2,192.168.0.3,192.168.0.4 \
-	--nodes 192.168.0.5,192.168.0.6,192.168.0.7 --registry 192.168.0.8 --port 24 --passwd xxx
+	--nodes 192.168.0.5,192.168.0.6,192.168.0.7 --port 24 --passwd xxx
   Different InfraSSH port numbers exist：
 	sealos run labring/kubernetes:v1.24.0 --masters 192.168.0.2,192.168.0.3:23,192.168.0.4:24 \
-	--nodes 192.168.0.5:25,192.168.0.6:25,192.168.0.7:27 --registry 192.168.0.8:28 --passwd xxx
+	--nodes 192.168.0.5:25,192.168.0.6:25,192.168.0.7:27 --passwd xxx
   
-  Use the first master node as the registry for the cluster (omit the --registry option)
-    sealos run labring/kubernetes:v1.24.0 --masters 192.168.0.2,192.168.0.3,192.168.0.4 \
+  Use an independent node as the registry node of the cluster (other than the first master node)
+    sealos run -e REGISTRY_HOST=192.168.0.8 labring/kubernetes:v1.24.0 --masters 192.168.0.2,192.168.0.3,192.168.0.4 \
 	--nodes 192.168.0.5,192.168.0.6,192.168.0.7 --passwd xxx
 
   Single kubernetes cluster：
@@ -54,7 +54,7 @@ create cluster to your baremetal server, appoint the iplist:
 
 create a cluster with custom environment variables:
 	sealos run -e DashBoardPort=8443 mydashboard:latest  --masters 192.168.0.2,192.168.0.3,192.168.0.4 \
-	--nodes 192.168.0.5,192.168.0.6,192.168.0.7 --registry 192.168.0.7 --passwd xxx
+	--nodes 192.168.0.5,192.168.0.6,192.168.0.7 --passwd xxx
 `
 
 func newRunCmd() *cobra.Command {
@@ -66,7 +66,7 @@ func newRunCmd() *cobra.Command {
 	var runCmd = &cobra.Command{
 		Use:     "run",
 		Short:   "simplest way to run your kubernetes HA cluster",
-		Long:    `sealos run labring/kubernetes:v1.24.0 --masters [arg] --nodes [arg] --registry [arg]`,
+		Long:    `sealos run labring/kubernetes:v1.24.0 --masters [arg] --nodes [arg]`,
 		Example: exampleRun,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if runSingle {

--- a/cmd/sealos/cmd/run.go
+++ b/cmd/sealos/cmd/run.go
@@ -33,23 +33,28 @@ import (
 var exampleRun = `
 create cluster to your baremetal server, appoint the iplist:
 	sealos run labring/kubernetes:v1.24.0 --masters 192.168.0.2,192.168.0.3,192.168.0.4 \
-		--nodes 192.168.0.5,192.168.0.6,192.168.0.7 --passwd xxx
+		--nodes 192.168.0.5,192.168.0.6,192.168.0.7 --registry 192.168.0.8 --passwd xxx
   multi image:
     sealos run labring/kubernetes:v1.24.0 calico:v3.24.1 \
-        --masters 192.168.64.2,192.168.64.22,192.168.64.20 --nodes 192.168.64.21,192.168.64.19
+        --masters 192.168.64.2,192.168.64.22,192.168.64.20 --nodes 192.168.64.21,192.168.64.19 --registry 192.168.64.18
   Specify server InfraSSH port :
   All servers use the same InfraSSH port (default port: 22)：
 	sealos run labring/kubernetes:v1.24.0 --masters 192.168.0.2,192.168.0.3,192.168.0.4 \
-	--nodes 192.168.0.5,192.168.0.6,192.168.0.7 --port 24 --passwd xxx
+	--nodes 192.168.0.5,192.168.0.6,192.168.0.7 --registry 192.168.0.8 --port 24 --passwd xxx
   Different InfraSSH port numbers exist：
 	sealos run labring/kubernetes:v1.24.0 --masters 192.168.0.2,192.168.0.3:23,192.168.0.4:24 \
-	--nodes 192.168.0.5:25,192.168.0.6:25,192.168.0.7:27 --passwd xxx
+	--nodes 192.168.0.5:25,192.168.0.6:25,192.168.0.7:27 --registry 192.168.0.8:28 --passwd xxx
+  
+  Use the first master node as the registry for the cluster (omit the --registry param)
+    sealos run labring/kubernetes:v1.24.0 --masters 192.168.0.2,192.168.0.3,192.168.0.4 \
+	--nodes 192.168.0.5,192.168.0.6,192.168.0.7 --passwd xxx
+
   Single kubernetes cluster：
 	sealos run labring/kubernetes:v1.24.0 --single
 
 create a cluster with custom environment variables:
 	sealos run -e DashBoardPort=8443 mydashboard:latest  --masters 192.168.0.2,192.168.0.3,192.168.0.4 \
-	--nodes 192.168.0.5,192.168.0.6,192.168.0.7 --passwd xxx
+	--nodes 192.168.0.5,192.168.0.6,192.168.0.7 --registry 192.168.0.7 --passwd xxx
 `
 
 func newRunCmd() *cobra.Command {
@@ -61,7 +66,7 @@ func newRunCmd() *cobra.Command {
 	var runCmd = &cobra.Command{
 		Use:     "run",
 		Short:   "simplest way to run your kubernetes HA cluster",
-		Long:    `sealos run labring/kubernetes:v1.24.0 --masters [arg] --nodes [arg]`,
+		Long:    `sealos run labring/kubernetes:v1.24.0 --masters [arg] --nodes [arg] --registry [arg]`,
 		Example: exampleRun,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if runSingle {

--- a/pkg/apply/applydrivers/apply_drivers_default.go
+++ b/pkg/apply/applydrivers/apply_drivers_default.go
@@ -127,21 +127,21 @@ func (c *Applier) updateStatus(err error) {
 }
 
 func (c *Applier) reconcileCluster() error {
-	//sync newVersion pki and etc dir in `.sealos/default/pki` and `.sealos/default/etc`
+	// sync newVersion pki and etc dir in `.sealos/default/pki` and `.sealos/default/etc`
 	processor.SyncNewVersionConfig(c.ClusterDesired)
 	if err := c.installApp(c.RunNewImages); err != nil {
 		return err
 	}
 	mj, md := iputils.GetDiffHosts(c.ClusterCurrent.GetMasterIPAndPortList(), c.ClusterDesired.GetMasterIPAndPortList())
 	nj, nd := iputils.GetDiffHosts(c.ClusterCurrent.GetNodeIPAndPortList(), c.ClusterDesired.GetNodeIPAndPortList())
-	//if len(mj) == 0 && len(md) == 0 && len(nj) == 0 && len(nd) == 0 {
+	// if len(mj) == 0 && len(md) == 0 && len(nj) == 0 && len(nd) == 0 {
 	//	return c.upgrade()
-	//}
+	// }
 	return c.scaleCluster(mj, md, nj, nd)
 }
 
 func (c *Applier) initCluster() error {
-	logger.Info("Start to create a new cluster: master %s, worker %s", c.ClusterDesired.GetMasterIPList(), c.ClusterDesired.GetNodeIPList())
+	logger.Info("Start to create a new cluster: master %s, worker %s, registry %s", c.ClusterDesired.GetMasterIPList(), c.ClusterDesired.GetNodeIPList(), c.ClusterDesired.GetRegistryIP())
 	createProcessor, err := processor.NewCreateProcessor(c.ClusterFile)
 	if err != nil {
 		return err

--- a/pkg/apply/args.go
+++ b/pkg/apply/args.go
@@ -28,12 +28,14 @@ import (
 type Cluster struct {
 	Masters     string
 	Nodes       string
+	Registry    string
 	ClusterName string
 }
 
 func (c *Cluster) RegisterFlags(fs *pflag.FlagSet, verb, action string) {
 	fs.StringVar(&c.Masters, "masters", "", fmt.Sprintf("masters to %s", verb))
 	fs.StringVar(&c.Nodes, "nodes", "", fmt.Sprintf("nodes to %s", verb))
+	fs.StringVar(&c.Registry, "registry", "", fmt.Sprintf("registry to %s", verb))
 	fs.StringVar(&c.ClusterName, "cluster", "default", fmt.Sprintf("name of cluster to applied %s action", action))
 }
 

--- a/pkg/apply/processor/create.go
+++ b/pkg/apply/processor/create.go
@@ -63,17 +63,17 @@ func (c *CreateProcessor) Execute(cluster *v2.Cluster) error {
 func (c *CreateProcessor) GetPipeLine() ([]func(cluster *v2.Cluster) error, error) {
 	var todoList []func(cluster *v2.Cluster) error
 	todoList = append(todoList,
-		//c.GetPhasePluginFunc(plugin.PhaseOriginally),
+		// c.GetPhasePluginFunc(plugin.PhaseOriginally),
 		c.Check,
 		c.PreProcess,
 		c.RunConfig,
 		c.MountRootfs,
-		//c.GetPhasePluginFunc(plugin.PhasePreInit),
+		// c.GetPhasePluginFunc(plugin.PhasePreInit),
 		c.Init,
 		c.Join,
-		//c.GetPhasePluginFunc(plugin.PhasePreGuest),
+		// c.GetPhasePluginFunc(plugin.PhasePreGuest),
 		c.RunGuest,
-		//c.GetPhasePluginFunc(plugin.PhasePostInstall),
+		// c.GetPhasePluginFunc(plugin.PhasePostInstall),
 	)
 	return todoList, nil
 }
@@ -155,6 +155,7 @@ func (c *CreateProcessor) RunConfig(cluster *v2.Cluster) error {
 func (c *CreateProcessor) MountRootfs(cluster *v2.Cluster) error {
 	logger.Info("Executing pipeline MountRootfs in CreateProcessor.")
 	hosts := append(cluster.GetMasterIPAndPortList(), cluster.GetNodeIPAndPortList()...)
+	hosts = append(hosts, cluster.GetRegistryIPAndPort())
 	fs, err := filesystem.NewRootfsMounter(cluster.Status.Mounts)
 	if err != nil {
 		return err

--- a/pkg/apply/processor/delete.go
+++ b/pkg/apply/processor/delete.go
@@ -46,7 +46,7 @@ func (d DeleteProcessor) Execute(cluster *v2.Cluster) (err error) {
 	if err != nil {
 		return err
 	}
-	//TODO if error is exec net process ???
+	// TODO if error is exec net process ???
 	for _, f := range pipLine {
 		if err = f(cluster); err != nil {
 			logger.Warn("failed to exec delete process, %s", err.Error())
@@ -81,6 +81,7 @@ func (d *DeleteProcessor) Reset(cluster *v2.Cluster) error {
 
 func (d DeleteProcessor) UnMountRootfs(cluster *v2.Cluster) error {
 	hosts := append(cluster.GetMasterIPAndPortList(), cluster.GetNodeIPAndPortList()...)
+	hosts = append(hosts, cluster.GetRegistryIPAndPort())
 	if cluster.Status.Mounts == nil {
 		logger.Warn("delete process unmount rootfs skip is cluster not mount any rootfs")
 		return nil

--- a/pkg/apply/processor/install.go
+++ b/pkg/apply/processor/install.go
@@ -84,10 +84,10 @@ func (c *InstallProcessor) GetPipeLine() ([]func(cluster *v2.Cluster) error, err
 		c.PreProcess,
 		c.RunConfig,
 		c.MountRootfs,
-		//i.GetPhasePluginFunc(plugin.PhasePreGuest),
+		// i.GetPhasePluginFunc(plugin.PhasePreGuest),
 		c.RunGuest,
 		c.PostProcess,
-		//i.GetPhasePluginFunc(plugin.PhasePostInstall),
+		// i.GetPhasePluginFunc(plugin.PhasePostInstall),
 	)
 	return todoList, nil
 }
@@ -123,7 +123,7 @@ func (c *InstallProcessor) PreProcess(cluster *v2.Cluster) error {
 	for _, img := range c.NewImages {
 		mount := cluster.FindImage(img)
 		if mount == nil {
-			//create
+			// create
 			mount = &v2.MountImage{
 				Name:      fmt.Sprintf("%s-%s", cluster.Name, rand.Generator(8)),
 				ImageName: img,
@@ -178,6 +178,7 @@ func (c *InstallProcessor) MountRootfs(cluster *v2.Cluster) error {
 		return nil
 	}
 	hosts := append(cluster.GetMasterIPAndPortList(), cluster.GetNodeIPAndPortList()...)
+	hosts = append(hosts, cluster.GetRegistryIPAndPort())
 	fs, err := filesystem.NewRootfsMounter(c.NewMounts)
 	if err != nil {
 		return err

--- a/pkg/apply/run.go
+++ b/pkg/apply/run.go
@@ -175,8 +175,8 @@ func (r *ClusterArgs) SetClusterRunArgs(imageList []string, args *RunArgs) error
 		if len(registries) == 0 {
 			roles = []string{v2.MASTER, v2.REGISTRY, GetHostArch(sshClient, masters[0])}
 		} else {
-			roles = []string{v2.MASTER, string(v2.AMD64)}
-			r.setHostWithIpsPort(registries, []string{v2.REGISTRY, GetHostArch(sshClient, masters[0])})
+			roles = []string{v2.MASTER, GetHostArch(sshClient, masters[0])}
+			r.setHostWithIpsPort(registries, []string{v2.REGISTRY, GetHostArch(sshClient, registries[0])})
 		}
 		r.setHostWithIpsPort(masters, roles)
 		if len(nodes) > 0 {
@@ -232,7 +232,7 @@ func (r *ClusterArgs) SetClusterResetArgs(args *ResetArgs) error {
 			roles = []string{v2.MASTER, v2.REGISTRY, GetHostArch(sshClient, masters[0])}
 		} else {
 			roles = []string{v2.MASTER, GetHostArch(sshClient, masters[0])}
-			r.setHostWithIpsPort(registries, []string{v2.REGISTRY, GetHostArch(sshClient, masters[0])})
+			r.setHostWithIpsPort(registries, []string{v2.REGISTRY, GetHostArch(sshClient, registries[0])})
 		}
 		r.setHostWithIpsPort(masters, roles)
 		if len(nodes) > 0 {

--- a/pkg/apply/run.go
+++ b/pkg/apply/run.go
@@ -162,12 +162,23 @@ func (r *ClusterArgs) SetClusterRunArgs(imageList []string, args *RunArgs) error
 	if len(args.Cluster.Masters) > 0 {
 		masters := stringsutil.SplitRemoveEmpty(args.Cluster.Masters, ",")
 		nodes := stringsutil.SplitRemoveEmpty(args.Cluster.Nodes, ",")
+		registries := stringsutil.SplitRemoveEmpty(args.Cluster.Registry, ",")
+		if len(registries) > 1 {
+			return fmt.Errorf("registry of multi nodes is not supported yet")
+		}
 		r.hosts = []v2.Host{}
 
 		clusterSSH := r.cluster.GetSSH()
 		sshClient := ssh.NewSSHClient(&clusterSSH, true)
 
-		r.setHostWithIpsPort(masters, []string{v2.MASTER, GetHostArch(sshClient, masters[0])})
+		var roles []string
+		if len(registries) == 0 {
+			roles = []string{v2.MASTER, v2.REGISTRY, GetHostArch(sshClient, masters[0])}
+		} else {
+			roles = []string{v2.MASTER, string(v2.AMD64)}
+			r.setHostWithIpsPort(registries, []string{v2.REGISTRY, GetHostArch(sshClient, masters[0])})
+		}
+		r.setHostWithIpsPort(masters, roles)
 		if len(nodes) > 0 {
 			r.setHostWithIpsPort(nodes, []string{v2.NODE, GetHostArch(sshClient, nodes[0])})
 		}
@@ -207,12 +218,23 @@ func (r *ClusterArgs) SetClusterResetArgs(args *ResetArgs) error {
 	if len(args.Cluster.Masters) > 0 {
 		masters := stringsutil.SplitRemoveEmpty(args.Cluster.Masters, ",")
 		nodes := stringsutil.SplitRemoveEmpty(args.Cluster.Nodes, ",")
+		registries := stringsutil.SplitRemoveEmpty(args.Cluster.Registry, ",")
+		if len(registries) > 1 {
+			return fmt.Errorf("registry of multi nodes is not supported yet")
+		}
 		r.hosts = []v2.Host{}
 
 		clusterSSH := r.cluster.GetSSH()
 		sshClient := ssh.NewSSHClient(&clusterSSH, true)
 
-		r.setHostWithIpsPort(masters, []string{v2.MASTER, GetHostArch(sshClient, masters[0])})
+		var roles []string
+		if len(registries) == 0 {
+			roles = []string{v2.MASTER, v2.REGISTRY, GetHostArch(sshClient, masters[0])}
+		} else {
+			roles = []string{v2.MASTER, GetHostArch(sshClient, masters[0])}
+			r.setHostWithIpsPort(registries, []string{v2.REGISTRY, GetHostArch(sshClient, masters[0])})
+		}
+		r.setHostWithIpsPort(masters, roles)
 		if len(nodes) > 0 {
 			r.setHostWithIpsPort(nodes, []string{v2.NODE, GetHostArch(sshClient, nodes[0])})
 		}

--- a/pkg/constants/data.go
+++ b/pkg/constants/data.go
@@ -39,8 +39,6 @@ const (
 	PkiEtcdDirName                   = "etcd"
 	ScriptsDirName                   = "scripts"
 	StaticsDirName                   = "statics"
-	OptDirName                       = "opt"
-	CriDirName                       = "cri"
 )
 
 func LogPath() string {
@@ -57,15 +55,11 @@ type Data interface {
 	RootFSStaticsPath() string
 	RootFSScriptsPath() string
 	RootFSRegistryPath() string
-	RootFSCriPath() string
-	RootFSOptPath() string
-	RootFSImagesPath() string
 
 	PkiPath() string
 	PkiEtcdPath() string
 	AdminFile() string
 	EtcPath() string
-	ScriptsPath() string
 	TmpPath() string
 
 	RootFSCharsPath() string
@@ -91,19 +85,6 @@ func (d *data) RootFSEtcPath() string {
 func (d *data) RootFSRegistryPath() string {
 	return filepath.Join(d.RootFSPath(), RegistryDirName)
 }
-
-func (d *data) RootFSCriPath() string {
-	return filepath.Join(d.RootFSPath(), CriDirName)
-}
-
-func (d *data) RootFSOptPath() string {
-	return filepath.Join(d.RootFSPath(), OptDirName)
-}
-
-func (d *data) RootFSImagesPath() string {
-	return filepath.Join(d.RootFSPath(), ImagesDirName)
-}
-
 func (d *data) RootFSCharsPath() string {
 	return filepath.Join(d.RootFSPath(), ChartsDirName)
 }
@@ -115,11 +96,6 @@ func (d *data) RootFSManifestsPath() string {
 func (d *data) EtcPath() string {
 	return filepath.Join(ClusterDir(d.clusterName), EtcDirName)
 }
-
-func (d *data) ScriptsPath() string {
-	return filepath.Join(ClusterDir(d.clusterName), ScriptsDirName)
-}
-
 func (d *data) AdminFile() string {
 	return filepath.Join(d.EtcPath(), "admin.conf")
 }

--- a/pkg/constants/data.go
+++ b/pkg/constants/data.go
@@ -39,6 +39,8 @@ const (
 	PkiEtcdDirName                   = "etcd"
 	ScriptsDirName                   = "scripts"
 	StaticsDirName                   = "statics"
+	OptDirName                       = "opt"
+	CriDirName                       = "cri"
 )
 
 func LogPath() string {
@@ -55,11 +57,15 @@ type Data interface {
 	RootFSStaticsPath() string
 	RootFSScriptsPath() string
 	RootFSRegistryPath() string
+	RootFSCriPath() string
+	RootFSOptPath() string
+	RootFSImagesPath() string
 
 	PkiPath() string
 	PkiEtcdPath() string
 	AdminFile() string
 	EtcPath() string
+	ScriptsPath() string
 	TmpPath() string
 
 	RootFSCharsPath() string
@@ -86,6 +92,18 @@ func (d *data) RootFSRegistryPath() string {
 	return filepath.Join(d.RootFSPath(), RegistryDirName)
 }
 
+func (d *data) RootFSCriPath() string {
+	return filepath.Join(d.RootFSPath(), CriDirName)
+}
+
+func (d *data) RootFSOptPath() string {
+	return filepath.Join(d.RootFSPath(), OptDirName)
+}
+
+func (d *data) RootFSImagesPath() string {
+	return filepath.Join(d.RootFSPath(), ImagesDirName)
+}
+
 func (d *data) RootFSCharsPath() string {
 	return filepath.Join(d.RootFSPath(), ChartsDirName)
 }
@@ -97,6 +115,11 @@ func (d *data) RootFSManifestsPath() string {
 func (d *data) EtcPath() string {
 	return filepath.Join(ClusterDir(d.clusterName), EtcDirName)
 }
+
+func (d *data) ScriptsPath() string {
+	return filepath.Join(ClusterDir(d.clusterName), ScriptsDirName)
+}
+
 func (d *data) AdminFile() string {
 	return filepath.Join(d.EtcPath(), "admin.conf")
 }

--- a/pkg/filesystem/rootfs/rootfs_default.go
+++ b/pkg/filesystem/rootfs/rootfs_default.go
@@ -39,9 +39,9 @@ import (
 )
 
 type defaultRootfs struct {
-	//clusterService image.ClusterService
-	//imgList types.ImageListOCIV1
-	//cluster types.ClusterManifestList
+	// clusterService image.ClusterService
+	// imgList types.ImageListOCIV1
+	// cluster types.ClusterManifestList
 	images []v2.MountImage
 }
 
@@ -107,7 +107,7 @@ func (f *defaultRootfs) mountRootfs(cluster *v2.Cluster, ipList []string, initFl
 				fileEg.Go(func() error {
 					if img.Type == v2.RootfsImage {
 						logger.Debug("send rootfs images ,ip: %s , init flag: %v, app flag: %v,image name: %s, image type: %s", ip, initFlag, appFlag, img.ImageName, img.Type)
-						err := CopyFiles(sshClient, iputils.GetHostIP(ip) == cluster.GetMaster0IP(), false, ip, img.MountPoint, target)
+						err := CopyFiles(sshClient, iputils.GetHostIP(ip) == cluster.GetRegistryIP(), false, ip, img.MountPoint, target)
 						if err != nil {
 							return fmt.Errorf("copy container %s rootfs failed %v", img.Name, err)
 						}
@@ -121,7 +121,7 @@ func (f *defaultRootfs) mountRootfs(cluster *v2.Cluster, ipList []string, initFl
 			for _, cInfo := range f.images {
 				if cInfo.Type == v2.PatchImage {
 					logger.Debug("send addons images ,ip: %s , init flag: %v, app flag: %v,image name: %s, image type: %s", ip, initFlag, appFlag, cInfo.ImageName, cInfo.Type)
-					err := CopyFiles(sshClient, iputils.GetHostIP(ip) == cluster.GetMaster0IP(), false, ip, cInfo.MountPoint, target)
+					err := CopyFiles(sshClient, iputils.GetHostIP(ip) == cluster.GetRegistryIP(), false, ip, cInfo.MountPoint, target)
 					if err != nil {
 						return fmt.Errorf("copy container %s rootfs failed %v", cInfo.Name, err)
 					}
@@ -154,7 +154,7 @@ func (f *defaultRootfs) mountRootfs(cluster *v2.Cluster, ipList []string, initFl
 		endEg.Go(func() error {
 			if appFlag && img.Type == v2.AppImage {
 				logger.Debug("send  app images ,ip: %s , init flag: %v, app flag: %v,image name: %s, image type: %s", ip, initFlag, appFlag, img.ImageName, img.Type)
-				err = CopyFiles(sshClient, iputils.GetHostIP(ip) == cluster.GetMaster0IP(), true, ip, img.MountPoint, target)
+				err = CopyFiles(sshClient, iputils.GetHostIP(ip) == cluster.GetRegistryIP(), true, ip, img.MountPoint, target)
 				if err != nil {
 					return fmt.Errorf("copy container %s app rootfs failed %v", img.Name, err)
 				}

--- a/pkg/runtime/registry.go
+++ b/pkg/runtime/registry.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/labring/sealos/pkg/constants"
 	"github.com/labring/sealos/pkg/passwd"
+	"github.com/labring/sealos/pkg/ssh"
 	"github.com/labring/sealos/pkg/types/v1beta1"
 	"github.com/labring/sealos/pkg/utils/file"
 	"github.com/labring/sealos/pkg/utils/iputils"
@@ -30,7 +31,7 @@ import (
 	"github.com/labring/sealos/pkg/utils/yaml"
 )
 
-func (k *KubeadmRuntime) GetRegistryInfo(rootfs, defaultRegistry string) *v1beta1.RegistryConfig {
+func GetRegistryInfo(sshInterface ssh.Interface, rootfs, defaultRegistry string) *v1beta1.RegistryConfig {
 	const registryCustomConfig = "registry.yml"
 	var DefaultConfig = &v1beta1.RegistryConfig{
 		IP:       defaultRegistry,
@@ -41,7 +42,7 @@ func (k *KubeadmRuntime) GetRegistryInfo(rootfs, defaultRegistry string) *v1beta
 		Data:     constants.DefaultRegistryData,
 	}
 	etcPath := path.Join(rootfs, constants.EtcDirName, registryCustomConfig)
-	out, _ := k.getSSHInterface().Cmd(defaultRegistry, fmt.Sprintf("cat %s", etcPath))
+	out, _ := sshInterface.Cmd(defaultRegistry, fmt.Sprintf("cat %s", etcPath))
 	logger.Debug("image shim data info: %s", string(out))
 	registryConfig, err := yaml.UnmarshalData(out)
 	if err != nil {

--- a/pkg/runtime/runtime_getter.go
+++ b/pkg/runtime/runtime_getter.go
@@ -34,7 +34,7 @@ import (
 
 func (k *KubeadmRuntime) getRegistry() *v1beta1.RegistryConfig {
 	k.registryOnce.Do(func() {
-		k.Registry = k.GetRegistryInfo(k.getContentData().RootFSPath(), k.getMaster0IPAndPort())
+		k.Registry = k.GetRegistryInfo(k.getContentData().RootFSPath(), k.getRegistryIPAndPort())
 	})
 	return k.Registry
 }
@@ -82,6 +82,10 @@ func (k *KubeadmRuntime) getNodeIPAndPortList() []string {
 
 func (k *KubeadmRuntime) getMaster0IPAndPort() string {
 	return k.Cluster.GetMaster0IPAndPort()
+}
+
+func (k *KubeadmRuntime) getRegistryIPAndPort() string {
+	return k.Cluster.GetRegistryIPAndPort()
 }
 
 func (k *KubeadmRuntime) getMaster0IPAPIServer() string {
@@ -139,7 +143,7 @@ func (k *KubeadmRuntime) execToken(ip string) (string, error) {
 }
 func (k *KubeadmRuntime) execHostname(ip string) (string, error) {
 	hostname, err := k.getRemoteInterface().Hostname(ip)
-	//tips: if hostname is upper,kubelet init master0 is not allowed to modify node
+	// tips: if hostname is upper,kubelet init master0 is not allowed to modify node
 	return strings.ToLower(hostname), err
 }
 func (k *KubeadmRuntime) execHostsAppend(ip, host, domain string) error {

--- a/pkg/runtime/runtime_getter.go
+++ b/pkg/runtime/runtime_getter.go
@@ -34,7 +34,7 @@ import (
 
 func (k *KubeadmRuntime) getRegistry() *v1beta1.RegistryConfig {
 	k.registryOnce.Do(func() {
-		k.Registry = k.GetRegistryInfo(k.getContentData().RootFSPath(), k.getRegistryIPAndPort())
+		k.Registry = GetRegistryInfo(k.getSSHInterface(), k.getContentData().RootFSPath(), k.getRegistryIPAndPort())
 	})
 	return k.Registry
 }

--- a/pkg/types/v1beta1/cluster_args.go
+++ b/pkg/types/v1beta1/cluster_args.go
@@ -47,6 +47,10 @@ func (c *Cluster) GetNodeIPList() []string {
 	return iputils.GetHostIPs(c.GetIPSByRole(NODE))
 }
 
+func (c *Cluster) GetRegistryIP() string {
+	return iputils.GetHostIPs(c.GetIPSByRole(REGISTRY))[0]
+}
+
 func (c *Cluster) GetNodeIPAndPortList() []string {
 	return c.GetIPSByRole(NODE)
 }
@@ -69,6 +73,10 @@ func (c *Cluster) GetMaster0IPAndPort() string {
 		return ""
 	}
 	return c.Spec.Hosts[0].IPS[0]
+}
+
+func (c *Cluster) GetRegistryIPAndPort() string {
+	return c.GetIPSByRole(REGISTRY)[0]
 }
 
 func (c *Cluster) GetMaster0IPAPIServer() string {

--- a/pkg/types/v1beta1/constants.go
+++ b/pkg/types/v1beta1/constants.go
@@ -21,8 +21,9 @@ const (
 )
 
 var (
-	MASTER = "master"
-	NODE   = "node"
+	MASTER   = "master"
+	NODE     = "node"
+	REGISTRY = "registry"
 )
 
 type Provider string


### PR DESCRIPTION
Signed-off-by: xuehaipeng <hpxue13@hotmail.com>

issue link: [1285](https://github.com/labring/sealos/issues/1285)

separated the registry from the first master node if specified `--registry` in command line, eg:

`sealos run labring/kubernetes:v1.25.0 labring/helm:v3.8.2 labring/calico:v3.24.1 --masters 192.168.116.138 --nodes 192.168.116.139 --registry 192.168.116.135 `

if the `--registry` option is not specified, the first master node (master0) is used as the registry node, as before.
