### PR TITLE
Replace all `math/rand` to safer `crypto/rand`.

### DIFF
--- a/pkg/buildah/imagecrbuilder.go
+++ b/pkg/buildah/imagecrbuilder.go
@@ -18,13 +18,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-
-	// ruleid: math-random-used
-	"math/rand"
 	"path/filepath"
-	"strconv"
 	"strings"
-	"time"
 
 	"github.com/containers/storage"
 	"github.com/openconfig/gnmi/errlist"
@@ -42,6 +37,7 @@ import (
 	"github.com/labring/sealos/pkg/client-go/kubernetes"
 	"github.com/labring/sealos/pkg/utils/file"
 	"github.com/labring/sealos/pkg/utils/logger"
+	"github.com/labring/sealos/pkg/utils/rand"
 )
 
 type ImageCRBuilder struct {
@@ -81,7 +77,7 @@ func (icb *ImageCRBuilder) Run() error {
 func (icb *ImageCRBuilder) CreateContainer() error {
 	logger.Debug("Executing CreateContainer in ImageCRBuilder")
 	// generate a random container name
-	containerID := fmt.Sprintf("%s-%s", icb.image, strconv.Itoa(rand.New(rand.NewSource(time.Now().UnixNano())).Int()))
+	containerID := fmt.Sprintf("%s-%s", icb.image, rand.Generator(8))
 	realImpl, err := New("")
 	if err != nil {
 		return err

--- a/test/testpg/pgstresstest.go
+++ b/test/testpg/pgstresstest.go
@@ -2,11 +2,10 @@ package testpg
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
 	"log"
-
-	// ruleid: math-random-used
-	mrand "math/rand"
+	"math/big"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -22,7 +21,6 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
-
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -114,8 +112,12 @@ func RunPostgresTest(config, userNamespace string) error {
 // PostgresClusterRandomCreate Create random PostgresCluster.
 func PostgresClusterRandomCreate(ctx context.Context, dr dynamic.ResourceInterface, obj *unstructured.Unstructured) ([]*unstructured.Unstructured, error) {
 	var err error
-	rnd := mrand.New(mrand.NewSource(time.Now().UnixNano()))
-	n := rnd.Intn(5)
+
+	var bigN *big.Int
+	if bigN, err = rand.Int(rand.Reader, big.NewInt(5)); err != nil {
+		return nil, fmt.Errorf("unable to read random bytes for jwt id: %s", err)
+	}
+	n := int(bigN.Int64())
 	var objSlice []*unstructured.Unstructured
 	//Create
 	for i := 0; i < n; i++ {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9805f5c</samp>

### Summary
🔐🐳🧪

<!--
1.  🔐 - This emoji represents security, encryption, or locking. It can be used to indicate that the changes improved the security or reliability of the code, such as using a more secure random number generator or generating more secure tokens.
2.  🐳 - This emoji represents a whale, which is the logo of Docker, a popular container platform. It can be used to indicate that the changes involved containers, such as creating or managing them, or using a custom package for generating container names.
3.  🧪 - This emoji represents a test tube, which is often used to symbolize testing, experimentation, or science. It can be used to indicate that the changes involved testing, such as creating a test Postgres cluster or running tests with random numbers.
-->
This pull request enhances the security and reliability of random number generation in various packages. It replaces `math/rand` with `crypto/rand` and other custom packages for creating container names, JWT tokens, and Postgres clusters. It affects the files `pkg/buildah/imagecrbuilder.go`, `service/hub/server/server.go`, and `test/testpg/pgstresstest.go`.

> _`rand` package changed_
> _More secure and reliable_
> _Winter of bugs ends_

### Walkthrough
*  Replace `math/rand` with more secure and reliable packages for random number generation ([link](https://github.com/labring/sealos/pull/3031/files?diff=unified&w=0#diff-b6eec98074d76fbaf36680721954be8b556d0c8709ad311b636d92d38c7da465L21-R22), [link](https://github.com/labring/sealos/pull/3031/files?diff=unified&w=0#diff-69250097ff164f66b3382682fd269f08adc3a9793987bf45bee01857001c7136L4-R7), [link](https://github.com/labring/sealos/pull/3031/files?diff=unified&w=0#diff-b15f16ea9411a44838fcfb048cd7217a5a3679e155a62cae4ffe93aff67c66ccL5-R8), [link](https://github.com/labring/sealos/pull/3031/files?diff=unified&w=0#diff-b15f16ea9411a44838fcfb048cd7217a5a3679e155a62cae4ffe93aff67c66ccL25))
*  Use `rand.Generator` from `pkg/utils/rand` to generate random container names in `CreateContainer` function in `pkg/buildah/imagecrbuilder.go` ([link](https://github.com/labring/sealos/pull/3031/files?diff=unified&w=0#diff-b6eec98074d76fbaf36680721954be8b556d0c8709ad311b636d92d38c7da465R40), [link](https://github.com/labring/sealos/pull/3031/files?diff=unified&w=0#diff-b6eec98074d76fbaf36680721954be8b556d0c8709ad311b636d92d38c7da465L84-R80))
*  Use base64-encoded random bytes as JWT ID in `CreateToken` function in `service/hub/server/server.go` ([link](https://github.com/labring/sealos/pull/3031/files?diff=unified&w=0#diff-69250097ff164f66b3382682fd269f08adc3a9793987bf45bee01857001c7136R247-R252), [link](https://github.com/labring/sealos/pull/3031/files?diff=unified&w=0#diff-69250097ff164f66b3382682fd269f08adc3a9793987bf45bee01857001c7136L256-R260))
*  Use `crypto/rand` and `math/big` to generate random integers for Postgres cluster creation test in `PostgresClusterRandomCreate` function in `test/testpg/pgstresstest.go` ([link](https://github.com/labring/sealos/pull/3031/files?diff=unified&w=0#diff-b15f16ea9411a44838fcfb048cd7217a5a3679e155a62cae4ffe93aff67c66ccL117-R120))

