### PR TITLE
Fix when no app image is specified, run error but the command condition still returns success

### DIFF
--- a/pkg/apply/applydrivers/apply_drivers_default.go
+++ b/pkg/apply/applydrivers/apply_drivers_default.go
@@ -143,7 +143,7 @@ func (c *Applier) updateStatus(clusterErr error, appErr error) {
 		} else {
 			cmdCondition = v2.NewFailedCommandCondition(appErr.Error())
 		}
-	} else {
+	} else if len(c.RunNewImages) > 0 {
 		cmdCondition = v2.NewSuccessCommandCondition()
 	}
 	cmdCondition.Images = c.RunNewImages


### PR DESCRIPTION
Fix when no app image is specified, run error but the command condition still returns success

fix #2714