### PR TITLE
feature: single host should allow scheduling to master

### DIFF
--- a/.github/workflows/test_run.yml
+++ b/.github/workflows/test_run.yml
@@ -35,6 +35,53 @@ jobs:
         with:
           name: sealos
           path: /usr/bin/sealos
+
+  verify-run-single:
+    needs: [build-sealos]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download sealos
+        uses: actions/download-artifact@v3
+        with:
+          name: sealos
+          path: /tmp/
+      - name: Verify sealos
+        run: |
+          sudo chmod a+x /tmp/sealos
+          sudo mv /tmp/sealos /usr/bin/
+          sudo sealos version
+      - name: Remove containerd && docker
+        uses: labring/sealos-action@v0.0.7
+        with:
+          type: prune
+      - name: Auto install k8s using sealos
+        run: |
+          sudo sealos run labring/kubernetes:v1.25.0 --single --debug
+          mkdir -p "$HOME/.kube"
+          sudo cp -i /etc/kubernetes/admin.conf "$HOME/.kube/config"
+          sudo chown "$(whoami)" "$HOME/.kube/config"
+          kubectl get svc
+          kubectl get pod -A
+          sudo cat /root/.sealos/default/etc/kubeadm-init.yaml
+          sudo cat /root/.sealos/default/Clusterfile
+      - name: Verify Single Node Cluster Status
+        run: |
+          echo "Verify Cluster"
+          echo "Current system info"
+          sudo /var/lib/sealos/data/default/rootfs/opt/sealctl cri socket
+          sudo /var/lib/sealos/data/default/rootfs/opt/sealctl cri cgroup-driver --short
+          echo "Check Single Node Stains"
+          taints=$(kubectl get nodes -o json | jq ".items[].spec.taints")
+          if [ grep -q "control-plane"< <(echo $taints) ]; then
+            printf "node taints: %s\n" $taints && false
+          fi
+          echo "Current Cluster info"
+          set -e
+          sudo cat /root/.sealos/default/etc/kubeadm-init.yaml | grep /run/containerd/containerd.sock
+          sudo cat /root/.sealos/default/etc/kubeadm-init.yaml | grep systemd
+          sudo cat /root/.sealos/default/etc/kubeadm-init.yaml | grep 100.64.0.0/10
+          sudo cat /root/.sealos/default/etc/kubeadm-init.yaml | grep 10.96.0.0/22
+
   verify-run-containerd:
     needs: [build-sealos]
     runs-on: ubuntu-latest

