### PR TITLE
Add rateLimiter for controllers

### DIFF
--- a/controllers/cluster/controllers/cluster_controller.go
+++ b/controllers/cluster/controllers/cluster_controller.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/ratelimiter"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	v1 "github.com/labring/sealos/controllers/cluster/api/v1"
@@ -82,6 +83,7 @@ type ClusterReconciler struct {
 
 type ClusterReconcilerOptions struct {
 	MaxConcurrentReconciles int
+	RateLimiter             ratelimiter.RateLimiter
 }
 
 //+kubebuilder:rbac:groups=cluster.sealos.io,resources=clusters,verbs=get;list;watch;create;update;patch;delete
@@ -399,6 +401,7 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager, opts ClusterRecon
 		Watches(&source.Kind{Type: &infrav1.Infra{}}, &handler.EnqueueRequestForObject{}).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: opts.MaxConcurrentReconciles,
+			RateLimiter:             opts.RateLimiter,
 		}).
 		Complete(r)
 }

--- a/controllers/pkg/utils/rate_limiter.go
+++ b/controllers/pkg/utils/rate_limiter.go
@@ -1,0 +1,58 @@
+// Copyright © 2023 sealos.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"flag"
+	"time"
+
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/ratelimiter"
+)
+
+const (
+	defaultMinRetryDelay = 750 * time.Millisecond
+	defaultMaxRetryDelay = 15 * time.Minute
+	flagMinRetryDelay    = "min-retry-delay"
+	flagMaxRetryDelay    = "max-retry-delay"
+)
+
+// RateLimiterOptions used on reconcilers.
+type RateLimiterOptions struct {
+	MinRetryDelay time.Duration
+
+	MaxRetryDelay time.Duration
+}
+
+func (o *RateLimiterOptions) BindFlags(fs *flag.FlagSet) {
+	fs.DurationVar(&o.MinRetryDelay, flagMinRetryDelay, defaultMinRetryDelay,
+		"The minimum amount of time for which an object being reconciled will have to wait before a retry.")
+	fs.DurationVar(&o.MaxRetryDelay, flagMaxRetryDelay, defaultMaxRetryDelay,
+		"The maximum amount of time for which an object being reconciled will have to wait before a retry.")
+}
+
+func GetRateLimiter(opts RateLimiterOptions) ratelimiter.RateLimiter {
+	return workqueue.NewItemExponentialFailureRateLimiter(
+		opts.MinRetryDelay,
+		opts.MaxRetryDelay)
+}
+
+// GetDefaultRateLimiter
+// rate-limiter.RateLimiter with the default configuration.
+func GetDefaultRateLimiter() ratelimiter.RateLimiter {
+	return workqueue.NewItemExponentialFailureRateLimiter(
+		defaultMinRetryDelay,
+		defaultMaxRetryDelay)
+}

--- a/controllers/pkg/utils/retry_create_or_update.go
+++ b/controllers/pkg/utils/retry_create_or_update.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package controller
+package utils
 
 import (
 	"context"


### PR DESCRIPTION
By setting RateLimiter, the processing rate of the controller can be effectively controlled, avoiding excessive load on the Kubernetes API Server and improving the performance and stability of the controller.I recommend adding RateLimiter to all controllers.
