### PR TITLE
rolebing.subject.naemspace should set user-system

### DIFF
--- a/controllers/account/config/default/manager_auth_proxy_patch.yaml
+++ b/controllers/account/config/default/manager_auth_proxy_patch.yaml
@@ -34,6 +34,8 @@ spec:
         env:
           - name: ACCOUNT_NAMESPACE
             value: "sealos-system"
+          - name: NAMESPACE_NAME
+            value: "user-system"
         args:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"


### PR DESCRIPTION
用户没有权限访问自己的account，发现subject.namespace是default，应该是user-system，在环境变量里面加上就行
```
[root@VM-4-13-centos manifests]# kubectl get rolebinding userAccountRoleBinding-ff84005c-4e28-4932-add0-f51ac834e489 -n sealos-system -oyaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  creationTimestamp: "2023-02-27T04:05:52Z"
  name: userAccountRoleBinding-ff84005c-4e28-4932-add0-f51ac834e489
  namespace: sealos-system
  resourceVersion: "124793303"
  uid: 03335733-8105-45e1-b091-1bf892692239
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: userAccountRole-ff84005c-4e28-4932-add0-f51ac834e489
subjects:
- kind: ServiceAccount
  name: ff84005c-4e28-4932-add0-f51ac834e489
  namespace: default
```