### PR TITLE
checker draft part1

### DIFF
--- a/pkg/checker/constants.go
+++ b/pkg/checker/constants.go
@@ -18,4 +18,91 @@ package checker
 
 const (
 	Nil = "<nil>"
+
+	// ControlPlaneNumCPU is the number of CPUs required on control-plane
+	ControlPlaneNumCPU = 2
+
+	// ControlPlaneMem is the number of megabytes of memory required on the control-plane
+	// Below that amount of RAM running a stable control plane would be difficult.
+	ControlPlaneMem = 1700
+
+	// KubeletPort is the default port for the kubelet server on each host machine.
+	// May be overridden by a flag at startup.
+	KubeletPort = 10250
+
+	// KubeSchedulerPort is the default port for the scheduler status server.
+	// May be overridden by a flag at startup.
+	KubeSchedulerPort = 10259
+
+	// KubeControllerManagerPort is the default port for the controller manager status server.
+	// May be overridden by a flag at startup.
+	KubeControllerManagerPort = 10257
+
+	// KubeAPIServerPort is the default port for the Api Server status server.
+	// May be overridden by a flag at startup.
+	KubeAPIServerPort = 6443
+
+	// EtcdListenClientPort defines the port etcd listen on for client traffic
+	EtcdListenClientPort = 2379
+
+	// EtcdMetricsPort is the port at which to obtain etcd metrics and health status
+	EtcdMetricsPort = 2381
+
+	// StoragePath is the default path for the cri registry .
+	StoragePath = "/var/lib/registry"
+
+	// DockerSock is the default path for the docker sock .
+	DockerSock = "/var/run/docker.sock"
+
+	// CrioSock is the default path for the Crio sock .
+	CrioSock = "/var/run/crio/crio.sock"
+
+	// Etcd defines variable used internally when referring to etcd component.
+	Etcd = "etcd"
+
+	// KubeAPIServer defines variable used internally when referring to kube-apiserver component.
+	KubeAPIServer = "kube-apiserver"
+
+	// KubeControllerManager defines variable used internally when referring to kube-controller-manager component.
+	KubeControllerManager = "kube-controller-manager"
+
+	// KubeScheduler defines variable used internally when referring to kube-scheduler component.
+	KubeScheduler = "kube-scheduler"
+
+	// KubernetesDir is the directory Kubernetes owns for storing various configuration files.
+	KubernetesDir = "/etc/kubernetes"
+
+	// ManifestsSubDirName defines directory name to store manifests.
+	ManifestsSubDirName = "manifests"
+
+	// SystemctlServiceActive defines Systemctl return when service is active.
+	SystemctlServiceActive = "active"
+
+	// KubeletKubeConfigFileName defines the file name for the kubeconfig that the control-plane kubelet will use for talking
+	// to the API server
+	KubeletKubeConfigFileName = "kubelet.conf"
+
+	// KubeletBootstrapKubeConfigFileName defines the file name for the kubeconfig that the kubelet will use to do
+	// the TLS bootstrap to get itself an unique credential
+	KubeletBootstrapKubeConfigFileName = "bootstrap-kubelet.conf"
+
+	// SystemctlServiceInactive defines Systemctl return when service is not active.
+	SystemctlServiceInactive = "inactive"
+
+	// SystemctlServiceEnabled defines Systemctl return when service is enabled.
+	SystemctlServiceEnabled = "enabled"
+
+	//Bridgnf related bridgenf and forwarding checks for ipv4
+	Bridgenf = "/proc/sys/net/bridge/bridge-nf-call-iptables"
+
+	//Bridgenf related bridgenf and forwarding checks for ipv6
+	Bridgenf6 = "/proc/sys/net/bridge/bridge-nf-call-ip6tables"
+
+	//Ipv4Forward related bridgenf and forwarding checks for ipv4
+	Ipv4Forward = "/proc/sys/net/ipv4/ip_forward"
+
+	//Ipv6Forward related bridgenf and forwarding checks for ipv6
+	Ipv6DefaultForwarding = "/proc/sys/net/ipv6/conf/default/forwarding"
+
+	FirewalldSvcName = "firewalld.service"
 )

--- a/pkg/checker/cri_checker.go
+++ b/pkg/checker/cri_checker.go
@@ -1,0 +1,32 @@
+package checker
+
+import (
+	"fmt"
+
+	v2 "github.com/labring/sealos/pkg/types/v1beta1"
+	"github.com/labring/sealos/pkg/utils/logger"
+)
+
+// CriChecker checks cri service install environment in sealos.
+type CriChecker struct {
+	mountpoint string
+	ip         string
+}
+
+func (cc CriChecker) Name() string {
+	return fmt.Sprintf("%s:CriChecker", cc.ip)
+}
+
+// Check checks cri service which will get script from images.
+func (cc CriChecker) Check(cluster *v2.Cluster, phase string) (warnings, errorList []error) {
+	if phase != PhasePre {
+		return nil, nil
+	}
+	logger.Debug("%s:CriChecker:validating whether cri service installed environment", cc.ip)
+	//checker logic
+	return nil, nil
+}
+
+func NewCriChecker(mountpoint string, ip string) Interface {
+	return &CriChecker{mountpoint: mountpoint, ip: ip}
+}

--- a/pkg/checker/cri_shim_checker.go
+++ b/pkg/checker/cri_shim_checker.go
@@ -38,9 +38,13 @@ type CRIShimStatus struct {
 	Error     string
 }
 
