### PR TITLE
fix len(deleteInstancesByOption.instanceIds) always gt 0

### DIFF
--- a/controllers/infra/drivers/aliyun/aliyun.go
+++ b/controllers/infra/drivers/aliyun/aliyun.go
@@ -9,6 +9,13 @@ import (
 	v1 "github.com/labring/sealos/controllers/infra/api/v1"
 )
 
+const (
+	AliyunRegionID        = "ALIYUN_REGION_ID"
+	AliyunAccessKeyID     = "ALIYUN_ACCESS_KEY_ID"
+	AliyunAccessKeySecret = "ALIYUN_ACCESS_KEY_SECRET"
+	AliyunResourceGroupID = "ALIYUN_RESOURCE_GROUP_ID"
+)
+
 type Driver struct {
 	ECSClient       *ecs.Client
 	VPCClient       *vpc.Client

--- a/controllers/infra/drivers/aliyun/delete_instance.go
+++ b/controllers/infra/drivers/aliyun/delete_instance.go
@@ -166,7 +166,7 @@ func (d Driver) deleteInfra(infra *v1.Infra) error {
 
 func (d Driver) deleteInstancesByOption(hosts *v1.Hosts, deleteAll bool) error {
 	client := d.ECSClient
-	instanceIDs := make([]string, hosts.Count)
+	var instanceIDs []string
 	idx := 0
 	for i := 0; i < hosts.Count; i++ {
 		if len(hosts.Metadata) <= idx {
@@ -179,10 +179,11 @@ func (d Driver) deleteInstancesByOption(hosts *v1.Hosts, deleteAll bool) error {
 			i--
 			continue
 		}
-		instanceIDs[i] = metadata.ID
+		instanceIDs = append(instanceIDs, metadata.ID)
 		idx++
 	}
 	if len(instanceIDs) == 0 {
+		logger.Info("not have Aliyun ECS instances to delete")
 		return nil
 	}
 

--- a/controllers/infra/drivers/driver.go
+++ b/controllers/infra/drivers/driver.go
@@ -20,10 +20,10 @@ import (
 	"context"
 	"fmt"
 	"os"
-
-	"github.com/aws/aws-sdk-go-v2/config"
+	"strings"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
+	"github.com/aws/aws-sdk-go-v2/config"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	"github.com/labring/sealos/controllers/infra/drivers/aliyun"
@@ -83,10 +83,16 @@ func NewAWSDriver() (Driver, error) {
 }
 
 func NewAliyunDriver() (Driver, error) {
-	regionID := os.Getenv("ALIYUN_REGION_ID")
-	accessKeyID := os.Getenv("ALIYUN_ACCESS_KEY_ID")
-	accessKeySecret := os.Getenv("ALIYUN_ACCESS_KEY_SECRET")
-	resourceGroupID := os.Getenv("ALIYUN_RESOURCE_GROUP_ID")
+	regionID := os.Getenv(aliyun.AliyunRegionID)
+	accessKeyID := os.Getenv(aliyun.AliyunAccessKeyID)
+	accessKeySecret := os.Getenv(aliyun.AliyunAccessKeySecret)
+	resourceGroupID := os.Getenv(aliyun.AliyunResourceGroupID)
+	if regionID == "" || accessKeyID == "" || accessKeySecret == "" || resourceGroupID == "" {
+		return nil, fmt.Errorf("need set aliyun driver env: %s ", strings.Join([]string{aliyun.AliyunRegionID,
+			aliyun.AliyunAccessKeyID,
+			aliyun.AliyunAccessKeySecret,
+			aliyun.AliyunResourceGroupID}, ","))
+	}
 	ecsClient, err := ecs.NewClientWithAccessKey(regionID, accessKeyID, accessKeySecret)
 	vpcClient, err1 := vpc.NewClientWithAccessKey(regionID, accessKeyID, accessKeySecret)
 	if err != nil || err1 != nil {


### PR DESCRIPTION
Fix deleteInstancesByOption.instanceIds length is always greater than 0, resulting in repeated attempts to delete instances
Check aliyun env to return error