### PR TITLE
fix concurrent map access in clusterClient

### DIFF
--- a/pkg/ssh/clusterclient.go
+++ b/pkg/ssh/clusterclient.go
@@ -21,7 +21,6 @@ import (
 	"github.com/labring/sealos/pkg/types/v1beta1"
 )
 
-// clusterClient is it necessary to use Mutex lock?
 type clusterClient struct {
 	cluster  *v1beta1.Cluster
 	isStdout bool

--- a/pkg/ssh/clusterclient.go
+++ b/pkg/ssh/clusterclient.go
@@ -16,6 +16,7 @@ package ssh
 
 import (
 	"strings"
+	"sync"
 
 	"github.com/labring/sealos/pkg/types/v1beta1"
 )
@@ -26,6 +27,7 @@ type clusterClient struct {
 	isStdout bool
 	configs  map[string]*Option
 	cache    map[*Option]Interface
+	mutex    sync.RWMutex
 }
 
 func overSSHConfig(original, override *v1beta1.SSH) {
@@ -52,7 +54,10 @@ func overSSHConfig(original, override *v1beta1.SSH) {
 }
 
 func (cc *clusterClient) getSSHOptionForHost(host string) (*Option, error) {
-	if v, ok := cc.configs[host]; ok {
+	cc.mutex.RLock()
+	v, ok := cc.configs[host]
+	cc.mutex.RUnlock()
+	if ok {
 		return v, nil
 	}
 	sshConfig := cc.cluster.Spec.SSH.DeepCopy()
@@ -65,7 +70,9 @@ func (cc *clusterClient) getSSHOptionForHost(host string) (*Option, error) {
 		}
 	}
 	opt := newOptionFromSSH(sshConfig, cc.isStdout)
+	cc.mutex.Lock()
 	cc.configs[host] = opt
+	cc.mutex.Unlock()
 	return opt, nil
 }
 
@@ -74,14 +81,18 @@ func (cc *clusterClient) getClientForHost(host string) (Interface, error) {
 	if err != nil {
 		return nil, err
 	}
+	cc.mutex.RLock()
 	client := cc.cache[sshConfig]
+	cc.mutex.RUnlock()
 	if client == nil {
 		var err error
 		client, err = newFromOptions(sshConfig)
 		if err != nil {
 			return nil, err
 		}
+		cc.mutex.Lock()
 		cc.cache[sshConfig] = client
+		cc.mutex.Unlock()
 	}
 	return client, nil
 }


### PR DESCRIPTION
Resolves #2807 

To ensure thread safety in `clusterClient` map access, this PR implements a solution that uses a mutex lock to synchronize concurrent reads and writes to the maps. This prevents race conditions and ensures safe access to the maps.