### PR TITLE
Fix println built-in function output to standard error

### DIFF
--- a/cmd/sealctl/cmd/cri.go
+++ b/cmd/sealctl/cmd/cri.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -66,7 +67,7 @@ func newCRISocketCmd() *cobra.Command {
 				logger.Error(err)
 				return
 			}
-			println(criSocket)
+			fmt.Println(criSocket)
 		},
 	}
 	return criSocketCmd
@@ -82,7 +83,7 @@ func newIsDockerCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			runtime := criRuntime()
 			isDocker := runtime.IsDocker()
-			println(strconv.FormatBool(isDocker))
+			fmt.Println(strconv.FormatBool(isDocker))
 		},
 	}
 	return isDockerCmd
@@ -100,7 +101,7 @@ func newIsRunningCmd() *cobra.Command {
 			runtime := criRuntime()
 			err := runtime.IsRunning()
 			if shortPrint {
-				println(strconv.FormatBool(err == nil))
+				fmt.Println(strconv.FormatBool(err == nil))
 				return
 			}
 			if err != nil {
@@ -130,7 +131,7 @@ func newListKubeContainersCmd() *cobra.Command {
 				os.Exit(1)
 			}
 			if sPrint {
-				println(strings.Join(containers, ","))
+				fmt.Println(strings.Join(containers, ","))
 				return
 			}
 			logger.Info("container runtime containers is %+v", containers)
@@ -209,7 +210,7 @@ func newImageExistsCmd() *cobra.Command {
 			runtime := criRuntime()
 			b := runtime.ImageExists(imageName)
 			if shortPrint {
-				println(strconv.FormatBool(b))
+				fmt.Println(strconv.FormatBool(b))
 				return
 			}
 			if !b {
@@ -239,7 +240,7 @@ func newCGroupDriverCmd() *cobra.Command {
 				os.Exit(1)
 			}
 			if shortPrint {
-				println(driver)
+				fmt.Println(driver)
 				return
 			}
 			logger.Info("container runtime cgroup-driver is %s", driver)

--- a/cmd/sealctl/cmd/kube.go
+++ b/cmd/sealctl/cmd/kube.go
@@ -58,7 +58,7 @@ func newKubeCmd() *cobra.Command {
 				logger.Error(err)
 				os.Exit(1)
 			}
-			println(data)
+			fmt.Println(data)
 		},
 	}
 	kubeCmd.Flags().BoolVar(&allNamespace, "--all-namespaces", false, " If present, list the requested object(s) across all namespaces. Namespace in current\ncontext is ignored even if specified with --namespace.")

--- a/cmd/sealctl/cmd/password.go
+++ b/cmd/sealctl/cmd/password.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -46,7 +47,7 @@ func newRegistryCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			pwd := passwd.Htpasswd(username, password)
 			if printBool {
-				println(pwd)
+				fmt.Println(pwd)
 				return
 			}
 			logger.Debug("password registry is %s", pwd)
@@ -75,7 +76,7 @@ func newContainerdCmd() *cobra.Command {
 		Short: "generator containerd password",
 		Run: func(cmd *cobra.Command, args []string) {
 			pwd := passwd.LoginAuth(username, password)
-			println(pwd)
+			fmt.Println(pwd)
 		},
 	}
 	// manually to set host via gateway

--- a/cmd/sealctl/cmd/static_pod.go
+++ b/cmd/sealctl/cmd/static_pod.go
@@ -64,7 +64,7 @@ func newLvscareCmd() *cobra.Command {
 				os.Exit(1)
 			}
 			if printBool {
-				println(yaml)
+				fmt.Println(yaml)
 				return
 			}
 			logger.Debug("lvscare static pod yaml is %s", yaml)

--- a/cmd/sealctl/cmd/token.go
+++ b/cmd/sealctl/cmd/token.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -35,7 +36,7 @@ func newTokenCmd() *cobra.Command {
 				os.Exit(1)
 			}
 			data, _ := json.Marshal(t)
-			println(string(data))
+			fmt.Println(string(data))
 		},
 	}
 	return tokenCmd

