### PR TITLE
add account balance when account is new user

### DIFF
--- a/controllers/account/api/v1/account_types.go
+++ b/controllers/account/api/v1/account_types.go
@@ -50,9 +50,10 @@ type Charge struct {
 	DeductionAmount    int64  `json:"deductionAmount,omitempty"`
 	AccountBalanceName string `json:"accountBalanceName,omitempty"`
 
-	Time    metav1.Time `json:"time,omitempty"`
-	Status  string      `json:"status,omitempty"`
-	TradeNO string      `json:"tradeNO,omitempty"`
+	Time     metav1.Time `json:"time,omitempty"`
+	Status   string      `json:"status,omitempty"`
+	TradeNO  string      `json:"tradeNO,omitempty"`
+	Describe string      `json:"describe,omitempty"`
 }
 
 // AccountSpec defines the desired state of Account

--- a/controllers/account/config/crd/bases/account.sealos.io_accounts.yaml
+++ b/controllers/account/config/crd/bases/account.sealos.io_accounts.yaml
@@ -54,6 +54,8 @@ spec:
                       description: deduction info will Record in the Charge
                       format: int64
                       type: integer
+                    describe:
+                      type: string
                     status:
                       type: string
                     time:

--- a/controllers/account/config/default/manager_auth_proxy_patch.yaml
+++ b/controllers/account/config/default/manager_auth_proxy_patch.yaml
@@ -26,7 +26,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 64Mi
@@ -36,6 +36,8 @@ spec:
             value: "sealos-system"
           - name: NAMESPACE_NAME
             value: "user-system"
+          - name: NEW_ACCOUNT_AMOUNT
+            value: "500"
         args:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"

--- a/controllers/account/config/manager/manager.yaml
+++ b/controllers/account/config/manager/manager.yaml
@@ -56,7 +56,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 64Mi

--- a/controllers/account/config/samples/account_v1_account.yaml
+++ b/controllers/account/config/samples/account_v1_account.yaml
@@ -2,5 +2,6 @@ apiVersion: account.sealos.io/v1
 kind: Account
 metadata:
   name: account-sample
+  namespace: sealos-system
 spec:
   # TODO(user): Add fields here

--- a/controllers/account/config/samples/account_v1_accountbalance.yaml
+++ b/controllers/account/config/samples/account_v1_accountbalance.yaml
@@ -3,4 +3,5 @@ kind: AccountBalance
 metadata:
   name: accountbalance-sample
 spec:
-  # TODO(user): Add fields here
+  owner: "account-sample"
+  amount: 100

--- a/controllers/account/controllers/account_controller.go
+++ b/controllers/account/controllers/account_controller.go
@@ -162,34 +162,39 @@ func (r *AccountReconciler) syncAccount(ctx context.Context, name, accountNamesp
 	}
 
 	// add account balance when account is new user
-	if key, ok := account.Annotations[AccountAnnotationNewAccount]; !ok || key != "false" {
-		stringAmount := os.Getenv(NEWACCOUNTAMOUNTENV)
-		if stringAmount != "" {
-			amount, err := strconv.Atoi(stringAmount)
-			if err != nil {
-				return nil, fmt.Errorf("convert %s to int failed: %v", stringAmount, err)
-			}
-			if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, &account, func() error {
-				if account.Annotations == nil {
-					account.Annotations = make(map[string]string, 0)
-				}
-				account.Annotations[AccountAnnotationNewAccount] = "false"
-				return nil
-			}); err != nil {
-				return nil, err
-			}
-			account.Status.Balance += int64(amount)
-			account.Status.ChargeList = append(account.Status.ChargeList, accountv1.Charge{
-				Amount:   int64(amount),
-				Time:     metav1.Time{Time: time.Now()},
-				Describe: "new account charge",
-			})
-			if err := r.Status().Update(ctx, &account); err != nil {
-				return nil, err
-			}
-			r.Logger.Info("account created,will charge new account some money", "account", account, "stringAmount", stringAmount)
-		}
+	stringAmount := os.Getenv(NEWACCOUNTAMOUNTENV)
+	if newAccountFlag, ok := account.Annotations[AccountAnnotationNewAccount]; ok && newAccountFlag == "false" {
+		r.Logger.V(1).Info("account is not a new user ", "account", account)
+		return &account, nil
 	}
+
+	// should set bonus amount that will give some money to new account
+	if stringAmount != "" {
+		amount, err := strconv.Atoi(stringAmount)
+		if err != nil {
+			return nil, fmt.Errorf("convert %s to int failed: %v", stringAmount, err)
+		}
+		if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, &account, func() error {
+			if account.Annotations == nil {
+				account.Annotations = make(map[string]string, 0)
+			}
+			account.Annotations[AccountAnnotationNewAccount] = "false"
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+		account.Status.Balance += int64(amount)
+		account.Status.ChargeList = append(account.Status.ChargeList, accountv1.Charge{
+			Amount:   int64(amount),
+			Time:     metav1.Time{Time: time.Now()},
+			Describe: "new account charge",
+		})
+		if err := r.Status().Update(ctx, &account); err != nil {
+			return nil, err
+		}
+		r.Logger.Info("account created,will charge new account some money", "account", account, "stringAmount", stringAmount)
+	}
+
 	return &account, nil
 }
 

