### PR TITLE
ci: pin ubuntu version in CI to 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   format-code:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -44,7 +44,7 @@ jobs:
           commit_options: "-s"
 
   check-license:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -60,7 +60,7 @@ jobs:
         run: make verify-license
 
   resolve-modules:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -73,7 +73,7 @@ jobs:
 
   golangci-lint:
     needs: [format-code, check-license, resolve-modules]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix: ${{ fromJson(needs.resolve-modules.outputs.matrix) }}
     steps:
@@ -97,7 +97,7 @@ jobs:
 
   coverage:
     needs: [format-code, check-license]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -118,7 +118,7 @@ jobs:
 
   build:
     needs: [golangci-lint, coverage]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         binary: [sealos, sealctl, lvscare, image-cri-shim]
@@ -155,7 +155,7 @@ jobs:
 
   docker:
     needs: [build]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       registry:
         image: registry:2
@@ -238,7 +238,7 @@ jobs:
 
   container:
     needs: [docker]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ github.event_name == 'push' }}
     steps:
       - name: Checkout
@@ -305,7 +305,7 @@ jobs:
 
   patch-oci:
     needs: [docker]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ github.event_name == 'push' }}
     steps:
       - name: Checkout


### PR DESCRIPTION
Signed-off-by: Mercurio <signormercurio@gmail.com>

According to [this blog](https://github.blog/changelog/2022-12-01-github-actions-larger-runners-using-ubuntu-latest-label-will-now-use-ubuntu-22-04/), `ubuntu-latest` version for actions runner may be updated soon and may affect the compiled binaries within. We should pin the ubuntu version to avoid possible breaking changes.