### PR TITLE
add kubernetes version cri version output in sealos verison cmd

### DIFF
--- a/cmd/sealos/cmd/version.go
+++ b/cmd/sealos/cmd/version.go
@@ -18,7 +18,9 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/labring/sealos/pkg/clusterfile"
 	"github.com/labring/sealos/pkg/constants"
+	"sigs.k8s.io/yaml"
 
 	"github.com/labring/sealos/pkg/version"
 
@@ -26,6 +28,7 @@ import (
 )
 
 var shortPrint bool
+var output string
 
 func newVersionCmd() *cobra.Command {
 	var versionCmd = &cobra.Command{
@@ -34,19 +37,18 @@ func newVersionCmd() *cobra.Command {
 		Args:    cobra.NoArgs,
 		Example: `sealos version`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			marshalled, err := json.Marshal(version.Get())
-			if err != nil {
-				return err
-			}
 			if shortPrint {
 				fmt.Println(version.Get().String())
-			} else {
-				fmt.Println(string(marshalled))
+				return nil
+			}
+			if err := PrintInfo(); err != nil {
+				return err
 			}
 			return nil
 		},
 	}
 	versionCmd.Flags().BoolVar(&shortPrint, "short", false, "if true, print just the version number.")
+	versionCmd.Flags().StringVarP(&output, "output", "o", "yaml", "One of 'yaml' or 'json'")
 	return versionCmd
 }
 
@@ -56,4 +58,30 @@ func init() {
 
 func getContact() string {
 	return fmt.Sprintf(constants.Contact, version.Get().String())
+}
+
+func PrintInfo() error {
+	var (
+		marshalled []byte
+	)
+	Output := &version.Output{}
+	Output.SealosVersion = version.Get()
+	cluster, err := clusterfile.GetClusterFromName(clusterName)
+	Output.KubernetesVersion = version.GetKubernetesVersion(cluster)
+	Output.CriRuntimeVersion = version.GetCriRuntimeVersion()
+
+	if output == "json" {
+		marshalled, err = json.Marshal(&Output)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(marshalled))
+		return nil
+	}
+	marshalled, err = yaml.Marshal(&Output)
+	if err != nil {
+		return err
+	}
+	fmt.Printf(string(marshalled))
+	return nil
 }

