### PR TITLE
fix: avoid invoking default function before complete merging kubeadmconfigs

### DIFF
--- a/pkg/clusterfile/clusterfile.go
+++ b/pkg/clusterfile/clusterfile.go
@@ -31,6 +31,7 @@ type ClusterFile struct {
 	customValues       []string
 	customSets         []string
 	customEnvs         []string
+	setDefaults        bool
 	Cluster            *v2.Cluster
 	Configs            []v2.Config
 	KubeConfig         *runtime.KubeadmConfig
@@ -59,6 +60,12 @@ func (c *ClusterFile) GetKubeadmConfig() *runtime.KubeadmConfig {
 }
 
 type OptionFunc func(*ClusterFile)
+
+func WithSetDefaults(v bool) OptionFunc {
+	return func(c *ClusterFile) {
+		c.setDefaults = true
+	}
+}
 
 func WithCustomConfigFiles(files []string) OptionFunc {
 	return func(c *ClusterFile) {

--- a/pkg/clusterfile/pre_process.go
+++ b/pkg/clusterfile/pre_process.go
@@ -162,7 +162,7 @@ func (c *ClusterFile) DecodeConfigs(data []byte) error {
 }
 
 func (c *ClusterFile) DecodeKubeadmConfig(data []byte) error {
-	kubeadmConfig, err := runtime.LoadKubeadmConfigs(string(data), runtime.DecodeCRDFromString)
+	kubeadmConfig, err := runtime.LoadKubeadmConfigs(string(data), c.setDefaults, runtime.DecodeCRDFromString)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
as PR #2752  add a default mergo option for var `defaultMergeOpts`, when there are some slice type fileds in the kubernetes builtin struct, and this field happens to be nil after marshaling from the clusterfile, the registered default function **might** set default val for those fields, then the appendslice option for mergo may cause problems when initializing the cluster.