### PR TITLE
feat: register all versions of the ImageServiceServer

### DIFF
--- a/fork/github.com/heroku/docker-registry-client/registry/registry.go
+++ b/fork/github.com/heroku/docker-registry-client/registry/registry.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"crypto/tls"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 )
@@ -98,7 +99,8 @@ func (r *Registry) Ping() error {
 	r.Logf("registry.ping url=%s", url)
 	resp, err := r.Client.Get(url)
 	if resp != nil {
-		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		err = resp.Body.Close()
 	}
 	return err
 }

--- a/pkg/checker/cri_shim_checker.go
+++ b/pkg/checker/cri_shim_checker.go
@@ -59,7 +59,6 @@ func (n *CRIShimChecker) Check(_ *v2.Cluster, phase string) error {
 		status.Config["ShimSocket"] = shimCfg.ImageShimSocket
 		status.Config["CRISocket"] = shimCfg.RuntimeSocket
 		status.Config["RegistryAddress"] = shimCfg.Address
-		status.Config["CRIVersion"] = string(shimCfg.CRIVersion)
 		if status.Config["CRIVersion"] == "" {
 			delete(status.Config, "CRIVersion")
 		}

--- a/staging/src/github.com/labring/image-cri-shim/pkg/server/utils.go
+++ b/staging/src/github.com/labring/image-cri-shim/pkg/server/utils.go
@@ -101,6 +101,7 @@ func replaceImage(image, action string, authConfig map[string]types.AuthConfig) 
 	logger.Debug("preDomain: %s, preImageAllName: %s, action: %s", preDomain, preImageAllName, action)
 	preImageName, preImageTag := parseImageNameAndTag(preImageAllName)
 	logger.Debug("preImageName: %s, preImageTag: %s, action: %s", preImageName, preImageTag, action)
+	// TODO: create a cache registry client for each authDomain
 	for authDomain, auth := range authConfig {
 		if reg, err := registry.NewRegistryForDomain(authDomain, auth.Username, auth.Password); err == nil {
 			if tags, err := reg.Tags(preImageName); err != nil {

--- a/staging/src/github.com/labring/image-cri-shim/pkg/server/utils.go
+++ b/staging/src/github.com/labring/image-cri-shim/pkg/server/utils.go
@@ -17,9 +17,7 @@ limitations under the License.
 package server
 
 import (
-	"context"
 	"strings"
-	"time"
 
 	"github.com/labring/image-cri-shim/pkg/types"
 
@@ -29,11 +27,6 @@ import (
 	"github.com/labring/sealos/pkg/utils/registry"
 	str "github.com/labring/sealos/pkg/utils/strings"
 )
-
-// getContextWithTimeout returns a context with timeout.
-func getContextWithTimeout(timeout time.Duration) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), timeout)
-}
 
 // parseImageNameAndTag splits the input image name into its name and tag.
 func parseImageNameAndTag(imageName string) (name, tag string) {

--- a/staging/src/github.com/labring/image-cri-shim/pkg/shim/shim.go
+++ b/staging/src/github.com/labring/image-cri-shim/pkg/shim/shim.go
@@ -75,7 +75,6 @@ func NewShim(cfg *types.Config) (Shim, error) {
 		Group:      -1,
 		Mode:       0660,
 		CRIConfigs: cfg.CRIConfigs,
-		CRIVersion: cfg.CRIVersion,
 	}
 	srv, err := server.NewServer(srvopts)
 	if err != nil {

--- a/staging/src/github.com/labring/image-cri-shim/pkg/types/config.go
+++ b/staging/src/github.com/labring/image-cri-shim/pkg/types/config.go
@@ -42,7 +42,6 @@ const (
 type Config struct {
 	ImageShimSocket string                `json:"shim"`
 	RuntimeSocket   string                `json:"cri"`
-	CRIVersion      CRIVersion            `json:"version"`
 	Address         string                `json:"address"`
 	Force           bool                  `json:"force"`
 	Debug           bool                  `json:"debug"`
@@ -82,11 +81,6 @@ func (c *Config) PreProcess() error {
 		c.Timeout.Duration, _ = time.ParseDuration("15m")
 	}
 
-	if c.CRIVersion == "" || (c.CRIVersion != CRIVersionV1Alpha2 && c.CRIVersion != CRIVersionV1) {
-		c.CRIVersion = CRIVersionV1Alpha2
-		logger.Info("Version error,Using default CRI v1alpha2 image API")
-	}
-
 	logger.Info("RegistryDomain: %v", domain)
 	logger.Info("Force: %v", c.Force)
 	logger.Info("Debug: %v", c.Debug)
@@ -96,7 +90,6 @@ func (c *Config) PreProcess() error {
 	logger.Info("Auth: %v", c.Auth)
 	logger.Info("Username: %s", username)
 	logger.Info("Password: %s", password)
-	logger.Info("CRIVersion: %s", c.CRIVersion)
 
 	if c.Address == "" {
 		return errors.New("registry addr is empty")


### PR DESCRIPTION
as a image shim service, it can register all versions of the `ImageServiceServer` cause it doesn't care what version of the ImageService the CRI had.

and also might fix #2851 