### PR TITLE
Fixed not using cert to pull the image when building

### DIFF
--- a/cmd/sealos/cmd/root.go
+++ b/cmd/sealos/cmd/root.go
@@ -58,7 +58,7 @@ func init() {
 	fs.BoolVar(&debug, "debug", false, "enable debug logger")
 	fs.StringVar(&clusterRootDir, "cluster-root", constants.DefaultClusterRootFsDir, "cluster root directory for remote")
 	_ = fs.MarkHidden("cluster-root")
-	fs.StringVar(&runtimeRootDir, "sealos-root", constants.DefaultRuntimeRootDir, "root directory for sealos actions")
+	fs.StringVar(&runtimeRootDir, "sealos-root", constants.RuntimeRootDir, "root directory for sealos actions")
 	_ = fs.MarkHidden("sealos-root")
 	// add unrelated command names that don't required buildah sdk.
 	buildah.AddUnrelatedCommandNames("cert", "status", "docs", "exec", "scp", "version")
@@ -66,7 +66,7 @@ func init() {
 
 func onBootOnDie() {
 	constants.DefaultClusterRootFsDir = clusterRootDir
-	constants.DefaultRuntimeRootDir = runtimeRootDir
+	constants.RuntimeRootDir = runtimeRootDir
 	var rootDirs = []string{
 		constants.LogPath(),
 		constants.Workdir(),

--- a/pkg/buildah/build.go
+++ b/pkg/buildah/build.go
@@ -72,10 +72,10 @@ func newBuildCommand() *cobra.Command {
 	flags.SetInterspersed(false)
 
 	// build is a all common flags
-	buildFlags := buildahcli.GetBudFlags(&buildFlagResults)
 	if buildFlagResults.CertDir == "" {
 		buildFlagResults.CertDir = constants.RegistryCertDir
 	}
+	buildFlags := buildahcli.GetBudFlags(&buildFlagResults)
 	buildFlags.StringVar(&buildFlagResults.Runtime, "runtime", util.Runtime(), "`path` to an alternate runtime. Use BUILDAH_RUNTIME environment variable to override.")
 
 	layerFlags := buildahcli.GetLayerFlags(&layerFlagsResults)

--- a/pkg/buildah/build.go
+++ b/pkg/buildah/build.go
@@ -20,6 +20,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/labring/sealos/pkg/constants"
+
 	"github.com/containers/buildah/define"
 	"github.com/containers/buildah/imagebuildah"
 	buildahcli "github.com/containers/buildah/pkg/cli"
@@ -71,6 +73,9 @@ func newBuildCommand() *cobra.Command {
 
 	// build is a all common flags
 	buildFlags := buildahcli.GetBudFlags(&buildFlagResults)
+	if buildFlagResults.CertDir == "" {
+		buildFlagResults.CertDir = constants.RegistryCertDir
+	}
 	buildFlags.StringVar(&buildFlagResults.Runtime, "runtime", util.Runtime(), "`path` to an alternate runtime. Use BUILDAH_RUNTIME environment variable to override.")
 
 	layerFlags := buildahcli.GetLayerFlags(&layerFlagsResults)

--- a/pkg/buildah/from.go
+++ b/pkg/buildah/from.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/labring/sealos/pkg/constants"
+
 	"github.com/containers/buildah"
 	"github.com/containers/buildah/define"
 	buildahcli "github.com/containers/buildah/pkg/cli"
@@ -62,6 +64,7 @@ func newDefaultFromReply() *fromReply {
 	}
 	return &fromReply{
 		authfile:  auth.GetDefaultAuthFile(),
+		certDir:   constants.RegistryCertDir,
 		format:    defaultFormat(),
 		pull:      "true",
 		tlsVerify: false,

--- a/pkg/buildah/manifest.go
+++ b/pkg/buildah/manifest.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/labring/sealos/pkg/constants"
+
 	"github.com/containers/buildah/pkg/cli"
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/buildah/util"
@@ -240,7 +242,7 @@ func newManifestCommand() *cobra.Command {
 	fs.BoolVar(&manifestPushOpts.rm, "rm", false, "remove the manifest list if push succeeds")
 	fs.BoolVar(&manifestPushOpts.all, "all", false, "also push the images in the list")
 	fs.StringVar(&manifestPushOpts.authfile, "authfile", auth.GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
-	fs.StringVar(&manifestPushOpts.certDir, "cert-dir", "", "use certificates at the specified path to access the registry")
+	fs.StringVar(&manifestPushOpts.certDir, "cert-dir", constants.RegistryCertDir, "use certificates at the specified path to access the registry")
 	fs.StringVar(&manifestPushOpts.creds, "creds", "", "use `[username[:password]]` for accessing the registry")
 	fs.StringVar(&manifestPushOpts.digestfile, "digestfile", "", "after copying the image, write the digest of the resulting digest to the file")
 	fs.StringVarP(&manifestPushOpts.format, "format", "f", "", "manifest type (oci or v2s2) to attempt to use when pushing the manifest list (default is manifest type of source)")

--- a/pkg/buildah/pull.go
+++ b/pkg/buildah/pull.go
@@ -21,6 +21,8 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/labring/sealos/pkg/constants"
+
 	"github.com/containers/buildah"
 	"github.com/containers/buildah/define"
 	buildahcli "github.com/containers/buildah/pkg/cli"
@@ -62,6 +64,7 @@ func (opts *pullOptions) HiddenFlags() []string {
 func newDefaultPullOptions() *pullOptions {
 	return &pullOptions{
 		authfile:   auth.GetDefaultAuthFile(),
+		certDir:    constants.RegistryCertDir,
 		pullPolicy: "missing",
 		tlsVerify:  false,
 		os:         runtime.GOOS,

--- a/pkg/buildah/push.go
+++ b/pkg/buildah/push.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/labring/sealos/pkg/constants"
+
 	"github.com/containers/buildah"
 	"github.com/containers/buildah/define"
 	buildahcli "github.com/containers/buildah/pkg/cli"
@@ -70,6 +72,7 @@ type pushOptions struct {
 func newDefaultPushOptions() *pushOptions {
 	return &pushOptions{
 		authfile:   auth.GetDefaultAuthFile(),
+		certDir:    constants.RegistryCertDir,
 		retry:      buildahcli.MaxPullPushRetries,
 		retryDelay: buildahcli.PullPushRetryDelay,
 		crOption:   CrOptionAuto,

--- a/pkg/constants/data.go
+++ b/pkg/constants/data.go
@@ -34,7 +34,8 @@ const (
 
 var (
 	DefaultClusterRootFsDir = path.Join(defaultDataRoot, AppName)
-	DefaultRuntimeRootDir   = GetRuntimeRootDir(AppName)
+	RuntimeRootDir          = GetDefaultRuntimeRootDir(AppName)
+	RegistryCertDir         = GetDefaultRegistryCertDir()
 )
 
 const (
@@ -58,15 +59,19 @@ const (
 	StaticsDirName                   = "statics"
 )
 
-func GetRuntimeRootDir(name string) string {
+func GetDefaultRuntimeRootDir(name string) string {
 	if v, ok := os.LookupEnv(strings.ToUpper(name) + "_RUNTIME_ROOT"); ok {
 		return v
 	}
 	return path.Join(homedir.Get(), fmt.Sprintf(".%s", name))
 }
 
+func GetDefaultRegistryCertDir() string {
+	return filepath.Join(RuntimeRootDir, "cert.d")
+}
+
 func LogPath() string {
-	return filepath.Join(DefaultRuntimeRootDir, "logs")
+	return filepath.Join(RuntimeRootDir, "logs")
 }
 
 func DataPath() string {

--- a/pkg/constants/data.go
+++ b/pkg/constants/data.go
@@ -67,7 +67,7 @@ func GetDefaultRuntimeRootDir(name string) string {
 }
 
 func GetDefaultRegistryCertDir() string {
-	return filepath.Join(RuntimeRootDir, "cert.d")
+	return filepath.Join(RuntimeRootDir, "certs.d")
 }
 
 func LogPath() string {

--- a/pkg/constants/worker.go
+++ b/pkg/constants/worker.go
@@ -23,7 +23,7 @@ const (
 )
 
 func Workdir() string {
-	return DefaultRuntimeRootDir
+	return RuntimeRootDir
 }
 
 func ClusterDir(clusterName string) string {

--- a/pkg/registry/distributionpkg/proxy/proxyregistry.go
+++ b/pkg/registry/distributionpkg/proxy/proxyregistry.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/docker/docker/registry"
 	"github.com/docker/go-connections/tlsconfig"
+
 	"github.com/labring/sealos/pkg/constants"
 
 	"github.com/labring/sealos/pkg/registry/distributionpkg/client"
@@ -90,7 +91,7 @@ func (pr *proxyingRegistry) Repositories(ctx context.Context, repos []string, la
 func (pr *proxyingRegistry) Repository(ctx context.Context, name reference.Named) (distribution.Repository, error) {
 	c := pr.authChallenger
 	tlsConfig := tlsconfig.ServerDefault()
-	// ex from ${RuntimeRootDir:-/root/.sealos}/cert.d/sealos.hub:5000/xx.crt
+	// ex from ${RuntimeRootDir:-/root/.sealos}/certs.d/sealos.hub:5000/xx.crt
 	if err := registry.ReadCertsDirectory(tlsConfig, filepath.Join(constants.GetDefaultRegistryCertDir(), pr.remoteURL.Host)); err != nil {
 		return nil, err
 	}
@@ -231,7 +232,7 @@ func (r *remoteAuthChallenger) tryEstablishChallenges(ctx context.Context) error
 		return err
 	}
 
-	//	dcontext.GetLogger(ctx).Infof("Challenge established with upstream : %s %s", remoteURL, r.cm)
+	//      dcontext.GetLogger(ctx).Infof("Challenge established with upstream : %s %s", remoteURL, r.cm)
 	return nil
 }
 


### PR DESCRIPTION
Fixed not using cert to pull the image when building
set default certificate directory for `sealos {build | pull | push}`: {$DefaultRuntimeRoot:-/root/.sealos}/cert.d
ex. cert file path: /root/.sealos/cert.d/{url_host}/xx.crt

fix #2091 