### PR TITLE
feature: Add SSH option to the scale command(sealos add/delete).

### DIFF
--- a/cmd/sealos/cmd/add.go
+++ b/cmd/sealos/cmd/add.go
@@ -30,12 +30,16 @@ add to nodes :
 add to default cluster:
 	sealos add --masters x.x.x.x --nodes x.x.x.x
 	sealos add --masters x.x.x.x-x.x.x.y --nodes x.x.x.x-x.x.x.y
+
+add with new ssh setting:
+	sealos add --masters x.x.x.x --nodes x.x.x.x --passwd yourpasswd --user root --port 22
 `
 
-// addCmd represents the delete command
+// addCmd represents the add command
 func newAddCmd() *cobra.Command {
 	addArgs := &apply.ScaleArgs{
 		Cluster: &apply.Cluster{},
+		SSH:     &apply.SSH{},
 	}
 	var addCmd = &cobra.Command{
 		Use:     "add",

--- a/cmd/sealos/cmd/delete.go
+++ b/cmd/sealos/cmd/delete.go
@@ -45,6 +45,7 @@ Please note that sealos will delete your master if the --masters parameter is sp
 func newDeleteCmd() *cobra.Command {
 	deleteArgs := &apply.ScaleArgs{
 		Cluster: &apply.Cluster{},
+		SSH:     &apply.SSH{},
 	}
 	var deleteCmd = &cobra.Command{
 		Use:     "delete",

--- a/pkg/apply/applydrivers/apply_drivers_default.go
+++ b/pkg/apply/applydrivers/apply_drivers_default.go
@@ -212,6 +212,7 @@ func (c *Applier) scaleCluster(mj, md, nj, nd []string) error {
 	cluster := c.ClusterDesired
 	err = scaleProcessor.Execute(cluster)
 	if err != nil {
+		// TODO: Roll back the hosts in the desired cluster when scaling the cluster fails to avoid adding unsuccessful joined nodes or masters to the clusterfile.
 		return err
 	}
 	logger.Info("succeeded in scaling this cluster")

--- a/pkg/apply/args.go
+++ b/pkg/apply/args.go
@@ -101,8 +101,12 @@ func (arg *ResetArgs) RegisterFlags(fs *pflag.FlagSet) {
 
 type ScaleArgs struct {
 	*Cluster
+	*SSH
+	fs *pflag.FlagSet
 }
 
 func (arg *ScaleArgs) RegisterFlags(fs *pflag.FlagSet, verb, action string) {
 	arg.Cluster.RegisterFlags(fs, verb, action)
+	arg.SSH.RegisterFlags(fs)
+	arg.fs = fs
 }

--- a/pkg/apply/args_test.go
+++ b/pkg/apply/args_test.go
@@ -213,12 +213,15 @@ func TestParseScaleArgsFlagsCorrect(t *testing.T) {
 		{
 			[]string{
 				"--masters", "10.74.22.22:22", "--nodes", "10.74.22.44:22", "--cluster", "default",
+				"-u", "root", "-p", "s3cret", "--port", "2222",
 			},
 			&ScaleArgs{
 				Cluster: &Cluster{},
+				SSH:     &SSH{},
 			},
 			&ScaleArgs{
 				Cluster: &Cluster{Masters: "10.74.22.22:22", Nodes: "10.74.22.44:22", ClusterName: "default"},
+				SSH:     &SSH{User: "root", Password: "s3cret", Port: 2222, Pk: path.Join(constants.GetHomeDir(), ".ssh", "id_rsa")},
 			},
 		},
 	}

--- a/pkg/apply/scale.go
+++ b/pkg/apply/scale.go
@@ -54,6 +54,23 @@ func NewScaleApplierFromArgs(scaleArgs *ScaleArgs, flag string) (applydrivers.In
 	if scaleArgs.Cluster.Nodes == "" && scaleArgs.Cluster.Masters == "" {
 		return nil, fmt.Errorf("the node or master parameter was not committed")
 	}
+	if scaleArgs.fs != nil {
+		if scaleArgs.fs.Changed("user") || cluster.Spec.SSH.User == "" {
+			cluster.Spec.SSH.User = scaleArgs.SSH.User
+		}
+		if scaleArgs.fs.Changed("pk") || cluster.Spec.SSH.Pk == "" {
+			cluster.Spec.SSH.Pk = scaleArgs.SSH.Pk
+		}
+		if scaleArgs.fs.Changed("pk-passwd") || cluster.Spec.SSH.PkPasswd == "" {
+			cluster.Spec.SSH.PkPasswd = scaleArgs.SSH.PkPassword
+		}
+		if scaleArgs.fs.Changed("port") || cluster.Spec.SSH.Port == 0 {
+			cluster.Spec.SSH.Port = scaleArgs.SSH.Port
+		}
+		if scaleArgs.fs.Changed("passwd") || cluster.Spec.SSH.Passwd == "" {
+			cluster.Spec.SSH.Passwd = scaleArgs.SSH.Password
+		}
+	}
 	var err error
 	switch flag {
 	case "add":

--- a/pkg/apply/scale_test.go
+++ b/pkg/apply/scale_test.go
@@ -19,6 +19,8 @@ package apply
 import (
 	"testing"
 
+	"github.com/spf13/pflag"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v2 "github.com/labring/sealos/pkg/types/v1beta1"
@@ -779,6 +781,29 @@ func TestNewScaleApplierFromArgs(t *testing.T) {
 					Nodes:       "",
 					ClusterName: "",
 				},
+			},
+			wantErr: true,
+		},
+		{
+			//Due to the difficulty of mocking the cluster file and pass to it, "wantErr" is set to True here.
+			//In fact, the error occurred during the join process
+			//because the original master in the cluster file was empty.
+			name: "add node with SSH options",
+			op:   "add",
+			args: &ScaleArgs{
+				Cluster: &Cluster{
+					Masters:     "192.168.1.2",
+					Nodes:       "192.168.1.3",
+					ClusterName: "",
+				},
+				SSH: &SSH{
+					User:       "root",
+					Password:   "xxxx",
+					PkPassword: "xxxx",
+					Pk:         "/path/to/private/key/file",
+					Port:       22,
+				},
+				fs: pflag.NewFlagSet("test", pflag.ExitOnError),
 			},
 			wantErr: true,
 		},

--- a/pkg/types/v1beta1/cluster_args.go
+++ b/pkg/types/v1beta1/cluster_args.go
@@ -107,6 +107,7 @@ func (c *Cluster) GetIPSByRole(role string) []string {
 		for _, hostRole := range host.Roles {
 			if role == hostRole {
 				hosts = append(hosts, host.IPS...)
+				break
 			}
 		}
 	}


### PR DESCRIPTION
- Added SSH to `apply.ScaleArgs`, making it possible to specify password and other SSH options when adding nodes, and modified the corresponding test files.
- Fixed a documentation error that incorrectly stated "addCmd represents the delete command".
- Added a TODO at a specific location.
- Added a break statement to GetIPSByRole to prevent unnecessary comparisons.

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note
-->