### PR TITLE
ci(sync-docs): fix sync docs error

### DIFF
--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run GitHub File Sync
-        uses: BetaHuhn/repo-file-sync-action@v1.16.5
+        uses: BetaHuhn/repo-file-sync-action@v1.21.0
         with:
           GH_PAT: ${{ secrets.GH_PAT }}
           CONFIG_PATH: .github/sync_docs.yml


### PR DESCRIPTION
https://github.com/labring/sealos/actions/runs/4687545323/jobs/8306974772
![](https://p.ipic.vip/ggbwsc.png)

https://github.com/BetaHuhn/repo-file-sync-action/pull/242
this error has been fixed in 1.17.21
