### PR TITLE
Title: Update auto-release logic to skip deb and rpm packages for non-production releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           VERSION: ${{ steps.prepare.outputs.tag_name }}
           USERNAME: ${{ github.repository_owner }}
         run: |
-          cd scripts/release && sh note.sh
+          cd scripts/release && bash note.sh
 
       - name: Install Dependencies
         run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -236,11 +236,12 @@ publishers:
       - packages
     dir: "{{ dir .ArtifactPath }}"
     cmd: |
+      bash -c '
       if [[ "{{ .Tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
         curl -F package=@{{ .ArtifactName }} https://{{ .Env.FURY_TOKEN }}@push.fury.io/{{ .Env.USERNAME }}/
       else
         echo "Skipping deployment: Non-production release detected"
-      fi
+      fi'
 archives:
   - id: archive
     format: tar.gz

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -236,8 +236,11 @@ publishers:
       - packages
     dir: "{{ dir .ArtifactPath }}"
     cmd: |
-      curl -F package=@{{ .ArtifactName }} https://{{ .Env.FURY_TOKEN }}@push.fury.io/{{ .Env.USERNAME }}/
-
+      if [[ "{{ .Tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        curl -F package=@{{ .ArtifactName }} https://{{ .Env.FURY_TOKEN }}@push.fury.io/{{ .Env.USERNAME }}/
+      else
+        echo "Skipping deployment: Non-production release detected"
+      fi
 archives:
   - id: archive
     format: tar.gz
@@ -252,6 +255,6 @@ checksum:
   algorithm: sha256
   ids:
     - archive
-  
+
 snapshot:
   name_template: "{{ .Tag }}-next"

--- a/scripts/release/note.sh
+++ b/scripts/release/note.sh
@@ -40,6 +40,10 @@ lvscare:
 docker pull ghcr.io/${USERNAME:-labring}/lvscare:${VERSION}
 \`\`\`
 
+EOF
+
+if [[ "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+cat << EOF >> Note.md
 ### APT 源
 
 Use your public APT Repository URL to install DEB packages:
@@ -72,7 +76,10 @@ baseurl=https://yum.repo.sealos.io/
 enabled=1
 gpgcheck=0
 \`\`\`
+EOF
+fi
+cat << EOF >> Note.md
 
 See [the CHANGELOG](https://github.com/${USERNAME:-labring}/sealos/blob/main/CHANGELOG/CHANGELOG.md) for more details.
-
 EOF
+


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note
-->

Description:

This pull request updates the auto-release logic to ensure that deb and rpm packages are not published for non-production releases. The updated logic checks the release version format and skips the deployment of deb and rpm packages if the version indicates a non-production release (e.g., v4.1.7-rc1, v4.1.7-alpha1).

By implementing this change, we can reduce the risk of accidentally publishing unstable or untested packages to end-users and better manage our release process.

Changes in this PR include:

- Updated release script to check for non-production version format
- Skipped deb and rpm package deployment for non-production releases
Please review the changes and let me know if any further adjustments are needed.


