### PR TITLE
fix: return image name if oci archive file has names instead of id

### DIFF
--- a/pkg/buildah/runtime.go
+++ b/pkg/buildah/runtime.go
@@ -24,6 +24,7 @@ import (
 	"github.com/containers/common/libimage"
 	"github.com/containers/common/pkg/config"
 	imagestorage "github.com/containers/image/v5/storage"
+	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
 	"github.com/spf13/cobra"
 )
@@ -31,6 +32,17 @@ import (
 type Runtime struct {
 	store           storage.Store
 	libimageRuntime *libimage.Runtime
+}
+
+func getRuntimeWithStoreAndSystemContext(store storage.Store, sc *types.SystemContext) (*Runtime, error) {
+	libimageRuntime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: sc})
+	if err != nil {
+		return nil, err
+	}
+	return &Runtime{
+		store:           store,
+		libimageRuntime: libimageRuntime,
+	}, nil
 }
 
 func getRuntime(c *cobra.Command) (*Runtime, error) {
@@ -45,14 +57,7 @@ func getRuntime(c *cobra.Command) (*Runtime, error) {
 	if err != nil {
 		return nil, fmt.Errorf("building system context: %w", err)
 	}
-	libimageRuntime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: sc})
-	if err != nil {
-		return nil, err
-	}
-	return &Runtime{
-		store:           store,
-		libimageRuntime: libimageRuntime,
-	}, nil
+	return getRuntimeWithStoreAndSystemContext(store, sc)
 }
 
 func (r *Runtime) getLayerID(id string, diffType DiffType) (string, error) {


### PR DESCRIPTION
fix issues like following:
1. running `sealos run labring/kubernetes:v1.25.0 xxx-helm.tar`, sealos will save the `xxx-helm.tar` as image id in the clusterfile;
2. after rebooting host which running sealos command, it'll failed to run any sealos commands , like `add`/`run` or whatever, cause image id cannot be pulled from docker.io/library/$imageid

---
looks like it's already fix in #2879, but to avoid this, we'd better refactor the `Load` function for good.