### PR TITLE
bugfix: Apply twice will call initCluster twice that causes kubelet port occupied.

### DIFF
--- a/pkg/apply/applydrivers/apply_drivers_default.go
+++ b/pkg/apply/applydrivers/apply_drivers_default.go
@@ -84,7 +84,7 @@ func (c *Applier) Apply() error {
 		}
 	}()
 	c.initStatus()
-	if c.ClusterDesired.CreationTimestamp.IsZero() && c.ClusterCurrent.CreationTimestamp.IsZero() {
+	if c.ClusterDesired.CreationTimestamp.IsZero() && (c.ClusterCurrent == nil || c.ClusterCurrent.CreationTimestamp.IsZero()) {
 		err = c.initCluster()
 		c.ClusterDesired.CreationTimestamp = metav1.Now()
 	} else {

--- a/pkg/apply/applydrivers/apply_drivers_default.go
+++ b/pkg/apply/applydrivers/apply_drivers_default.go
@@ -84,7 +84,7 @@ func (c *Applier) Apply() error {
 		}
 	}()
 	c.initStatus()
-	if c.ClusterDesired.CreationTimestamp.IsZero()&& c.ClusterCurrent.CreationTimestamp.IsZero(){
+	if c.ClusterDesired.CreationTimestamp.IsZero() && c.ClusterCurrent.CreationTimestamp.IsZero() {
 		err = c.initCluster()
 		c.ClusterDesired.CreationTimestamp = metav1.Now()
 	} else {

--- a/pkg/apply/applydrivers/apply_drivers_default.go
+++ b/pkg/apply/applydrivers/apply_drivers_default.go
@@ -84,11 +84,12 @@ func (c *Applier) Apply() error {
 		}
 	}()
 	c.initStatus()
-	if c.ClusterDesired.CreationTimestamp.IsZero() {
+	if c.ClusterDesired.CreationTimestamp.IsZero()&& c.ClusterCurrent.CreationTimestamp.IsZero(){
 		err = c.initCluster()
 		c.ClusterDesired.CreationTimestamp = metav1.Now()
 	} else {
 		err = c.reconcileCluster()
+		c.ClusterDesired.CreationTimestamp = c.ClusterCurrent.CreationTimestamp
 	}
 	c.updateStatus(err)
 	return err

--- a/pkg/apply/run.go
+++ b/pkg/apply/run.go
@@ -95,7 +95,6 @@ func NewApplierFromFile(path string, args *Args) (applydrivers.Interface, error)
 		}
 		path = filepath.Join(pa, path)
 	}
-
 	Clusterfile := clusterfile.NewClusterFile(path,
 		clusterfile.WithCustomValues(args.Values),
 		clusterfile.WithCustomSets(args.Sets),
@@ -110,10 +109,18 @@ func NewApplierFromFile(path string, args *Args) (applydrivers.Interface, error)
 		return nil, fmt.Errorf("cluster name cannot be empty, make sure %s file is correct", path)
 	}
 
+	localpath := constants.Clusterfile(cluster.Name)
+	cf := clusterfile.NewClusterFile(localpath)
+	err := cf.Process()
+	if err != nil && err != clusterfile.ErrClusterFileNotExists {
+		return nil, err
+	}
+	currentCluster := cf.GetCluster()
+
 	return &applydrivers.Applier{
 		ClusterDesired: cluster,
 		ClusterFile:    Clusterfile,
-		ClusterCurrent: cluster,
+		ClusterCurrent: currentCluster,
 		RunNewImages:   nil,
 	}, nil
 }


