### PR TITLE
fix: misuse of *cluster pointer

### DIFF
--- a/pkg/apply/run.go
+++ b/pkg/apply/run.go
@@ -74,6 +74,8 @@ func NewApplierFromArgs(imageName []string, args *RunArgs) (applydrivers.Interfa
 	if cluster == nil {
 		logger.Debug("creating new cluster")
 		cluster = initCluster(args.ClusterName)
+	} else {
+		cluster = cluster.DeepCopy()
 	}
 	c := &ClusterArgs{
 		clusterName: cluster.Name,


### PR DESCRIPTION
Signed-off-by: fengxsong <fengxsong@outlook.com>

should use a copy of *v2.Cluster.