--- a/controllers/user/controllers/helper/webhook.md
+++ b/controllers/user/controllers/helper/webhook.md
@@ -199,14 +199,14 @@ func HttpServer(port uint16) error {
 var serverLogger = ctrl.Log.WithName("serverLogger")
 
 func Auth(ctx *gin.Context) {
-	println("auth in ...")
+	fmt.Println("auth in ...")
 	var review v1.SubjectAccessReview
 	err := ctx.BindJSON(&review)
 	//{"kind":"SubjectAccessReview","apiVersion":"authorization.k8s.io/v1beta1","metadata":{"creationTimestamp":null},"spec":{"resourceAttributes":{"namespace":"ns-cuisongliu","verb":"list","version":"v1","resource":"pods"},"user":"system:serviceaccount:default:cuisongliu","group":["system:serviceaccounts","system:serviceaccounts:default","system:authenticated"],"uid":"01575033-6a76-4426-88d0-3da94c6c3e03"},"status":{"allowed":false}}
 	//d, err := ctx.GetRawData()
-	println("inff", "msg", string(review.Spec.User))
+	fmt.Println("inff", "msg", string(review.Spec.User))
 	if err != nil {
-		println(err, "has error")
+		fmt.Println(err, "has error")
 	}
 
 	//allow := true

--- a/docs/4.0/docs/cloud/apps/postgres/postgres.md
+++ b/docs/4.0/docs/cloud/apps/postgres/postgres.md
@@ -76,7 +76,7 @@ Your own PG Cluster is created。
 
 Once PG is created, it will generate a corresponding password for each user by default. The password can be obtained by obtaining the secret, and then used after base64 transcoding.
 ```cmd
-kubectl get scret ${UserName}.${CRDName}.credentials.postgresql.acid.zalan.do -o yaml
+kubectl get secrets ${UserName}.${CRDName}.credentials.postgresql.acid.zalan.do --template '{{.data.password}}' | base64 -d
 ```
 The username and password can also be copied manually through the cluster management interface.
 ![pgsqlimg.png](pgsqlimg.png)

--- a/docs/4.0/i18n/zh-Hans/cloud/apps/postgres/postgres.md
+++ b/docs/4.0/i18n/zh-Hans/cloud/apps/postgres/postgres.md
@@ -76,7 +76,7 @@ kubectl apply -f pgtest.yaml
 
 PG在创建时会对每个用户默认生成相应的密码，可以通过获取secret的方式来获取密码,然后经过base64转码后使用。
 ```cmd
-kubectl get scret ${UserName}.${CRDName}.credentials.postgresql.acid.zalan.do -o yaml
+kubectl get secrets ${UserName}.${CRDName}.credentials.postgresql.acid.zalan.do --template '{{.data.password}}' | base64 -d
 ```
 也可以通过集群管理界面手动复制用户名和密码。
 ![pgsqlimg.png](pgsqlimg.png)

--- a/pkg/buildah/create.go
+++ b/pkg/buildah/create.go
@@ -15,6 +15,7 @@
 package buildah
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 
@@ -72,7 +73,8 @@ func newCreateCmd() *cobra.Command {
 			if !opts.short {
 				logger.Info("Mount point: %s", info.MountPoint)
 			} else {
-				println(info.MountPoint)
+				println()
+				fmt.Println(info.MountPoint)
 			}
 			if !IsRootless() {
 				return nil

--- a/pkg/buildah/create.go
+++ b/pkg/buildah/create.go
@@ -73,7 +73,6 @@ func newCreateCmd() *cobra.Command {
 			if !opts.short {
 				logger.Info("Mount point: %s", info.MountPoint)
 			} else {
-				println()
 				fmt.Println(info.MountPoint)
 			}
 			if !IsRootless() {

--- a/pkg/utils/maps/maps_test.go
+++ b/pkg/utils/maps/maps_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package maps
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -119,5 +120,5 @@ func TestMergeMap(t *testing.T) {
 
 func TestStringToMap(t *testing.T) {
 	data := StringToMap("address=reg.real-ai.cn,auth=xxx", ",")
-	println(data["address"])
+	fmt.Println(data["address"])
 }

--- a/pkg/utils/yaml/yaml.go
+++ b/pkg/utils/yaml/yaml.go
@@ -19,6 +19,7 @@ package yaml
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
@@ -127,5 +128,5 @@ func Matcher(path string) bool {
 
 func ShowStructYaml(s interface{}) {
 	data, _ := yaml.Marshal(s)
-	println(string(data))
+	fmt.Println(string(data))
 }

--- a/staging/src/github.com/labring/image-cri-shim/pkg/cri/cri_test.go
+++ b/staging/src/github.com/labring/image-cri-shim/pkg/cri/cri_test.go
@@ -26,5 +26,5 @@ func TestNewContainerRuntime(t *testing.T) {
 	//driver,_:=cr.processConfigFile()
 	//t.Log(driver)
 	cc := []string{"aa", "bb", "cc"}
-	println(fmt.Sprintf("%+v", cc))
+	fmt.Println(fmt.Sprintf("%+v", cc))
 }

--- a/staging/src/github.com/labring/image-cri-shim/pkg/cri/cri_test.go
+++ b/staging/src/github.com/labring/image-cri-shim/pkg/cri/cri_test.go
@@ -26,5 +26,5 @@ func TestNewContainerRuntime(t *testing.T) {
 	//driver,_:=cr.processConfigFile()
 	//t.Log(driver)
 	cc := []string{"aa", "bb", "cc"}
-	fmt.Println(fmt.Sprintf("%+v", cc))
+	fmt.Printf("%+v\n", cc)
 }


### PR DESCRIPTION
1. The print built-in function formats its arguments in an implementation-specific way and writes the result to standard error.
Use `fmt.Println` instead.  fix #2723 
2. change docs: `kubectl get secrets ${UserName}.${CRDName}.credentials.postgresql.acid.zalan.do --template '{{.data.password}}' | base64 -d`