### PR TITLE
fix: more friendly error output when running rootless mode 

### DIFF
--- a/cmd/sealos/cmd/root.go
+++ b/cmd/sealos/cmd/root.go
@@ -59,7 +59,7 @@ func init() {
 	fs.StringVar(&runtimeRootDir, "sealos-root", constants.DefaultRuntimeRootDir, "root directory for sealos actions")
 	_ = fs.MarkHidden("sealos-root")
 	// add unrelated command names that don't required buildah sdk.
-	buildah.AddUnrelatedCommandNames("docs", "exec", "gen", "scp", "version")
+	buildah.AddUnrelatedCommandNames("cert", "docs", "exec", "gen", "scp", "version")
 }
 
 func onBootOnDie() {

--- a/cmd/sealos/cmd/root.go
+++ b/cmd/sealos/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/labring/sealos/pkg/buildah"
 	"github.com/labring/sealos/pkg/constants"
 	"github.com/labring/sealos/pkg/utils/file"
 	"github.com/labring/sealos/pkg/utils/logger"
@@ -57,6 +58,8 @@ func init() {
 	_ = fs.MarkHidden("cluster-root")
 	fs.StringVar(&runtimeRootDir, "sealos-root", constants.DefaultRuntimeRootDir, "root directory for sealos actions")
 	_ = fs.MarkHidden("sealos-root")
+	// add unrelated command names that don't required buildah sdk.
+	buildah.AddUnrelatedCommandNames("docs", "exec", "gen", "scp", "version")
 }
 
 func onBootOnDie() {

--- a/pkg/buildah/build.go
+++ b/pkg/buildah/build.go
@@ -62,7 +62,7 @@ func newBuildCommand() *cobra.Command {
 		Args: cobra.MaximumNArgs(1),
 		Example: fmt.Sprintf(`%[1]s build
   %[1]s bud -f Kubefile.simple .
-  %[1]s bud -f Kubefile.simple -f Kubefile.notsosimple .`, rootCmdName),
+  %[1]s bud -f Kubefile.simple -f Kubefile.notsosimple .`, rootCmd.CommandPath()),
 	}
 	buildCommand.SetUsageTemplate(UsageTemplate())
 

--- a/pkg/buildah/buildah.go
+++ b/pkg/buildah/buildah.go
@@ -27,7 +27,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/labring/sealos/pkg/utils/logger"
 )
@@ -108,7 +107,7 @@ func RegisterGlobalFlags(fs *pflag.FlagSet) error {
 var (
 	globalFlagResults globalFlags
 	rootCmd           *cobra.Command
-	unrelatedCommands = sets.NewString("version")
+	unrelatedCommands = []string{"version"}
 	postRunHooks      []func() error
 )
 
@@ -164,11 +163,16 @@ func RegisterPostRun(fn func() error) {
 }
 
 func AddUnrelatedCommandNames(names ...string) {
-	unrelatedCommands.Insert(names...)
+	unrelatedCommands = append(unrelatedCommands, names...)
 }
 
 func skipUnrelatedCommandRun(cmd *cobra.Command) bool {
-	return unrelatedCommands.Has(cmd.Use)
+	for _, name := range unrelatedCommands {
+		if name == cmd.Name() {
+			return true
+		}
+	}
+	return false
 }
 
 func wrapPrePersistentRun(cmd *cobra.Command) {

--- a/pkg/buildah/containers.go
+++ b/pkg/buildah/containers.go
@@ -110,7 +110,7 @@ func newContainersCommand() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`%[1]s containers
   %[1]s containers --format "{{.ContainerID}} {{.ContainerName}}"
-  %[1]s containers -q --noheading --notruncate`, rootCmdName),
+  %[1]s containers -q --noheading --notruncate`, rootCmd.CommandPath()),
 	}
 	containersCommand.SetUsageTemplate(UsageTemplate())
 
@@ -120,7 +120,7 @@ func newContainersCommand() *cobra.Command {
 
 func containersCmd(c *cobra.Command, args []string, iopts *containersResults) error {
 	if len(args) > 0 {
-		return fmt.Errorf("'%s containers' does not accept arguments", rootCmdName)
+		return fmt.Errorf("'%s' does not accept arguments", c.CommandPath())
 	}
 	store, err := getStore(c)
 	if err != nil {

--- a/pkg/buildah/from.go
+++ b/pkg/buildah/from.go
@@ -128,7 +128,7 @@ func newFromCommand() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`%[1]s from --pull imagename
   %[1]s from docker-daemon:imagename:imagetag
-  %[1]s from --name "myimagename" myregistry/myrepository/imagename:imagetag`, rootCmdName),
+  %[1]s from --name "myimagename" myregistry/myrepository/imagename:imagetag`, rootCmd.CommandPath()),
 	}
 	fromCommand.SetUsageTemplate(UsageTemplate())
 	opts.RegisterFlags(fromCommand.Flags())

--- a/pkg/buildah/images.go
+++ b/pkg/buildah/images.go
@@ -122,7 +122,7 @@ func newImagesCommand() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`%[1]s images --all
   %[1]s images [imageName]
-  %[1]s images --format '{{.ID}} {{.Name}} {{.Size}} {{.CreatedAtRaw}}'`, rootCmdName),
+  %[1]s images --format '{{.ID}} {{.Name}} {{.Size}} {{.CreatedAtRaw}}'`, rootCmd.CommandPath()),
 	}
 	imagesCommand.SetUsageTemplate(UsageTemplate())
 
@@ -140,7 +140,7 @@ func imagesCmd(c *cobra.Command, args []string, iopts *imageResults) error {
 			return err
 		}
 		if len(args) > 1 {
-			return fmt.Errorf("'%s images' requires at most 1 argument", rootCmdName)
+			return fmt.Errorf("'%s' requires at most 1 argument", c.CommandPath())
 		}
 	}
 	if iopts.quiet && iopts.format != "" {

--- a/pkg/buildah/inspect.go
+++ b/pkg/buildah/inspect.go
@@ -70,7 +70,7 @@ func newInspectCommand() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`%[1]s inspect containerID
   %[1]s inspect --type image imageID
-  %[1]s inspect --format '{{.OCIv1.Config.Env}}' alpine`, rootCmdName),
+  %[1]s inspect --format '{{.OCIv1.Config.Env}}' alpine`, rootCmd.CommandPath()),
 	}
 	inspectCommand.SetUsageTemplate(UsageTemplate())
 	opts.RegisterFlags(inspectCommand.Flags())

--- a/pkg/buildah/load.go
+++ b/pkg/buildah/load.go
@@ -34,7 +34,7 @@ func newLoadCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return pullCmd(cmd, []string{fmt.Sprintf("%s:%s", DockerArchive, archiveName)}, opts)
 		},
-		Example: fmt.Sprintf(`%[1]s load -i kubernetes.tar`, rootCmdName),
+		Example: fmt.Sprintf(`%[1]s load -i kubernetes.tar`, rootCmd.CommandPath()),
 	}
 	loadCommand.SetUsageTemplate(UsageTemplate())
 	fs := loadCommand.Flags()

--- a/pkg/buildah/login.go
+++ b/pkg/buildah/login.go
@@ -109,7 +109,7 @@ func newLoginCommand() *cobra.Command {
 			}
 			return nil
 		},
-		Example: fmt.Sprintf(`%s login quay.io`, rootCmdName),
+		Example: fmt.Sprintf(`%s login quay.io`, rootCmd.CommandPath()),
 	}
 	loginCommand.SetUsageTemplate(UsageTemplate())
 	opts.RegisterFlags(loginCommand.Flags())

--- a/pkg/buildah/logout.go
+++ b/pkg/buildah/logout.go
@@ -39,7 +39,7 @@ func newLogoutCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return logoutCmd(cmd, args, &opts)
 		},
-		Example: fmt.Sprintf(`%s logout quay.io`, rootCmdName),
+		Example: fmt.Sprintf(`%s logout quay.io`, rootCmd.CommandPath()),
 	}
 	logoutCommand.SetUsageTemplate(UsageTemplate())
 

--- a/pkg/buildah/manifest.go
+++ b/pkg/buildah/manifest.go
@@ -134,7 +134,7 @@ func newManifestCommand() *cobra.Command {
   %[1]s manifest inspect localhost/list
   %[1]s manifest push localhost/list transport:destination
   %[1]s manifest remove localhost/list sha256:entryManifestDigest
-  %[1]s manifest rm localhost/list`, rootCmdName),
+  %[1]s manifest rm localhost/list`, rootCmd.CommandPath()),
 	}
 	manifestCommand.SetUsageTemplate(UsageTemplate())
 
@@ -147,7 +147,7 @@ func newManifestCommand() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`%[1]s manifest create mylist:v1.11
   %[1]s manifest create mylist:v1.11 arch-specific-image-to-add
