### PR TITLE
fix: only run guest command for app type cloudimage

### DIFF
--- a/pkg/guest/guest.go
+++ b/pkg/guest/guest.go
@@ -81,6 +81,9 @@ func (d *Default) getGuestCmd(envs map[string]string, cluster *v2.Cluster, mount
 		return fmt.Sprintf(constants.CdAndExecCmd, constants.GetAppWorkDir(cluster.Name, applicationName), cmd)
 	}
 	for idx, i := range mounts {
+		if i.Type != v2.AppImage {
+			continue
+		}
 		mergeENV := maps.MergeMap(i.Env, envs)
 		mapping := expansion.MappingFuncFor(mergeENV)
 		for _, cmd := range i.Entrypoint {


### PR DESCRIPTION
Signed-off-by: fengxsong <fengxsong@outlook.com>

No need to run guest command for rootfs/patch type cloudimages.