### PR TITLE
feat: refactor buildah's inspect method so we can inspect remote image

### DIFF
--- a/pkg/apply/processor/interface.go
+++ b/pkg/apply/processor/interface.go
@@ -85,7 +85,7 @@ func SyncClusterStatus(cluster *v2.Cluster, bdah buildah.Interface, reset bool) 
 }
 
 type imageInspector interface {
-	InspectImage(string) (v1.Image, error)
+	InspectImage(imgName string, opts ...string) (*v1.Image, error)
 }
 
 func OCIToImageMount(mount *v2.MountImage, inspector imageInspector) error {

--- a/pkg/buildah/constants.go
+++ b/pkg/buildah/constants.go
@@ -19,6 +19,15 @@ import (
 	"strings"
 
 	"github.com/containers/buildah/define"
+	"github.com/containers/image/v5/directory"
+	"github.com/containers/image/v5/docker"
+	"github.com/containers/image/v5/docker/archive"
+	ociarchive "github.com/containers/image/v5/oci/archive"
+	"github.com/containers/image/v5/oci/layout"
+	"github.com/containers/image/v5/openshift"
+	"github.com/containers/image/v5/sif"
+	"github.com/containers/image/v5/storage"
+	"github.com/containers/image/v5/tarball"
 )
 
 const (
@@ -47,3 +56,26 @@ const (
 	PullIfNewer   = define.PullIfNewer
 	PullNever     = define.PullNever
 )
+
+var (
+	TransportDir               = directory.Transport.Name()
+	TransportDocker            = docker.Transport.Name()
+	TransportDockerArchive     = archive.Transport.Name()
+	TransportOCIArchive        = ociarchive.Transport.Name()
+	TransportOCI               = layout.Transport.Name()
+	TransportAtomic            = openshift.Transport.Name()
+	TransportSif               = sif.Transport.Name()
+	TransportTarball           = tarball.Transport.Name()
+	TransportContainersStorage = storage.Transport.Name()
+)
+
+func formatReferenceWithTransportName(tr string, ref string) string {
+	switch tr {
+	case TransportAtomic, TransportDir, TransportDockerArchive, TransportOCI, TransportOCIArchive, TransportTarball, TransportSif:
+		return tr + ":" + ref
+	case TransportContainersStorage, TransportDocker:
+		return tr + "://" + ref
+	default:
+		panic(fmt.Errorf("unknown transport %s", tr))
+	}
+}

--- a/pkg/buildah/merge.go
+++ b/pkg/buildah/merge.go
@@ -133,7 +133,7 @@ func mergeImagesWithScratchContainer(newImageName string, images []string, platf
 	imageObjList := make([]map[string]v1.Image, 0)
 	for _, i := range images {
 		obj, _ := b.InspectImage(i)
-		imageObjList = append(imageObjList, map[string]v1.Image{i: obj})
+		imageObjList = append(imageObjList, map[string]v1.Image{i: *obj})
 	}
 
 	dockerfile, err := buildimage.MergeDockerfileFromImages(imageObjList)


### PR DESCRIPTION
Signed-off-by: fengxsong <fengxsong@outlook.com>

inspect image in local store

```go
.InspectImage("containers-storage://apache/apisix:3.1.0-debian")
.InspectImage("apache/apisix:3.1.0-debian")
.InspectImage("@digestID")
```

inspect remote image

```go
.InspectImage("docker://apache/apisix:3.1.0-debian")
.InspectImage("apache/apisix:3.1.0-debian", "docker")
```

inspect oci-archive, docker-archive

```go
.InspectImage("path/of/oci/tarfile.tar", "oci-archive")
.InspectImage("path/of/docker/tarfile.tar", "docker-archive")
```