### PR TITLE
Feature: upgrade the cluster

### DIFF
--- a/docs/4.0/docs/examples/how-to-upgrade-cluster.md
+++ b/docs/4.0/docs/examples/how-to-upgrade-cluster.md
@@ -1,0 +1,38 @@
+# how to upgrade cluster
+
+Just run the command '**sealos run labring/kubernetes:<new-version>**' . **Make sure that you have built the cluster before. **
+
+## For examples
+
+1. You have run the command :
+
+```sh
+sealos run labring/kubernetes:v1.24.0 labring/calico:v3.22.1 --masters 192.168.64.8 --nodes 192.168.64.7
+```
+
+2. To upgrade cluster to v1.25.0 :
+
+```sh
+sealos run labring/kubernetes:v1.25.0 
+```
+
+​	And when it comes to 'kubeadm upgrade v1.25.0', you will see :
+
+```txt
+[upgrade/version] You have chosen to change the cluster version to "v1.25.0"
+[upgrade/versions] Cluster version: v1.24.0
+[upgrade/versions] kubeadm version: v1.25.0
+[upgrade] Are you sure you want to proceed? [y/N]: 
+```
+
+​	Input 'y' so that cluster upgrade goes on. 
+
+​	If **error happen**s, you can run the command 'sealos run labring/kubernetes:v1.25.0' again. It assure the same result after failure. 
+
+## Usage
+
+1. **Upgrade cannot skip minor version**. Like 'v1.23.0 to v1.25.0' that is not allowed. If really need to upgrade from v1.23.0 to v1.25.0, you can split to two steps like 'v1.23.0 to v1.24.0' and 'v1.24.0 to v1.25.0'.
+
+2. Upgrade once succeed the cluster mount image of old version was replaced. Add masters or nodes will apply the new version.
+
+​	

--- a/pkg/apply/processor/install.go
+++ b/pkg/apply/processor/install.go
@@ -28,6 +28,7 @@ import (
 	"github.com/labring/sealos/pkg/config"
 	"github.com/labring/sealos/pkg/filesystem"
 	"github.com/labring/sealos/pkg/guest"
+	runtime "github.com/labring/sealos/pkg/runtime"
 	v2 "github.com/labring/sealos/pkg/types/v1beta1"
 	"github.com/labring/sealos/pkg/utils/confirm"
 	"github.com/labring/sealos/pkg/utils/logger"
@@ -39,6 +40,7 @@ var ForceOverride bool
 type InstallProcessor struct {
 	ClusterFile      clusterfile.Interface
 	Buildah          buildah.Interface
+	Runtime          runtime.Interface
 	Guest            guest.Interface
 	NewMounts        []v2.MountImage
 	NewImages        []string
@@ -87,6 +89,7 @@ func (c *InstallProcessor) GetPipeLine() ([]func(cluster *v2.Cluster) error, err
 		c.RunConfig,
 		c.MountRootfs,
 		c.MirrorRegistry,
+		c.UpgradeIfNeed,
 		// i.GetPhasePluginFunc(plugin.PhasePreGuest),
 		c.RunGuest,
 		c.PostProcess,
@@ -160,6 +163,30 @@ func (c *InstallProcessor) PreProcess(cluster *v2.Cluster) error {
 			c.NewMounts = append(c.NewMounts, *mount)
 		}
 	}
+	runTime, err := runtime.NewDefaultRuntime(cluster, c.ClusterFile.GetKubeadmConfig())
+	if err != nil {
+		return fmt.Errorf("failed to init runtime, %v", err)
+	}
+	c.Runtime = runTime
+	return nil
+}
+
+func (c *InstallProcessor) UpgradeIfNeed(cluster *v2.Cluster) error {
+	logger.Info("Executing UpgradeIfNeed Pipeline in InstallProcessor")
+	for i := range c.NewMounts {
+		img := c.NewMounts[i]
+		if img.Type != v2.RootfsImage {
+			continue
+		}
+		logger.Debug("try Upgrade Cluster to %s", img.Labels[v2.ImageKubeVersionKey])
+		err := c.Runtime.UpgradeCluster(img.Labels[v2.ImageKubeVersionKey])
+		if err != nil {
+			logger.Info("upgrade cluster failure")
+			return err
+		}
+		//upgrade success; replace the old cluster mount
+		cluster.ReplaceRootfsImage()
+	}
 	return nil
 }
 
@@ -199,6 +226,7 @@ func (c *InstallProcessor) RunConfig(cluster *v2.Cluster) error {
 }
 
 func (c *InstallProcessor) MountRootfs(cluster *v2.Cluster) error {
+	logger.Info("Executing pipeline MountRootfs in InstallProcessor.")
 	if len(c.NewMounts) == 0 {
 		return nil
 	}

--- a/pkg/apply/run.go
+++ b/pkg/apply/run.go
@@ -161,7 +161,7 @@ func (r *ClusterArgs) SetClusterRunArgs(imageList []string, args *RunArgs) error
 		}
 	}
 
