### PR TITLE
fix: modify delete logic to support cloud provider

### DIFF
--- a/pkg/apply/processor/scale.go
+++ b/pkg/apply/processor/scale.go
@@ -150,8 +150,8 @@ func (c *ScaleProcessor) DeleteCheck(cluster *v2.Cluster) error {
 	logger.Info("Executing pipeline DeleteCheck in ScaleProcessor.")
 	var ips []string
 	ips = append(ips, cluster.GetMaster0IPAndPort())
-	ips = append(ips, c.MastersToDelete...)
-	ips = append(ips, c.NodesToDelete...)
+	//ips = append(ips, c.MastersToDelete...)
+	//ips = append(ips, c.NodesToDelete...)
 	err := checker.RunCheckList([]checker.Interface{checker.NewIPsHostChecker(ips)}, cluster, checker.PhasePre)
 	if err != nil {
 		return err

--- a/pkg/client-go/kubernetes/attribute.go
+++ b/pkg/client-go/kubernetes/attribute.go
@@ -1,0 +1,62 @@
+// Copyright © 2023 sealos.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/labring/sealos/pkg/utils/iputils"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	client "k8s.io/client-go/kubernetes"
+)
+
+func GetHostNameFromInternalIP(client client.Interface, nodeIP string) (string, error) {
+	ip := iputils.GetHostIP(nodeIP)
+	nodeList, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("get node list failed: %v", err)
+	}
+	for _, node := range nodeList.Items {
+		for _, address := range node.Status.Addresses {
+			if address.Type == corev1.NodeInternalIP {
+				if address.Address == ip {
+					return node.Name, nil
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("get hostname from internal ip %v failed", ip)
+}
+
+func GetHostNameFromExternalIP(client client.Interface, nodeIP string) (string, error) {
+	ip := iputils.GetHostIP(nodeIP)
+	nodeList, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("get node list failed: %v", err)
+	}
+	for _, node := range nodeList.Items {
+		for _, address := range node.Status.Addresses {
+			if address.Type == corev1.NodeExternalIP {
+				if address.Address == ip {
+					return node.Name, nil
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("get hostname from external ip %v failed", ip)
+}

--- a/pkg/runtime/master.go
+++ b/pkg/runtime/master.go
@@ -184,15 +184,16 @@ func (k *KubeadmRuntime) deleteMasters(masters []string) error {
 }
 
 func (k *KubeadmRuntime) deleteMaster(master string) error {
-	if err := k.resetNode(master); err != nil {
-		return err
-	}
 	//remove master
 	masterIPs := strings.SliceRemoveStr(k.getMasterIPList(), master)
 	if len(masterIPs) > 0 {
 		if err := k.deleteKubeNode(master); err != nil {
 			return fmt.Errorf("delete master %s failed %v", master, err)
 		}
+	}
+
+	if err := k.resetNode(master); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/runtime/node.go
+++ b/pkg/runtime/node.go
@@ -122,12 +122,13 @@ func (k *KubeadmRuntime) deleteNodes(nodes []string) error {
 }
 
 func (k *KubeadmRuntime) deleteNode(node string) error {
-	if err := k.resetNode(node); err != nil {
-		return err
-	}
 	//remove node
 	if len(k.getMasterIPList()) > 0 {
 		return k.deleteKubeNode(node)
+	}
+
+	if err := k.resetNode(node); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/runtime/utils.go
+++ b/pkg/runtime/utils.go
@@ -120,7 +120,7 @@ func (k *KubeadmRuntime) deleteKubeNode(ip string) error {
 		return err
 	}
 	ctx := context.Background()
-	hostname, err := k.execHostname(ip)
+	hostname, err := kubernetes.GetHostNameFromInternalIP(cli.Kubernetes(), ip)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
bug: Cloud provider will firstly delete instance and then the control-plane will lost connection with the host, which causes deleting node in k8s failed.
solution:  Delete the node in k8s first and then reset the node, this operating order would prevent deleting failure when the nodes to be deleted crashed or not reachable.