### PR TITLE
CI: add create dev cluster image ci

### DIFF
--- a/.github/workflows/controllers.yml
+++ b/.github/workflows/controllers.yml
@@ -7,6 +7,10 @@ on:
         description: 'Push images'
         required: false
         type: boolean
+      build_dev:
+        description: 'build dev images'
+        required: false
+        type: boolean
   push:
     branches: [ "main" ]
     paths:
@@ -215,8 +219,18 @@ jobs:
       - name: Manifest Cluster Images
         # if push to master, then patch images to ghcr.io
         run: |
+          CLUSTER_IMAGE_NAME=${{ steps.prepare.outputs.cluster_repo }}:${{ steps.prepare.outputs.tag_name }}
           sudo sealos images
-          bash docker/patch/manifest-cluster-images.sh "sealos-cloud-${{ matrix.module }}-controller"
+          bash docker/patch/manifest-cluster-images.sh $CLUSTER_IMAGE_NAME
+        env:
+          OWNER: ${{ github.repository_owner }}
+
+      - name: Build Dev Cluster Images
+        if: ${{ inputs.build_dev == true }}
+        run: |
+          CLUSTER_IMAGE_NAME=${{ steps.prepare.outputs.cluster_repo }}:dev
+          sudo sealos images
+          bash docker/patch/manifest-cluster-images.sh $CLUSTER_IMAGE_NAME
         env:
           OWNER: ${{ github.repository_owner }}
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -7,6 +7,10 @@ on:
         description: 'Push images'
         required: false
         type: boolean
+      build_dev:
+        description: 'build dev images'
+        required: false
+        type: boolean
   push:
     branches: [ "main" ]
     paths:
@@ -90,7 +94,7 @@ jobs:
   save-sealos:
     uses: ./.github/workflows/import-save-sealos.yml
   cluster-image-build:
-    if: ${{ (github.event_name == 'push') || (inputs.push_mage == true) }}
+    if: ${{ (github.event_name == 'push') || (inputs.push_mage == true) || (inputs.build_dev == true)}}
     needs:
       - image-build
       - save-sealos
@@ -150,8 +154,18 @@ jobs:
 
       - name: Manifest Cluster Images
         run: |
+          CLUSTER_IMAGE_NAME=${{ steps.prepare.outputs.cluster_image }}
           sudo sealos images
-          bash docker/patch/manifest-cluster-images.sh "sealos-cloud-${{ env.MODULE_NAME }}-frontend"
+          bash docker/patch/manifest-cluster-images.sh $CLUSTER_IMAGE_NAME
+        env:
+          OWNER: ${{ github.repository_owner }}
+
+      - name: Build Dev Cluster Images
+        if: ${{ inputs.build_dev == true }}
+        run: |
+          CLUSTER_IMAGE_NAME=${{ steps.prepare.outputs.cluster_repo }}:dev
+          sudo sealos images
+          bash docker/patch/manifest-cluster-images.sh $CLUSTER_IMAGE_NAME
         env:
           OWNER: ${{ github.repository_owner }}
 

--- a/.github/workflows/services.yml
+++ b/.github/workflows/services.yml
@@ -8,6 +8,10 @@ on:
         description: 'Push images'
         required: false
         type: boolean
+      build_dev:
+        description: 'build dev images'
+        required: false
+        type: boolean
   push:
     branches: [ "main" ]
     paths:
@@ -215,8 +219,18 @@ jobs:
       - name: Manifest Cluster Images
         # if push to master, then patch images to ghcr.io
         run: |
+          CLUSTER_IMAGE_NAME=${{ steps.prepare.outputs.cluster_repo }}:${{ steps.prepare.outputs.tag_name }}
           sudo sealos images
-          bash docker/patch/manifest-cluster-images.sh "sealos-cloud-${{ matrix.module }}-service"
+          bash docker/patch/manifest-cluster-images.sh $CLUSTER_IMAGE_NAME
+        env:
+          OWNER: ${{ github.repository_owner }}
+
+      - name: Build Dev Cluster Images
+        if: ${{ inputs.build_dev == true }}
+        run: |
+          CLUSTER_IMAGE_NAME=${{ steps.prepare.outputs.cluster_repo }}:dev
+          sudo sealos images
+          bash docker/patch/manifest-cluster-images.sh $CLUSTER_IMAGE_NAME
         env:
           OWNER: ${{ github.repository_owner }}
 

