### PR TITLE
change cert env

### DIFF
--- a/frontend/desktop/deploy/Kubefile
+++ b/frontend/desktop/deploy/Kubefile
@@ -5,6 +5,6 @@ COPY registry registry
 COPY manifests manifests
 
 ENV cloudDomain="cloud.example.com"
-ENV desktopCertSecretName="wildcard-cert"
+ENV certSecretName="wildcard-cert"
 
 CMD ["kubectl apply -f manifests/deploy.yaml -f manifests/ingress.yaml"]

--- a/frontend/desktop/deploy/manifests/ingress.yaml.tmpl
+++ b/frontend/desktop/deploy/manifests/ingress.yaml.tmpl
@@ -24,4 +24,4 @@ spec:
   tls:
     - hosts:
         - '{{ .cloudDomain }}'
-      secretName: {{ .desktopCertSecretName }}
+      secretName: {{ .certSecretName }}

--- a/frontend/providers/applaunchpad/deploy/Kubefile
+++ b/frontend/providers/applaunchpad/deploy/Kubefile
@@ -6,5 +6,6 @@ COPY registry registry
 COPY manifests manifests
 
 ENV cloudDomain="cloud.example.com"
+ENV certSecretName="wildcard-cert"
 
 CMD ["kubectl apply -f manifests"]

--- a/frontend/providers/applaunchpad/deploy/manifests/ingress.yaml.tmpl
+++ b/frontend/providers/applaunchpad/deploy/manifests/ingress.yaml.tmpl
@@ -1,31 +1,31 @@
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
-  name: applaunchpad-cluster-issuer
-  namespace: applaunchpad-frontend
-spec:
-  acme:
-    server: https://acme-v02.api.letsencrypt.org/directory
-    email: admin@sealos.io
-    privateKeySecretRef:
-      name: letsencrypt-prod
-    solvers:
-      - http01:
-          ingress:
-            class: nginx
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: applaunchpad-cert
-  namespace: applaunchpad-frontend
-spec:
-  secretName: applaunchpad-cert-secret
-  dnsNames:
-    - applaunchpad.{{ .cloudDomain }}
-  issuerRef:
-    name: applaunchpad-cluster-issuer
-    kind: ClusterIssuer
+#apiVersion: cert-manager.io/v1
+#kind: ClusterIssuer
+#metadata:
+#  name: applaunchpad-cluster-issuer
+#  namespace: applaunchpad-frontend
+#spec:
+#  acme:
+#    server: https://acme-v02.api.letsencrypt.org/directory
+#    email: admin@sealos.io
+#    privateKeySecretRef:
+#      name: letsencrypt-prod
+#    solvers:
+#      - http01:
+#          ingress:
+#            class: nginx
+#---
+#apiVersion: cert-manager.io/v1
+#kind: Certificate
+#metadata:
+#  name: applaunchpad-cert
+#  namespace: applaunchpad-frontend
+#spec:
+#  secretName: applaunchpad-cert-secret
+#  dnsNames:
+#    - applaunchpad.{{ .cloudDomain }}
+#  issuerRef:
+#    name: applaunchpad-cluster-issuer
+#    kind: ClusterIssuer
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -59,4 +59,4 @@ spec:
   tls:
     - hosts:
         - applaunchpad.{{ .cloudDomain }}
-      secretName: applaunchpad-cert-secret
+      secretName: {{ .certSecretName }}

--- a/frontend/providers/bytebase/deploy/Kubefile
+++ b/frontend/providers/bytebase/deploy/Kubefile
@@ -6,5 +6,6 @@ COPY registry registry
 COPY manifests manifests
 
 ENV cloudDomain="cloud.example.com"
+ENV certSecretName="wildcard-cert"
 
 CMD ["kubectl apply -f manifests"]

--- a/frontend/providers/bytebase/deploy/manifests/ingress.yaml.tmpl
+++ b/frontend/providers/bytebase/deploy/manifests/ingress.yaml.tmpl
@@ -12,35 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
-  name: bytebase-cluster-issuer
-  namespace: bytebase-frontend
-spec:
-  acme:
-    server: https://acme-v02.api.letsencrypt.org/directory
-    email: admin@sealos.io
-    privateKeySecretRef:
-      name: letsencrypt-prod
-    solvers:
-      - http01:
-          ingress:
-            class: nginx
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: bytebase-cert
-  namespace: bytebase-frontend
-spec:
-  secretName: bytebase-cert-secret
-  dnsNames:
-    - bytebase.{{ .cloudDomain }}
-  issuerRef:
-    name: bytebase-cluster-issuer
-    kind: ClusterIssuer
----
+#apiVersion: cert-manager.io/v1
+#kind: ClusterIssuer
+#metadata:
+#  name: bytebase-cluster-issuer
+#  namespace: bytebase-frontend
+#spec:
+#  acme:
+#    server: https://acme-v02.api.letsencrypt.org/directory
+#    email: admin@sealos.io
+#    privateKeySecretRef:
+#      name: letsencrypt-prod
+#    solvers:
+#      - http01:
+#          ingress:
+#            class: nginx
+#---
+#apiVersion: cert-manager.io/v1
+#kind: Certificate
+#metadata:
+#  name: bytebase-cert
+#  namespace: bytebase-frontend
+#spec:
+#  secretName: bytebase-cert-secret
+#  dnsNames:
+#    - bytebase.{{ .cloudDomain }}
+#  issuerRef:
+#    name: bytebase-cluster-issuer
+#    kind: ClusterIssuer
+#---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -73,4 +73,4 @@ spec:
   tls:
     - hosts:
         - bytebase.{{ .cloudDomain }}