### PR DESCRIPTION
related with issue https://github.com/labring/sealos/issues/2140
reproduce the bug
the first apply -f : 
```
root@lin-master:~/tmp/cf# cat Clusterfile
apiVersion: apps.sealos.io/v1beta1
kind: Cluster
metadata:
  name: default
spec:
  hosts:
  - ips:
    - 10.35.128.5:22
    roles:
    - master
    - amd64
  image:
  - labring/kubernetes:v1.24.0
  - labring/calico:v3.22.1
root@lin-master:~/tmp/cf# sealos apply -f Clusterfile
2022-12-22T03:59:26 info Start to create a new cluster: master [10.35.128.5], worker [], registry 10.35.128.5
......
2022-12-22T04:01:28 info succeeded in creating a new cluster, enjoy it!
2022-12-22T04:01:28 info 
      ___           ___           ___           ___       ___           ___
     /\  \         /\  \         /\  \         /\__\     /\  \         /\  \
    /::\  \       /::\  \       /::\  \       /:/  /    /::\  \       /::\  \
   /:/\ \  \     /:/\:\  \     /:/\:\  \     /:/  /    /:/\:\  \     /:/\ \  \
  _\:\~\ \  \   /::\~\:\  \   /::\~\:\  \   /:/  /    /:/  \:\  \   _\:\~\ \  \
 /\ \:\ \ \__\ /:/\:\ \:\__\ /:/\:\ \:\__\ /:/__/    /:/__/ \:\__\ /\ \:\ \ \__\
 \:\ \:\ \/__/ \:\~\:\ \/__/ \/__\:\/:/  / \:\  \    \:\  \ /:/  / \:\ \:\ \/__/
  \:\ \:\__\    \:\ \:\__\        \::/  /   \:\  \    \:\  /:/  /   \:\ \:\__\
   \:\/:/  /     \:\ \/__/        /:/  /     \:\  \    \:\/:/  /     \:\/:/  /
    \::/  /       \:\__\         /:/  /       \:\__\    \::/  /       \::/  /
     \/__/         \/__/         \/__/         \/__/     \/__/         \/__/

                  Website :https://www.sealos.io/
                  Address :github.com/labring/sealos
		BuildVersion: latest-
```
the second apply -f :
```
root@lin-master:~/tmp/cf# sealos apply -f Clusterfile
2022-12-22T04:04:57 info Start to create a new cluster: master [10.35.128.5], worker [], registry 10.35.128.5
......
 ERROR [2022-12-22 04:05:35] >> Port: 10249 occupied. Please turn off port service. 
2022-12-22T04:05:35 error Applied to cluster error: exit status 1
Error: exit status 1
exit status 1
```

the result of the second 'apply -f' after bugfix : 
```
root@lin-master:~/tmp/cf# sealos apply -f Clusterfile
2022-12-22T05:33:03 info no nodes that need to be scaled
2022-12-22T05:33:03 info 
      ___           ___           ___           ___       ___           ___
     /\  \         /\  \         /\  \         /\__\     /\  \         /\  \
    /::\  \       /::\  \       /::\  \       /:/  /    /::\  \       /::\  \
   /:/\ \  \     /:/\:\  \     /:/\:\  \     /:/  /    /:/\:\  \     /:/\ \  \
  _\:\~\ \  \   /::\~\:\  \   /::\~\:\  \   /:/  /    /:/  \:\  \   _\:\~\ \  \
 /\ \:\ \ \__\ /:/\:\ \:\__\ /:/\:\ \:\__\ /:/__/    /:/__/ \:\__\ /\ \:\ \ \__\
 \:\ \:\ \/__/ \:\~\:\ \/__/ \/__\:\/:/  / \:\  \    \:\  \ /:/  / \:\ \:\ \/__/
  \:\ \:\__\    \:\ \:\__\        \::/  /   \:\  \    \:\  /:/  /   \:\ \:\__\
   \:\/:/  /     \:\ \/__/        /:/  /     \:\  \    \:\/:/  /     \:\/:/  /
    \::/  /       \:\__\         /:/  /       \:\__\    \::/  /       \::/  /
     \/__/         \/__/         \/__/         \/__/     \/__/         \/__/

                  Website :https://www.sealos.io/
                  Address :github.com/labring/sealos
		BuildVersion: latest-
root@lin-master:~/tmp/cf# sealos apply -f Clusterfile
2022-12-22T05:33:58 info no nodes that need to be scaled
2022-12-22T05:33:58 info 
```
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note
-->