-  %[1]s manifest create --all mylist:v1.11 transport:tagged-image-to-add`, rootCmdName),
+  %[1]s manifest create --all mylist:v1.11 transport:tagged-image-to-add`, rootCmd.CommandPath()),
 		Args: cobra.MinimumNArgs(1),
 	}
 	manifestCreateCommand.SetUsageTemplate(UsageTemplate())
@@ -163,7 +163,7 @@ func newManifestCommand() *cobra.Command {
 			return manifestAddCmd(cmd, args, manifestAddOpts)
 		},
 		Example: fmt.Sprintf(`%[1]s manifest add mylist:v1.11 image:v1.11-amd64
-  %[1]s manifest add mylist:v1.11 transport:imageName`, rootCmdName),
+  %[1]s manifest add mylist:v1.11 transport:imageName`, rootCmd.CommandPath()),
 		Args: cobra.MinimumNArgs(2),
 	}
 	manifestAddCommand.SetUsageTemplate(UsageTemplate())
@@ -178,7 +178,7 @@ func newManifestCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return manifestRemoveCmd(cmd, args, manifestRemoveOpts)
 		},
-		Example: fmt.Sprintf(`%s manifest remove mylist:v1.11 sha256:15352d97781ffdf357bf3459c037be3efac4133dc9070c2dce7eca7c05c3e736`, rootCmdName),
+		Example: fmt.Sprintf(`%s manifest remove mylist:v1.11 sha256:15352d97781ffdf357bf3459c037be3efac4133dc9070c2dce7eca7c05c3e736`, rootCmd.CommandPath()),
 		Args:    cobra.MinimumNArgs(2),
 	}
 	manifestRemoveCommand.SetUsageTemplate(UsageTemplate())
@@ -192,7 +192,7 @@ func newManifestCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return manifestExistsCmd(cmd, args)
 		},
-		Example: fmt.Sprintf(`%s manifest exists mylist`, rootCmdName),
+		Example: fmt.Sprintf(`%s manifest exists mylist`, rootCmd.CommandPath()),
 	}
 	manifestExistsCommand.SetUsageTemplate(UsageTemplate())
 	manifestCommand.AddCommand(manifestExistsCommand)
@@ -204,7 +204,7 @@ func newManifestCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return manifestAnnotateCmd(cmd, args, manifestAnnotateOpts)
 		},
-		Example: fmt.Sprintf(`%s manifest annotate --annotation left=right mylist:v1.11 image:v1.11-amd64`, rootCmdName),
+		Example: fmt.Sprintf(`%s manifest annotate --annotation left=right mylist:v1.11 image:v1.11-amd64`, rootCmd.CommandPath()),
 		Args:    cobra.MinimumNArgs(2),
 	}
 	manifestAnnotateCommand.SetUsageTemplate(UsageTemplate())
@@ -219,7 +219,7 @@ func newManifestCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return manifestInspectCmd(cmd, args, manifestInspectOpts)
 		},
-		Example: fmt.Sprintf(`%s manifest inspect mylist:v1.11`, rootCmdName),
+		Example: fmt.Sprintf(`%s manifest inspect mylist:v1.11`, rootCmd.CommandPath()),
 		Args:    cobra.MinimumNArgs(1),
 	}
 	manifestInspectCommand.SetUsageTemplate(UsageTemplate())
@@ -232,7 +232,7 @@ func newManifestCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return manifestPushCmd(cmd, args, manifestPushOpts)
 		},
-		Example: fmt.Sprintf(`%s manifest push mylist:v1.11 transport:imageName`, rootCmdName),
+		Example: fmt.Sprintf(`%s manifest push mylist:v1.11 transport:imageName`, rootCmd.CommandPath()),
 		Args:    cobra.MinimumNArgs(2),
 	}
 	manifestPushCommand.SetUsageTemplate(UsageTemplate())
@@ -261,7 +261,7 @@ func newManifestCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return manifestRmCmd(cmd, args)
 		},
-		Example: fmt.Sprintf(`%s manifest rm mylist:v1.11`, rootCmdName),
+		Example: fmt.Sprintf(`%s manifest rm mylist:v1.11`, rootCmd.CommandPath()),
 		Args:    cobra.MinimumNArgs(1),
 	}
 	manifestRmCommand.SetUsageTemplate(UsageTemplate())

--- a/pkg/buildah/mount.go
+++ b/pkg/buildah/mount.go
@@ -37,7 +37,7 @@ func newMountCommand() *cobra.Command {
 	var (
 		mountDescription = fmt.Sprintf(`%[1]s mount
   mounts a working container's root filesystem for manipulation.