-      secretName: bytebase-cert-secret
+      secretName: {{ .certSecretName }}

--- a/frontend/providers/imagehub/deploy/Kubefile
+++ b/frontend/providers/imagehub/deploy/Kubefile
@@ -6,5 +6,6 @@ COPY registry registry
 COPY manifests manifests
 
 ENV cloudDomain="cloud.example.com"
+ENV certSecretName="wildcard-cert"
 
 CMD ["kubectl apply -f manifests"]

--- a/frontend/providers/imagehub/deploy/manifests/ingress.yaml.tmpl
+++ b/frontend/providers/imagehub/deploy/manifests/ingress.yaml.tmpl
@@ -1,32 +1,3 @@
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
-  name: imagehub-cluster-issuer
-  namespace: imagehub-frontend
-spec:
-  acme:
-    server: https://acme-v02.api.letsencrypt.org/directory
-    email: admin@sealos.io
-    privateKeySecretRef:
-      name: letsencrypt-prod
-    solvers:
-      - http01:
-          ingress:
-            class: nginx
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: imagehub-cert
-  namespace: imagehub-frontend
-spec:
-  secretName: imagehub-cert-secret
-  dnsNames:
-    - imagehub.{{ .cloudDomain }}
-  issuerRef:
-    name: imagehub-cluster-issuer
-    kind: ClusterIssuer
----
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -52,4 +23,4 @@ spec:
   tls:
     - hosts:
         - imagehub.{{ .cloudDomain }}
-      secretName: imagehub-cert-secret
+      secretName: {{ .certSecretName }}

--- a/frontend/providers/terminal/deploy/Kubefile
+++ b/frontend/providers/terminal/deploy/Kubefile
@@ -5,6 +5,7 @@ USER 65532:65532
 COPY registry registry
 COPY manifests manifests
 
+ENV certSecretName="wildcard-cert"
 ENV cloudDomain="cloud.example.com"
 
 CMD ["kubectl apply -f manifests"]

--- a/frontend/providers/terminal/deploy/manifests/ingress.yaml.tmpl
+++ b/frontend/providers/terminal/deploy/manifests/ingress.yaml.tmpl
@@ -12,35 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
-  name: terminal-cluster-issuer
-  namespace: terminal-frontend
-spec:
-  acme:
-    server: https://acme-v02.api.letsencrypt.org/directory
-    email: admin@sealos.io
-    privateKeySecretRef:
-      name: letsencrypt-prod
-    solvers:
-      - http01:
-          ingress:
-            class: nginx
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: terminal-cert
-  namespace: terminal-frontend
-spec:
-  secretName: terminal-cert-secret
-  dnsNames:
-    - terminal.{{ .cloudDomain }}
-  issuerRef:
-    name: terminal-cluster-issuer
-    kind: ClusterIssuer
----
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -79,4 +50,4 @@ spec:
   tls:
     - hosts:
         - terminal.{{ .cloudDomain }}
-      secretName: terminal-cert-secret
+      secretName: {{ .certSecretName }}

--- a/service/auth/deploy/Kubefile
+++ b/service/auth/deploy/Kubefile
@@ -5,7 +5,7 @@ COPY registry registry
 COPY manifests manifests
 
 ENV cloudDomain="cloud.example.com"
-ENV wildcardCertSecretName="wildcard-cert"
+ENV certSecretName="wildcard-cert"
 ENV callbackUrl="cloud.example.com/login/callback"
 ENV ssoEndpoint="login.cloud.example.com"
 ENV casdoorMysqlRootPassword="c2VhbG9zcHdk"

--- a/service/auth/deploy/manifests/ingress.yaml.tmpl
+++ b/service/auth/deploy/manifests/ingress.yaml.tmpl
@@ -38,7 +38,7 @@ spec:
   tls:
     - hosts:
         - '{{ .cloudDomain }}'
-      secretName: {{ .wildcardCertSecretName }}
+      secretName: {{ .certSecretName }}
 ---
 # casdoor's ingress
 apiVersion: networking.k8s.io/v1
@@ -72,4 +72,4 @@ spec:
   tls:
     - hosts:
         - '{{ .ssoEndpoint }}'
-      secretName: {{ .wildcardCertSecretName }}
+      secretName: {{ .certSecretName }}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6320e5f</samp>

### Summary
🔒🔄🗑️

