### PR TITLE
add docs how-to-deploy-postgresql-with-kubeblocks-on-sealos-cloud

### DIFF
--- a/docs/4.0/docs/cloud/examples/how-to-deploy-postgresql-with-kubeblocks-on-sealos-cloud.md
+++ b/docs/4.0/docs/cloud/examples/how-to-deploy-postgresql-with-kubeblocks-on-sealos-cloud.md
@@ -1,0 +1,249 @@
+# How to deploy PostgreSQL with Kubeblocks on Sealos Cloud
+
+## Create a PostgreSQL instance.
+
+Click on the terminal icon and directly write the YAML file.
+
+Here are the parts that can be modified:
+1. Resources field: The CPU and Memory resources used can be modified as per requirement.
+2. Replicas field: The number of replicas can be modified as required.
+3. ClusterVersionRef field: Specify the cluster version in this field.
+
+```yaml
+# cluster.yaml
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: Cluster
+metadata:
+  finalizers:
+  - cluster.kubeblocks.io/finalizer
+  generation: 1
+  labels:
+    clusterdefinition.kubeblocks.io/name: postgresql
+    clusterversion.kubeblocks.io/name: postgresql-12.14.0
+  name: pg-cluster
+spec:
+  affinity:
+    nodeLabels: {}
+    podAntiAffinity: Preferred
+    tenancy: SharedNode
+    topologyKeys: []
+  clusterDefinitionRef: postgresql
+  clusterVersionRef: postgresql-12.14.0
+  componentSpecs:
+  - componentDefRef: postgresql
+    monitor: true
+    name: postgresql
+    replicas: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
+    serviceAccountName: kb-sa-pg-sql
+    switchPolicy:
+      type: Noop
+    volumeClaimTemplates:
+    - name: data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 2Gi
+  terminationPolicy: Delete
+  tolerations: []
+```
+
+## Connect to a PostgreSQL instance
+
+### Connect locally.
+
+To obtain the address and perform access, follow these steps:
+1. Run the command `kubectl get service` to get the address.
+2. Username, password, and other information are stored in the secret kind, for example: `kubectl get secrets pg-cluster-conn-credential -o yaml` find the username and password fields.
+
+    ```bash
+    data:
+        ...
+        password: MTIzCg==
+        ...
+    ```
+
+3. Decode to obtain password
+
+    ```bash
+    $ echo MTIzCg== | base64 -d
+    > 123
+    ```
+
+4. Connect to the specified database using the command: `psql -h <hostname> -p <port> -U <username> <database>`.
+
+## Modify the state of a PostgreSQL instance.
+
+You can modify the state of a PostgreSQL instance by using the `kubectl apply -f <yaml>command`.
+
+### Vertical Scaling
+
+To vertically scale a PostgreSQL instance, modify the requests and limits fields in the YAML file corresponding to CPU and memory resources.
+
+```yaml
+# ops-vertical-scaling.yaml
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: OpsRequest
+metadata:
+  name: ops-verticalscaling
+spec:
+  clusterRef: pg-cluster # mysql-cluster
+  type: VerticalScaling
+  verticalScaling:
+  - componentName: postgresql # mysql
+    requests:
+      memory: "1Gi"
+      cpu: "1"
+    limits:
+      memory: "2Gi"
+      cpu: "2"
+```
+
+### Volume Expansion
+
+To scale the disk of a PostgreSQL instance, modify the storage field in the YAML file to expand the volume.
+
+Note that the destination storage size cannot be smaller than the current storage size.
+
+```yaml
+# ops-volume-expand.yaml
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: OpsRequest
+metadata:
+  name: ops-volume-expansion
+spec:
+  clusterRef: pg-cluster #mysql-cluster
+  type: VolumeExpansion
+  volumeExpansion:
+  - componentName: postgresql #mysql
+    volumeClaimTemplates:
+    - name: data
+      storage: "2Gi"
+```
+
+### Stop / Start
+
+To stop or start a PostgreSQL instance, modify the type field in the YAML file to either stop or start respectively.
+
+```yaml
+# ops-start.yaml
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: OpsRequest
+metadata:
+  name: ops-stop
+spec:
+  clusterRef: pg-cluster # mysql-cluster
+  type: Stop # or Start
+```
+
+### Restart
+
+To restart a PostgreSQL instance, use the following YAML file.
+
+```yaml
+# ops-restart.yaml
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: OpsRequest
+metadata:
+  name: ops-restart
+spec:
+  clusterRef: pg-cluster
+  type: Restart
+  restart:
+  - componentName: postgresql # mysql
+```
+
+## Backup and restore pgsql
+
+### Prepare work
+
+Create a PVC for backup.
+
+```yaml
+# backup-pvc.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    dataprotection.kubeblocks.io/backup-policy: pg-sql-postgresql-backup-policy
+    dataprotection.kubeblocks.io/created-by-policy: "true"
+    volume.beta.kubernetes.io/storage-provisioner: local.csi.openebs.io
+    volume.kubernetes.io/storage-provisioner: local.csi.openebs.io
+  finalizers:
+  - dataprotection.kubeblocks.io/finalizer
+  - kubernetes.io/pvc-protection
+  name: mysql-backup
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: openebs-lvmpv-backup
+  volumeMode: Filesystem
+```
+
+### Backup
+
+use the command `kubectl apply -f <yaml>` to start the backup process.
+
+```yaml
+# backup.yaml
+apiVersion: dataprotection.kubeblocks.io/v1alpha1
+kind: Backup
+metadata:
+  annotations:
+    dataprotection.kubeblocks.io/target-pod-name: pg-sql-postgresql-0
+  finalizers:
+  - dataprotection.kubeblocks.io/finalizer
+  generation: 1
+  labels:
+    app.kubernetes.io/component: postgresql
+    app.kubernetes.io/instance: pg-sql
+    app.kubernetes.io/managed-by: kubeblocks
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/version: postgresql-12.14.0
+    apps.kubeblocks.io/component-name: postgresql
+    apps.kubeblocks.io/workload-type: Replication
+    apps.kubeblocks.postgres.patroni/role: master
+    apps.kubeblocks.postgres.patroni/scope: pg-sql-postgresql-patroni
+    dataprotection.kubeblocks.io/backup-type: full
+    kubeblocks.io/backup-protection: retain
+    kubeblocks.io/role: primary
+    statefulset.kubernetes.io/pod-name: pg-sql-postgresql-0
+  name: backup-default-pg-cluster
+spec:
+  backupPolicyName: pg-cluster-postgresql-backup-policy
+  backupType: full
+```
+
+backup successful
+
+```bash
+NAME                        TYPE   STATUS       TOTAL-SIZE   DURATION   CREATE-TIME    COMPLETION-TIME
+backup-default-pg-cluster   full   Completed                 43s        xxxx-xx        xxxx-xx
+```
+
+### Restore from backup
+
+You only need to add the `kubeblocks.io/restore-from-backup` field in the same deployment file and specify the backup source name.
+
+Then create the instance normally to complete the restore process.
+
+```yaml
+# cluster.yaml
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: Cluster
+metadata:
+  annotations:
+    kubeblocks.io/restore-from-backup: '{"postgresql":"backup-default-pg-cluster"}'
+...
+```

