### PR TITLE
feature(main): support checking cluster's no-odd number of master node

### DIFF
--- a/pkg/checker/host_checker.go
+++ b/pkg/checker/host_checker.go
@@ -31,8 +31,15 @@ type HostChecker struct {
 
 func (a HostChecker) Check(cluster *v2.Cluster, _ string) error {
 	var ipList []string
+	var masterNum int
 	for _, hosts := range cluster.Spec.Hosts {
+		if len(hosts.Roles) > 0 && hosts.Roles[0] == v2.MASTER {
+			masterNum++
+		}
 		ipList = append(ipList, hosts.IPS...)
+	}
+	if masterNum&1 == 0 {
+		return fmt.Errorf("checker: occurs no-odd number of master nodes")
 	}
 	if len(a.IPs) != 0 {
 		ipList = a.IPs


### PR DESCRIPTION
Support checking cluster's master node number as request in #2829
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction rmation of the PR, 
because it will be placed in the release note
-->