-func (n *CRIShimChecker) Check(cluster *v2.Cluster, phase string) error {
+func (n *CRIShimChecker) Name() string {
+	return "CRIShimChecker"
+}
+
+func (n *CRIShimChecker) Check(cluster *v2.Cluster, phase string) (warnings, errorList []error) {
 	if phase != PhasePost {
-		return nil
+		return nil, nil
 	}
 	status := &CRIShimStatus{}
 	defer func() {
@@ -77,7 +81,7 @@ func (n *CRIShimChecker) Check(cluster *v2.Cluster, phase string) error {
 	}
 
 	status.Error = Nil
-	return nil
+	return nil, nil
 }
 
 func (n *CRIShimChecker) Output(status *CRIShimStatus) error {

--- a/pkg/checker/crictl_checker.go
+++ b/pkg/checker/crictl_checker.go
@@ -41,6 +41,10 @@ import (
 type CRICtlChecker struct {
 }
 
+func (n *CRICtlChecker) Name() string {
+	return "CRICtlChecker"
+}
+
 type Container struct {
 	Container string
 	State     string
@@ -58,9 +62,9 @@ type CRICtlStatus struct {
 	Error               string
 }
 
-func (n *CRICtlChecker) Check(cluster *v2.Cluster, phase string) error {
+func (n *CRICtlChecker) Check(cluster *v2.Cluster, phase string) (warnings, errorList []error) {
 	if phase != PhasePost {
-		return nil
+		return nil, nil
 	}
 	status := &CRICtlStatus{}
 	defer func() {
@@ -83,7 +87,7 @@ func (n *CRICtlChecker) Check(cluster *v2.Cluster, phase string) error {
 	crictlPath, err := execer.LookPath("crictl")
 	if err != nil {
 		status.Error = errors.Wrap(err, "error looking for path of crictl").Error()
-		return nil
+		return nil, nil
 	}
 
 	imageList, err := n.getCRICtlImageList(crictlPath)
@@ -107,7 +111,7 @@ func (n *CRICtlChecker) Check(cluster *v2.Cluster, phase string) error {
 	sshCtx, err := ssh.NewSSHByCluster(cluster, false)
 	if err != nil {
 		status.Error = errors.Wrap(err, "get ssh interface error").Error()
-		return nil
+		return nil, nil
 	}
 
 	root := constants.NewData(cluster.Name).RootFSPath()
@@ -125,7 +129,7 @@ func (n *CRICtlChecker) Check(cluster *v2.Cluster, phase string) error {
 	}
 	status.ImageShimPullStatus = shimStatus
 	status.Error = Nil
-	return nil
+	return nil, nil
 }
 
 func (n *CRICtlChecker) Output(status *CRICtlStatus) error {

--- a/pkg/checker/file_checker.go
+++ b/pkg/checker/file_checker.go
@@ -1,0 +1,168 @@
+package checker
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/labring/sealos/pkg/utils/logger"
+
+	"github.com/labring/sealos/pkg/ssh"
+	"github.com/pkg/errors"
+
+	v2 "github.com/labring/sealos/pkg/types/v1beta1"
+)
+
+// FileAvailableCheck checks that the given file does not already exist.
+type FileAvailableCheck struct {
+	path  string
+	label string
+	ip    string
+}
+
+func NewFileAvailableCheck(path, label string, ip string) Interface {
+	return &FileAvailableCheck{
+		path:  path,
+		label: label,
+		ip:    ip,
+	}
+}
+
+// Name returns label for individual FileAvailableChecks. If not known, will return based on path.
+func (fac FileAvailableCheck) Name() string {
+	if fac.label != "" {
+		return fmt.Sprintf("%s:%s", fac.ip, fac.label)
+	}
+	return fmt.Sprintf("%s:FileAvailable-%s", fac.ip, strings.Replace(fac.path, "/", "-", -1))
+}
+
+// Check validates if the given file does not already exist.
+func (fac FileAvailableCheck) Check(cluster *v2.Cluster, phase string) (warnings, errorList []error) {
+	logger.Debug("validating the existence of file %s", fac.path)
+	FileAvailableCMD := fmt.Sprintf("stat %s", fac.path)
+	SSH := ssh.NewSSHClient(&cluster.Spec.SSH, false)
+	FileInfo, err := SSH.CmdToString(fac.ip, FileAvailableCMD, "")
+	if err != nil {
+		return nil, []error{fmt.Errorf(err.Error() + "failed to get file info")}
+	}
+	if FileInfo != fmt.Sprintf("stat: cannot stat %s: No such file or directory", fac.path) {
+		return nil, []error{fmt.Errorf("%s already exists", fac.path)}
+	}
+	return nil, nil
+}
+
+// InpathCheck checks if the given executable is present in $path
+type InpathCheck struct {
+	//executable is the name of the executable to check.
+	executable string
+	//mandatory indicates if the executable is mandatory for the operation to continue.
+	mandatory  bool
+	suggestion string
+	label      string
+	ip         string
+}
+
+func NewInpathCheck(executable string, mandatory bool, suggestion string, label string, ip string) Interface {
+	return &InpathCheck{executable: executable, mandatory: mandatory, suggestion: suggestion, label: label, ip: ip}
+}
+
+// Name returns label for individual InPathCheck. If not known, will return based on path.
+func (ipc InpathCheck) Name() string {
+	if ipc.label != "" {
+		return fmt.Sprintf("%s :%s", ipc.ip, ipc.label)
+	}
+	return fmt.Sprintf("%s :InpathCheck", ipc.ip)
+}
+
+// Check validates if the given commend does not in path.
+func (ipc InpathCheck) Check(cluster *v2.Cluster, phase string) (warnings, errorList []error) {
+	if phase != PhasePre {
+		return nil, nil
+	}
+	logger.Debug("%s:validating the presence of executable %s ", ipc.ip, ipc.executable)
+	SSH := ssh.NewSSHClient(&cluster.Spec.SSH, false)
+	InpathCMD := fmt.Sprintf("which  %s", ipc.executable)
+	_, err := SSH.CmdToString(ipc.ip, InpathCMD, "")
+	if err != nil {
+		return nil, []error{errors.Errorf("executable %s not found in $PATH", ipc.executable)}
+	}
+	if ipc.mandatory {
+		//Return as a error:
+		return nil, []error{errors.Errorf("%s not found in system path", ipc.executable)}
+	}
+	// Return as a warning:
+	warningMessage := fmt.Sprintf("%s not found in system path", ipc.executable)
+	if ipc.suggestion != "" {
+		warningMessage += fmt.Sprintf("\nSuggestion: %s", ipc.suggestion)
+	}
+	return []error{errors.New(warningMessage)}, nil
+}
+
+// FileContentCheck checks that the given file contains the string Content.
+type FileContentCheck struct {
+	path    string
+	content []byte
+	label   string
+	ip      string
+}
+
+func NewFileContentCheck(path string, content []byte, label string, ip string) Interface {
+	return &FileContentCheck{}
+}
+
+// Name returns label for individual FileContentChecks. If not known, will return based on path.
+func (fcc FileContentCheck) Name() string {
+	if fcc.label != "" {
+		return fmt.Sprintf("%s :%s", fcc.ip, fcc.label)
+	}
+	return fmt.Sprintf("%s :FileContent-%s", fcc.ip, strings.Replace(fcc.path, "/", "-", -1))
+}
+
+// Check validates if the given file contains the given content.
+func (fcc FileContentCheck) Check(cluster *v2.Cluster, phase string) (warnings, errorList []error) {
+	logger.Debug("%s:validating the content of file %s", fcc.ip, fcc.path)
+	FileContentCMD := fmt.Sprintf("cat %s | grep \"%s\"", fcc.path, string(fcc.content))
+	SSH := ssh.NewSSHClient(&cluster.Spec.SSH, false)
+	FileContent, err := SSH.CmdToString(fcc.ip, FileContentCMD, "")
+	if err != nil {
+		return nil, []error{fmt.Errorf(err.Error() + "failed to get file content")}
+	}
+	if FileContent != "" {
+		return nil, []error{fmt.Errorf("%s contents are not set to %s", fcc.path, fcc.content)}
+	}
+	return nil, nil
+}
+
+type DirAvailableCheck struct {
+	path  string
+	label string
+	ip    string
+}
+
+func NewDirAvailableCheck(path, label string, ip string) Interface {
+	return &DirAvailableCheck{
+		path:  path,
+		label: label,
+		ip:    ip,
+	}
+}
+
+func (dac DirAvailableCheck) Name() string {
+	if dac.label != "" {
+		return fmt.Sprintf("%s:%s", dac.ip, dac.label)
+	}
+	return fmt.Sprintf("%s:DirAvailable-%s", dac.ip, strings.Replace(dac.path, "/", "-", -1))
+}
+
+func (dac DirAvailableCheck) Check(cluster *v2.Cluster, phase string) (warnings, errorList []error) {
+	logger.Debug("validating the existence of directory %s", dac.path)
+	DirAvailableCMD := fmt.Sprintf("stat %s", dac.path)
+	SSH := ssh.NewSSHClient(&cluster.Spec.SSH, false)
+	FileInfo, err := SSH.CmdToString(dac.ip, DirAvailableCMD, "")
+	if err != nil {
+		return nil, []error{fmt.Errorf(err.Error() + "failed to get file info")}
+	}
+	if FileInfo != fmt.Sprintf("stat: cannot stat %s: No such file or directory", dac.path) {
+		return nil, []error{fmt.Errorf("the file %s already exists", dac.path)}
+	}
+	return nil, nil
+}

--- a/pkg/checker/httpproxy_checker.go
+++ b/pkg/checker/httpproxy_checker.go
@@ -1,0 +1,57 @@
+package checker
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+
+	"github.com/labring/sealos/pkg/utils/logger"
+
+	v2 "github.com/labring/sealos/pkg/types/v1beta1"
+	netutil "k8s.io/apimachinery/pkg/util/net"
+	netutils "k8s.io/utils/net"
+)
+
+// HTTPProxyCheck checks if https connection to specific host is going
+// to be done directly or over proxy. If proxy detected, it will return warning.
+type HTTPProxyCheck struct {
+	proto string
+	ip    string
+}
+
+func NewHTTPProxyCheck(proto, host string) Interface {
+	return &HTTPProxyCheck{
+		proto: proto,
+		ip:    host,
+	}
+}
+
+// Name returns HTTPProxy as name for HTTPProxyCheck
+func (hpc HTTPProxyCheck) Name() string {
+	return fmt.Sprintf("%s:HTTPProxyCheck", hpc.ip)
+}
+
+// Check validates http connectivity type, direct or via proxy.
+func (hpc HTTPProxyCheck) Check(cluster *v2.Cluster, phase string) (warnings, errorList []error) {
+	if phase != PhasePre {
+		return nil, nil
+	}
+	logger.Info("%s:validating if the connectivity type is via proxy or direct", hpc.ip)
+	u := &url.URL{Scheme: hpc.proto, Host: hpc.ip}
+	if netutils.IsIPv6String(hpc.ip) {
+		u.Host = net.JoinHostPort(hpc.ip, "1234")
+	}
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, []error{err}
+	}
+	proxy, err := netutil.SetOldTransportDefaults(&http.Transport{}).Proxy(req)
+	if err != nil {
+		return nil, []error{err}
+	}
+	if proxy != nil {
+		return []error{fmt.Errorf("connection to %q uses proxy %q. If that is not intended, adjust your proxy settings", u, proxy)}, nil
+	}
+	return nil, nil
+}

--- a/pkg/checker/initsystem_check.go
+++ b/pkg/checker/initsystem_check.go
@@ -42,9 +42,13 @@ type InitSystemStatus struct {
 	ServiceList []systemStatus
 }
 
-func (n *InitSystemChecker) Check(cluster *v2.Cluster, phase string) error {
+func (n *InitSystemChecker) Name() string {
+	return "InitSystemChecker"
+}
+
+func (n *InitSystemChecker) Check(cluster *v2.Cluster, phase string) (warnings, errorList []error) {
 	if phase != PhasePost {
-		return nil
+		return nil, nil
 	}
 	status := &InitSystemStatus{}
 
@@ -57,7 +61,7 @@ func (n *InitSystemChecker) Check(cluster *v2.Cluster, phase string) error {
 	initsystemvar, err := initsystem.GetInitSystem()
 	if err != nil {
 		status.Error = errors.Wrap(err, "get initsystem error").Error()
-		return nil
+		return nil, nil
 	}
 
 	serviceNames := []string{"kubelet", "containerd", "cri-docker", "docker", "registry", "image-cri-shim"}
@@ -70,7 +74,7 @@ func (n *InitSystemChecker) Check(cluster *v2.Cluster, phase string) error {
 	}
 
 	status.Error = Nil
-	return nil
+	return nil, nil
 }
 
 func (n *InitSystemChecker) Output(status *InitSystemStatus) error {

--- a/pkg/checker/isprivilegeduser_checker.go
+++ b/pkg/checker/isprivilegeduser_checker.go
@@ -1,0 +1,47 @@
+package checker
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/labring/sealos/pkg/utils/logger"
+
+	"github.com/labring/sealos/pkg/ssh"
+
+	v2 "github.com/labring/sealos/pkg/types/v1beta1"
+)
+
+// IsPrivilegedUserCheck verifies user is privileged (linux - root, windows - Administrator)
+type IsPrivilegedUserCheck struct {
+	ip string
+}
+
+func NewIsPrivilegedUserCheck(ip string) Interface {
+	return &IsPrivilegedUserCheck{ip: ip}
+}
+
+func (ipuc IsPrivilegedUserCheck) Name() string {
+	return fmt.Sprintf("%s:IsPrivilegedUserCheck", ipuc.ip)
+}
+
+// Check validates if an user has elevated (root) privileges.
+func (ipuc IsPrivilegedUserCheck) Check(cluster *v2.Cluster, phase string) (warnings, errorList []error) {
+	if phase != PhasePre {
+		return nil, nil
+	}
+	logger.Debug("%s:validating if an user has elevated (root) privileges", ipuc.ip)
+	IsPrivilegedUserCMD := "id -u"
+	SSH := ssh.NewSSHClient(&cluster.Spec.SSH, false)
+	IsPrivilegedUserInfo, err := SSH.CmdToString(ipuc.ip, IsPrivilegedUserCMD, "")
+	if err != nil {
+		return nil, []error{fmt.Errorf(err.Error() + "failed to get IsPrivilegedUserInfo info")}
+	}
+	IsPrivilegedUser, err := strconv.Atoi(IsPrivilegedUserInfo)
+	if err != nil {
+		return nil, []error{fmt.Errorf(err.Error() + "failed to get IsPrivilegedUser info")}
+	}
+	if IsPrivilegedUser != 0 {
+		return nil, []error{fmt.Errorf("user is not privileged")}
+	}
+	return nil, nil
+}

--- a/pkg/checker/model.sh
+++ b/pkg/checker/model.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+BASE=$(pwd)
+
+common_log() {
+	echo $(date +"[%Y%m%d %H:%M:%S]: ") $1 >&2
+}
+
+arch_env() {
+    ARCH=$(uname -m)
+    case $ARCH in
+        armv5*) ARCH="armv5" ;;
+        armv6*) ARCH="armv6" ;;
+        armv7*) ARCH="armv7" ;;
+        aarch64) ARCH="arm64" ;;
+        x86) ARCH="386" ;;
+        x86_64) ARCH="amd64" ;;
+        i686) ARCH="386" ;;
+        i386) ARCH="386" ;;
+    esac
+}
+
+os_env() {
+    ubu=$(cat /etc/issue | grep -i "ubuntu" | wc -l)
+    debian=$(cat /etc/issue | grep -i "debian" | wc -l)
+    cet=$(cat /etc/centos-release | grep "CentOS" | wc -l)
+    redhat=$(cat /etc/redhat-release | grep "Red Hat" | wc -l)
+    alios=$(cat /etc/redhat-release | grep "Alibaba" | wc -l)
+    if [ "$ubu" == "1" ];then
+        export OS="Ubuntu"
+    elif [ "$cet" == "1" ];then
+        export OS="CentOS"
+    elif [ "$redhat" == "1" ];then
+        export OS="RedHat"
+    elif [ "$debian" == "1" ];then
+        export OS="Debian"
+    elif [ "$alios" == "1" ];then
+        export OS="AliOS"
+    else
+       echo "unkown os...   exit"
+       exit 1
+    fi
+
+    case "$OS" in
+        CentOS)
+            OSVersion="$(cat /etc/centos-release |awk '{print $4}')"
+            ;;
+        *)
+            echo -e "Not support get OS version of ${OS}"
+    esac
+}
+
+kube::nvidia::setup_lspci(){
+    which lspci > /dev/null 2>&1
+    i=$?
+    if [ $i -ne 0 ]; then
+        if [ "$1" == "CentOS" ] || [ "$OS" == "AliOS" ] || [ "$1" == "RedHat" ]; then
+            yum install -y pciutils
+        else
+            apt install -y pciutils
+        fi
+    fi
+}
+
+kube::nvidia::detect_gpu(){
+    set +e
+    kube::nvidia::setup_lspci $OS
+    lspci | grep -i nvidia > /dev/null 2>&1
+    i=$?
+    if [ $i -eq 0 ]; then
+        export GPU_FOUNDED=true
+    else
+        export GPU_FOUNDED=false
+    fi
+    set -e
+}
+
+detect_timesync(){
+    ntpd_status=`systemctl is-active ntpd`
+    chronyd_status=`systemctl is-active chronyd`
+}
+
+#system info
+system_info() {
+    #kube::nvidia::detect_gpu 2>/dev/null
+
+    os_env 2>/dev/null
+
+    arch_env 2>/dev/null
+
+    detect_timesync 2>/dev/null
+
+    SPLITER="##SPLITER##"
+    BLKS=""
+    IFS='
+'
+    for blk in `lsblk -P -b --output=NAME,PKNAME,MOUNTPOINT,FSTYPE,SIZE,TYPE`;do
+        BLKS=${BLKS}${SPLITER}${blk}
+    done
+    BLKS=`echo -n ${BLKS:11} | base64 | tr -d '\n'`
+
+    IFACES=""
+    for iface_line in $(ip -o -4 addr list);do
+        iface_name=$(echo ${iface_line} | awk '{print $2}')
+        addr=$(echo ${iface_line} | awk '{print $4}' | cut -d/ -f1)
+        mac=$(ip link show dev $iface_name |awk '/link/{print $2}')
+        iface="NAME=\"$iface_name\" IP=\"$addr\" MAC=\"$mac\""
+        IFACES=${IFACES}${SPLITER}${iface}
+    done
+    IFACES=`echo -n ${IFACES:11} | base64 | tr -d '\n'`
+
+#    "system_uuid": "$(dmidecode -s system-uuid | grep -v "^#")",
+#    "processor_id": "$(dmidecode -t processor | grep ID | head -1 | sed 's/ID://g' | sed -e 's/^[ ,\t]*//g' | sed -e 's/[ ]*$//g')",
+#    "baseboard_number": "$(dmidecode -s baseboard-serial-number | grep -v "^#")",
+
+    echo -n "##INSTANCE_INFO_BEGIN##"
+    cat - << EOF
+{
+    "instanceInfo": {
+        "cpu": $(grep -c ^processor /proc/cpuinfo),
+        "memory": $(cat /proc/meminfo | grep MemTotal | awk -F ' ' '{print $2}'),
+        "os": "${OS}",
+        "osVersion": "${OSVersion}",
+        "arch": "${ARCH}",
+        "kernel": "$(uname -r)",
+        "hostName": "${HOSTNAME}"
+    },
+    "timeSyncStatus": {
+        "ntpd": "${ntpd_status}",
+        "chronyd": "${chronyd_status}"
+    },
+    "networkDevicesStr": "${IFACES}",
+    "blockDevicesStr": "${BLKS}"
+}
+EOF
+    echo -n "##INSTANCE_INFO_END##"
+}
+
+system_info

