### PR TITLE
fix: move IsRootless out of pkg/buildah

### DIFF
--- a/pkg/buildah/common.go
+++ b/pkg/buildah/common.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containers/storage/pkg/unshare"
 	"github.com/spf13/cobra"
 
+	wrapunshare "github.com/labring/sealos/pkg/unshare"
 	"github.com/labring/sealos/pkg/utils/logger"
 )
 
@@ -37,7 +38,10 @@ var (
 	needToShutdownStore = false
 )
 
-var DefaultPlatform = platforms.DefaultSpec
+var (
+	DefaultPlatform = platforms.DefaultSpec
+	IsRootless      = wrapunshare.IsRootless
+)
 
 func flagChanged(c *cobra.Command, name string) bool {
 	if fs := c.Flag(name); fs != nil && fs.Changed {

--- a/pkg/buildah/setup.go
+++ b/pkg/buildah/setup.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/storage/pkg/homedir"
@@ -105,13 +104,6 @@ func writeFileIfNotExists(filename string, data []byte) error {
 		err = file.WriteFile(filename, data)
 	}
 	return err
-}
-
-func IsRootless() bool {
-	if v, ok := os.LookupEnv(DisableAutoRootless); ok && strings.ToLower(v) == "true" {
-		return false
-	}
-	return unshare.IsRootless()
 }
 
 func MaybeReexecUsingUserNamespace() error {

--- a/pkg/ssh/scp.go
+++ b/pkg/ssh/scp.go
@@ -27,7 +27,7 @@ import (
 	"github.com/schollz/progressbar/v3"
 	"golang.org/x/crypto/ssh"
 
-	"github.com/labring/sealos/pkg/buildah"
+	"github.com/labring/sealos/pkg/unshare"
 	"github.com/labring/sealos/pkg/utils/file"
 	"github.com/labring/sealos/pkg/utils/hash"
 	"github.com/labring/sealos/pkg/utils/iputils"
@@ -71,7 +71,7 @@ func (s *SSH) sftpConnect(host string) (*ssh.Client, *sftp.Client, error) {
 
 // Copy is copy file or dir to remotePath, add md5 validate
 func (s *SSH) Copy(host, localPath, remotePath string) error {
-	if iputils.IsLocalIP(host, s.localAddress) && !buildah.IsRootless() {
+	if iputils.IsLocalIP(host, s.localAddress) && !unshare.IsRootless() {
 		logger.Debug("local %s copy files src %s to dst %s", host, localPath, remotePath)
 		return file.RecursionCopy(localPath, remotePath)
 	}

--- a/pkg/ssh/sshcmd.go
+++ b/pkg/ssh/sshcmd.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/labring/sealos/pkg/buildah"
+	"github.com/labring/sealos/pkg/unshare"
 	"github.com/labring/sealos/pkg/utils/exec"
 	"github.com/labring/sealos/pkg/utils/iputils"
 	"github.com/labring/sealos/pkg/utils/logger"
@@ -29,7 +29,7 @@ import (
 )
 
 func (s *SSH) Ping(host string) error {
-	if iputils.IsLocalIP(host, s.localAddress) && !buildah.IsRootless() {
+	if iputils.IsLocalIP(host, s.localAddress) && !unshare.IsRootless() {
 		logger.Debug("host %s is local, ping is always true", host)
 		return nil
 	}
@@ -46,7 +46,7 @@ func (s *SSH) Ping(host string) error {
 
 func (s *SSH) CmdAsync(host string, cmds ...string) error {
 	var isLocal bool
-	if iputils.IsLocalIP(host, s.localAddress) && !buildah.IsRootless() {
+	if iputils.IsLocalIP(host, s.localAddress) && !unshare.IsRootless() {
 		logger.Debug("host %s is local, command via exec", host)
 		isLocal = true
 	}
@@ -106,7 +106,7 @@ func (s *SSH) CmdAsync(host string, cmds ...string) error {
 }
 
 func (s *SSH) Cmd(host, cmd string) ([]byte, error) {
-	if iputils.IsLocalIP(host, s.localAddress) && !buildah.IsRootless() {
+	if iputils.IsLocalIP(host, s.localAddress) && !unshare.IsRootless() {
 		logger.Debug("host %s is local, command via exec", host)
 		d, err := exec.RunBashCmd(cmd)
 		return []byte(d), err

--- a/pkg/unshare/unshare.go
+++ b/pkg/unshare/unshare.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 sealos.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unshare
+
+import (
+	"os"
+	"strings"
+
+	"github.com/containers/storage/pkg/unshare"
+)
+
+const (
+	DisableAutoRootless = "DISABLE_AUTO_ROOTLESS"
+)
+
+func IsRootless() bool {
+	if v, ok := os.LookupEnv(DisableAutoRootless); ok && strings.ToLower(v) == "true" {
+		return false
+	}
+	return unshare.IsRootless()
+}


### PR DESCRIPTION
Signed-off-by: fengxsong <fengxsong@outlook.com>

In case some other go module require pkg/ssh, so move the only necessary function out of pkg/buildah.