### PR TITLE
fix: replace text/template from html/template

### DIFF
--- a/pkg/checker/cluster_checker.go
+++ b/pkg/checker/cluster_checker.go
@@ -16,8 +16,8 @@ package checker
 
 import (
 	"context"
-	"html/template"
 	"os"
+	"text/template"
 	"time"
 
 	"github.com/labring/sealos/pkg/constants"

--- a/pkg/checker/cluster_checker.go
+++ b/pkg/checker/cluster_checker.go
@@ -14,6 +14,7 @@
 
 package checker
 
+// nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
 import (
 	"context"
 	"os"

--- a/pkg/checker/node_checker.go
+++ b/pkg/checker/node_checker.go
@@ -17,8 +17,8 @@ package checker
 import (
 	"context"
 	"fmt"
-	"html/template"
 	"os"
+	"text/template"
 
 	"github.com/labring/sealos/pkg/constants"
 	"github.com/labring/sealos/pkg/utils/logger"

--- a/pkg/checker/node_checker.go
+++ b/pkg/checker/node_checker.go
@@ -14,6 +14,7 @@
 
 package checker
 
+// nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
 import (
 	"context"
 	"fmt"

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -14,6 +14,7 @@
 
 package env
 
+// nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
 import (
 	"fmt"
 	"os"

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -16,10 +16,10 @@ package env
 
 import (
 	"fmt"
-	"html/template"
 	"os"
 	"path/filepath"
 	"strings"
+	"text/template"
 
 	"github.com/labring/sealos/pkg/utils/maps"
 	strings2 "github.com/labring/sealos/pkg/utils/strings"

--- a/pkg/image/buildah/cluster/buildah/inspect.go
+++ b/pkg/image/buildah/cluster/buildah/inspect.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 package buildah
 
+// nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
 import (
 	"fmt"
 	"os"

--- a/pkg/image/buildah/cluster/buildah/inspect.go
+++ b/pkg/image/buildah/cluster/buildah/inspect.go
@@ -15,9 +15,9 @@ package buildah
 
 import (
 	"fmt"
-	"html/template"
 	"os"
 	"regexp"
+	"text/template"
 
 	"github.com/containers/buildah"
 	"github.com/pkg/errors"

--- a/pkg/image/merge.go
+++ b/pkg/image/merge.go
@@ -20,10 +20,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"html/template"
 	"os"
 	"path"
 	"strings"
+	"text/template"
 
 	"golang.org/x/sync/errgroup"
 

--- a/pkg/image/merge.go
+++ b/pkg/image/merge.go
@@ -16,6 +16,7 @@ limitations under the License.
 
 package image
 
+// nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
 import (
 	"bytes"
 	"context"

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -16,6 +16,7 @@ limitations under the License.
 
 package remote
 
+// nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
 import (
 	"fmt"
 	"text/template"

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -18,7 +18,7 @@ package remote
 
 import (
 	"fmt"
-	"html/template"
+	"text/template"
 
 	"github.com/labring/sealos/pkg/utils/iputils"
 

--- a/pkg/remote/util.go
+++ b/pkg/remote/util.go
@@ -16,6 +16,7 @@ limitations under the License.
 
 package remote
 
+// nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
 import (
 	"bytes"
 	"fmt"

--- a/pkg/remote/util.go
+++ b/pkg/remote/util.go
@@ -19,7 +19,7 @@ package remote
 import (
 	"bytes"
 	"fmt"
-	"html/template"
+	"text/template"
 
 	"github.com/labring/sealos/pkg/constants"
 	"github.com/labring/sealos/pkg/ssh"

--- a/pkg/template/funcmap.go
+++ b/pkg/template/funcmap.go
@@ -23,9 +23,9 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"html/template"
 	"net"
 	"strings"
+	"text/template"
 
 	"github.com/BurntSushi/toml"
 	"github.com/Masterminds/sprig/v3"

--- a/pkg/template/funcmap.go
+++ b/pkg/template/funcmap.go
@@ -18,6 +18,7 @@ limitations under the License.
 
 package template
 
+// nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
 import (
 	"bytes"
 	"encoding/binary"

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -14,6 +14,7 @@
 
 package template
 
+// nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
 import (
 	"text/template"
 )

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -15,7 +15,7 @@
 package template
 
 import (
-	"html/template"
+	"text/template"
 )
 
 var defaultTpl *template.Template
@@ -29,7 +29,7 @@ func init() {
 
 func TryParse(text string) (*template.Template, bool, error) {
 	tmp, err := defaultTpl.Parse(text)
-	isFailed := err != nil && err.Error() == "html/template: cannot Parse after Execute"
+	isFailed := err != nil && err.Error() == "text/template: cannot Parse after Execute"
 	return tmp, !isFailed, err
 }
 

--- a/pkg/utils/template/template.go
+++ b/pkg/utils/template/template.go
@@ -18,7 +18,7 @@ package template
 
 import (
 	"bytes"
-	"html/template"
+	"text/template"
 )
 
 func FromContent(templateContent string, param interface{}) (string, error) {

--- a/pkg/utils/template/template.go
+++ b/pkg/utils/template/template.go
@@ -16,6 +16,7 @@ limitations under the License.
 
 package template
 
+// nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
 import (
 	"bytes"
 	"text/template"


### PR DESCRIPTION
Signed-off-by: fengxsong <fengxsong@outlook.com>

use `text/template` to avoid string escaping.