--- a/controllers/account/controllers/account_controller.go
+++ b/controllers/account/controllers/account_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	meteringv1 "github.com/labring/sealos/controllers/metering/api/v1"
@@ -44,8 +45,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const ACCOUNTNAMESPACEENV = "ACCOUNT_NAMESPACE"
-const DEFAULTACCOUNTNAMESPACE = "sealos-system"
+const (
+	ACCOUNTNAMESPACEENV         = "ACCOUNT_NAMESPACE"
+	DEFAULTACCOUNTNAMESPACE     = "sealos-system"
+	AccountAnnotationNewAccount = "account.sealos.io/new-account"
+	NEWACCOUNTAMOUNTENV         = "NEW_ACCOUNT_AMOUNT"
+)
 
 // AccountReconciler reconciles a Account object
 type AccountReconciler struct {
@@ -143,6 +148,10 @@ func (r *AccountReconciler) syncAccount(ctx context.Context, name, accountNamesp
 		},
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, &account, func() error {
+		if account.Annotations == nil {
+			account.Annotations = make(map[string]string, 0)
+		}
+		account.Annotations[AccountAnnotationNewAccount] = "true"
 		return nil
 	}); err != nil {
 		return nil, err
@@ -150,6 +159,36 @@ func (r *AccountReconciler) syncAccount(ctx context.Context, name, accountNamesp
 	// add role get account permission
 	if err := r.syncRoleAndRoleBinding(ctx, name, userNamespace); err != nil {
 		return nil, fmt.Errorf("sync role and rolebinding failed: %v", err)
+	}
+
+	// add account balance when account is new user
+	if key, ok := account.Annotations[AccountAnnotationNewAccount]; !ok || key != "false" {
+		stringAmount := os.Getenv(NEWACCOUNTAMOUNTENV)
+		if stringAmount != "" {
+			amount, err := strconv.Atoi(stringAmount)
+			if err != nil {
+				return nil, fmt.Errorf("convert %s to int failed: %v", stringAmount, err)
+			}
+			if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, &account, func() error {
+				if account.Annotations == nil {
+					account.Annotations = make(map[string]string, 0)
+				}
+				account.Annotations[AccountAnnotationNewAccount] = "false"
+				return nil
+			}); err != nil {
+				return nil, err
+			}
+			account.Status.Balance += int64(amount)
+			account.Status.ChargeList = append(account.Status.ChargeList, accountv1.Charge{
+				Amount:   int64(amount),
+				Time:     metav1.Time{Time: time.Now()},
+				Describe: "new account charge",
+			})
+			if err := r.Status().Update(ctx, &account); err != nil {
+				return nil, err
+			}
+			r.Logger.Info("account created,will charge new account some money", "account", account, "stringAmount", stringAmount)
+		}
 	}
 	return &account, nil
 }

--- a/controllers/account/deploy/manifests/deploy.yaml
+++ b/controllers/account/deploy/manifests/deploy.yaml
@@ -131,6 +131,8 @@ spec:
                       description: deduction info will Record in the Charge
                       format: int64
                       type: integer
+                    describe:
+                      type: string
                     status:
                       type: string
                     time:
@@ -515,7 +517,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 64Mi
@@ -531,6 +533,8 @@ spec:
         env:
         - name: ACCOUNT_NAMESPACE
           value: sealos-system
+        - name: NEW_ACCOUNT_AMOUNT
+          value: "500"
         envFrom:
         - secretRef:
             name: payment-secret
@@ -552,7 +556,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 64Mi


### PR DESCRIPTION
if user is new,will get 5 RMB to use sealos cloud apps.

test success
```
kubectl apply -f ./config/sample/account_v1_accountyaml   
kubectl apply -f ./config/sample/account_v1_accountbalance.yaml   
kubectl get account  account-sample  -n sealos-system -oyaml
apiVersion: account.sealos.io/v1
kind: Account
metadata:
  annotations:
    account.sealos.io/new-account: "false" # get annotation success
  creationTimestamp: "2023-03-02T07:00:29Z"
  generation: 1
  name: account-sample
  namespace: sealos-system
  resourceVersion: "2988085"
  uid: 6f6c116f-5225-40fd-806d-73015348daf9
spec: {}
status:
  balance: 500. # recharge success
  chargeList:
  - balance: 500
    describe: new account charge
    time: "2023-03-02T07:00:29Z"
  - accountBalanceName: accountbalance-sample
    balance: 100
    time: "2023-03-02T07:00:29Z"
  deductionBalance: 100

```