### PR TITLE
Pin ubuntu version in Release workflow, use correct goreleaser args for sealctl and add release checksum

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,7 +56,8 @@ builds:
 
   - id: sealctl
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
+      - CC=aarch64-linux-gnu-gcc
     main: ./cmd/sealctl
     hooks:
       post: upx "{{ .Path }}"
@@ -80,6 +81,15 @@ builds:
       - -X github.com/labring/sealos/pkg/version.gitCommit={{.ShortCommit}}
       - -X github.com/labring/sealos/pkg/version.buildDate={{.Date}}
       - -s -w
+    overrides:
+      - goos: linux
+        goarch: amd64
+        goamd64: v1
+        goarm: ""
+        gomips: ""
+        env:
+          - CGO_ENABLED=1
+          - CC=x86_64-linux-gnu-gcc
 
   - id: lvscare
     env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -247,8 +247,8 @@ publishers:
       curl -F package=@{{ .ArtifactName }} https://{{ .Env.FURY_TOKEN }}@push.fury.io/{{ .Env.USERNAME }}/
 
 checksum:
-  disable: true
   name_template: "{{ .ProjectName }}_checksums.txt"
-
+  algorithm: sha256
+  
 snapshot:
   name_template: "{{ .Tag }}-next"


### PR DESCRIPTION
1. In the Release workflow we were still using `ubuntu-latest`. This PR pins it down to `ubuntu-18.04` for better compatibility.

2. From https://github.com/labring/sealos/commit/0eb99622295b1f35885c044ddaa95326fdb9f66b, sealctl now needs CGO support, so we should use correct args in goreleaser too. This should fix #2246.

3. Add release checksum.