### PR TITLE
fix sha len not same

### DIFF
--- a/.github/workflows/frontend-providers.yml
+++ b/.github/workflows/frontend-providers.yml
@@ -51,6 +51,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Expose git commit data
+        uses: rlespinasse/git-commit-data-action@v1
+
+      - name: Prepare
+        id: prepare
+        run: |
+          TAG=${GIT_COMMIT_SHORT_SHA}
+          echo tag_name=${TAG} >> $GITHUB_OUTPUT
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -60,7 +69,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
             type=raw,value=dev,enable=true
-            type=sha,enable=true,prefix=,suffix=,format=short
+            type=raw,value=${{ steps.prepare.outputs.tag_name }},enable=true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7901255</samp>

### Summary
🏷️🔎🐳

<!--
1.  🏷️ - This emoji represents the addition of a tag to the docker image, which is the main change in this pull request.
2.  🔎 - This emoji represents the improvement in traceability of the image to the source code, which is a benefit of this change for debugging and auditing purposes.
3.  🐳 - This emoji represents the docker image itself, which is the artifact that is being modified by this change.
-->
This pull request enhances the frontend-providers workflow by adding a tag name generation step and tagging the docker image with it. This allows easier mapping of the image to the git commit.

> _Oh we are the docker crew, we build and push and tag_
> _We use the git commit SHA to name our image flag_
> _So heave away, me hearties, heave away with me_
> _We'll trace our code to docker, on the count of three_

### Walkthrough
* Add a step to expose git commit data as environment variables ([link](https://github.com/labring/sealos/pull/3025/files?diff=unified&w=0#diff-a063aec1c8d2593bd643a0cd02daf8581ebf75eb1fe702fe8169b4ca1250448dR54-R62))
* Use the commit SHA as a tag for the docker image ([link](https://github.com/labring/sealos/pull/3025/files?diff=unified&w=0#diff-a063aec1c8d2593bd643a0cd02daf8581ebf75eb1fe702fe8169b4ca1250448dL63-R72))

