### PR TITLE
fix: adjust sealos reset process order

### DIFF
--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -108,8 +108,9 @@ func (bs *realBootstrap) RegisterApplier(phase Phase, appliers ...Applier) error
 
 func (bs *realBootstrap) Reset(hosts ...string) error {
 	appliers := make([]Applier, 0)
-	// only undo addons OR?
+	// first addons, second initializers
 	appliers = append(appliers, bs.addons...)
+	appliers = append(appliers, bs.initializers...)
 	return runParallel(hosts, func(host string) error {
 		for i := range appliers {
 			applier := appliers[i]

--- a/pkg/runtime/reset.go
+++ b/pkg/runtime/reset.go
@@ -35,12 +35,10 @@ rm -rf %s
 )
 
 func (k *KubeadmRuntime) reset() error {
-	//Why delete registry is first?
-	//Because the registry use some cri command, eg 'nerdctl'
-	bs := bootstrap.New(k.Cluster)
-	err := bs.Reset(k.Cluster.GetRegistryIPAndPortList()...)
 	k.resetNodes(k.getNodeIPAndPortList())
 	k.resetMasters(k.getMasterIPAndPortList())
+	bs := bootstrap.New(k.Cluster)
+	err := bs.Reset(k.Cluster.GetAllIPS()...)
 	return err
 }
 

--- a/pkg/types/v1beta1/cluster_args.go
+++ b/pkg/types/v1beta1/cluster_args.go
@@ -112,6 +112,14 @@ func (c *Cluster) GetIPSByRole(role string) []string {
 	return hosts
 }
 
+func (c *Cluster) GetAllIPS() []string {
+	var hosts []string
+	for _, host := range c.Spec.Hosts {
+		hosts = append(hosts, host.IPS...)
+	}
+	return hosts
+}
+
 func (c *Cluster) GetRootfsImage(defaultMount string) *MountImage {
 	var image *MountImage
 	if c.Status.Mounts != nil {


### PR DESCRIPTION
Signed-off-by: fengxsong <fengxsong@outlook.com>

Move nodes reset(including addons and system reset) process after kubeadm reset.