### PR TITLE
feat: refactor imagecrbuilder, add cr-option flag.

### DIFF
--- a/pkg/apply/processor/scale.go
+++ b/pkg/apply/processor/scale.go
@@ -119,7 +119,7 @@ func (c *ScaleProcessor) Join(cluster *v2.Cluster) error {
 	return c.Runtime.SyncNodeIPVS(cluster.GetMasterIPAndPortList(), c.NodesToJoin)
 }
 
-func (c *ScaleProcessor) UnMountRootfs(cluster *v2.Cluster) error {
+func (c ScaleProcessor) UnMountRootfs(cluster *v2.Cluster) error {
 	logger.Info("Executing pipeline UnMountRootfs in ScaleProcessor.")
 	hosts := append(c.MastersToDelete, c.NodesToDelete...)
 	if cluster.Status.Mounts == nil {

--- a/pkg/apply/processor/scale.go
+++ b/pkg/apply/processor/scale.go
@@ -119,7 +119,7 @@ func (c *ScaleProcessor) Join(cluster *v2.Cluster) error {
 	return c.Runtime.SyncNodeIPVS(cluster.GetMasterIPAndPortList(), c.NodesToJoin)
 }
 
-func (c ScaleProcessor) UnMountRootfs(cluster *v2.Cluster) error {
+func (c *ScaleProcessor) UnMountRootfs(cluster *v2.Cluster) error {
 	logger.Info("Executing pipeline UnMountRootfs in ScaleProcessor.")
 	hosts := append(c.MastersToDelete, c.NodesToDelete...)
 	if cluster.Status.Mounts == nil {

--- a/pkg/buildah/imagecr.go
+++ b/pkg/buildah/imagecr.go
@@ -1,3 +1,17 @@
+// Copyright © 2023 sealos.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package buildah
 
 import (

--- a/pkg/buildah/imagecr.go
+++ b/pkg/buildah/imagecr.go
@@ -74,7 +74,7 @@ func NewImageCRBuilderFromArgs(cmd *cobra.Command, args []string) (*ImageCRBuild
 }
 
 func NewAndRunImageCRBuilder(cmd *cobra.Command, args []string, iopts *pushOptions) error {
-	if iopts.crOption != CrOptionYes {
+	if iopts.crOption == CrOptionNo {
 		logger.Debug("skip image cr build by flag cr-option")
 		return nil
 	}

--- a/pkg/buildah/imagecr.go
+++ b/pkg/buildah/imagecr.go
@@ -1,0 +1,114 @@
+package buildah
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/containers/image/v5/pkg/docker/config"
+	imagev1 "github.com/labring/sealos/controllers/imagehub/api/v1"
+	"github.com/labring/sealos/pkg/utils/file"
+	"github.com/labring/sealos/pkg/utils/logger"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/util/homedir"
+)
+
+// SpecificCroption is used to parse the cr-option `auto` to `yes` or `no`.
+func SpecificCroption(args []string) CrOpionEnum {
+	var dest, username string
+	switch len(args) {
+	case 1:
+		dest = args[0]
+	case 2:
+		dest = args[1]
+	}
+	registry, err := parseRawURL(dest)
+	if err != nil {
+		logger.Debug("parse image url failed, skip image cr build")
+		return CrOptionNo
+	}
+	creds, err := config.GetAllCredentials(nil)
+	if err != nil {
+		logger.Debug("get all credentials failed, skip image cr build")
+		return CrOptionNo
+	}
+	if _, ok := creds[registry]; ok {
+		username = creds[registry].Username
+	} else {
+		logger.Debug("no credentials for this registry, skip image cr build")
+		return CrOptionNo
+	}
+	if !file.IsExist(filepath.Join(homedir.HomeDir(), SealosRootPath, registry)) ||
+		!file.IsExist(filepath.Join(homedir.HomeDir(), SealosRootPath, registry, username)) {
+		logger.Debug("no kubeconfig file for this registry, skip image cr build")
+		return CrOptionNo
+	}
+	return CrOptionYes
+}
+
+func NewImageCRBuilderFromArgs(cmd *cobra.Command, args []string) (*ImageCRBuilder, error) {
+	var dest string
+	switch len(args) {
+	case 1:
+		dest = args[0]
+	case 2:
+		dest = args[1]
+	default:
+		return nil, errors.New("dest image name must be specified")
+	}
+	store, err := getStore(cmd)
+	if err != nil {
+		return nil, err
+	}
+	registr, err := parseRawURL(dest)
+	if err != nil {
+		return nil, err
+	}
+	icb := &ImageCRBuilder{
+		image:    dest,
+		store:    store,
+		registry: registr,
+		imageCR:  &imagev1.Image{},
+	}
+	return icb, nil
+}
+
+func NewAndRunImageCRBuilder(cmd *cobra.Command, args []string, iopts *pushOptions) error {
+	if iopts.crOption != CrOptionYes {
+		logger.Debug("skip image cr build by flag cr-option")
+		return nil
+	}
+	icb, err := NewImageCRBuilderFromArgs(cmd, args)
+	if err != nil {
+		logger.Debug("new image cr builder failed, skip image cr build")
+		return err
+	}
+	// check if sealos registry, pahse registry info to ibc.
+	if !IsSealosRegistry(icb) {
+		logger.Debug("skip image cr build, not sealos registry")
+		return nil
+	}
+	return icb.Run()
+}
+
+func IsSealosRegistry(icb *ImageCRBuilder) bool {
+	//Check Cri Login
+	creds, err := config.GetAllCredentials(nil)
+	if err != nil {
+		logger.Debug("get credentials err ,please login first ." + fmt.Sprintf("%v", err))
+		return false
+	}
+	if _, ok := creds[icb.registry]; ok {
+		icb.username = creds[icb.registry].Username
+		icb.userconfig = creds[icb.registry].Password
+	} else {
+		logger.Debug("get registry login info err, please login " + icb.registry + " first")
+		return false
+	}
+	if !file.IsExist(filepath.Join(homedir.HomeDir(), SealosRootPath, icb.registry)) ||
+		!file.IsExist(filepath.Join(homedir.HomeDir(), SealosRootPath, icb.registry, icb.username)) {
+		logger.Debug("no kubeconfig file for this registry, skip image cr build")
+		return false
+	}
+	return true
+}

--- a/pkg/buildah/imagecr.go
+++ b/pkg/buildah/imagecr.go
@@ -78,6 +78,7 @@ func NewAndRunImageCRBuilder(cmd *cobra.Command, args []string, iopts *pushOptio
 		logger.Debug("skip image cr build by flag cr-option")
 		return nil
 	}
+	logger.Info("start image cr build and push")
 	icb, err := NewImageCRBuilderFromArgs(cmd, args)
 	if err != nil {
 		logger.Debug("new image cr builder failed, skip image cr build")
@@ -88,7 +89,12 @@ func NewAndRunImageCRBuilder(cmd *cobra.Command, args []string, iopts *pushOptio
 		logger.Debug("skip image cr build, not sealos registry")
 		return nil
 	}
-	return icb.Run()
+	if err := icb.Run(); err != nil {
+		logger.Error(err)
+		return err
+	}
+	logger.Info("image cr build and push success")
+	return nil
 }
 
 func IsSealosRegistry(icb *ImageCRBuilder) bool {

--- a/pkg/buildah/imagecr.go
+++ b/pkg/buildah/imagecr.go
@@ -6,11 +6,12 @@ import (
 	"path/filepath"
 
 	"github.com/containers/image/v5/pkg/docker/config"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/util/homedir"
+
 	imagev1 "github.com/labring/sealos/controllers/imagehub/api/v1"
 	"github.com/labring/sealos/pkg/utils/file"
 	"github.com/labring/sealos/pkg/utils/logger"
-	"github.com/spf13/cobra"
-	"k8s.io/client-go/util/homedir"
 )
 
 // SpecificCroption is used to parse the cr-option `auto` to `yes` or `no`.

--- a/pkg/buildah/imagecrbuilder.go
+++ b/pkg/buildah/imagecrbuilder.go
@@ -50,7 +50,7 @@ type ImageCRBuilder struct {
 	userconfig string
 	imageCR    *imagev1.Image
 
-	containerId string
+	containerID string
 	mountPoint  string
 	store       storage.Store
 }
@@ -75,23 +75,23 @@ func (icb *ImageCRBuilder) Run() error {
 	return nil
 }
 
-// CreateContainer create a container, return mountpoint and containerId
+// CreateContainer create a container, return mountpoint and containerID
 func (icb *ImageCRBuilder) CreateContainer() error {
 	logger.Debug("Executing CreateContainer in ImageCRBuilder")
 	// generate a random container name
-	containeruid := fmt.Sprintf("%s-%s", icb.image, strconv.Itoa(rand.New(rand.NewSource(time.Now().UnixNano())).Int()))
+	containerID := fmt.Sprintf("%s-%s", icb.image, strconv.Itoa(rand.New(rand.NewSource(time.Now().UnixNano())).Int()))
 	realImpl, err := New("")
 	if err != nil {
 		return err
 	}
-	builderInfo, err := realImpl.Create(containeruid, icb.image)
+	builderInfo, err := realImpl.Create(containerID, icb.image)
 	if err != nil {
 		return err
 	}
 	if isExist := file.IsExist(builderInfo.MountPoint); !isExist {
 		return fmt.Errorf("mountPoint not Exist")
 	}
-	icb.containerId = containeruid
+	icb.containerID = containerID
 	icb.mountPoint = builderInfo.MountPoint
 	return nil
 }
@@ -187,7 +187,7 @@ func (icb *ImageCRBuilder) DeleteContainer() error {
 	if err != nil {
 		return err
 	}
-	return realImpl.Delete(icb.containerId)
+	return realImpl.Delete(icb.containerID)
 }
 
 // ParseImageCR parse image cr yaml file ot an image cr obj
@@ -222,7 +222,7 @@ func (icb *ImageCRBuilder) GetInspectInfo() error {
 	if err != nil {
 		return err
 	}
-	containerInfo, err := realImpl.InspectContainer(icb.containerId)
+	containerInfo, err := realImpl.InspectContainer(icb.containerID)
 	if err != nil {
 		return err
 	}

--- a/pkg/buildah/imagecrbuilder.go
+++ b/pkg/buildah/imagecrbuilder.go
@@ -235,12 +235,13 @@ func (icb *ImageCRBuilder) GetInspectInfo() error {
 		return err
 	}
 
-	icb.imageCR.Spec.DetailInfo.ID = containerInfo.FromImageID
-	icb.imageCR.Spec.DetailInfo.Arch = image.Architecture
-	icb.imageCR.Spec.DetailInfo.Size, err = icb.store.ImageSize(containerInfo.FromImageID)
+	sz, err := icb.store.ImageSize(containerInfo.FromImageID)
 	if err != nil {
 		return err
 	}
+	icb.imageCR.Spec.DetailInfo.ID = containerInfo.FromImageID
+	icb.imageCR.Spec.DetailInfo.Arch = image.Architecture
+	icb.imageCR.Spec.DetailInfo.Size = sz
 	return nil
 }
 

--- a/pkg/buildah/imagecrbuilder.go
+++ b/pkg/buildah/imagecrbuilder.go
@@ -77,7 +77,7 @@ func (icb *ImageCRBuilder) Run() error {
 
 // CreateContainer create a container, return mountpoint and containerId
 func (icb *ImageCRBuilder) CreateContainer() error {
-	logger.Info("Executing CreateContainer in ImageCRBuilder")
+	logger.Debug("Executing CreateContainer in ImageCRBuilder")
 	// generate a random container name
 	containeruid := fmt.Sprintf("%s-%s", icb.image, strconv.Itoa(rand.New(rand.NewSource(time.Now().UnixNano())).Int()))
 	realImpl, err := New("")
@@ -182,7 +182,7 @@ func (icb *ImageCRBuilder) ApplyImageCR() error {
 }
 
 func (icb *ImageCRBuilder) DeleteContainer() error {
-	logger.Info("Executing DeleteContainer in ImageCRBuilder")
+	logger.Debug("Executing DeleteContainer in ImageCRBuilder")
 	realImpl, err := New("")
 	if err != nil {
 		return err

--- a/pkg/buildah/imagecrtypes.go
+++ b/pkg/buildah/imagecrtypes.go
@@ -1,3 +1,17 @@
+// Copyright © 2023 sealos.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package buildah
 
 import "errors"

--- a/pkg/buildah/imagecrtypes.go
+++ b/pkg/buildah/imagecrtypes.go
@@ -1,0 +1,49 @@
+package buildah
+
+import "errors"
+
+const (
+	// DocsPath ImageStdPath  ImageCRFile are path to image cr and readme
+	DocsPath     = "README.md"
+	ImageStdPath = "metadata"
+	// ImageCRFile Todo how can we support both config.yml and config.yaml
+	ImageCRFile = "config.yaml"
+
+	// SealosRootPath and KubeConfigPath is path to user kubeconfig
+	SealosRootPath = ".sealos"
+	KubeConfigPath = "config"
+
+	// ImagehubGroup ImagehubVersion ImagehubKind are group version kind of image cr
+	ImagehubGroup    = "imagehub.sealos.io"
+	ImagehubVersion  = "v1"
+	ImagehubKind     = "Image"
+	ImagehubResource = "images"
+)
+
+type CrOpionEnum string
+
+const (
+	CrOptionNo   CrOpionEnum = "no"
+	CrOptionYes  CrOpionEnum = "yes"
+	CrOptionOnly CrOpionEnum = "only"
+	CrOptionAuto CrOpionEnum = "auto"
+)
+
+// String is used both by fmt.Print and by Cobra in help text
+func (e *CrOpionEnum) String() string {
+	return string(*e)
+}
+
+func (e *CrOpionEnum) Set(v string) error {
+	switch v {
+	case "only", "yes", "no", "auto":
+		*e = CrOpionEnum(v)
+		return nil
+	default:
+		return errors.New(`must be one of "only", "yes", "no", "auto"`)
+	}
+}
+
+func (e *CrOpionEnum) Type() string {
+	return "image cr opion enum"
+}

--- a/pkg/buildah/push.go
+++ b/pkg/buildah/push.go
@@ -62,6 +62,9 @@ type pushOptions struct {
 	encryptionKeys     []string
 	encryptLayers      []int
 	insecure           bool
+
+	// TODO: remove this flag once we have a better way to handle image cr pushing to the dest registry
+	crOption crOpionEnum
 }
 
 func newDefaultPushOptions() *pushOptions {
@@ -94,6 +97,9 @@ func (opts *pushOptions) RegisterFlags(fs *pflag.FlagSet) error {
 	fs.StringSliceVar(&opts.encryptionKeys, "encryption-key", opts.encryptionKeys, "key with the encryption protocol to use needed to encrypt the image (e.g. jwe:/path/to/key.pem)")
 	fs.IntSliceVar(&opts.encryptLayers, "encrypt-layer", opts.encryptLayers, "layers to encrypt, 0-indexed layer indices with support for negative indexing (e.g. 0 is the first layer, -1 is the last layer). If not defined, will encrypt all layers if encryption-key flag is specified")
 	fs.BoolVar(&opts.tlsVerify, "tls-verify", opts.tlsVerify, "require HTTPS and verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
+
+	// TODO: remove this flag once we have a better way to handle image cr pushing to the dest registry
+	fs.Var(&opts.crOption, "cr-option", "push image cr to the dest registry")
 	return markFlagsHidden(fs, []string{"signature-policy", "blob-cache", "tls-verify"}...)
 }
 
@@ -117,8 +123,11 @@ func newPushCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return pushCmd(cmd, args, opts)
 		},
-		PostRun: func(cmd *cobra.Command, args []string) {
-			NewAndRunImageCRBuilder(cmd, args)
+		PostRunE: func(cmd *cobra.Command, args []string) error {
+			if opts.crOption == CrOptionYes || opts.crOption == CrOptionOnly {
+				return NewAndRunImageCRBuilder(cmd, args)
+			}
+			return nil
 		},
 		Example: fmt.Sprintf(`%[1]s push imageID docker://registry.example.com/repository:tag
   %[1]s push imageID docker-daemon:image:tagi
@@ -240,6 +249,12 @@ func pushCmd(c *cobra.Command, args []string, iopts *pushOptions) error {
 	}
 	if flagChanged(c, "compression-level") {
 		options.CompressionLevel = &iopts.compressionLevel
+	}
+
+	// check if the cr option is set to only and return before push.
+	if iopts.crOption == CrOptionOnly {
+		logger.Info("Only push image cr to the dest registry")
+		return nil
 	}
 
 	ref, digest, err := buildah.Push(getContext(), src, dest, options)

--- a/pkg/buildah/push.go
+++ b/pkg/buildah/push.go
@@ -72,6 +72,7 @@ func newDefaultPushOptions() *pushOptions {
 		authfile:   auth.GetDefaultAuthFile(),
 		retry:      buildahcli.MaxPullPushRetries,
 		retryDelay: buildahcli.PullPushRetryDelay,
+		crOption:   CrOptionNo,
 	}
 }
 
@@ -99,7 +100,7 @@ func (opts *pushOptions) RegisterFlags(fs *pflag.FlagSet) error {
 	fs.BoolVar(&opts.tlsVerify, "tls-verify", opts.tlsVerify, "require HTTPS and verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
 
 	// TODO: remove this flag once we have a better way to handle image cr pushing to the dest registry
-	fs.Var(&opts.crOption, "cr-option", "push image cr to the dest registry")
+	fs.Var(&opts.crOption, "cr-option", `push image cr to the dest registry, allow values: "yes", "no", "only", default is "no"`)
 	return markFlagsHidden(fs, []string{"signature-policy", "blob-cache", "tls-verify"}...)
 }
 


### PR DESCRIPTION
Refactor imagecrbuilder, add cr-option flag.

Default `cr-option` is `auto`, if registry is sealos registry, `auto` will switch to `yes` otherwise `no`.

Add `--cr-option only` flag, apply image cr only without push image.

Add `--cr-option yes` flag, apply cr when push images, will check registry too.

Add `--cr-option no` flag, will not apply cr when push images.