--- a/docs/4.0/i18n/zh-Hans/cloud/examples/how-to-deploy-postgresql-with-kubeblocks-on-sealos-cloud.md
+++ b/docs/4.0/i18n/zh-Hans/cloud/examples/how-to-deploy-postgresql-with-kubeblocks-on-sealos-cloud.md
@@ -1,0 +1,248 @@
+# 如何在 sealos cloud 上用 kubeblocks 部署pgsql
+
+## 创建一个 pgsql 实例
+
+点击 terminal 图标，直接编写 yaml 文件即可.
+
+可以修改的部分：
+1. resources 字段中可以选择修改，使用的 cpu、memory 资源
+2. replicas 字段可以修改复制品数目
+3. clusterVersionRef 字段指定 cluster 版本
+
+```yaml
+# cluster.yaml
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: Cluster
+metadata:
+  finalizers:
+  - cluster.kubeblocks.io/finalizer
+  generation: 1
+  labels:
+    clusterdefinition.kubeblocks.io/name: postgresql
+    clusterversion.kubeblocks.io/name: postgresql-12.14.0
+  name: pg-cluster
+spec:
+  affinity:
+    nodeLabels: {}
+    podAntiAffinity: Preferred
+    tenancy: SharedNode
+    topologyKeys: []
+  clusterDefinitionRef: postgresql
+  clusterVersionRef: postgresql-12.14.0
+  componentSpecs:
+  - componentDefRef: postgresql
+    monitor: true
+    name: postgresql
+    replicas: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
+    serviceAccountName: kb-sa-pg-sql
+    switchPolicy:
+      type: Noop
+    volumeClaimTemplates:
+    - name: data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 2Gi
+  terminationPolicy: Delete
+  tolerations: []
+```
+
+## 连接 pgsql 实例
+### 本地连接
+
+获取地址到访问的步骤：
+1. 指令：`kubectl get service`，得到地址
+2. 用户名、密码、端口等信息在 `secret` 对象中，例如：`kubectl get secrets pg-cluster-conn-credential -o yaml` 找到用户名和密码字段
+
+    ```bash
+    data:
+        ...
+        password: MTIzCg==
+        ...
+    ```
+
+3. 解密得到密码
+
+    ```bash
+    $ echo MTIzCg== | base64 -d
+    > 123
+    ```
+
+4. 指令：`psql -h <hostname> -p <port> -U <username> <database>`，连入指定数据库
+
+## 修改 pgsql 状态
+
+改变 pgsql 的方式都是通过 `kubectl apply -f <yaml>` 的方式进行
+
+### 垂直扩容
+
+修改 reqeusts 和 limits 对应字段，从而改变数据库的 cpu、memory 使用
+
+```yaml
+# ops-vertical-scaling.yaml
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: OpsRequest
+metadata:
+  name: ops-verticalscaling
+spec:
+  clusterRef: pg-cluster # mysql-cluster
+  type: VerticalScaling
+  verticalScaling:
+  - componentName: postgresql # mysql
+    requests:
+      memory: "1Gi"
+      cpu: "1"
+    limits:
+      memory: "2Gi"
+      cpu: "2"
+```
+
+### 磁盘扩容
+
+通过修改 storage 字段进行卷扩展
+
+> 其中目标 storage 大小不能小于当前
+
+```yaml
+# ops-volume-expand.yaml
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: OpsRequest
+metadata:
+  name: ops-volume-expansion
+spec:
+  clusterRef: pg-cluster #mysql-cluster
+  type: VolumeExpansion
+  volumeExpansion:
+  - componentName: postgresql #mysql
+    volumeClaimTemplates:
+    - name: data
+      storage: "2Gi"
+```
+
+### 停止/启动
+
+通过修改 type 类型进行停止或启动操作
+
+```yaml
+# ops-start.yaml
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: OpsRequest
+metadata:
+  name: ops-stop
+spec:
+  clusterRef: pg-cluster # mysql-cluster
+  type: Stop # or Start
+```
+
+### 重启
+
+修改 type 类型为 restart 实现重启
+
+```yaml
+# ops-restart.yaml
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: OpsRequest
+metadata:
+  name: ops-restart
+spec:
+  clusterRef: pg-cluster
+  type: Restart
+  restart:
+  - componentName: postgresql # mysql
+```
+
+## 备份并恢复 pgsql
+
+### 准备工作
+
+备份数据库首先创建用于备份的 pvc
+
+```yaml
+# backup-pvc.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    dataprotection.kubeblocks.io/backup-policy: pg-sql-postgresql-backup-policy
+    dataprotection.kubeblocks.io/created-by-policy: "true"
+    volume.beta.kubernetes.io/storage-provisioner: local.csi.openebs.io
+    volume.kubernetes.io/storage-provisioner: local.csi.openebs.io
+  finalizers:
+  - dataprotection.kubeblocks.io/finalizer
+  - kubernetes.io/pvc-protection
+  name: mysql-backup
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: openebs-lvmpv-backup
+  volumeMode: Filesystem
+```
+
+### 备份
+
+`kubectl apply -f <yaml>` 开始备份
+
+```yaml
+# backup.yaml
+apiVersion: dataprotection.kubeblocks.io/v1alpha1
+kind: Backup
+metadata:
+  annotations:
+    dataprotection.kubeblocks.io/target-pod-name: pg-sql-postgresql-0
+  finalizers:
+  - dataprotection.kubeblocks.io/finalizer
+  generation: 1
+  labels:
+    app.kubernetes.io/component: postgresql
+    app.kubernetes.io/instance: pg-sql
+    app.kubernetes.io/managed-by: kubeblocks
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/version: postgresql-12.14.0
+    apps.kubeblocks.io/component-name: postgresql
+    apps.kubeblocks.io/workload-type: Replication
+    apps.kubeblocks.postgres.patroni/role: master
+    apps.kubeblocks.postgres.patroni/scope: pg-sql-postgresql-patroni
+    dataprotection.kubeblocks.io/backup-type: full
+    kubeblocks.io/backup-protection: retain
+    kubeblocks.io/role: primary
+    statefulset.kubernetes.io/pod-name: pg-sql-postgresql-0
+  name: backup-default-pg-cluster
+spec:
+  backupPolicyName: pg-cluster-postgresql-backup-policy
+  backupType: full
+```
+
+备份成功
+
+```bash
+NAME                        TYPE   STATUS       TOTAL-SIZE   DURATION   CREATE-TIME    COMPLETION-TIME
+backup-default-pg-cluster   full   Completed                 43s        xxxx-xx        xxxx-xx
+```
+
+### 恢复
+
+恢复只需要在相同的部署文件下添加 `kubeblocks.io/restore-from-backup` 字段指定所用备份源
+
+然后正常创建该实例即可实现恢复功能
+
+```yaml
+# cluster.yaml
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: Cluster
+metadata:
+  annotations:
+    kubeblocks.io/restore-from-backup: '{"postgresql":"backup-default-pg-cluster"}'
+...
+```


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 77792f4</samp>

