### PR TITLE
fix(ci): metering e2e ci error

### DIFF
--- a/.github/workflows/e2e_metering.yml
+++ b/.github/workflows/e2e_metering.yml
@@ -9,6 +9,7 @@ on:
     branches: [ "main" ]
     paths:
       - "controllers/metering/**"
+      - "controllers/common/metering/**"
       - ".github/workflows/e2e_metering.yml"
       - "!**/*.md"
       - "!**/*.yaml"
@@ -23,34 +24,49 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Setup Golang with cache
+        uses: magnetikonline/action-golang-cache@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
       - name: Auto install sealos
         uses: labring/sealos-action@v0.0.4
         with:
           sealosVersion: 4.1.5-alpha2
-
       - name: Build ${{ matrix.module }} amd64
         working-directory: controllers/${{ matrix.module }}
         run: |
           GOARCH=amd64 make build
           mv bin/manager bin/controller-${{ matrix.module }}-amd64
           chmod +x bin/controller-${{ matrix.module }}-amd64
+      - name: Build ${{ matrix.module }} arm64
+        working-directory: controllers/${{ matrix.module }}
+        run: |
+          GOARCH=arm64 make build
+          mv bin/manager bin/controller-${{ matrix.module }}-arm64
+          chmod +x bin/controller-${{ matrix.module }}-arm64
       - name: Prepare
         id: prepare
         working-directory: controllers/${{ matrix.module }}
         run: |
           TAG=deploy
           echo tag_name=${TAG} >> $GITHUB_OUTPUT
-          IMG=ghcr.io/${{ github.repository_owner }}/sealos-${{ matrix.module }}-controller:dev make pre-deploy
-      - name: build   ${{ matrix.module }} main controller image
-        env:
-          # fork friendly ^^
-          DOCKER_REPO: ghcr.io/${{ github.repository_owner }}/sealos-${{ matrix.module }}-controller
+          DOCKER_REPO=ghcr.io/${{ github.repository_owner }}/sealos-${{ matrix.module }}-controller
+          echo docker_repo=${DOCKER_REPO} >> $GITHUB_OUTPUT
+          
+          IMG=${DOCKER_REPO}:dev make pre-deploy
+      - name: Build ${{ matrix.module }} image
+        working-directory: controllers/${{ matrix.module }}
+        run: |
+          sealos login -u ${{ github.repository_owner }} -p ${{ secrets.GH_PAT }} --debug ghcr.io
+          sealos build --debug  -t ${{ steps.prepare.outputs.docker_repo }}:dev .
+          sealos push  ${{ steps.prepare.outputs.docker_repo }}:dev
+
+      - name: build   ${{ matrix.module }} main controller cluster image
         working-directory: controllers/${{ matrix.module }}/deploy
         run: |
           ls -l
-          sealos build --debug  -t ${DOCKER_REPO}:${{ steps.prepare.outputs.tag_name }}-cluster .
-          sealos login -u ${{ github.repository_owner }} -p ${{ secrets.GH_PAT }} --debug ghcr.io
-          sealos push  ${DOCKER_REPO}:${{ steps.prepare.outputs.tag_name }}-cluster
+          sealos build --debug  -t ${{ steps.prepare.outputs.docker_repo }}:${{ steps.prepare.outputs.tag_name }}-cluster .
+          sealos push  ${{ steps.prepare.outputs.docker_repo }}:${{ steps.prepare.outputs.tag_name }}-cluster
       - name: docker images
         run: |
           sudo sealos images
@@ -90,7 +106,6 @@ jobs:
           sudo -u root cat /etc/hosts
           sudo -u root systemctl status kubelet
           sudo -u root kubectl get nodes 
-          sudo -u root kubectl get nodes 
           sudo -u root kubectl get pods -A
       - name: Prepare
         id: prepare
@@ -116,10 +131,6 @@ jobs:
           sudo -u root kubectl create namespace sealos-system
           sudo -u root kubectl create secret generic payment-secret -n account-system
           sudo -u root kubectl apply -f ./deploy/manifests/deploy.yaml
-      - name: Setup Golang with cache
-        uses: magnetikonline/action-golang-cache@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
       -  name: e2e Test
          working-directory: ./controllers/metering
          run: |


### PR DESCRIPTION
The reason why metering e2e ci fail is that just build ghcr.io/labring/sealos-metering-controller:deploy-cluster,but not build newest ghcr.io/labring/sealos-metering-controller:dev.
local repo test is correct.https://github.com/xiao-jay/sealos/actions/runs/4549846850/jobs/8022346983