-`, rootCmdName)
+`, rootCmd.CommandPath())
 		opts       mountOptions
 		noTruncate bool
 	)
@@ -52,7 +52,7 @@ func newMountCommand() *cobra.Command {
 		Example: fmt.Sprintf(`%[1]s mount
   %[1]s mount containerID
   %[1]s mount containerID1 containerID2
-`, rootCmdName),
+`, rootCmd.CommandPath()),
 	}
 	mountCommand.SetUsageTemplate(UsageTemplate())
 

--- a/pkg/buildah/pull.go
+++ b/pkg/buildah/pull.go
@@ -112,7 +112,7 @@ func newPullCommand() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`%[1]s pull imagename
   %[1]s pull docker-daemon:imagename:imagetag
-  %[1]s pull myregistry/myrepository/imagename:imagetag`, rootCmdName),
+  %[1]s pull myregistry/myrepository/imagename:imagetag`, rootCmd.CommandPath()),
 	}
 	pullCommand.SetUsageTemplate(UsageTemplate())
 

--- a/pkg/buildah/push.go
+++ b/pkg/buildah/push.go
@@ -119,7 +119,7 @@ func newPushCommand() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`%[1]s push imageID docker://registry.example.com/repository:tag
   %[1]s push imageID docker-daemon:image:tagi
-  %[1]s push imageID oci:/path/to/layout:image:tag`, rootCmdName),
+  %[1]s push imageID oci:/path/to/layout:image:tag`, rootCmd.CommandPath()),
 	}
 	pushCommand.SetUsageTemplate(UsageTemplate())
 	err := opts.RegisterFlags(pushCommand.Flags())

--- a/pkg/buildah/rm.go
+++ b/pkg/buildah/rm.go
@@ -43,7 +43,7 @@ func newRMCommand() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`%[1]s rm containerID
   %[1]s rm containerID1 containerID2 containerID3
