### PR TITLE
fix `runtime error: slice bounds out of range [:19] with length 0`

### DIFF
--- a/pkg/registry/save.go
+++ b/pkg/registry/save.go
@@ -326,6 +326,9 @@ func (is *DefaultImage) saveBlobs(imageDigests []digest.Digest, repo distributio
 	ls, _ := blobStore.(localStore).Local(is.ctx)
 	for _, blob := range blobLists {
 		tmpBlob := blob
+		if len(blob) == 0 {
+			continue
+		}
 		numCh <- struct{}{}
 		eg.Go(func() error {
 			defer func() {


### PR DESCRIPTION
fix #2061

From the log, the reason for the error is that `manifest.layer.digest` is 0,
Not sure why it's empty.