### PR TITLE
bugfix: sealos build with parse image name error

### DIFF
--- a/pkg/buildimage/manifests/utils.go
+++ b/pkg/buildimage/manifests/utils.go
@@ -59,7 +59,7 @@ func parseImageRefFromLine(s string) string {
 		return ""
 	}
 	imageStr := strutil.TrimQuotes(strings.TrimSpace(s[idx+len(imageIdentity):]))
-	if imageStr == "" {
+	if imageStr == "" || strings.HasPrefix(imageStr, "{{") && strings.HasSuffix(imageStr, "}}") {
 		return ""
 	}
 	named, err := reference.ParseNormalizedNamed(imageStr)


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note
-->
fixes: #1487 

Add ignore for images that fail to render by helm