### Summary
📝🌐🐘

<!--
1.  📝 - This emoji represents the addition of a new document or tutorial, which is the main feature of these changes.
2.  🌐 - This emoji represents the internationalization or localization of the document, which is the secondary feature of these changes.
3.  🐘 - This emoji represents PostgreSQL, which is the database service that the tutorial covers. This emoji is also commonly used by the PostgreSQL community.
-->
This pull request adds a new tutorial on how to deploy PostgreSQL with Kubeblocks on Sealos Cloud, both in English and Chinese. The tutorial is a markdown file in the `docs/4.0/docs/cloud/examples` and `docs/4.0/i18n/zh-Hans/cloud/examples` directories, respectively. The tutorial aims to help users who want to use PostgreSQL as a database service on Sealos Cloud, which is a cloud platform that provides Kubernetes clusters and Kubeblocks is a Kubernetes operator that manages database clusters.

> _`PostgreSQL` guide_
> _Kubeblocks on Sealos Cloud_
> _Spring for new users_

### Walkthrough
* Add a tutorial on how to deploy PostgreSQL with Kubeblocks on Sealos Cloud ([link](https://github.com/labring/sealos/pull/3045/files?diff=unified&w=0#diff-7b52303a01b4555a35a0b5479f5ad6b30ca75930326830ca43f10a83fb719a5fR1-R249))
* Translate the tutorial to Chinese ([link](https://github.com/labring/sealos/pull/3045/files?diff=unified&w=0#diff-f81a754e4fa9232fb3263a3fd8592fd05aa015d5c22eec788a785e011540a959R1-R248))

