### PR TITLE
rename CopyR to Fetch

### DIFF
--- a/pkg/ssh/clusterclient.go
+++ b/pkg/ssh/clusterclient.go
@@ -104,12 +104,12 @@ func (cc *clusterClient) Copy(host, src, dst string) error {
 	return client.Copy(host, src, dst)
 }
 
-func (cc *clusterClient) CopyR(host, src, dst string) error {
+func (cc *clusterClient) Fetch(host, src, dst string) error {
 	client, err := cc.getClientForHost(host)
 	if err != nil {
 		return err
 	}
-	return client.CopyR(host, src, dst)
+	return client.Fetch(host, src, dst)
 }
 
 func (cc *clusterClient) CmdAsync(host string, cmds ...string) error {

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -40,9 +40,9 @@ type Interface interface {
 	// scp -r /tmp root@192.168.0.2:/root/tmp => Copy("192.168.0.2","tmp","/root/tmp")
 	// skip checksum if env DO_NOT_CHECKSUM=true
 	Copy(host, src, dst string) error
-	// CopyR copy remote file to local
-	// scp -r root@192.168.0.2:/root/tmp/file /tmp/file => Copy("192.168.0.2","/tmp/file","/root/tmp/file")
-	CopyR(host, dst, src string) error
+	// Fetch fetch remote file to local
+	// scp -r root@192.168.0.2:/remote/path/file /local/path/file => Fetch("192.168.0.2","/remote/path/file", "/local/path/file",)
+	Fetch(host, src, dst string) error
 	// CmdAsync exec commands on remote host asynchronously
 	CmdAsync(host string, cmds ...string) error
 	// Cmd exec command on remote host, and return combined standard output and standard error

--- a/test/e2e/testhelper/cmd/cmd.go
+++ b/test/e2e/testhelper/cmd/cmd.go
@@ -38,7 +38,7 @@ func (c RemoteCmd) Copy(src string, dst string) error {
 }
 
 func (c RemoteCmd) CopyR(dst string, src string) error {
-	return c.Interface.CopyR(c.Host, dst, src)
+	return c.Interface.Fetch(c.Host, src, dst)
 }
 
 // RemoteCmd implements the Interface for remote command execution using SSH


### PR DESCRIPTION
rename function name.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 15029e9</samp>

### Summary
🔁🔄🗑️

<!--
1.  🔁 - This emoji can be used to indicate the renaming of the `CopyR` method to `Fetch`, which is a more descriptive and accurate name for the functionality of copying remote files to local. The emoji also suggests the idea of fetching or retrieving something from a source, which is what the method does.
2.  🔄 - This emoji can be used to indicate the swapping of the parameter order for the `Fetch` method, which now takes the source as the first argument and the destination as the second, instead of the other way around. The emoji also implies the idea of changing or updating something, which is what the refactoring of the method does.
3.  🗑️ - This emoji can be used to indicate the removal of the unused dependency and the refactoring of the file copying functionality in `scp.go`, which simplifies and cleans up the code. The emoji also conveys the idea of deleting or discarding something, which is what the removal of the dependency does.
-->
Renamed and refactored the `CopyR` method to `Fetch` in the `pkg/ssh` package and its dependencies. This change improves the clarity and consistency of the file copying functionality and removes an unused dependency.

> _Sing, O Muse, of the skillful refactorer who changed the code_
> _Of the clusterClient and the RemoteCmd, the swift and the bold_
> _Who renamed the CopyR method to Fetch, as clear as the sun_
> _And made it fetch remote files to local, like Hermes the cunning_

### Walkthrough
*  Rename `CopyR` method to `Fetch` and swap parameters for `clusterClient`, `Client`, and `Interface` types ([link](https://github.com/labring/sealos/pull/3061/files?diff=unified&w=0#diff-1baac2ea8345e53e2716ac9b5cff21a6ada2c1370b6fea837d3f47c7b2a23537L107-R112), [link](https://github.com/labring/sealos/pull/3061/files?diff=unified&w=0#diff-b16c36d4f08b48cbf3c1ea3ba2e4cc74463e7581ea73b0827620e04841061051L135-R138), [link](https://github.com/labring/sealos/pull/3061/files?diff=unified&w=0#diff-3303f911d20ef483b36a10b77c70879ce69969b77ef249e4c407fc49f5e9ff69L43-R45))
*  Refactor `Fetch` method implementation to use better variable names, error handling, and `io.Copy` function ([link](https://github.com/labring/sealos/pull/3061/files?diff=unified&w=0#diff-b16c36d4f08b48cbf3c1ea3ba2e4cc74463e7581ea73b0827620e04841061051L150-R170))
*  Simplify logging statements in `Fetch` method to use `logger` package instead of `logrus` ([link](https://github.com/labring/sealos/pull/3061/files?diff=unified&w=0#diff-b16c36d4f08b48cbf3c1ea3ba2e4cc74463e7581ea73b0827620e04841061051L135-R138))
*  Remove unused `logrus` import from `scp.go` ([link](https://github.com/labring/sealos/pull/3061/files?diff=unified&w=0#diff-b16c36d4f08b48cbf3c1ea3ba2e4cc74463e7581ea73b0827620e04841061051L27-L28))
*  Update `RemoteCmd` type to use `Fetch` method and swap parameters in `test/e2e/testhelper/cmd/cmd.go` ([link](https://github.com/labring/sealos/pull/3061/files?diff=unified&w=0#diff-23e485b0854959ac3ccb8555dd8bcd8aa41b9650f66e2dd28cd76a14a2f0eb55L41-R41))

