### PR TITLE
feat:  add describe image api and get root device name from ami.

### DIFF
--- a/controllers/infra/drivers/aws/create_instance.go
+++ b/controllers/infra/drivers/aws/create_instance.go
@@ -197,7 +197,7 @@ func (d Driver) createInstances(hosts *v1.Hosts, infra *v1.Infra) error {
 	userData := base64.StdEncoding.EncodeToString([]byte(userData))
 	// set bdms, and read name and size from hosts
 
-	rootDeviceName, err := d.getImageRootDeviceNameById(hosts.Image)
+	rootDeviceName, err := d.getImageRootDeviceNameByID(hosts.Image)
 	if err != nil {
 		return err
 	}

--- a/controllers/infra/drivers/aws/get_image.go
+++ b/controllers/infra/drivers/aws/get_image.go
@@ -31,12 +31,12 @@ func GetImages(c context.Context, api EC2DescribeAMIAPI, input *ec2.DescribeImag
 }
 
 // getImageRootDeviceNameByID get images root device name from image api
-func (d Driver) getImageRootDeviceNameByID(amiId string) (rootDeviceName string, err error) {
+func (d Driver) getImageRootDeviceNameByID(amiID string) (rootDeviceName string, err error) {
 
 	client := d.Client
 	input := &ec2.DescribeImagesInput{
 		ImageIds: []string{
-			amiId,
+			amiID,
 		},
 	}
 
@@ -45,10 +45,10 @@ func (d Driver) getImageRootDeviceNameByID(amiId string) (rootDeviceName string,
 		return "", err
 	}
 	if len(result.Images) == 0 {
-		return "", fmt.Errorf("not find this image: %s", amiId)
+		return "", fmt.Errorf("not find this image: %s", amiID)
 	}
 	if *result.Images[0].RootDeviceName == "" {
-		return "", fmt.Errorf("this image: %s doesn't has a valid root device name", amiId)
+		return "", fmt.Errorf("this image: %s doesn't has a valid root device name", amiID)
 	}
 	return *result.Images[0].RootDeviceName, nil
 }

--- a/controllers/infra/drivers/aws/get_image.go
+++ b/controllers/infra/drivers/aws/get_image.go
@@ -30,7 +30,7 @@ func GetImages(c context.Context, api EC2DescribeAMIAPI, input *ec2.DescribeImag
 	return api.DescribeImages(c, input)
 }
 
-// getInstances get all instances for an infra
+// getImageRootDeviceNameById get images root device name from image api
 func (d Driver) getImageRootDeviceNameById(amiId string) (rootDeviceName string, err error) {
 
 	client := d.Client

--- a/controllers/infra/drivers/aws/get_image.go
+++ b/controllers/infra/drivers/aws/get_image.go
@@ -2,8 +2,8 @@ package aws
 
 import (
 	"context"
-	"errors"
 	"fmt"
+
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 )
 
@@ -30,8 +30,8 @@ func GetImages(c context.Context, api EC2DescribeAMIAPI, input *ec2.DescribeImag
 	return api.DescribeImages(c, input)
 }
 
-// getImageRootDeviceNameById get images root device name from image api
-func (d Driver) getImageRootDeviceNameById(amiId string) (rootDeviceName string, err error) {
+// getImageRootDeviceNameByID get images root device name from image api
+func (d Driver) getImageRootDeviceNameByID(amiId string) (rootDeviceName string, err error) {
 
 	client := d.Client
 	input := &ec2.DescribeImagesInput{
@@ -45,7 +45,7 @@ func (d Driver) getImageRootDeviceNameById(amiId string) (rootDeviceName string,
 		return "", err
 	}
 	if len(result.Images) == 0 {
-		return "", errors.New(fmt.Sprintf("not find this image: %s", amiId))
+		return "", fmt.Errorf("not find this image: %s", amiId)
 	}
 	return *result.Images[0].RootDeviceName, nil
 }

--- a/controllers/infra/drivers/aws/get_image.go
+++ b/controllers/infra/drivers/aws/get_image.go
@@ -47,5 +47,8 @@ func (d Driver) getImageRootDeviceNameByID(amiId string) (rootDeviceName string,
 	if len(result.Images) == 0 {
 		return "", fmt.Errorf("not find this image: %s", amiId)
 	}
+	if *result.Images[0].RootDeviceName == "" {
+		return "", fmt.Errorf("this image: %s doesn't has a valid root device name", amiId)
+	}
 	return *result.Images[0].RootDeviceName, nil
 }

--- a/controllers/infra/drivers/aws/get_image.go
+++ b/controllers/infra/drivers/aws/get_image.go
@@ -25,14 +25,13 @@ type EC2DescribeAMIAPI interface {
 // Output:
 //
 //	If success, a DescribeImagesOutput object containing the result of the service call and nil.
-//	Otherwise, nil and an error from the call to DescribeInstances.
+//	Otherwise, nil and an error from the call to DescribeImages.
 func GetImages(c context.Context, api EC2DescribeAMIAPI, input *ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error) {
 	return api.DescribeImages(c, input)
 }
 
 // getImageRootDeviceNameByID get images root device name from image api
 func (d Driver) getImageRootDeviceNameByID(amiID string) (rootDeviceName string, err error) {
-
 	client := d.Client
 	input := &ec2.DescribeImagesInput{
 		ImageIds: []string{

--- a/controllers/infra/drivers/aws/get_image.go
+++ b/controllers/infra/drivers/aws/get_image.go
@@ -1,0 +1,51 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+)
+
+// EC2DescribeAMIAPI defines the interface for the DescribeInstances function.
+// We use this interface to test the function using a mocked service.
+type EC2DescribeAMIAPI interface {
+	DescribeImages(ctx context.Context,
+		params *ec2.DescribeImagesInput,
+		optFns ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error)
+}
+
+// GetImages retrieves information about your Amazon Elastic Compute Cloud (Amazon EC2) images.
+// Inputs:
+//
+//	c is the context of the method call, which includes the AWS Region.
+//	api is the interface that defines the method call.
+//	input defines the input arguments to the service call.
+//
+// Output:
+//
+//	If success, a DescribeImagesOutput object containing the result of the service call and nil.
+//	Otherwise, nil and an error from the call to DescribeInstances.
+func GetImages(c context.Context, api EC2DescribeAMIAPI, input *ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error) {
+	return api.DescribeImages(c, input)
+}
+
+// getInstances get all instances for an infra
+func (d Driver) getImageRootDeviceNameById(amiId string) (rootDeviceName string, err error) {
+
+	client := d.Client
+	input := &ec2.DescribeImagesInput{
+		ImageIds: []string{
+			amiId,
+		},
+	}
+
+	result, err := GetImages(context.TODO(), client, input)
+	if err != nil {
+		return "", err
+	}
+	if len(result.Images) == 0 {
+		return "", errors.New(fmt.Sprintf("not find this image: %s", amiId))
+	}
+	return *result.Images[0].RootDeviceName, nil
+}


### PR DESCRIPTION
1. add aws images client api
2. get root device name from image
3.  rename data disks to bdms(blockdevicemappings)


Signed-off-by: ybyang <ybyang7@iflytek.com>

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note
-->