### PR TITLE
mark tls-verify flag hidden

### DIFF
--- a/pkg/buildah/build.go
+++ b/pkg/buildah/build.go
@@ -83,6 +83,8 @@ func newBuildCommand() *cobra.Command {
 	flags.AddFlagSet(&fromAndBudFlags)
 	flags.SetNormalizeFunc(buildahcli.AliasFlags)
 
+	bailOnError(markFlagsHidden(flags, "tls-verify"), "")
+
 	return buildCommand
 }
 

--- a/pkg/buildah/from.go
+++ b/pkg/buildah/from.go
@@ -100,7 +100,8 @@ func (opts *fromReply) RegisterFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&opts.signaturePolicy, "signature-policy", opts.signaturePolicy, "`pathname` of signature policy file (not usually used)")
 	fs.StringVar(&suffix, "suffix", "", "suffix to add to intermediate containers")
 	fs.BoolVar(&opts.tlsVerify, "tls-verify", opts.tlsVerify, "require HTTPS and verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
-	_ = markFlagsHidden(fs, "pull-always", "pull-never", "suffix", "signature-policy")
+	bailOnError(markFlagsHidden(fs, "pull-always", "pull-never", "suffix", "signature-policy", "tls-verify"), "")
+
 	// Add in the common flags
 	fromAndBudFlags, err := buildahcli.GetFromAndBudFlags(opts.FromAndBudResults, opts.UserNSResults, opts.NameSpaceResults)
 	bailOnError(err, "failed to setup From and Bud flags")

--- a/pkg/buildah/login.go
+++ b/pkg/buildah/login.go
@@ -55,6 +55,7 @@ func (opts *loginReply) RegisterFlags(fs *pflag.FlagSet) {
 	fs.AddFlagSet(auth.GetLoginFlags(&opts.loginOpts))
 	// e.g sealos login --kubeconfig /root/.kube/config hub.sealos.io
 	fs.StringVarP(&opts.kubeconfig, "kubeconfig", "k", opts.kubeconfig, "Login to sealos registry: hub.sealos.io by kubeconfig")
+	bailOnError(markFlagsHidden(fs, "tls-verify"), "")
 }
 
 func newLoginCommand() *cobra.Command {

--- a/pkg/buildah/manifest.go
+++ b/pkg/buildah/manifest.go
@@ -57,7 +57,7 @@ func (opts *manifestCreateOpts) RegisterFlags(fs *pflag.FlagSet) error {
 	fs.BoolVar(&opts.insecure, "insecure", false, "neither require HTTPS nor verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
 	fs.BoolVar(&opts.tlsVerify, "tls-verify", false, "require HTTPS and verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
 	fs.SetNormalizeFunc(cli.AliasFlags)
-	return markFlagsHidden(fs, []string{"os", "arch", "insecure"}...)
+	return markFlagsHidden(fs, []string{"os", "arch", "insecure", "tls-verify"}...)
 }
 
 type manifestAddOpts struct {
@@ -81,7 +81,7 @@ func (opts *manifestAddOpts) RegisterFlags(fs *pflag.FlagSet) error {
 	fs.BoolVar(&opts.tlsVerify, "tls-verify", false, "require HTTPS and verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
 	fs.BoolVar(&opts.all, "all", false, "add all of the list's images if the image is a list")
 	fs.SetNormalizeFunc(cli.AliasFlags)
-	return markFlagsHidden(fs, []string{"insecure"}...)
+	return markFlagsHidden(fs, []string{"insecure", "tls-verify"}...)
 }
 
 type manifestRemoveOpts struct{}
@@ -251,8 +251,7 @@ func newManifestCommand() *cobra.Command {
 	fs.BoolVar(&manifestPushOpts.tlsVerify, "tls-verify", false, "require HTTPS and verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
 	fs.BoolVarP(&manifestPushOpts.quiet, "quiet", "q", false, "don't output progress information when pushing lists")
 	fs.SetNormalizeFunc(cli.AliasFlags)
-	err = markFlagsHidden(fs, "signature-policy", "insecure")
-	bailOnError(err, "")
+	bailOnError(markFlagsHidden(fs, "signature-policy", "insecure", "tls-verify"), "")
 	manifestCommand.AddCommand(manifestPushCommand)
 
 	manifestRmCommand := &cobra.Command{

--- a/pkg/buildah/pull.go
+++ b/pkg/buildah/pull.go
@@ -55,7 +55,7 @@ type pullOptions struct {
 
 func (opts *pullOptions) HiddenFlags() []string {
 	return []string{
-		"signature-policy", "blob-cache",
+		"signature-policy", "blob-cache", "tls-verify",
 	}
 }
 

--- a/pkg/buildah/push.go
+++ b/pkg/buildah/push.go
@@ -94,7 +94,7 @@ func (opts *pushOptions) RegisterFlags(fs *pflag.FlagSet) error {
 	fs.StringSliceVar(&opts.encryptionKeys, "encryption-key", opts.encryptionKeys, "key with the encryption protocol to use needed to encrypt the image (e.g. jwe:/path/to/key.pem)")
 	fs.IntSliceVar(&opts.encryptLayers, "encrypt-layer", opts.encryptLayers, "layers to encrypt, 0-indexed layer indices with support for negative indexing (e.g. 0 is the first layer, -1 is the last layer). If not defined, will encrypt all layers if encryption-key flag is specified")
 	fs.BoolVar(&opts.tlsVerify, "tls-verify", opts.tlsVerify, "require HTTPS and verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
-	return markFlagsHidden(fs, []string{"signature-policy", "blob-cache"}...)
+	return markFlagsHidden(fs, []string{"signature-policy", "blob-cache", "tls-verify"}...)
 }
 
 func newPushCommand() *cobra.Command {

--- a/pkg/buildah/save.go
+++ b/pkg/buildah/save.go
@@ -40,5 +40,6 @@ func newSaveCommand() *cobra.Command {
 	saveCommand.SetUsageTemplate(UsageTemplate())
 
 	saveCommand.Flags().StringVarP(&archiveName, "output", "o", "", "save image into tar archive file")
+	_ = saveCommand.MarkFlagRequired("output")
 	return saveCommand
 }


### PR DESCRIPTION
Signed-off-by: fengxsong <fengxsong@outlook.com>

since `tls-verify` is default to `false`, so we mark this flag as hidden.