### PR TITLE
bugfix: the failure to add master after updating the certificate

### DIFF
--- a/pkg/apply/applydrivers/apply_drivers_default.go
+++ b/pkg/apply/applydrivers/apply_drivers_default.go
@@ -79,6 +79,10 @@ func (c *Applier) Apply() error {
 	var clusterErr, appErr error
 	// save cluster to file after apply
 	defer func() {
+		switch clusterErr.(type) {
+		case *processor.CheckError, *processor.PreProcessError:
+			return
+		}
 		logger.Debug("write cluster file to local storage: %s", clusterPath)
 		saveErr := yaml.MarshalYamlToFile(clusterPath, c.getWriteBackObjects()...)
 		if saveErr != nil {
@@ -123,6 +127,10 @@ func (c *Applier) initStatus() {
 // todo: atomic updating status after each installation for better reconcile?
 // todo: set up signal handler
 func (c *Applier) updateStatus(clusterErr error, appErr error) {
+	switch clusterErr.(type) {
+	case *processor.CheckError, *processor.PreProcessError:
+		return
+	}
 	// update cluster condition using clusterErr
 	var condition v2.ClusterCondition
 	if clusterErr != nil {

--- a/pkg/apply/processor/create.go
+++ b/pkg/apply/processor/create.go
@@ -78,15 +78,15 @@ func (c *CreateProcessor) GetPipeLine() ([]func(cluster *v2.Cluster) error, erro
 
 func (c *CreateProcessor) Check(cluster *v2.Cluster) error {
 	logger.Info("Executing pipeline Check in CreateProcessor.")
-	err := checker.RunCheckList([]checker.Interface{checker.NewHostChecker()}, cluster, checker.PhasePre)
-	if err != nil {
-		return err
-	}
-	return nil
+	return NewCheckError(checker.RunCheckList([]checker.Interface{checker.NewHostChecker()}, cluster, checker.PhasePre))
 }
 
 func (c *CreateProcessor) PreProcess(cluster *v2.Cluster) error {
 	logger.Info("Executing pipeline PreProcess in CreateProcessor.")
+	return NewPreProcessError(c.preProcess(cluster))
+}
+
+func (c *CreateProcessor) preProcess(cluster *v2.Cluster) error {
 	if err := MountClusterImages(cluster, c.Buildah); err != nil {
 		return err
 	}

--- a/pkg/apply/processor/delete.go
+++ b/pkg/apply/processor/delete.go
@@ -71,7 +71,7 @@ func (d DeleteProcessor) GetPipeLine() ([]func(cluster *v2.Cluster) error, error
 }
 
 func (d *DeleteProcessor) PreProcess(cluster *v2.Cluster) error {
-	return SyncClusterStatus(cluster, d.Buildah, true)
+	return NewPreProcessError(SyncClusterStatus(cluster, d.Buildah, true))
 }
 
 func (d *DeleteProcessor) UndoBootstrap(cluster *v2.Cluster) error {

--- a/pkg/apply/processor/error.go
+++ b/pkg/apply/processor/error.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package processor
 
 type CheckError struct {

--- a/pkg/apply/processor/error.go
+++ b/pkg/apply/processor/error.go
@@ -1,0 +1,31 @@
+package processor
+
+type CheckError struct {
+	err error
+}
+
+func (e *CheckError) Error() string {
+	return e.err.Error()
+}
+
+func NewCheckError(err error) error {
+	if err != nil {
+		err = &CheckError{err: err}
+	}
+	return err
+}
+
+type PreProcessError struct {
+	err error
+}
+
+func (e *PreProcessError) Error() string {
+	return e.err.Error()
+}
+
+func NewPreProcessError(err error) error {
+	if err != nil {
+		err = &PreProcessError{err: err}
+	}
+	return err
+}

--- a/pkg/apply/processor/scale.go
+++ b/pkg/apply/processor/scale.go
@@ -140,11 +140,7 @@ func (c *ScaleProcessor) JoinCheck(cluster *v2.Cluster) error {
 	ips = append(ips, cluster.GetMaster0IPAndPort())
 	ips = append(ips, c.MastersToJoin...)
 	ips = append(ips, c.NodesToJoin...)
-	err := checker.RunCheckList([]checker.Interface{checker.NewIPsHostChecker(ips)}, cluster, checker.PhasePre)
-	if err != nil {
-		return err
-	}
-	return nil
+	return NewCheckError(checker.RunCheckList([]checker.Interface{checker.NewIPsHostChecker(ips)}, cluster, checker.PhasePre))
 }
 
 func (c *ScaleProcessor) DeleteCheck(cluster *v2.Cluster) error {
@@ -153,14 +149,14 @@ func (c *ScaleProcessor) DeleteCheck(cluster *v2.Cluster) error {
 	ips = append(ips, cluster.GetMaster0IPAndPort())
 	//ips = append(ips, c.MastersToDelete...)
 	//ips = append(ips, c.NodesToDelete...)
-	err := checker.RunCheckList([]checker.Interface{checker.NewIPsHostChecker(ips)}, cluster, checker.PhasePre)
-	if err != nil {
-		return err
-	}
-	return nil
+	return NewCheckError(checker.RunCheckList([]checker.Interface{checker.NewIPsHostChecker(ips)}, cluster, checker.PhasePre))
 }
 
 func (c *ScaleProcessor) PreProcess(cluster *v2.Cluster) error {
+	return NewPreProcessError(c.preProcess(cluster))
+}
+
+func (c *ScaleProcessor) preProcess(cluster *v2.Cluster) error {
 	logger.Info("Executing pipeline PreProcess in ScaleProcessor.")
 	err := c.ClusterFile.Process()
 	if err != nil {

--- a/pkg/checker/host_checker.go
+++ b/pkg/checker/host_checker.go
@@ -15,9 +15,12 @@
 package checker
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
+
+	"github.com/labring/sealos/pkg/utils/confirm"
 
 	"github.com/labring/sealos/pkg/ssh"
 	"github.com/labring/sealos/pkg/utils/logger"
@@ -31,15 +34,8 @@ type HostChecker struct {
 
 func (a HostChecker) Check(cluster *v2.Cluster, _ string) error {
 	var ipList []string
-	var masterNum int
-	for _, hosts := range cluster.Spec.Hosts {
-		if len(hosts.Roles) > 0 && hosts.Roles[0] == v2.MASTER {
-			masterNum++
-		}
-		ipList = append(ipList, hosts.IPS...)
-	}
-	if masterNum&1 == 0 {
-		return fmt.Errorf("checker: occurs no-odd number of master nodes")
+	if len(cluster.GetMasterIPList())&1 == 0 {
+		return confirmNonOddMasters()
 	}
 	if len(a.IPs) != 0 {
 		ipList = a.IPs
@@ -95,6 +91,21 @@ func checkTimeSync(s ssh.Interface, ipList []string) error {
 		if timeDiff < -1 || timeDiff > 1 {
 			return fmt.Errorf("the time of %s node is not synchronized", ip)
 		}
+	}
+	return nil
+}
+
+func confirmNonOddMasters() error {
+	prompt := "Warning: Using an even number of master nodes is a risky operation and can lead to reduced high availability and potential resource wastage. " +
+		"It is strongly recommended to use an odd number of master nodes for optimal cluster stability. " +
+		"Are you sure you want to proceed?"
+	cancel := "The number of masters needs to be set to an odd number."
+	yes, err := confirm.Confirm(prompt, cancel)
+	if err != nil {
+		return err
+	}
+	if !yes {
+		return errors.New("cancelled")
 	}
 	return nil
 }

--- a/pkg/runtime/kubeadm.go
+++ b/pkg/runtime/kubeadm.go
@@ -20,6 +20,10 @@ import (
 	"path/filepath"
 	"time"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/labring/sealos/pkg/client-go/kubernetes"
+
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/labring/sealos/pkg/constants"
@@ -183,6 +187,55 @@ func (k *KubeadmRuntime) getCertSANS() []string {
 	return k.ClusterConfiguration.APIServer.CertSANs
 }
 
+func (k *KubeadmRuntime) initCertSANS() {
+	var certSans []string
+	certSans = append(certSans, "127.0.0.1")
+	certSans = append(certSans, k.getAPIServerDomain())
+	certSans = append(certSans, k.getVip())
+	certSans = append(certSans, k.getMasterIPList()...)
+	certSans = append(certSans, k.getCertSANS()...)
+	k.setCertSANS(certSans)
+}
+
+func (k *KubeadmRuntime) setCertSANS(certs []string) {
+	var certSans []string
+	certSans = append(certSans, certs...)
+	certSans = strings2.RemoveDuplicate(certSans)
+	k.ClusterConfiguration.APIServer.CertSANs = certSans
+}
+
+func (k *KubeadmRuntime) fetchCertSANS() error {
+	logger.Info("fetch certSANs from kubeadm configmap")
+	cli, err := kubernetes.NewKubernetesClient(k.getContentData().AdminFile(), k.getMaster0IPAPIServer())
+	if err != nil {
+		return err
+	}
+	data, err := kubernetes.GetKubeadmConfig(cli.Kubernetes())
+	if err != nil {
+		return err
+	}
+	//unmarshal data from configmap
+	obj, err := yaml.UnmarshalData([]byte(data.Data[ClusterConfiguration]))
+	if err != nil {
+		return err
+	}
+	logger.Debug("current cluster config data: %+v", obj)
+
+	var certs []string
+	certsStruct, exist, err := unstructured.NestedSlice(obj, "apiServer", "certSANs")
+	if !exist {
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("apiServer certSANs not exist")
+	}
+	for i := range certsStruct {
+		certs = append(certs, certsStruct[i].(string))
+	}
+	k.setCertSANS(certs)
+	return nil
+}
+
 func (k *KubeadmRuntime) getServiceCIDR() string {
 	return k.ClusterConfiguration.Networking.ServiceSubnet
 }
@@ -331,18 +384,6 @@ func (k *KubeadmRuntime) setCgroupDriver(cGroup string) {
 	k.KubeletConfiguration.CgroupDriver = cGroup
 }
 
-func (k *KubeadmRuntime) setCertSANS(certs []string) {
-	var certSans []string
-	certSans = append(certSans, "127.0.0.1")
-	certSans = append(certSans, k.getAPIServerDomain())
-	certSans = append(certSans, k.getVip())
-	certSans = append(certSans, certs...)
-	certSans = append(certSans, k.getMasterIPList()...)
-	certSans = append(certSans, k.getCertSANS()...)
-	certSans = strings2.RemoveDuplicate(certSans)
-	k.ClusterConfiguration.APIServer.CertSANs = certSans
-}
-
 func (k *KubeadmRuntime) setInitTaints() {
 	if len(k.Cluster.GetAllIPS()) == 1 &&
 		k.InitConfiguration.NodeRegistration.Taints == nil {
@@ -431,7 +472,7 @@ func (k *KubeadmRuntime) ConvertInitConfigConversion(fns ...func(*KubeadmRuntime
 		k.APIServer.ExtraArgs = make(map[string]string)
 	}
 	k.setExcludeCIDRs()
-	k.setCertSANS([]string{})
+	k.initCertSANS()
 	k.setInitTaints()
 	// after all merging done, set default fields
 	k.finalizeInitConfig()

--- a/pkg/runtime/kubeadm.go
+++ b/pkg/runtime/kubeadm.go
@@ -232,6 +232,7 @@ func (k *KubeadmRuntime) fetchCertSANS() error {
 	for i := range certsStruct {
 		certs = append(certs, certsStruct[i].(string))
 	}
+	logger.Debug("current cluster certSANs: %+v", certs)
 	k.setCertSANS(certs)
 	return nil
 }

--- a/pkg/runtime/master.go
+++ b/pkg/runtime/master.go
@@ -107,6 +107,9 @@ func (k *KubeadmRuntime) joinMasters(masters []string) error {
 	if err = k.sendJoinCPConfig(masters); err != nil {
 		return err
 	}
+	if err = k.fetchCertSANS(); err != nil {
+		return err
+	}
 	cmd := k.Command(k.getKubeVersion(), JoinMaster)
 	if cmd == "" {
 		return fmt.Errorf("get join master command failed, kubernetes version is %s", k.getKubeVersion())


### PR DESCRIPTION
fix:
![image](https://user-images.githubusercontent.com/69408038/231645593-d1181431-7ef8-4303-bdd7-3f818ea2f08a.png)

fix: #2398 
Get certSANS from kubeadm config after initializing cluster (join master, update cert)

Fix incorrect cluster state saving, skip precheck && preProcess incorrectly save cluster state.