--- a/pkg/version/types.go
+++ b/pkg/version/types.go
@@ -16,21 +16,61 @@ limitations under the License.
 
 package version
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // Info contains versioning information.
 // TODO: Add []string of api versions supported? It's still unclear
 // how we'll want to distribute that information.
 type Info struct {
-	GitVersion string `json:"gitVersion"`
-	GitCommit  string `json:"gitCommit,omitempty"`
-	BuildDate  string `json:"buildDate"`
-	GoVersion  string `json:"goVersion"`
-	Compiler   string `json:"compiler"`
-	Platform   string `json:"platform"`
+	GitVersion string `json:"gitVersion" yaml:"gitVersion"`
+	GitCommit  string `json:"gitCommit,omitempty" yaml:"gitCommit,omitempty"`
+	BuildDate  string `json:"buildDate" yaml:"buildDate"`
+	GoVersion  string `json:"goVersion" yaml:"goVersion"`
+	Compiler   string `json:"compiler" yaml:"compiler"`
+	Platform   string `json:"platform" yaml:"platform"`
 }
 
 // String returns info as a human-friendly version string.
 func (info Info) String() string {
 	return fmt.Sprintf("%s-%s", info.GitVersion, info.GitCommit)
+}
+
+type Output struct {
+	SealosVersion     Info               `json:"SealosVersion,omitempty" yaml:"SealosVersion,omitempty"`
+	CriRuntimeVersion *CriRuntimeVersion `json:"CriVersionInfo,omitempty" yaml:"CriVersionInfo,omitempty"`
+	KubernetesVersion *KubernetesVersion `json:"KubernetesVersionInfo,omitempty" yaml:"KubernetesVersionInfo,omitempty"`
+}
+
+type CriRuntimeVersion struct {
+	// Version of the kubelet runtime API.
+	Version string `json:"Version,omitempty" yaml:"Version,omitempty"`
+	// Name of the container runtime.
+	RuntimeName string `json:"RuntimeName,omitempty" yaml:"RuntimeName,omitempty"`
+	// Version of the container runtime. The string must be
+	// semver-compatible.
+	RuntimeVersion string `json:"RuntimeVersion,omitempty" yaml:"RuntimeVersion,omitempty"`
+	// API version of the container runtime. The string must be
+	// semver-compatible.
+	RuntimeAPIVersion string `json:"RuntimeApiVersion,omitempty" yaml:"RuntimeApiVersion,omitempty"`
+}
+
+// Version is a struct for version information
+type KubernetesVersion struct {
+	ClientVersion    *KubectlInfo `json:"clientVersion,omitempty" yaml:"clientVersion,omitempty"`
+	KustomizeVersion string       `json:"kustomizeVersion,omitempty" yaml:"kustomizeVersion,omitempty"`
+	ServerVersion    *KubectlInfo `json:"serverVersion,omitempty" yaml:"serverVersion,omitempty"`
+}
+
+type KubectlInfo struct {
+	Major        string `json:"major" yaml:"major"`
+	Minor        string `json:"minor" yaml:"minor"`
+	GitVersion   string `json:"gitVersion" yaml:"gitVersion"`
+	GitCommit    string `json:"gitCommit" yaml:"gitCommit"`
+	GitTreeState string `json:"gitTreeState" yaml:"gitTreeState"`
+	BuildDate    string `json:"buildDate" yaml:"buildDate"`
+	GoVersion    string `json:"goVersion" yaml:"goVersion"`
+	Compiler     string `json:"compiler" yaml:"compiler"`
+	Platform     string `json:"platform" yaml:"platform"`
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -19,6 +19,14 @@ package version
 import (
 	"fmt"
 	"runtime"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/labring/sealos/pkg/utils/exec"
+
+	"github.com/labring/sealos/pkg/constants"
+
+	v2 "github.com/labring/sealos/pkg/types/v1beta1"
 )
 
 // Get returns the overall codebase version. It's for detecting
@@ -34,4 +42,36 @@ func Get() Info {
 		Compiler:   runtime.Compiler,
 		Platform:   fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
+}
+
+func GetKubernetesVersion(cluster *v2.Cluster) *KubernetesVersion {
+	var cmd string
+	if cluster == nil {
+		cmd = "kubectl version -o yaml"
+	} else {
+		data := constants.NewData(cluster.Name)
+		cmd = fmt.Sprintf("kubectl version --kubeconfig %s -o yaml", data.AdminFile())
+	}
+	serverVersion, err := exec.RunBashCmd(cmd)
+	if err != nil || serverVersion == "" {
+		return nil
+	}
+	var Unmarshaled KubernetesVersion
+	if err = yaml.Unmarshal([]byte(serverVersion), &Unmarshaled); err != nil {
+		return nil
+	}
+	return &Unmarshaled
+}
+
+func GetCriRuntimeVersion() *CriRuntimeVersion {
+	cmd := "crictl version"
+	criRuntimeVersion, err := exec.RunBashCmd(cmd)
+	if err != nil || criRuntimeVersion == "" {
+		return nil
+	}
+	var Unmarshaled CriRuntimeVersion
+	if err = yaml.Unmarshal([]byte(criRuntimeVersion), &Unmarshaled); err != nil {
+		return nil
+	}
+	return &Unmarshaled
 }


### PR DESCRIPTION
sealos version OutPut example

CriVersionInfo:
  RuntimeApiVersion: v1
  RuntimeName: containerd
  RuntimeVersion: v1.6.16
  Version: 0.1.0
KubernetesVersionInfo:
  clientVersion:
    buildDate: "2022-08-23T17:44:59Z"
    compiler: gc
    gitCommit: a866cbe2e5bbaa01cfd5e969aa3e033f3282a8a2
    gitTreeState: clean
    gitVersion: v1.25.0
    goVersion: go1.19
    major: "1"
    minor: "25"
    platform: linux/amd64
  kustomizeVersion: v4.5.7
  serverVersion:
    buildDate: "2022-08-23T17:38:15Z"
    compiler: gc
    gitCommit: a866cbe2e5bbaa01cfd5e969aa3e033f3282a8a2
    gitTreeState: clean
    gitVersion: v1.25.0
    goVersion: go1.19
    major: "1"
    minor: "25"
    platform: linux/amd64
SealosVersion:
  buildDate: 2023-02-06T15:58:37+0800
  compiler: gc
  gitCommit: cc92b5cc
  gitVersion: untagged
  goVersion: go1.19.2
  platform: linux/amd64

get kubernetes version and criversion by cmd "kubectl version" and "crictl version"
if there cant find kuberentes version and criruntime version .It only print sealos version.