-  %[1]s rm --all`, rootCmdName),
+  %[1]s rm --all`, rootCmd.CommandPath()),
 	}
 	rmCommand.SetUsageTemplate(UsageTemplate())
 

--- a/pkg/buildah/rmi.go
+++ b/pkg/buildah/rmi.go
@@ -47,7 +47,7 @@ func newRMICommand() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`%[1]s rmi imageID
   %[1]s rmi --all --force
-  %[1]s rmi imageID1 imageID2 imageID3`, rootCmdName),
+  %[1]s rmi imageID1 imageID2 imageID3`, rootCmd.CommandPath()),
 	}
 	rmiCommand.SetUsageTemplate(UsageTemplate())
 

--- a/pkg/buildah/save.go
+++ b/pkg/buildah/save.go
@@ -35,7 +35,7 @@ func newSaveCommand() *cobra.Command {
 				fmt.Sprintf("%s:%s:%s", DockerArchive, archiveName, args[0]),
 			}, opts)
 		},
-		Example: fmt.Sprintf(`%[1]s save -o kubernetes.tar labring/kubernetes:latest`, rootCmdName),
+		Example: fmt.Sprintf(`%[1]s save -o kubernetes.tar labring/kubernetes:latest`, rootCmd.CommandPath()),
 	}
 	saveCommand.SetUsageTemplate(UsageTemplate())
 

--- a/pkg/buildah/tag.go
+++ b/pkg/buildah/tag.go
@@ -33,7 +33,7 @@ func newTagCommand() *cobra.Command {
 		RunE:  tagCmd,
 
 		Example: fmt.Sprintf(`%[1]s tag imageName firstNewName
-  %[1]s tag imageName firstNewName SecondNewName`, rootCmdName),
+  %[1]s tag imageName firstNewName SecondNewName`, rootCmd.CommandPath()),
 		Args: cobra.MinimumNArgs(2),
 	}
 	tagCommand.SetUsageTemplate(UsageTemplate())

--- a/pkg/buildah/umount.go
+++ b/pkg/buildah/umount.go
@@ -34,7 +34,7 @@ func newUmountCommand() *cobra.Command {
 		RunE:    umountCmd,
 		Example: fmt.Sprintf(`%[1]s umount containerID
   %[1]s umount containerID1 containerID2 containerID3
-  %[1]s umount --all`, rootCmdName),
+  %[1]s umount --all`, rootCmd.CommandPath()),
 	}
 	umountCommand.SetUsageTemplate(UsageTemplate())
 

--- a/pkg/buildah/unshare.go
+++ b/pkg/buildah/unshare.go
@@ -41,7 +41,7 @@ func newUnshareCommand() *cobra.Command {
 			RunE:   unshareCmd,
 			Example: fmt.Sprintf(`%[1]s unshare id
   %[1]s unshare cat /proc/self/uid_map
-  %[1]s unshare buildah-script.sh`, rootCmdName),
+  %[1]s unshare buildah-script.sh`, rootCmd.CommandPath()),
 		}
 		unshareMounts []string
 	)


### PR DESCRIPTION
1. more friendly error output when running rootless mode without required packages like `uidmap`/`fuse-overlayfs`
2. use builtin `cobra.Command.CommandPath()` to replace `getFullCmdName`

Signed-off-by: fengxsong <fengxsong@outlook.com>