--- a/pkg/checker/node_checker.go
+++ b/pkg/checker/node_checker.go
@@ -40,6 +40,10 @@ const (
 type NodeChecker struct {
 }
 
+func (n *NodeChecker) Name() string {
+	return "NodeChecker"
+}
+
 type NodeClusterStatus struct {
 	ReadyCount       uint32
 	NotReadyCount    uint32
@@ -47,19 +51,19 @@ type NodeClusterStatus struct {
 	NotReadyNodeList []string
 }
 
-func (n *NodeChecker) Check(cluster *v2.Cluster, phase string) error {
+func (n *NodeChecker) Check(cluster *v2.Cluster, phase string) (warnings, errorList []error) {
 	if phase != PhasePost {
-		return nil
+		return nil, nil
 	}
 	// checker if all the node is ready
 	data := constants.NewData(cluster.Name)
 	c, err := kubernetes.NewKubernetesClient(data.AdminFile(), "")
 	if err != nil {
-		return err
+		return nil, []error{err}
 	}
 	nodes, err := c.Kubernetes().CoreV1().Nodes().List(context.Background(), v1.ListOptions{})
 	if err != nil {
-		return err
+		return nil, []error{err}
 	}
 	var notReadyNodeList []string
 	var readyCount uint32
@@ -83,9 +87,9 @@ func (n *NodeChecker) Check(cluster *v2.Cluster, phase string) error {
 	}
 	err = n.Output(nodeClusterStatus)
 	if err != nil {
-		return err
+		return nil, []error{err}
 	}
-	return nil
+	return nil, nil
 }
 
 func (n *NodeChecker) Output(nodeCLusterStatus NodeClusterStatus) error {

--- a/pkg/checker/portopen_checker.go
+++ b/pkg/checker/portopen_checker.go
@@ -1,0 +1,43 @@
+package checker
+
+import (
+	"fmt"
+
+	"github.com/labring/sealos/pkg/utils/logger"
+
+	"github.com/labring/sealos/pkg/ssh"
+
+	v2 "github.com/labring/sealos/pkg/types/v1beta1"
+)
+
+// PortOpenCheck ensures the given port is available for use.
+type PortOpenCheck struct {
+	port int
+	ip   string
+}
+
+func (poc *PortOpenCheck) Name() string {
+	return fmt.Sprintf("%s:PortOpenCheck", poc.ip)
+}
+
+func NewPortOpenCheck(port int, ip string) Interface {
+	return &PortOpenCheck{port: port, ip: ip}
+}
+
+// Check validates if the particular port is available.
+func (poc PortOpenCheck) Check(cluster *v2.Cluster, phase string) (warnings, errorList []error) {
+	if phase != PhasePre {
+		return nil, nil
+	}
+	logger.Debug("%s:validating whether port %d is available", poc.ip, poc.port)
+	PortOpenCMD := fmt.Sprintf("lsof -i:%d", poc.port)
+	SSH := ssh.NewSSHClient(&cluster.Spec.SSH, false)
+	PortOpenInfo, err := SSH.CmdToString(poc.ip, PortOpenCMD, "")
+	if err != nil {
+		return nil, []error{fmt.Errorf(err.Error() + "failed to get portinfo info")}
+	}
+	if PortOpenInfo != "" {
+		return nil, []error{fmt.Errorf("port %d is already in use", poc.port)}
+	}
+	return nil, nil
+}

--- a/pkg/checker/resource_checker.go
+++ b/pkg/checker/resource_checker.go
@@ -1,0 +1,86 @@
+package checker
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/labring/sealos/pkg/utils/logger"
+
+	"github.com/labring/sealos/pkg/ssh"
+	v2 "github.com/labring/sealos/pkg/types/v1beta1"
+)
+
+// NumCPUCheck checks if current number of CPUs is not less than required
+type NumCPUCheck struct {
+	limit int
+	ip    string
+}
+
+// Name returns the label for NumCPUCheck
+func (ncc *NumCPUCheck) Name() string {
+	return fmt.Sprintf("%s:NumCPUCheck", ncc.ip)
+}
+
+func NewNumCPUCheck(NumsCPU int, ip string) Interface {
+	return &NumCPUCheck{limit: NumsCPU, ip: ip}
+}
+
+// Check number of CPUs required by kubeadm
+func (ncc NumCPUCheck) Check(cluster *v2.Cluster, phase string) (warnings, errorList []error) {
+	if phase != PhasePre {
+		return nil, nil
+	}
+	logger.Debug("%s:start CPU check", ncc.ip)
+	NumCPUCMD := "cat /proc/cpuinfo| grep \"processor\"| wc -l"
+	SSH := ssh.NewSSHClient(&cluster.Spec.SSH, false)
+	numCPU, err := SSH.CmdToString(ncc.ip, NumCPUCMD, "")
+	if err != nil {
+		return nil, []error{fmt.Errorf(err.Error() + "failed to get cpu info")}
+	}
+	nCPU, err := strconv.Atoi(numCPU)
+	if err != nil {
+		return nil, []error{fmt.Errorf(err.Error() + "failed to get cpu info")}
+	}
+	if nCPU < ncc.limit {
+		return nil, []error{fmt.Errorf("the number of available CPUs %s is less than the required %d", numCPU, ncc.limit)}
+	}
+	return nil, nil
+}
+
+// MemCheck checks if the number of megabytes of memory is not less than required
+type MemCheck struct {
+	limit uint64
+	ip    string
+}
+
+// Name returns the label for NewMemCheck
+func NewMemCheck(NumsMem uint64, ip string) Interface {
+	return &MemCheck{limit: NumsMem, ip: ip}
+}
+
+func (mc MemCheck) Name() string {
+	return fmt.Sprintf("%s:MemCheck", mc.ip)
+}
+
+// Check number of memory required by kubeadm
+func (mc MemCheck) Check(cluster *v2.Cluster, phase string) (warnings, errorList []error) {
+	if phase != PhasePre {
+		return nil, nil
+	}
+	logger.Debug("%s:start MemCheck", mc.ip)
+	NumMemTotalCMD := "cat /proc/meminfo | grep \"MemTotal\" | awk '{print $2}'"
+	SSH := ssh.NewSSHClient(&cluster.Spec.SSH, false)
+	numMem, err := SSH.CmdToString(mc.ip, NumMemTotalCMD, "")
+	if err != nil {
+		return nil, []error{fmt.Errorf(err.Error() + "failed to get system info")}
+	}
+	memTotal, err := strconv.ParseUint(numMem, 10, 64)
+	if err != nil {
+		return nil, []error{fmt.Errorf(err.Error() + "failed to get system info")}
+	}
+	actual := memTotal / 1024
+	if actual < mc.limit {
+		return nil, []error{fmt.Errorf("the system RAM (%d MB) is less than the minimum %d MB", actual, mc.limit)}
+	}
+	return nil, nil
+}

--- a/pkg/checker/swap_checker.go
+++ b/pkg/checker/swap_checker.go
@@ -1,0 +1,42 @@
+package checker
+
+import (
+	"fmt"
+
+	"github.com/labring/sealos/pkg/utils/logger"
+
+	"github.com/labring/sealos/pkg/ssh"
+	v2 "github.com/labring/sealos/pkg/types/v1beta1"
+)
+
+// SwapCheck warns if swap is enabled
+type SwapCheck struct {
+	ip string
+}
+
+func NewSwapCheck(ip string) Interface {
+	return &SwapCheck{}
+}
+
+// Name will return Swap as name for SwapCheck
+func (swc SwapCheck) Name() string {
+	return fmt.Sprintf("%s:SwapCheck", swc.ip)
+}
+
+// Check validates whether swap is enabled or not
+func (swc SwapCheck) Check(cluster *v2.Cluster, phase string) (warnings, errorList []error) {
+	if phase != PhasePre {
+		return nil, nil
+	}
+	logger.Debug("%s:validating whether swap is enabled or not")
+	SwapStatCMD := "swapon"
+	SSH := ssh.NewSSHClient(&cluster.Spec.SSH, false)
+	SwapInfo, err := SSH.CmdToString(swc.ip, SwapStatCMD, "")
+	if err != nil {
+		return nil, []error{fmt.Errorf(err.Error() + "failed to get swap info")}
+	}
+	if SwapInfo != "" {
+		return nil, []error{fmt.Errorf("swap is enabled")}
+	}
+	return nil, nil
+}

--- a/pkg/runtime/precheck.go
+++ b/pkg/runtime/precheck.go
@@ -1,0 +1,171 @@
+package runtime
+
+import (
+	"context"
+	"path/filepath"
+
+	netutils "k8s.io/utils/net"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/labring/sealos/pkg/checker"
+	"github.com/labring/sealos/pkg/utils/logger"
+)
+
+func (k *KubeadmRuntime) preCheck() error {
+	logger.Info("Executing pipeline Check in CreateProcessor.")
+	err := k.RunBaseCheck()
+	if err != nil {
+		return err
+	}
+	err = k.RunKubeadmInitCheck()
+	if err != nil {
+		return err
+	}
+	err = k.RunKubeadmJoinCheck()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// BaseCheck is a basic check for all nodes,which check the total environment,such as nodename ssh connection.
+func (k *KubeadmRuntime) RunBaseCheck() error {
+	allNodeIPs := k.Cluster.GetAllIPS()
+	check := []checker.Interface{
+		checker.NewHostnameUniqueChecker(allNodeIPs),
+		checker.NewTimeSyncChecker(allNodeIPs),
+		checker.NewHostnameFormatChecker(allNodeIPs),
+	}
+	return checker.RunCheckList(check, k.Cluster, checker.PhasePre)
+}
+
+func (k *KubeadmRuntime) RunKubeadmInitCheck() error {
+	var InitCheck []checker.Interface
+
+	masterList := k.getMasterIPList()
+	eg, _ := errgroup.WithContext(context.Background())
+	for _, IP := range masterList {
+		ip := IP
+		eg.Go(func() error {
+			InitCheck = k.addInitChecks(InitCheck, ip)
+			err := checker.RunCheckList(InitCheck, k.Cluster, checker.PhasePre)
+			if err != nil {
+				return err
+			}
+			return nil
+		})
+	}
+	return nil
+}
+
+func (k *KubeadmRuntime) RunKubeadmJoinCheck() error {
+	var JoinCheck []checker.Interface
+
+	nodeList := k.getNodeIPList()
+	eg, _ := errgroup.WithContext(context.Background())
+	for _, IP := range nodeList {
+		ip := IP
+		eg.Go(func() error {
+			JoinCheck = k.addJoinChecks(JoinCheck, ip)
+			err := checker.RunCheckList(JoinCheck, k.Cluster, checker.PhasePre)
+			if err != nil {
+				return err
+			}
+			return nil
+		})
+	}
+	return nil
+}
+
+func (k *KubeadmRuntime) addInitChecks(checks []checker.Interface, ip string) []checker.Interface {
+	manifestsDir := filepath.Join(checker.KubernetesDir, checker.ManifestsSubDirName)
+	checks = append(checks, checker.NewIsPrivilegedUserCheck(ip),
+		checker.NewIsPrivilegedUserCheck(ip),
+		checker.NewNumCPUCheck(checker.ControlPlaneNumCPU, ip),
+		checker.NewMemCheck(checker.ControlPlaneMem, ip),
+		checker.NewServiceCheck(checker.FirewalldSvcName, "", ip),
+		checker.NewPortOpenCheck(checker.KubeSchedulerPort, ip),
+		checker.NewPortOpenCheck(checker.KubeControllerManagerPort, ip),
+		checker.NewPortOpenCheck(int(k.getAPIServerPort()), ip),
+		checker.NewFileAvailableCheck(k.GetStaticPodFilepath(checker.KubeAPIServer, manifestsDir), "", ip),
+		checker.NewFileAvailableCheck(k.GetStaticPodFilepath(checker.KubeControllerManager, manifestsDir), "", ip),
+		checker.NewFileAvailableCheck(k.GetStaticPodFilepath(checker.KubeScheduler, manifestsDir), "", ip),
+		checker.NewFileAvailableCheck(k.GetStaticPodFilepath(checker.Etcd, manifestsDir), "", ip),
+		checker.NewHTTPProxyCheck("https", k.InitConfiguration.LocalAPIEndpoint.AdvertiseAddress),
+	)
+	checks = addCommenChecks(checks, ip)
+	//TODO：support external etcd
+
+	// Check if Bridge-netfilter and IPv6 relevant flags are set
+	if ip := netutils.ParseIPSloppy(k.InitConfiguration.LocalAPIEndpoint.AdvertiseAddress); ip != nil {
+		if netutils.IsIPv6(ip) {
+			checks = addIPv6Checks(checks, string(ip))
+		}
+	}
+	if k.InitConfiguration.Etcd.Local != nil {
+		// Only do etcd related checks when required to install a local etcd
+		checks = append(checks,
+			checker.NewPortOpenCheck(checker.EtcdListenClientPort, ip),
+			checker.NewPortOpenCheck(checker.EtcdMetricsPort, ip),
+			checker.NewDirAvailableCheck(k.InitConfiguration.Etcd.Local.DataDir, "", ip),
+		)
+	}
+
+	return checks
+}
+
+func (k *KubeadmRuntime) addJoinChecks(checks []checker.Interface, ip string) []checker.Interface {
+	checks = append(checks,
+		checker.NewIsPrivilegedUserCheck(ip),
+		checker.NewFileAvailableCheck(filepath.Join(checker.KubernetesDir, checker.KubeletKubeConfigFileName), "", ip),
+		checker.NewFileAvailableCheck(filepath.Join(checker.KubernetesDir, checker.KubeletBootstrapKubeConfigFileName), "", ip),
+	)
+	checks = addCommenChecks(checks, ip)
+	return checks
+}
+
+func addCommenChecks(checks []checker.Interface, ip string) []checker.Interface {
+	checks = addIPv4Checks(checks, ip)
+	checks = addExecChecks(checks, ip)
+	checks = append(checks,
+		checker.NewSwapCheck(ip),
+		checker.NewPortOpenCheck(checker.KubeletPort, ip),
+	)
+	return checks
+}
+
+// addIPv4Checks add ipv4 checks,just support linux env now.
+func addIPv4Checks(checks []checker.Interface, ip string) []checker.Interface {
+	checks = append(checks, checker.NewFileContentCheck(
+		checker.Bridgenf, []byte{'1'}, "", ip),
+		checker.NewFileContentCheck(checker.Ipv4Forward, []byte{'1'}, "", ip),
+	)
+	return checks
+}
+
+// addIPv6Checks add ipv6 checks,just support linux env now.
+func addIPv6Checks(checks []checker.Interface, ip string) []checker.Interface {
+	checks = append(checks, checker.NewFileContentCheck(
+		checker.Bridgenf6, []byte{'1'}, "", ip),
+		checker.NewFileContentCheck(checker.Ipv6DefaultForwarding, []byte{'1'}, "", ip),
+	)
+	return checks
+}
+
+// addExecChecks adds checks that verify if certain binaries are in PATH
+func addExecChecks(checks []checker.Interface, ip string) []checker.Interface {
+	checks = append(checks,
+		checker.NewInpathCheck("conntrack", true, "", "", ip),
+		checker.NewInpathCheck("ip", true, "", "", ip),
+		checker.NewInpathCheck("iptables", true, "", "", ip),
+		checker.NewInpathCheck("mount", true, "", "", ip),
+		checker.NewInpathCheck("nsenter", true, "", "", ip),
+		checker.NewInpathCheck("ebtables", false, "", "", ip),
+		checker.NewInpathCheck("ethtool", false, "", "", ip),
+		checker.NewInpathCheck("socat", false, "", "", ip),
+		checker.NewInpathCheck("tc", false, "", "", ip),
+		checker.NewInpathCheck("touch", false, "", "", ip),
+	)
+	return checks
+}


### PR DESCRIPTION
this is sealos precheck checkers draft !!! 
this is sealos precheck checkers draft !!! 
this is sealos precheck checkers draft !!! 

this is part of sealos precheck implement .
main logic was implement in precheck.go and different checkers.

what i did ?
* add precheck door in pkg/runtime. why this place ? only this place can obtain dynamic port hostname,cfg etc.
* change checker interface , check() func return two values ,the first is an array of warnings ,the second is an array of errors.with this format ,when checker checks ,it won't interrupt by something wrong happened.
* add cpu , mem ,ip , net ,ssh ,kubeadm ,and some other checkers.
* the total check phase was divided into three phase ,the first is cri check(not implement now),the second is kubeadm init check ,the third is kubeadm join checks.
* I use a lot ssh to replace code logic in checker ,the reason is that this may be best way to support multipy node checks.