### PR TITLE
bugfix: kubelet cgroup driver not match containerd

### DIFF
--- a/pkg/runtime/kubeadm.go
+++ b/pkg/runtime/kubeadm.go
@@ -349,10 +349,11 @@ func (k *KubeadmRuntime) setCRISocket(criSocket string) {
 }
 
 func (k *KubeadmRuntime) generateInitConfigs() ([]byte, error) {
-	if err := k.ConvertInitConfigConversion(); err != nil {
+	if err := k.setCGroupDriverAndSocket(k.getMaster0IPAndPort()); err != nil {
 		return nil, err
 	}
-	if err := k.setCGroupDriverAndSocket(k.getMaster0IPAndPort()); err != nil {
+
+	if err := k.ConvertInitConfigConversion(); err != nil {
 		return nil, err
 	}
 	return yaml.MarshalYamlConfigs(&k.conversion.InitConfiguration,


### PR DESCRIPTION
Signed-off-by: 晓杰 <2561589453@qq.com>

fix #2459 #2447 

i also test sealos add node/master, del node/master, is ok