--- a/docker/patch/manifest-cluster-images.sh
+++ b/docker/patch/manifest-cluster-images.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-REPO_NAME=${1:-sealos-patch}
-IMAGE_NAME=ghcr.io/${OWNER}/${REPO_NAME}:$GIT_COMMIT_SHORT_SHA
+DEFAULT_REPO_NAME="sealos-patch"
+IMAGE_NAME=${1:-"ghcr.io/${OWNER}/${DEFAULT_REPO_NAME}:$GIT_COMMIT_SHORT_SHA"}
 sudo sealos push "${IMAGE_NAME}"-amd64
 sudo sealos push "${IMAGE_NAME}"-arm64
 sudo sealos images


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 468359f</samp>

### Summary
🛠️🚀🌐

<!--
1.  🛠️ - This emoji represents the modification of the script to make it more flexible and reusable. It also implies that the script is a tool or a utility that can be used for different purposes.
2.  🚀 - This emoji represents the enhancement of the workflows to support optional dev image builds. It also implies that the dev image builds are faster and more convenient than the regular image builds, and that they can help speed up the development and testing process.
3.  🌐 - This emoji represents the addition of the option to build dev images for the frontend and the services modules, as well as the cluster image. It also implies that these images are related to the web or the network, and that they can be used to deploy or run the application on different environments.
-->
This pull request adds optional dev image builds for the controllers, frontend, and services modules in the GitHub workflows. It also refactors the `cluster-image-build` jobs and the `docker/patch/manifest-cluster-images.sh` script to make them more reusable and flexible.

> _We build the images of doom_
> _With scripts that seal our fate_
> _We push the code to the repo of gloom_
> _With workflows that deviate_

### Walkthrough
*  Add `build_dev` input parameter to workflows `controllers.yml`, `frontend.yml`, and `services.yml` to enable optional dev image builds ([link](https://github.com/labring/sealos/pull/3058/files?diff=unified&w=0#diff-8e0e4903d4e4f8b8844d36370ca2d71c7c72d03ddb7a9cdcedc6328dfc5da8faR10-R13), [link](https://github.com/labring/sealos/pull/3058/files?diff=unified&w=0#diff-ffe3a297ed15e9a79846161a3731a580511bf13c6b5cc5a9e03ddcbd8515fdeeR10-R13), [link](https://github.com/labring/sealos/pull/3058/files?diff=unified&w=0#diff-48839d65f7bfedd91312ee406fd94da103ede7d3c7e791eb2c1657f46afdea00R11-R14))
*  Modify `cluster-image-build` jobs in workflows `controllers.yml`, `frontend.yml`, and `services.yml` to use the output of the `prepare` step for cluster image name and tag, and to conditionally build dev cluster images based on the `build_dev` input ([link](https://github.com/labring/sealos/pull/3058/files?diff=unified&w=0#diff-8e0e4903d4e4f8b8844d36370ca2d71c7c72d03ddb7a9cdcedc6328dfc5da8faL218-R236), [link](https://github.com/labring/sealos/pull/3058/files?diff=unified&w=0#diff-ffe3a297ed15e9a79846161a3731a580511bf13c6b5cc5a9e03ddcbd8515fdeeL93-R97), [link](https://github.com/labring/sealos/pull/3058/files?diff=unified&w=0#diff-ffe3a297ed15e9a79846161a3731a580511bf13c6b5cc5a9e03ddcbd8515fdeeL153-R171), [link](https://github.com/labring/sealos/pull/3058/files?diff=unified&w=0#diff-48839d65f7bfedd91312ee406fd94da103ede7d3c7e791eb2c1657f46afdea00L218-R236))
*  Modify script `docker/patch/manifest-cluster-images.sh` to add a default value for the repo name argument and to use the image name argument as the base for the sealos push commands ([link](https://github.com/labring/sealos/pull/3058/files?diff=unified&w=0#diff-81d7e448adcdfbc16262623513f25ad6edfb5c6720c2c1ab166ab826cb12900eL2-R3))


