### PR TITLE
refactor: implement exponential backoff retry for ssh connect

### DIFF
--- a/pkg/ssh/exec.go
+++ b/pkg/ssh/exec.go
@@ -53,19 +53,12 @@ func NewExecCmdFromIPs(cluster *v2.Cluster, ips []string) (Exec, error) {
 }
 
 func (e *Exec) RunCmd(cmd string) error {
+	sshClient := NewSSHClient(&e.cluster.Spec.SSH, true)
 	eg, _ := errgroup.WithContext(context.Background())
 	for _, ipAddr := range e.ipList {
 		ip := ipAddr
 		eg.Go(func() error {
-			sshClient, sshErr := NewSSHByCluster(e.cluster, true)
-			if sshErr != nil {
-				return sshErr
-			}
-			err := sshClient.CmdAsync(ip, cmd)
-			if err != nil {
-				return err
-			}
-			return nil
+			return sshClient.CmdAsync(ip, cmd)
 		})
 	}
 	if err := eg.Wait(); err != nil {
@@ -75,19 +68,12 @@ func (e *Exec) RunCmd(cmd string) error {
 }
 
 func (e *Exec) RunCopy(srcFilePath, dstFilePath string) error {
+	sshClient := NewSSHClient(&e.cluster.Spec.SSH, true)
 	eg, _ := errgroup.WithContext(context.Background())
 	for _, ipAddr := range e.ipList {
 		ip := ipAddr
 		eg.Go(func() error {
-			sshClient, sshErr := NewSSHByCluster(e.cluster, true)
-			if sshErr != nil {
-				return sshErr
-			}
-			err := sshClient.Copy(ip, srcFilePath, dstFilePath)
-			if err != nil {
-				return err
-			}
-			return nil
+			return sshClient.Copy(ip, srcFilePath, dstFilePath)
 		})
 	}
 	if err := eg.Wait(); err != nil {


### PR DESCRIPTION
Signed-off-by: fengxsong <fengxsong@outlook.com>

1. fix `connection reset by peer` error during executing sealos exec/scp command, not need to check ssh connections for all nodes;
2. refactor ssh.Connect with backoff retry;
3. rename some function names;