### PR TITLE
ci: publish docker image for the release workflow with goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,13 @@ jobs:
           sudo cp tools/upx /usr/bin/
           sudo chmod a+x /usr/bin/upx
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GH_TOKEN }}
+          
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
@@ -55,52 +62,4 @@ jobs:
           USERNAME: ${{ github.repository_owner }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
-
-      - name: set up buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          version: latest
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GH_TOKEN }}
-
-      - name: Docker build and publish lvscare image
-        env:
-          # fork friendly ^^
-          DOCKER_REPO: ghcr.io/${{ github.repository_owner }}/lvscare
-        run: |
-          docker buildx build \
-          --platform linux/amd64,linux/arm64 \
-          --push \
-          -t ${DOCKER_REPO}:${{ steps.prepare.outputs.tag_name }} \
-          -f docker/lvscare/Dockerfile \
-          .
-          docker buildx build \
-          --platform linux/amd64,linux/arm64 \
-          --push \
-          -t ${DOCKER_REPO}:latest \
-          -f docker/lvscare/Dockerfile \
-          .
-
-      - name: Docker build and publish sealos image
-        env:
-          # fork friendly ^^
-          DOCKER_REPO: ghcr.io/${{ github.repository_owner }}/sealos
-        run: |
-          docker buildx build \
-          --platform linux/amd64,linux/arm64 \
-          --push \
-          -t ${DOCKER_REPO}:${{ steps.prepare.outputs.tag_name }} \
-          -f docker/sealos/Dockerfile \
-          .
-          docker buildx build \
-          --platform linux/amd64,linux/arm64 \
-          --push \
-          -t ${DOCKER_REPO}:latest \
-          -f docker/sealos/Dockerfile \
-          .
+          

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -140,6 +140,81 @@ release:
 #    name: sealos
   prerelease: auto
 
+dockers:
+  - use: buildx
+    ids:
+      - lvscare
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - ghcr.io/{{ .Env.USERNAME }}//lvscare:{{ .Tag }}-amd64
+    dockerfile: docker/lvscare/Dockerfile.release
+    build_flag_templates:
+      - --pull
+      - --platform=linux/amd64
+      - --label=io.sealos.image.created={{.Date}}
+      - --label=io.sealos.image.title=lvscare
+      - --label=io.sealos.image.revision={{.ShortCommit}}
+      - --label=io.sealos.image.version={{.Tag }}
+      - --label=io.sealos.image.auth={{ .Env.USERNAME }}
+  - use: buildx
+    ids:
+      - lvscare
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - ghcr.io/{{ .Env.USERNAME }}//lvscare:{{ .Tag }}-arm64
+    dockerfile: docker/lvscare/Dockerfile.release
+    build_flag_templates:
+      - --pull
+      - --platform=linux/arm64
+      - --label=io.sealos.image.created={{.Date}}
+      - --label=io.sealos.image.title=lvscare
+      - --label=io.sealos.image.revision={{.ShortCommit}}
+      - --label=io.sealos.image.version={{.Tag }}
+      - --label=io.sealos.image.auth={{ .Env.USERNAME }}
+  - use: buildx
+    ids:
+      - sealos
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - ghcr.io/{{ .Env.USERNAME }}/sealos:{{ .Tag }}-amd64
+    dockerfile: docker/sealos/Dockerfile.release
+    build_flag_templates:
+      - --pull
+      - --platform=linux/amd64
+      - --label=io.sealos.image.created={{.Date}}
+      - --label=io.sealos.image.title=sealos
+      - --label=io.sealos.image.revision={{.ShortCommit}}
+      - --label=io.sealos.image.version={{.Tag }}
+      - --label=io.sealos.image.auth={{ .Env.USERNAME }}
+  - use: buildx
+    ids:
+      - sealos
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - ghcr.io/{{ .Env.USERNAME }}/sealos:{{ .Tag }}-arm64
+    dockerfile: docker/sealos/Dockerfile.release
+    build_flag_templates:
+      - --pull
+      - --platform=linux/arm64
+      - --label=io.sealos.image.created={{.Date}}
+      - --label=io.sealos.image.title=sealos
+      - --label=io.sealos.image.revision={{.ShortCommit}}
+      - --label=io.sealos.image.version={{.Tag }}
+      - --label=io.sealos.image.auth={{ .Env.USERNAME }}
+docker_manifests:
+  - name_template: ghcr.io/{{ .Env.USERNAME }}/lvscare:{{ .Tag }}
+    image_templates:
+      - ghcr.io/{{ .Env.USERNAME }}/lvscare:{{ .Tag }}-amd64
+      - ghcr.io/{{ .Env.USERNAME }}/lvscare:{{ .Tag }}-arm64
+  - name_template: ghcr.io/{{ .Env.USERNAME }}/sealos:{{ .Tag }}
+    image_templates:
+      - ghcr.io/{{ .Env.USERNAME }}/sealos:{{ .Tag }}-amd64
+      - ghcr.io/{{ .Env.USERNAME }}/sealos:{{ .Tag }}-arm64
+
 nfpms:
   - id: packages
     builds:
@@ -167,20 +242,3 @@ checksum:
 
 snapshot:
   name_template: "{{ .Tag }}-next"
-
-changelog:
-  use: github
-  sort: asc
-  groups:
-    - title: Features
-      regexp: "^.*feat[(\\w)]*:+.*$"
-      order: 0
-    - title: "Bug fixes"
-      regexp: "^.*fix[(\\w)]*:+.*$"
-      order: 1
-    - title: Others
-      order: 999
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"

--- a/docker/lvscare/Dockerfile.release
+++ b/docker/lvscare/Dockerfile.release
@@ -1,0 +1,10 @@
+FROM alpine:3.16.2
+
+RUN apk add --no-cache ipset iptables
+
+COPY lvscare /usr/bin/
+
+# nosemgrep: dockerfile.security.missing-user.missing-user
+ENTRYPOINT ["/usr/bin/lvscare"]
+# nosemgrep: dockerfile.security.missing-user.missing-user
+CMD ["--help"]

--- a/docker/sealos/Dockerfile.release
+++ b/docker/sealos/Dockerfile.release
@@ -1,0 +1,8 @@
+FROM ubuntu:18.04
+
+COPY sealos /usr/bin/
+
+# nosemgrep: dockerfile.security.missing-user.missing-user
+ENTRYPOINT ["/usr/bin/sealos"]
+# nosemgrep: dockerfile.security.missing-user.missing-user
+CMD ["--help"]


### PR DESCRIPTION
Re-introduce docker image building using GoReleaser as we are now able to fix issues with ARM64 images. This should (hopefully) be less error-prone than manual scripts.