-	r.cluster.Spec.Image = append(r.cluster.Spec.Image, imageList...)
+	r.cluster.SetNewImages(imageList)
 
 	// set host when cluster is not yet initialized
 	if !r.cluster.CreationTimestamp.IsZero() {

--- a/pkg/constants/data.go
+++ b/pkg/constants/data.go
@@ -48,6 +48,7 @@ const (
 	EtcDirName                       = "etc"
 	ChartsDirName                    = "charts"
 	ManifestsDirName                 = "manifests"
+	BinDirName                       = "bin"
 	RegistryDirName                  = "registry"
 	ImagesDirName                    = "images"
 	ImageShimDirName                 = "shim"
@@ -96,6 +97,7 @@ type Data interface {
 
 	RootFSCharsPath() string
 	RootFSManifestsPath() string
+	RootFSBinPath() string
 	RootFSSealctlPath() string
 }
 
@@ -124,6 +126,10 @@ func (d *data) RootFSCharsPath() string {
 
 func (d *data) RootFSManifestsPath() string {
 	return filepath.Join(d.RootFSPath(), ManifestsDirName)
+}
+
+func (d *data) RootFSBinPath() string {
+	return filepath.Join(d.RootFSPath(), BinDirName)
 }
 
 func (d *data) EtcPath() string {

--- a/pkg/runtime/defaults/default_kubeadm_config.go
+++ b/pkg/runtime/defaults/default_kubeadm_config.go
@@ -41,7 +41,7 @@ apiServer:
   #    - 10.103.97.2
   extraArgs:
     #    etcd-servers: https://192.168.2.110:2379
-    feature-gates: EphemeralContainers=true
+    feature-gates: TTLAfterFinished=true,EphemeralContainers=true
     audit-policy-file: "/etc/kubernetes/audit-policy.yml"
     audit-log-path: "/var/log/kubernetes/audit.log"
     audit-log-format: json
@@ -66,7 +66,8 @@ apiServer:
 controllerManager:
   extraArgs:
     bind-address: 0.0.0.0
-    feature-gates: EphemeralContainers=true
+    feature-gates: TTLAfterFinished=true,EphemeralContainers=true
+    experimental-cluster-signing-duration: 876000h
   extraVolumes:
     - hostPath: /etc/localtime
       mountPath: /etc/localtime
@@ -76,7 +77,7 @@ controllerManager:
 scheduler:
   extraArgs:
     bind-address: 0.0.0.0
-    feature-gates: EphemeralContainers=true
+    feature-gates: TTLAfterFinished=true,EphemeralContainers=true
   extraVolumes:
     - hostPath: /etc/localtime
       mountPath: /etc/localtime

--- a/pkg/runtime/defaults/default_kubeadm_config.go
+++ b/pkg/runtime/defaults/default_kubeadm_config.go
@@ -41,7 +41,7 @@ apiServer:
   #    - 10.103.97.2
   extraArgs:
     #    etcd-servers: https://192.168.2.110:2379
-    feature-gates: TTLAfterFinished=true,EphemeralContainers=true
+    feature-gates: EphemeralContainers=true
     audit-policy-file: "/etc/kubernetes/audit-policy.yml"
     audit-log-path: "/var/log/kubernetes/audit.log"
     audit-log-format: json
@@ -66,8 +66,7 @@ apiServer:
 controllerManager:
   extraArgs:
     bind-address: 0.0.0.0
-    feature-gates: TTLAfterFinished=true,EphemeralContainers=true
-    experimental-cluster-signing-duration: 876000h
+    feature-gates: EphemeralContainers=true
   extraVolumes:
     - hostPath: /etc/localtime
       mountPath: /etc/localtime
@@ -77,7 +76,7 @@ controllerManager:
 scheduler:
   extraArgs:
     bind-address: 0.0.0.0
-    feature-gates: TTLAfterFinished=true,EphemeralContainers=true
+    feature-gates: EphemeralContainers=true
   extraVolumes:
     - hostPath: /etc/localtime
       mountPath: /etc/localtime

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 
 	"github.com/labring/sealos/pkg/utils/logger"
+	"github.com/labring/sealos/pkg/utils/versionutil"
 
 	v2 "github.com/labring/sealos/pkg/types/v1beta1"
 )
@@ -61,6 +62,7 @@ type Interface interface {
 	DeleteMasters(mastersIPList []string) error
 	SyncNodeIPVS(mastersIPList, nodeIPList []string) error
 	UpdateCert(certs []string) error
+	UpgradeCluster(version string) error
 }
 
 func (k *KubeadmRuntime) Reset() error {
@@ -141,4 +143,19 @@ func (k *KubeadmRuntime) Validate() error {
 		return fmt.Errorf("cluster image kubernetes version cannot be empty")
 	}
 	return nil
+}
+
+func (k *KubeadmRuntime) UpgradeCluster(version string) error {
+	curversion := k.getKubeVersionFromImage()
+	if curversion == version {
+		logger.Info("the cluster version no change")
+		return nil
+	} else if versionutil.Compare(version, curversion) {
+		logger.Info("cluster vesion: %s will be upgraded into %s.", curversion, version)
+		return k.upgradeCluster(version)
+	} else if versionutil.Compare(curversion, version) {
+		logger.Info("new cluster version %s behind the current version %s", version, curversion)
+		return nil
+	}
+	return fmt.Errorf("verion format error")
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -151,6 +151,9 @@ func (k *KubeadmRuntime) UpgradeCluster(version string) error {
 		logger.Info("The cluster version has not changed")
 		return nil
 	} else if versionutil.Compare(version, curversion) {
+		if err := versionutil.UpgradeVersionLimit(curversion, version); err != nil {
+			return err
+		}
 		logger.Info("cluster vesion: %s will be upgraded into %s.", curversion, version)
 		return k.upgradeCluster(version)
 	} else if versionutil.Compare(curversion, version) {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -148,7 +148,7 @@ func (k *KubeadmRuntime) Validate() error {
 func (k *KubeadmRuntime) UpgradeCluster(version string) error {
 	curversion := k.getKubeVersionFromImage()
 	if curversion == version {
-		logger.Info("the cluster version no change")
+		logger.Info("The cluster version has not changed")
 		return nil
 	} else if versionutil.Compare(version, curversion) {
 		logger.Info("cluster vesion: %s will be upgraded into %s.", curversion, version)

--- a/pkg/runtime/runtime_getter.go
+++ b/pkg/runtime/runtime_getter.go
@@ -46,13 +46,13 @@ func (k *KubeadmRuntime) getKubeVersion() string {
 	return k.ClusterConfiguration.KubernetesVersion
 }
 
+// old implementation doesn't consider multiple rootfs images; here get the first rootfs image
 func (k *KubeadmRuntime) getKubeVersionFromImage() string {
-	labels := k.getImageLabels()
-	image := labels[v1beta1.ImageKubeVersionKey]
-	if image == "" {
+	img := k.Cluster.GetRootfsImage("")
+	if img.Labels == nil {
 		return ""
 	}
-	return image
+	return img.Labels[v1beta1.ImageKubeVersionKey]
 }
 
 func (k *KubeadmRuntime) getMaster0IP() string {

--- a/pkg/runtime/upgrade.go
+++ b/pkg/runtime/upgrade.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2022 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"fmt"
+	"time"
+)
+
+var (
+	upgradeApplyCmd = "kubeadm upgrade apply %s"
+	upradeNodeCmd   = "kubeadm upgrade node"
+	drainNodeCmd    = "kubectl drain %s --ignore-daemonsets"
+	uncordonNodeCmd = "kubectl uncordon %s"
+	daemonReload    = "systemctl daemon-reload"
+	restartKubelet  = "systemctl restart kubelet"
+	kubeBinaryPath  = "/var/lib/sealos/data/default/rootfs/bin"
+)
+
+func (k *KubeadmRuntime) upgradeCluster(version string) error {
+	//upgrade control-plane
+	err := k.upgradeMaster0(version)
+	if err != nil {
+		return err
+	}
+	//upgrade other control-planes and worker nodes
+	upgradeNodes := []string{}
+	for _, ip := range append(k.getMasterIPList(), k.getNodeIPList()...) {
+		if ip == k.getMaster0IP() {
+			continue
+		}
+		upgradeNodes = append(upgradeNodes, ip)
+	}
+	return k.upgradeNode(upgradeNodes)
+}
+
+func (k *KubeadmRuntime) upgradeMaster0(version string) error {
+	master0ip := k.getMaster0IP()
+	//install kubeadm:{version} at master0
+	err := k.sshCmdAsync(master0ip,
+		fmt.Sprintf("cp -rf %s/kubeadm /usr/bin", kubeBinaryPath),
+		//execute  kubeadm upgrade apply {version} at master0
+		fmt.Sprintf(upgradeApplyCmd, version),
+		//install kubelet:{version},kubectl{version} at master0
+		fmt.Sprintf("cp -rf %s/kubectl /usr/bin", kubeBinaryPath),
+		fmt.Sprintf("cp -rf %s/kubelet /usr/bin", kubeBinaryPath),
+		//reload kubelet daemon
+		daemonReload,
+		restartKubelet,
+	)
+	return err
+}
+
+func (k *KubeadmRuntime) upgradeNode(ips []string) error {
+	for _, ip := range ips {
+		nodename, err := k.getRemoteInterface().Hostname(ip)
+		if err != nil {
+			return err
+		}
+		err = k.sshCmdAsync(ip,
+			//install kubeadm:{version} at the node
+			fmt.Sprintf("cp -rf %s/kubeadm /usr/bin", kubeBinaryPath),
+			//upgrade other control-plane and nodes
+			upradeNodeCmd,
+			//kubectl drain <node-to-drain> --ignore-daemonsets
+			fmt.Sprintf(drainNodeCmd, nodename),
+			//install kubelet:{version},kubectl{version} at the node
+			fmt.Sprintf("cp -rf %s/kubectl /usr/bin", kubeBinaryPath),
+			fmt.Sprintf("cp -rf %s/kubelet /usr/bin", kubeBinaryPath),
+			//reload kubelet daemon
+			daemonReload,
+			restartKubelet,
+		)
+		if err != nil {
+			return err
+		}
+		//kubectl uncordon <node-to-uncordon>
+		err = k.sshCmdAsync(ip, fmt.Sprintf(uncordonNodeCmd, nodename))
+		now := time.Now()
+		//restart api-server takes a few seconds
+		for err != nil {
+			if time.Now().After(now.Add(2 * time.Minute)) {
+				return err
+			}
+			time.Sleep(5 * time.Second)
+			err = k.sshCmdAsync(ip, fmt.Sprintf(uncordonNodeCmd, nodename))
+		}
+	}
+
+	return nil
+}

--- a/pkg/runtime/upgrade.go
+++ b/pkg/runtime/upgrade.go
@@ -75,7 +75,7 @@ func (k *KubeadmRuntime) upgradeMaster0(version string) error {
 	}
 	kubeBinaryPath := k.getContentData().RootFSBinPath()
 	//assure the connection to api-server succeed before executing upgrade cmds
-	if err = k.pingApiServer(); err != nil {
+	if err = k.pingAPIServer(); err != nil {
 		return err
 	}
 	err = k.sshCmdAsync(master0ip,
@@ -106,7 +106,7 @@ func (k *KubeadmRuntime) upgradeOtherNodes(ips []string) error {
 		}
 		kubeBinaryPath := k.getContentData().RootFSBinPath()
 		//assure the connection to api-server succeed before executing upgrade cmds
-		if err = k.pingApiServer(); err != nil {
+		if err = k.pingAPIServer(); err != nil {
 			return err
 		}
 		logger.Info("upgrade node %s", nodename)
@@ -161,7 +161,7 @@ func (k *KubeadmRuntime) ChangeConfigToV125() error {
 	return nil
 }
 
-func (k *KubeadmRuntime) pingApiServer() error {
+func (k *KubeadmRuntime) pingAPIServer() error {
 	cli, err := kubernetes.NewKubernetesClient(k.getContentData().AdminFile(), k.getMaster0IPAPIServer())
 	if err != nil {
 		return err

--- a/pkg/runtime/upgrade.go
+++ b/pkg/runtime/upgrade.go
@@ -1,30 +1,28 @@
-/*
-Copyright 2022 cuisongliu@qq.com.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright © 2022 sealos.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package runtime
 
 import (
 	"fmt"
-	"time"
 )
 
 var (
 	upgradeApplyCmd = "kubeadm upgrade apply %s"
 	upradeNodeCmd   = "kubeadm upgrade node"
-	drainNodeCmd    = "kubectl drain %s --ignore-daemonsets"
+	//drainNodeCmd    = "kubectl drain %s --ignore-daemonsets"
+	cordonNodeCmd   = "kubectl cordon %s"
 	uncordonNodeCmd = "kubectl uncordon %s"
 	daemonReload    = "systemctl daemon-reload"
 	restartKubelet  = "systemctl restart kubelet"
@@ -45,27 +43,36 @@ func (k *KubeadmRuntime) upgradeCluster(version string) error {
 		}
 		upgradeNodes = append(upgradeNodes, ip)
 	}
-	return k.upgradeNode(upgradeNodes)
+	return k.upgradeOtherNodes(upgradeNodes)
 }
 
 func (k *KubeadmRuntime) upgradeMaster0(version string) error {
 	master0ip := k.getMaster0IP()
+	master0Name, err := k.getRemoteInterface().Hostname(master0ip)
+	if err != nil {
+		return err
+	}
 	//install kubeadm:{version} at master0
-	err := k.sshCmdAsync(master0ip,
+	err = k.sshCmdAsync(master0ip,
 		fmt.Sprintf("cp -rf %s/kubeadm /usr/bin", kubeBinaryPath),
 		//execute  kubeadm upgrade apply {version} at master0
 		fmt.Sprintf(upgradeApplyCmd, version),
+		// kubectl drain <node-to-drain> --ignore-daemonsets
+		// fmt.Sprintf(drainNodeCmd, nodename),
+		//kubectl cordon <node-to-cordon>
+		fmt.Sprintf(cordonNodeCmd, master0Name),
 		//install kubelet:{version},kubectl{version} at master0
 		fmt.Sprintf("cp -rf %s/kubectl /usr/bin", kubeBinaryPath),
 		fmt.Sprintf("cp -rf %s/kubelet /usr/bin", kubeBinaryPath),
 		//reload kubelet daemon
 		daemonReload,
 		restartKubelet,
+		fmt.Sprintf(uncordonNodeCmd, master0Name),
 	)
 	return err
 }
 
-func (k *KubeadmRuntime) upgradeNode(ips []string) error {
+func (k *KubeadmRuntime) upgradeOtherNodes(ips []string) error {
 	for _, ip := range ips {
 		nodename, err := k.getRemoteInterface().Hostname(ip)
 		if err != nil {
@@ -76,30 +83,21 @@ func (k *KubeadmRuntime) upgradeNode(ips []string) error {
 			fmt.Sprintf("cp -rf %s/kubeadm /usr/bin", kubeBinaryPath),
 			//upgrade other control-plane and nodes
 			upradeNodeCmd,
-			//kubectl drain <node-to-drain> --ignore-daemonsets
-			fmt.Sprintf(drainNodeCmd, nodename),
+			// kubectl drain <node-to-drain> --ignore-daemonsets
+			// fmt.Sprintf(drainNodeCmd, nodename),
+			//kubectl cordon <node-to-cordon>
+			fmt.Sprintf(cordonNodeCmd, nodename),
 			//install kubelet:{version},kubectl{version} at the node
 			fmt.Sprintf("cp -rf %s/kubectl /usr/bin", kubeBinaryPath),
 			fmt.Sprintf("cp -rf %s/kubelet /usr/bin", kubeBinaryPath),
 			//reload kubelet daemon
 			daemonReload,
 			restartKubelet,
+			fmt.Sprintf(uncordonNodeCmd, nodename),
 		)
 		if err != nil {
 			return err
 		}
-		//kubectl uncordon <node-to-uncordon>
-		err = k.sshCmdAsync(ip, fmt.Sprintf(uncordonNodeCmd, nodename))
-		now := time.Now()
-		//restart api-server takes a few seconds
-		for err != nil {
-			if time.Now().After(now.Add(2 * time.Minute)) {
-				return err
-			}
-			time.Sleep(5 * time.Second)
-			err = k.sshCmdAsync(ip, fmt.Sprintf(uncordonNodeCmd, nodename))
-		}
 	}
-
 	return nil
 }

--- a/pkg/types/v1beta1/cluster_args.go
+++ b/pkg/types/v1beta1/cluster_args.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/labring/sealos/pkg/utils/iputils"
 	"github.com/labring/sealos/pkg/utils/maps"
+	"github.com/labring/sealos/pkg/utils/versionutil"
 )
 
 func (c *Cluster) GetSSH() SSH {
@@ -178,6 +179,44 @@ func (c *Cluster) SetMountImage(targetMount *MountImage) {
 	}
 }
 
+func (c *Cluster) ReplaceRootfsImage() {
+	i1, i2 := -1, -1
+	var v1, v2 string
+	for i := range c.Status.Mounts {
+		img := c.Status.Mounts[i]
+		if img.Type == RootfsImage {
+			if v1 == "" {
+				v1, i1 = img.Labels[ImageKubeVersionKey], i
+			} else {
+				v2, i2 = img.Labels[ImageKubeVersionKey], i
+			}
+		}
+	}
+	//if no two rootfsImages, never replace
+	if v1 == "" || v2 == "" {
+		return
+	}
+	//if version format error, never replace
+	if versionutil.Compare(v2, v1) {
+		c.Status.Mounts[i1], c.Status.Mounts[i2] = c.Status.Mounts[i2], c.Status.Mounts[i1]
+		c.Status.Mounts = append(c.Status.Mounts[:i2], c.Status.Mounts[i2+1:]...)
+	} else if versionutil.Compare(v1, v2) {
+		c.Status.Mounts[i2], c.Status.Mounts[i1] = c.Status.Mounts[i1], c.Status.Mounts[i2]
+		c.Status.Mounts = append(c.Status.Mounts[:i1], c.Status.Mounts[i1+1:]...)
+	}
+}
+
+func (c *Cluster) SetNewImages(images []string) {
+	imageSets := map[string]struct{}{}
+	for _, img := range c.Spec.Image {
+		imageSets[img] = struct{}{}
+	}
+	for _, img := range images {
+		if _, ok := imageSets[img]; !ok {
+			c.Spec.Image = append(c.Spec.Image, img)
+		}
+	}
+}
 func (c *Cluster) GetImageLabels() map[string]string {
 	var imageLabelMap map[string]string
 	for _, img := range c.Status.Mounts {

--- a/pkg/utils/images/images.go
+++ b/pkg/utils/images/images.go
@@ -23,6 +23,7 @@ import (
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/pkg/errors"
 
+	"github.com/labring/sealos/pkg/types/v1beta1"
 	"github.com/labring/sealos/pkg/utils/file"
 	"github.com/labring/sealos/pkg/utils/logger"
 	str "github.com/labring/sealos/pkg/utils/strings"
@@ -128,4 +129,14 @@ func normalizeTaggedDigestedNamed(named reference.Named) (reference.Named, error
 // prefix the specified name with "localhost/".
 func toLocalImageName(name string) string {
 	return "localhost/" + strings.TrimLeft(name, "/")
+}
+
+func GetKubeVersionFromImage(img v1beta1.MountImage) string {
+	if img.Type != v1beta1.RootfsImage {
+		return ""
+	}
+	if img.Labels == nil {
+		return ""
+	}
+	return img.Labels[v1beta1.ImageKubeVersionKey]
 }

--- a/pkg/utils/versionutil/version.go
+++ b/pkg/utils/versionutil/version.go
@@ -46,8 +46,8 @@ func Compare(v1, v2 string) bool {
 	} else if v1List[1] < v2List[1] {
 		return false
 	}
-	if v1List[2] > v2List[2] {
+	if v1List[2] >= v2List[2] {
 		return true
 	}
-	return true
+	return false
 }

--- a/pkg/utils/versionutil/version.go
+++ b/pkg/utils/versionutil/version.go
@@ -17,6 +17,8 @@ limitations under the License.
 package versionutil
 
 import (
+	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/labring/sealos/pkg/utils/logger"
@@ -50,4 +52,30 @@ func Compare(v1, v2 string) bool {
 		return true
 	}
 	return false
+}
+
+// assure version format right and new >=
+// The upgrade of minor version number cannot be skipped
+func UpgradeVersionLimit(old, new string) error {
+	new = strings.Replace(new, "v", "", -1)
+	old = strings.Replace(old, "v", "", -1)
+	new = strings.Split(new, "-")[0]
+	old = strings.Split(old, "-")[0]
+	newList := strings.Split(new, ".")
+	oldList := strings.Split(old, ".")
+
+	minorNewV, err := strconv.Atoi(newList[1])
+	if err != nil {
+		return err
+	}
+	minorOldV, err := strconv.Atoi(oldList[1])
+	if err != nil {
+		return err
+	}
+	if newList[0] > oldList[0] {
+		return fmt.Errorf("upgrade of senior version cannot be executed")
+	} else if minorNewV > minorOldV+1 {
+		return fmt.Errorf("upgrade of minor version number cannot be skipped")
+	}
+	return nil
 }


### PR DESCRIPTION
solve issue #1944 .
the upgrade process contains :
1. upgrade kubeadm,kubeclt,kubelet.
2. upgrade static pods including api-server, controller-manager,scheduler,etcd.
usage in the docs.
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note
-->