<!--
1.  🔒 - This emoji represents the security and encryption aspect of the changes, as they involve TLS certificates and secrets for the ingresses of the providers and services.
2.  🔄 - This emoji represents the refactoring and renaming aspect of the changes, as they involve changing the environment variables and secret names to make them more consistent and avoid confusion.
3.  🗑️ - This emoji represents the removal and simplification aspect of the changes, as they involve deleting unnecessary resources and reducing duplication in the manifests.
-->
Refactored the ingress secret name configuration for all providers and services. Removed unnecessary certificate resources and made the secret name configurable through the `certSecretName` environment variable in the Kubefiles. This improves the deployment simplicity and flexibility and allows using a shared wildcard certificate for all ingresses.

> _`certSecretName` now_
> _unifies providers' ingresses_
> _simpler, less conflict_

### Walkthrough
*  Rename `desktopCertSecretName` to `certSecretName` in desktop provider to avoid confusion ([link](https://github.com/labring/sealos/pull/3033/files?diff=unified&w=0#diff-c53d791a14261818a9ec59ec54514732985b966a56f047a2e02e854665f6a137L8-R8))
*  Use `certSecretName` variable instead of hardcoded secret names for ingress resources in desktop, applaunchpad, bytebase, imagehub, terminal, auth, and casdoor ([link](https://github.com/labring/sealos/pull/3033/files?diff=unified&w=0#diff-ba197426dbf4586bc8df461cc54d3580044cfcccf9fe9598b836382a5e71e371L27-L26), [link](https://github.com/labring/sealos/pull/3033/files?diff=unified&w=0#diff-98152272443968804cab1a8adb158cd8a8cd6e7ce5679ab0e0388ffec7692390L62-R62), [link](https://github.com/labring/sealos/pull/3033/files?diff=unified&w=0#diff-31c50ec81e7c1c1805badec5bf8c9cd9abeb49e207c66d0c5fc1d1b63fd2ed06L76-R76), [link](https://github.com/labring/sealos/pull/3033/files?diff=unified&w=0#diff-ac30219746961abe1328c781b9faf5dc7e509fe88797322105d13274bc54ee0dL55-L54), [link](https://github.com/labring/sealos/pull/3033/files?diff=unified&w=0#diff-47695228e3b26a0a56ef442536051acd5d68452449b38da7d816f6175ecb4a9cL82-R53), [link](https://github.com/labring/sealos/pull/3033/files?diff=unified&w=0#diff-ce733d8928680686199ea6990536c9af2a0d85c8ef320a65e5d8cef55d84f77bL41-R41), [link](https://github.com/labring/sealos/pull/3033/files?diff=unified&w=0#diff-ce733d8928680686199ea6990536c9af2a0d85c8ef320a65e5d8cef55d84f77bL75-L74))
*  Add `certSecretName` variable to applaunchpad, bytebase, imagehub, and terminal providers to specify the secret name for ingress ([link](https://github.com/labring/sealos/pull/3033/files?diff=unified&w=0#diff-1b5cef8190443ad639ccbb6510d692e3c45def8f5dc29414e9016a5a20277e3eR9), [link](https://github.com/labring/sealos/pull/3033/files?diff=unified&w=0#diff-dde88f659e084a0c7ddad64c2708e624820a01f6bff84071faea8d9940592f2bR9), [link](https://github.com/labring/sealos/pull/3033/files?diff=unified&w=0#diff-11ad9458abec6c0b4ec3121c3a8a6505d6520fa6808868ab7ae0027485091e46R9), [link](https://github.com/labring/sealos/pull/3033/files?diff=unified&w=0#diff-9752ab96d7b50ddf1a1449d6507d6ceea19fc178945fab85aea67c68251c039bR8))
*  Remove or comment out cluster issuer and certificate resources for applaunchpad, bytebase, imagehub, and terminal providers, as they are not needed when using a wildcard certificate from desktop provider ([link](https://github.com/labring/sealos/pull/3033/files?diff=unified&w=0#diff-98152272443968804cab1a8adb158cd8a8cd6e7ce5679ab0e0388ffec7692390L1-R29), [link](https://github.com/labring/sealos/pull/3033/files?diff=unified&w=0#diff-31c50ec81e7c1c1805badec5bf8c9cd9abeb49e207c66d0c5fc1d1b63fd2ed06L15-R43), [link](https://github.com/labring/sealos/pull/3033/files?diff=unified&w=0#diff-ac30219746961abe1328c781b9faf5dc7e509fe88797322105d13274bc54ee0dL1-L29), [link](https://github.com/labring/sealos/pull/3033/files?diff=unified&w=0#diff-47695228e3b26a0a56ef442536051acd5d68452449b38da7d816f6175ecb4a9cL15-L43))
*  Rename `wildcardCertSecretName` to `certSecretName` in auth service to make it consistent with other providers ([link](https://github.com/labring/sealos/pull/3033/files?diff=unified&w=0#diff-f45ddcd259e20afc98b04a7806c33e2c386b441b59d8ee46eb66fb662411a85eL8-R8))

