### PR TITLE
docs(main): fix run workflow to test-run

### DIFF
--- a/.github/workflows/patch-image.yml
+++ b/.github/workflows/patch-image.yml
@@ -1,0 +1,125 @@
+name: Patch Images Package
+
+env:
+  # Common versions
+  GO_VERSION: "1.20"
+
+on:
+  workflow_call:
+  workflow_dispatch:
+    inputs:
+      push_mage:
+        description: 'Push images'
+        required: false
+        type: boolean
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        binary: [ sealos, sealctl, lvscare, image-cri-shim ]
+        arch: [  amd64 ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Golang with cache
+        uses: magnetikonline/action-golang-cache@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Build Binaries
+        run: |
+          make build BINS=${{ matrix.binary }} PLATFORM=linux_${{ matrix.arch }}
+
+      - name: Save Binaries
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.binary }}-${{ matrix.arch }}
+          path: bin/linux_${{ matrix.arch}}/${{ matrix.binary }}
+
+  docker:
+    needs: [ build ]
+    runs-on: ubuntu-20.04
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    strategy:
+      matrix:
+        arch: [ amd64 ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Expose git commit data
+        uses: rlespinasse/git-commit-data-action@v1
+
+      - name: Download lvscare
+        uses: actions/download-artifact@v3
+        with:
+          name: lvscare-${{ matrix.arch }}
+          path: docker/patch
+
+      - name: Download sealctl
+        uses: actions/download-artifact@v3
+        with:
+          name: sealctl-${{ matrix.arch }}
+          path: docker/patch
+
+      - name: Download image-cri-shim
+        uses: actions/download-artifact@v3
+        with:
+          name: image-cri-shim-${{ matrix.arch }}
+          path: docker/patch
+
+      - name: Download sealos
+        uses: actions/download-artifact@v3
+        with:
+          name: sealos-${{ matrix.arch }}
+          path: docker/sealos
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver-opts: network=host
+
+      - name: Chmod a+x for docker
+        run: |
+          chmod a+x docker/sealos/*
+          chmod a+x docker/patch/*
+          chmod a+x docker/lvscare/*
+
+      - name: Build and Push lvscare Image
+        uses: docker/build-push-action@v3
+        with:
+          context: docker/patch
+          file: docker/patch/Dockerfile.build
+          push: true
+          build-args: Bin=lvscare
+          platforms: linux/${{ matrix.arch }}
+          tags: localhost:5000/labring/lvscare:${{ env.GIT_COMMIT_SHORT_SHA }}-${{ matrix.arch }}
+
+      - name: Build and Save Cluster Images
+        run: scripts/save-cluster-images.sh
+        env:
+          ARCH: ${{ matrix.arch }}
+
+      - name: Upload Cluster Images
+        uses: actions/upload-artifact@v3
+        with:
+          name: patch-image-${{ matrix.arch }}.tar
+          path: patch-${{ matrix.arch }}.tar
+
+      - name: Delete Artifacts
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: |
+            lvscare-${{ matrix.arch }}
+            sealctl-${{ matrix.arch }}
+            image-cri-shim-${{ matrix.arch }}
+          failOnError: false

--- a/.github/workflows/patch-image.yml
+++ b/.github/workflows/patch-image.yml
@@ -7,11 +7,6 @@ env:
 on:
   workflow_call:
   workflow_dispatch:
-    inputs:
-      push_mage:
-        description: 'Push images'
-        required: false
-        type: boolean
 
 jobs:
   build:
@@ -31,18 +26,42 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: Install Dependencies
+        run: sudo apt update && sudo apt install -y libgpgme-dev libbtrfs-dev libdevmapper-dev
+
       - name: Build Binaries
         run: |
           make build BINS=${{ matrix.binary }} PLATFORM=linux_${{ matrix.arch }}
-
       - name: Save Binaries
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.binary }}-${{ matrix.arch }}
           path: bin/linux_${{ matrix.arch}}/${{ matrix.binary }}
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
+      - name: Setup Golang with cache
+        uses: magnetikonline/action-golang-cache@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Install Dependencies
+        run: sudo apt update && sudo apt install -y libgpgme-dev libbtrfs-dev libdevmapper-dev
+      - name: Build E2e Test
+        run: |
+          go install github.com/onsi/ginkgo/v2/ginkgo
+          cd test/e2e && ginkgo build .
+      - name: Save E2e Test
+        uses: actions/upload-artifact@v3
+        with:
+          name: e2e.test
+          path: test/e2e/e2e.test
   docker:
-    needs: [ build ]
+    needs: [ build,test ]
     runs-on: ubuntu-20.04
     services:
       registry:

--- a/.github/workflows/test_run.yml
+++ b/.github/workflows/test_run.yml
@@ -3,19 +3,17 @@ name: Test Sealos Run Command
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
     paths:
-      - ".github/workflows/test_run.yml"
+      - ".github/workflows/**"
       - "cmd/**"
-      - "pkg/runtime/**"
-      - "pkg/buildah/**"
-    pull_request:
-      branches: [ "*" ]
-      paths:
-        - ".github/workflows/test_run.yml"
-        - "cmd/**"
-        - "pkg/runtime/**"
-        - "pkg/buildah/**"
+      - "pkg/**"
+  pull_request:
+    branches: ["*"]
+    paths:
+      - ".github/workflows/**"
+      - "cmd/**"
+      - "pkg/**"
 
 jobs:
   call_ci_workflow:

--- a/.github/workflows/test_run.yml
+++ b/.github/workflows/test_run.yml
@@ -18,20 +18,20 @@ on:
 jobs:
   call_ci_workflow:
     uses: ./.github/workflows/patch-image.yml
-  build-sealos:
+  download-sealos:
     needs: [call_ci_workflow]
     runs-on: ubuntu-latest
     steps:
       - name: Download sealos binary
         uses: actions/download-artifact@v3
         with:
-          name: sealos-${{ matrix.arch }}
+          name: sealos-amd64
           path: /tmp/sealos/bin/
 
       - name: Download patch image tar
         uses: actions/download-artifact@v3
         with:
-          name: patch-image-${{ matrix.arch }}.tar
+          name: patch-image-amd64.tar
           path: /tmp/sealos/images/
 
       - name: Save Binaries
@@ -42,10 +42,10 @@ jobs:
       - name: Save Tars
         uses: actions/upload-artifact@v3
         with:
-          name: patch-image.tar
+          name: patch-amd64.tar
           path: /tmp/sealos/images/patch-amd64.tar
   verify-run-single:
-    needs: [build-sealos]
+    needs: [download-sealos]
     runs-on: ubuntu-latest
     steps:
       - name: Download sealos
@@ -92,7 +92,7 @@ jobs:
           sudo cat /root/.sealos/default/etc/kubeadm-init.yaml | grep 10.96.0.0/22
 
   verify-run-containerd:
-    needs: [build-sealos]
+    needs: [download-sealos]
     runs-on: ubuntu-latest
     steps:
       - name: Download sealos
@@ -133,7 +133,7 @@ jobs:
           sudo cat /root/.sealos/default/etc/kubeadm-init.yaml | grep 10.96.0.0/22
 
   verify-run-docker:
-    needs: [build-sealos]
+    needs: [download-sealos]
     runs-on: ubuntu-latest
     steps:
       - name: Download sealos
@@ -176,7 +176,7 @@ jobs:
 
 
   verify-run-containerd-buildimage:
-    needs: [build-sealos]
+    needs: [download-sealos]
     runs-on: ubuntu-latest
     steps:
       - name: Download sealos
@@ -236,7 +236,7 @@ jobs:
           sudo cat /root/.sealos/default/etc/kubeadm-init.yaml | grep ${local_ip}
 
   verify-run-docker-buildimage:
-    needs: [build-sealos]
+    needs: [download-sealos]
     runs-on: ubuntu-latest
     steps:
       - name: Download sealos
@@ -292,7 +292,7 @@ jobs:
 
 
   verify-run-containerd-apply:
-    needs: [build-sealos]
+    needs: [download-sealos]
     runs-on: ubuntu-latest
     steps:
       - name: Download sealos
@@ -373,7 +373,7 @@ jobs:
           sudo cat /root/.sealos/default/etc/kubeadm-init.yaml | grep 192.168.72.100
 
   verify-run-docker-apply:
-    needs: [build-sealos]
+    needs: [download-sealos]
     runs-on: ubuntu-latest
     steps:
       - name: Download sealos
@@ -446,7 +446,7 @@ jobs:
           sudo cat /root/.sealos/default/etc/kubeadm-init.yaml | grep 100.55.0.0/16
 
   verify-run-containerd-apply-with-external-etcd:
-    needs: [build-sealos]
+    needs: [download-sealos]
     runs-on: ubuntu-latest
     steps:
       - name: Download sealos
@@ -545,7 +545,7 @@ jobs:
           sudo cat /root/.sealos/default/etc/kubeadm-init.yaml | grep http://127.0.0.1:2379
 
   verify-run-containerd-buildimage-apply:
-    needs: [build-sealos]
+    needs: [download-sealos]
     runs-on: ubuntu-latest
     steps:
       - name: Download sealos
@@ -632,7 +632,7 @@ jobs:
           sudo cat /root/.sealos/default/etc/kubeadm-init.yaml | grep 100.56.0.0/16
 
   verify-run-docker-buildimage-apply:
-    needs: [build-sealos]
+    needs: [download-sealos]
     runs-on: ubuntu-latest
     steps:
       - name: Download sealos
@@ -720,7 +720,7 @@ jobs:
           sudo cat /root/.sealos/default/etc/kubeadm-init.yaml | grep 10.160.0.0/12
           sudo cat /root/.sealos/default/etc/kubeadm-init.yaml | grep 100.56.0.0/16
   verify-run-by-loadtar:
-    needs: [ build-sealos ]
+    needs: [ download-sealos ]
     runs-on: ubuntu-latest
     steps:
       - name: Download sealos
@@ -746,7 +746,7 @@ jobs:
           sudo sealos run  labring/kubernetes:v1.25.0 --single --debug
           sudo sealos run  $PWD/oci-helm.tar
   verify-run-by-shortname:
-    needs: [build-sealos]
+    needs: [download-sealos]
     runs-on: ubuntu-latest
     steps:
       - name: Download sealos
@@ -770,7 +770,7 @@ jobs:
           sudo sealos run  k8s:dev  labring/helm:v3.8.2 labring/calico:v3.24.1 --single --debug
 
   verify-run-by-load-shortname:
-    needs: [build-sealos]
+    needs: [download-sealos]
     runs-on: ubuntu-latest
     steps:
       - name: Download sealos
@@ -797,23 +797,23 @@ jobs:
           sudo sealos load -i k8s.tar
           sudo sealos run  k8s:dev  labring/helm:v3.8.2 labring/calico:v3.24.1 --single --debug
   verify-run-by-newimage:
-    needs: [ build-sealos ]
+    needs: [ download-sealos ]
     runs-on: ubuntu-latest
     steps:
       - name: Download sealos
         uses: actions/download-artifact@v3
         with:
           name: sealos
-          path: /tmp/sealos
+          path: /tmp/
       - name: Download image
         uses: actions/download-artifact@v3
         with:
-          name: patch-image.tar
-          path: /tmp/patch-image.tar
+          name: patch-amd64.tar
+          path: /tmp/
       - name: Verify sealos
         run: |
-          sudo chmod a+x /tmp/sealos
           sudo mv /tmp/sealos /usr/bin/
+          sudo chmod a+x /usr/bin/sealos
           sudo sealos version
       - name: Remove containerd && docker
         uses: labring/sealos-action@v0.0.7
@@ -821,12 +821,10 @@ jobs:
           type: prune
       - name: Run
         run: |
-          sudo sealos load -i /tmp/patch-image.tar
-          sudo sealos images
-          sudo sealos run ghcr.io/labring-actions/dev-merge-containerd-k8s:1.23.17-amd64 labring/helm:v3.8.2 labring/calico:v3.24.1 --single --debug
-
+          sudo sealos run ghcr.io/labring-actions/dev-merge-containerd-k8s:1.23.17-amd64 /tmp/patch-amd64.tar labring/helm:v3.8.2 labring/calico:v3.24.1 --single --debug
+          sudo crictl images
   verify-run-containerd-apply-with-external-taint:
-    needs: [build-sealos]
+    needs: [download-sealos]
     runs-on: ubuntu-latest
     steps:
       - name: Download sealos

--- a/.github/workflows/test_run.yml
+++ b/.github/workflows/test_run.yml
@@ -17,8 +17,9 @@ on:
 
 jobs:
   call_ci_workflow:
-    uses: ./.github/workflows/ci.yml
+    uses: ./.github/workflows/patch-image.yml
   build-sealos:
+    needs: [call_ci_workflow]
     runs-on: ubuntu-latest
     steps:
       - name: Download sealos binary

--- a/.github/workflows/test_run.yml
+++ b/.github/workflows/test_run.yml
@@ -1,21 +1,10 @@
 name: Test Sealos Run Command
 
 on:
+  workflow_run:
+    workflows: [ CI ]
+    types: [ completed ]
   workflow_dispatch:
-  push:
-    branches: ["main"]
-    paths:
-      - ".github/workflows/test_run.yml"
-      - "cmd/**"
-      - "pkg/runtime/**"
-      - "pkg/buildah/**"
-  pull_request:
-    branches: ["*"]
-    paths:
-      - ".github/workflows/test_run.yml"
-      - "cmd/**"
-      - "pkg/runtime/**"
-      - "pkg/buildah/**"
 
 
 jobs:
@@ -24,17 +13,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Auto install sealos
-        uses: labring/sealos-action@v0.0.5
+      - name: Download sealos
+        uses: actions/download-artifact@v3
         with:
-          type: install-dev
-          pruneCRI: true
-          autoFetch: false
+          name: sealos
+          path: /tmp/
+      - name: Verify sealos
+        run: |
+          ls -l /tmp/
+          sudo chmod a+x /tmp/sealos
+          sudo /tmp/sealos version
       - name: Save Binaries
         uses: actions/upload-artifact@v3
         with:
           name: sealos
-          path: /usr/bin/sealos
+          path: /tmp/sealos
 
   verify-run-single:
     needs: [build-sealos]
@@ -472,7 +465,7 @@ jobs:
           echo "ETCD info"
           /tmp/etcd-download-test/etcd --version
           /tmp/etcd-download-test/etcdctl version
-        
+          
           echo "Start a local ETCD server"
           ALLOW_NONE_AUTHENTICATION=yes
           nohup /tmp/etcd-download-test/etcd --listen-client-urls http://0.0.0.0:2379 \
@@ -686,7 +679,7 @@ jobs:
           kind: ClusterConfiguration
           networking:
             serviceSubnet: "100.56.0.0/16"
-            
+          
           EOF
           cat /tmp/apply/Clusterfile
       - name: Auto install k8s using sealos

--- a/.github/workflows/test_run.yml
+++ b/.github/workflows/test_run.yml
@@ -1,9 +1,6 @@
 name: Test Sealos Run Command
 
 on:
-  workflow_run:
-    workflows: [ CI ]
-    types: [ completed ]
   workflow_dispatch:
   push:
     branches: [ "main" ]
@@ -21,28 +18,33 @@ on:
         - "pkg/buildah/**"
 
 jobs:
+  call_ci_workflow:
+    uses: ./.github/workflows/ci.yml
   build-sealos:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Download sealos
+      - name: Download sealos binary
         uses: actions/download-artifact@v3
         with:
-          name: sealos
-          path: /tmp/
-      - name: Verify sealos
-        run: |
-          ls -l /tmp/
-          sudo chmod a+x /tmp/sealos
-          sudo /tmp/sealos version
+          name: sealos-${{ matrix.arch }}
+          path: /tmp/sealos/bin/
+
+      - name: Download patch image tar
+        uses: actions/download-artifact@v3
+        with:
+          name: patch-image-${{ matrix.arch }}.tar
+          path: /tmp/sealos/images/
+
       - name: Save Binaries
         uses: actions/upload-artifact@v3
         with:
           name: sealos
-          path: /tmp/sealos
-
+          path: /tmp/sealos/bin/sealos
+      - name: Save Tars
+        uses: actions/upload-artifact@v3
+        with:
+          name: patch-image.tar
+          path: /tmp/sealos/images/patch-amd64.tar
   verify-run-single:
     needs: [build-sealos]
     runs-on: ubuntu-latest
@@ -803,7 +805,12 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: sealos
-          path: /tmp/
+          path: /tmp/sealos
+      - name: Download image
+        uses: actions/download-artifact@v3
+        with:
+          name: patch-image.tar
+          path: /tmp/patch-image.tar
       - name: Verify sealos
         run: |
           sudo chmod a+x /tmp/sealos
@@ -815,6 +822,8 @@ jobs:
           type: prune
       - name: Run
         run: |
+          sudo sealos load -i /tmp/patch-image.tar
+          sudo sealos images
           sudo sealos run ghcr.io/labring-actions/dev-merge-containerd-k8s:1.23.17-amd64 labring/helm:v3.8.2 labring/calico:v3.24.1 --single --debug
 
   verify-run-containerd-apply-with-external-taint:

--- a/.github/workflows/test_run.yml
+++ b/.github/workflows/test_run.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build-sealos:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test_run.yml
+++ b/.github/workflows/test_run.yml
@@ -5,7 +5,20 @@ on:
     workflows: [ CI ]
     types: [ completed ]
   workflow_dispatch:
-
+  push:
+    branches: [ "main" ]
+    paths:
+      - ".github/workflows/test_run.yml"
+      - "cmd/**"
+      - "pkg/runtime/**"
+      - "pkg/buildah/**"
+    pull_request:
+      branches: [ "*" ]
+      paths:
+        - ".github/workflows/test_run.yml"
+        - "cmd/**"
+        - "pkg/runtime/**"
+        - "pkg/buildah/**"
 
 jobs:
   build-sealos:


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9b96303</samp>

### Summary
🛠️🐳🚀

<!--
1.  🛠️ - This emoji represents the building and testing of the sealos binaries and the patch image, which are the core components of sealos. The emoji also conveys the idea of improving the CI/CD process by using a reusable workflow.
2.  🐳 - This emoji represents the use of Docker Buildx to build and push the lvscare image, which is a key feature of sealos that enables load balancing and service discovery for Kubernetes clusters. The emoji also conveys the idea of supporting multiple architectures for the image.
3.  🚀 - This emoji represents the use of artifacts to store and share the sealos binary, the patch image, the cluster images and the e2e test binary, which can speed up the workflow execution and the deployment of sealos. The emoji also conveys the idea of enhancing the performance and reliability of sealos.
-->
This pull request introduces a new reusable workflow `patch-image.yml` to build and test the sealos binaries and the patch image for different architectures and to save them as artifacts. It also refactors the `test_run.yml` workflow to use the new workflow and to download the artifacts for the e2e tests. This improves the code quality and the consistency of the CI/CD process.

> _`patch-image.yml`_
> _Builds and tests sealos tools_
> _New workflow call_

### Walkthrough
*  Add a new workflow file `patch-image.yml` to build and test the sealos binaries and the patch image ([link](https://github.com/labring/sealos/pull/2970/files?diff=unified&w=0#diff-93608906b17a83aa05b96eeca328c44cc2c56f9fd92aaa6b9baea4653d2e923eR1-R144))
*  Modify the `test_run.yml` workflow to trigger on any changes to the `.github/workflows`, `cmd` or `pkg` directories ([link](https://github.com/labring/sealos/pull/2970/files?diff=unified&w=0#diff-fa5cab70821b4247f7c79d8940fcfb1a5238824b38be64f9e8ea8bcf672fac8eL8-R48))
*  Replace the `build-sealos` job with a `call_ci_workflow` job that uses the `patch-image.yml` workflow as a reusable workflow ([link](https://github.com/labring/sealos/pull/2970/files?diff=unified&w=0#diff-fa5cab70821b4247f7c79d8940fcfb1a5238824b38be64f9e8ea8bcf672fac8eL87-R95))
*  Add a `download-sealos` job that downloads the sealos binary and the patch image from the artifacts created by the `call_ci_workflow` job ([link](https://github.com/labring/sealos/pull/2970/files?diff=unified&w=0#diff-fa5cab70821b4247f7c79d8940fcfb1a5238824b38be64f9e8ea8bcf672fac8eL128-R136), [link](https://github.com/labring/sealos/pull/2970/files?diff=unified&w=0#diff-fa5cab70821b4247f7c79d8940fcfb1a5238824b38be64f9e8ea8bcf672fac8eL800-R816))
*  Modify the e2e test jobs to depend on the `download-sealos` job and use the latest sealos binary and patch image ([link](https://github.com/labring/sealos/pull/2970/files?diff=unified&w=0#diff-fa5cab70821b4247f7c79d8940fcfb1a5238824b38be64f9e8ea8bcf672fac8eL171-R179), [link](https://github.com/labring/sealos/pull/2970/files?diff=unified&w=0#diff-fa5cab70821b4247f7c79d8940fcfb1a5238824b38be64f9e8ea8bcf672fac8eL231-R239), [link](https://github.com/labring/sealos/pull/2970/files?diff=unified&w=0#diff-fa5cab70821b4247f7c79d8940fcfb1a5238824b38be64f9e8ea8bcf672fac8eL287-R295), [link](https://github.com/labring/sealos/pull/2970/files?diff=unified&w=0#diff-fa5cab70821b4247f7c79d8940fcfb1a5238824b38be64f9e8ea8bcf672fac8eL368-R376), [link](https://github.com/labring/sealos/pull/2970/files?diff=unified&w=0#diff-fa5cab70821b4247f7c79d8940fcfb1a5238824b38be64f9e8ea8bcf672fac8eL441-R449), [link](https://github.com/labring/sealos/pull/2970/files?diff=unified&w=0#diff-fa5cab70821b4247f7c79d8940fcfb1a5238824b38be64f9e8ea8bcf672fac8eL540-R548), [link](https://github.com/labring/sealos/pull/2970/files?diff=unified&w=0#diff-fa5cab70821b4247f7c79d8940fcfb1a5238824b38be64f9e8ea8bcf672fac8eL627-R635), [link](https://github.com/labring/sealos/pull/2970/files?diff=unified&w=0#diff-fa5cab70821b4247f7c79d8940fcfb1a5238824b38be64f9e8ea8bcf672fac8eL715-R723), [link](https://github.com/labring/sealos/pull/2970/files?diff=unified&w=0#diff-fa5cab70821b4247f7c79d8940fcfb1a5238824b38be64f9e8ea8bcf672fac8eL741-R749), [link](https://github.com/labring/sealos/pull/2970/files?diff=unified&w=0#diff-fa5cab70821b4247f7c79d8940fcfb1a5238824b38be64f9e8ea8bcf672fac8eL765-R773), [link](https://github.com/labring/sealos/pull/2970/files?diff=unified&w=0#diff-fa5cab70821b4247f7c79d8940fcfb1a5238824b38be64f9e8ea8bcf672fac8eL792-R800))
*  Modify the `verify-run-by-newimage` job to use the patch image as an argument to the `sealos run` command and check the images loaded by the command ([link](https://github.com/labring/sealos/pull/2970/files?diff=unified&w=0#diff-fa5cab70821b4247f7c79d8940fcfb1a5238824b38be64f9e8ea8bcf672fac8eL811-R827))
*  Remove redundant blank lines in some jobs ([link](https://github.com/labring/sealos/pull/2970/files?diff=unified&w=0#diff-fa5cab70821b4247f7c79d8940fcfb1a5238824b38be64f9e8ea8bcf672fac8eL475-R483), [link](https://github.com/labring/sealos/pull/2970/files?diff=unified&w=0#diff-fa5cab70821b4247f7c79d8940fcfb1a5238824b38be64f9e8ea8bcf672fac8eL689-R697), [link](https://github.com/labring/sealos/pull/2970/files?diff=unified&w=0#diff-fa5cab70821b4247f7c79d8940fcfb1a5238824b38be64f9e8ea8bcf672fac8eL896-R909))

