### PR TITLE
fix stop kube-apiserver pod cause `DeadlineExceeded` when update cert.

### DIFF
--- a/pkg/runtime/update_cert.go
+++ b/pkg/runtime/update_cert.go
@@ -167,7 +167,7 @@ func (k *KubeadmRuntime) deleteAPIServer() error {
 				podID := ps.Containers[0].PodSandboxID[:13]
 				logger.Debug("found podID %s in %s", podID, m)
 				//crictl stopp
-				if err = k.sshCmdAsync(m, fmt.Sprintf("crictl stopp %s", podID)); err != nil {
+				if err = k.sshCmdAsync(m, fmt.Sprintf("crictl --timeout=10s stopp %s", podID)); err != nil {
 					return err
 				}
 				//crictl rmp


### PR DESCRIPTION
```
sealos cert --alt-names xxxx
...
2023-04-06T15:32:44 info delete pod apiserver from crictl
E0406 15:32:46.219015 3681139 remote_runtime.go:269] "StopPodSandbox from runtime service failed" err="rpc error: code = DeadlineExceeded desc = context deadline exceeded" podSandboxID="8f04a0e57f14c"
FATA[0002] stopping the pod sandbox "8f04a0e57f14c": rpc error: code = DeadlineExceeded desc = context deadline exceeded 
Error: failed to generate cert exit status 1
```
#2497