--- a/cmd/sealos/cmd/run.go
+++ b/cmd/sealos/cmd/run.go
@@ -71,6 +71,7 @@ func newRunCmd() *cobra.Command {
 			if runSingle {
 				addr, _ := iputils.ListLocalHostAddrs()
 				runArgs.Masters = iputils.LocalIP(addr)
+				runArgs.Single = true
 			}
 
 			images, err := args2Images(args, transport)

--- a/pkg/apply/args.go
+++ b/pkg/apply/args.go
@@ -60,6 +60,7 @@ type RunArgs struct {
 	CustomEnv         []string
 	CustomCMD         []string
 	CustomConfigFiles []string
+	Single            bool
 	fs                *pflag.FlagSet
 }
 

--- a/pkg/apply/run.go
+++ b/pkg/apply/run.go
@@ -44,6 +44,10 @@ func NewApplierFromArgs(imageName []string, args *RunArgs) (applydrivers.Interfa
 	if err != nil && err != clusterfile.ErrClusterFileNotExists {
 		return nil, err
 	}
+	if err = cf.SetSingleMode(args.Single); err != nil {
+		return nil, err
+	}
+
 	cluster := cf.GetCluster()
 	if cluster == nil {
 		logger.Debug("creating new cluster")

--- a/pkg/clusterfile/clusterfile.go
+++ b/pkg/clusterfile/clusterfile.go
@@ -43,6 +43,7 @@ type Interface interface {
 	GetCluster() *v2.Cluster
 	GetConfigs() []v2.Config
 	GetKubeadmConfig() *runtime.KubeadmConfig
+	SetSingleMode(bool) error
 }
 
 func (c *ClusterFile) GetCluster() *v2.Cluster {

--- a/pkg/clusterfile/clusterfile_test.go
+++ b/pkg/clusterfile/clusterfile_test.go
@@ -19,7 +19,9 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 
+	"github.com/labring/sealos/pkg/runtime"
 	v2 "github.com/labring/sealos/pkg/types/v1beta1"
 )
 
@@ -112,6 +114,169 @@ func Test_NewClusterFile(t *testing.T) {
 			}
 			if !reflect.DeepEqual(cf.GetConfigs()[0], tt.args.config) {
 				t.Error("config not equal")
+			}
+		})
+	}
+}
+
+func Test_NoClusterFileWithSingleSchedule(t *testing.T) {
+	type args struct {
+		kubeadmConfig *runtime.KubeadmConfig
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "run single with cluster file not exists",
+			args: args{
+				kubeadmConfig: &runtime.KubeadmConfig{
+					InitConfiguration: kubeadm.InitConfiguration{
+						SkipPhases: []string{
+							"mark-control-plane",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cf := NewClusterFile("")
+			err := cf.Process()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("newClusterfile(string, ...OptionFunc) error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err = cf.SetSingleMode(true); err != nil {
+				t.Errorf("SingleMode(bool) error: %v", err)
+			}
+
+			if cf.GetCluster() != nil {
+				t.Errorf("cluster is not nil")
+			}
+			if cf.GetConfigs() != nil {
+				t.Error("configs is not nil")
+			}
+			if !reflect.DeepEqual(cf.GetKubeadmConfig(), tt.args.kubeadmConfig) {
+				t.Error("kubeadmConfig not equal")
+			}
+		})
+	}
+}
+
+func Test_NewClusterFileWithSingleSchedule(t *testing.T) {
+	type args struct {
+		cluster            *v2.Cluster
+		config             v2.Config
+		kubeadmConfig      *runtime.KubeadmConfig
+		customEnv          []string
+		sets               []string
+		values             []string
+		customConfigs      []string
+		customKubeadmFiles []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "run single",
+			args: args{
+				cluster: &v2.Cluster{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Cluster",
+						APIVersion: "apps.sealos.io/v1beta1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "default",
+					},
+					Spec: v2.ClusterSpec{
+						Image: v2.ImageList{
+							"dockerhub.tencentcloudcr.com/labring/kubernetes:v1.23.8",
+							"dockerhub.tencentcloudcr.com/labring/calico:v3.24.1",
+						},
+						SSH: v2.SSH{
+							User:   "root",
+							Passwd: "s3cret",
+							Pk:     "/path/to/private/key/file",
+							Port:   22,
+						},
+						Hosts: []v2.Host{
+							{
+								IPS:   []string{"10.74.16.27:22", "10.74.16.140:22", "10.74.16.101:22"},
+								Roles: []string{v2.MASTER, string(v2.AMD64)},
+							},
+						},
+					},
+					Status: v2.ClusterStatus{},
+				},
+				config: v2.Config{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Config",
+						APIVersion: "apps.sealos.io/v1beta1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "redis-config",
+					},
+					Spec: v2.ConfigSpec{
+						Path: "etc/redis.yaml",
+						Data: "test\n",
+					},
+				},
+				kubeadmConfig: &runtime.KubeadmConfig{
+					InitConfiguration: kubeadm.InitConfiguration{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "kubeadm.k8s.io/v1beta3",
+							Kind:       "InitConfiguration",
+						},
+						SkipPhases: []string{
+							"mark-control-plane",
+							"addon/kube-proxy",
+						},
+					},
+				},
+				customEnv: []string{
+					"SSH_PASSWORD=s3cret",
+				},
+				sets: []string{
+					"clusterName=default",
+				},
+				values:             []string{"testdata/example.values.yaml"},
+				customConfigs:      []string{"testdata/config.yaml"},
+				customKubeadmFiles: []string{"testdata/kubeadmConf.yaml"},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cf := NewClusterFile("testdata/clusterfile.yaml",
+				WithCustomEnvs(tt.args.customEnv),
+				WithCustomSets(tt.args.sets),
+				WithCustomValues(tt.args.values),
+				WithCustomConfigFiles(tt.args.customConfigs),
+				WithCustomKubeadmFiles(tt.args.customKubeadmFiles),
+			)
+			err := cf.Process()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("newClusterfile(string, ...OptionFunc) error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err = cf.SetSingleMode(true); err != nil {
+				t.Errorf("SingleMode(bool) error: %v", err)
+			}
+
+			equal := reflect.DeepEqual(cf.GetCluster(), tt.args.cluster)
+			if !equal {
+				t.Errorf("rendered clusterfile not equal")
+			}
+			if !reflect.DeepEqual(cf.GetConfigs()[0], tt.args.config) {
+				t.Error("config not equal")
+			}
+			if !reflect.DeepEqual(cf.GetKubeadmConfig(), tt.args.kubeadmConfig) {
+				t.Error("kubeadmConfig not equal")
 			}
 		})
 	}

--- a/pkg/clusterfile/pre_process.go
+++ b/pkg/clusterfile/pre_process.go
@@ -17,13 +17,16 @@ package clusterfile
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 
 	"github.com/labring/sealos/pkg/utils/logger"
 
+	"github.com/imdario/mergo"
 	"helm.sh/helm/v3/pkg/cli/values"
 	"helm.sh/helm/v3/pkg/getter"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 
 	"github.com/labring/sealos/pkg/constants"
 	"github.com/labring/sealos/pkg/runtime"
@@ -165,6 +168,26 @@ func (c *ClusterFile) DecodeKubeadmConfig(data []byte) error {
 	}
 	if kubeadmConfig == nil {
 		return ErrTypeNotFound
+	}
+	c.KubeConfig = kubeadmConfig
+	return nil
+}
+
+func (c *ClusterFile) SetSingleMode(enable bool) error {
+	if !enable {
+		return nil
+	}
+
+	kubeadmConfig := &runtime.KubeadmConfig{
+		InitConfiguration: kubeadm.InitConfiguration{
+			SkipPhases: []string{"mark-control-plane"},
+		},
+	}
+	if c.KubeConfig != nil {
+		err := mergo.Merge(kubeadmConfig, c.KubeConfig, mergo.WithAppendSlice)
+		if err != nil {
+			return fmt.Errorf("merge: %v", err)
+		}
 	}
 	c.KubeConfig = kubeadmConfig
 	return nil

--- a/pkg/clusterfile/testdata/kubeadmConf.yaml
+++ b/pkg/clusterfile/testdata/kubeadmConf.yaml
@@ -1,0 +1,18 @@
+# Copyright © 2022 sealos.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kubeadm.k8s.io/v1beta3
+kind: InitConfiguration
+skipPhases:
+  - addon/kube-proxy


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note
-->

Every time I run a Single host cluster, I need to manual remove the Taint.

```shell
$ sealos run labring/kubernetes:v1.25.0 labring/helm:v3.8.2 labring/calico:v3.24.1 --single
# remove taint
$ kubectl taint nodes --all node-role.kubernetes.io/master:NoSchedule-
```

I add a patch to do the untaint automatic #2317.