### PR TITLE
Fix readme md usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A Cloud Operating System designed for managing Cloud Native applications
 
 </div>
 
-<img width="1304" alt="image" src="https://user-images.githubusercontent.com/8912557/236477759-3532fdec-c355-4f8d-92ef-9f6fce3c50da.png">
+![](https://user-images.githubusercontent.com/8912557/236477759-3532fdec-c355-4f8d-92ef-9f6fce3c50da.png)
 
 > [Docs](https://www.sealos.io/docs/Intro) | [简体中文](https://www.sealos.io/zh-Hans/docs/Intro) ｜ [Roadmap](https://github.com/orgs/labring/projects/4/views/9)
 
@@ -37,7 +37,7 @@ A Cloud Operating System designed for managing Cloud Native applications
 
 Run nginx on Sealos in 30 seconds.
 
-<img width="1493" alt="image" src="https://user-images.githubusercontent.com/8912557/236479998-c4949070-a4bc-4900-bfe8-d8b3b4728e60.png">
+![](https://user-images.githubusercontent.com/8912557/236479998-c4949070-a4bc-4900-bfe8-d8b3b4728e60.png)
 
 Some Screen Shots of `Sealos Desktop`:
 
@@ -45,7 +45,7 @@ Some Screen Shots of `Sealos Desktop`:
 
 | Sealos Terminal | Sealos App Launchpad |
 | :---: | :---: |
-| <img width="1183" alt="image" src="https://user-images.githubusercontent.com/8912557/236481248-1bd521ae-b483-440a-8177-ae90081f8973.png"> | <img width="1495" alt="image" src="https://user-images.githubusercontent.com/8912557/236480220-5a3f09c1-8e75-4727-a398-244d86f32133.png"> |
+| ![](https://user-images.githubusercontent.com/8912557/236481248-1bd521ae-b483-440a-8177-ae90081f8973.png) | ![](https://user-images.githubusercontent.com/8912557/236480220-5a3f09c1-8e75-4727-a398-244d86f32133.png) |
 
 </div>
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 07544c3</samp>

### Summary
:memo::sparkles::lipstick:

<!--
1.  :memo: - This emoji is often used to indicate documentation updates or improvements, and replacing image tags with markdown syntax is a way of enhancing the readability and formatting of the `README.md` file.
2.  :sparkles: - This emoji is typically used to signify new features or enhancements, and replacing image tags with markdown syntax can also be seen as a way of adding some flair and style to the `README.md` file.
3.  :lipstick: - This emoji is commonly used to indicate cosmetic changes or improvements, and replacing image tags with markdown syntax can also be considered as a way of beautifying the `README.md` file.
-->
Fixed image display in `README.md` by using markdown instead of HTML.

> _To make the README more clear_
> _They changed how they showed each `image`_
> _Instead of using tags_
> _They switched to markdown flags_
> _And now it looks great on every page_

### Walkthrough
*  Replace image tags with markdown syntax for embedding images in `README.md` ([link](https://github.com/labring/sealos/pull/3046/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L26-R26), [link](https://github.com/labring/sealos/pull/3046/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L40-R40), [link](https://github.com/labring/sealos/pull/3046/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L48-R48))

