### PR TITLE
refactor(main): trigger release ci

### DIFF
--- a/.github/workflows/controllers.yml
+++ b/.github/workflows/controllers.yml
@@ -1,12 +1,19 @@
 name: Build Controllers image
 
 on:
+  workflow_call:
+    inputs:
+      release:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       push_image:
         description: 'Push images'
         required: false
         type: boolean
+        default: false
       release_tag:
         description: 'Release images'
         default: 'dev'
@@ -105,9 +112,7 @@ jobs:
       - name: Prepare
         id: prepare
         run: |
-          SHA_TAG=${GIT_COMMIT_SHORT_SHA}
-          tag_name=$(if [ ${{ inputs.push_image }} ]; then echo "${{ inputs.release_tag }}"; else echo "$SHA_TAG"; fi);
-          echo tag_name=$tag_name >> $GITHUB_OUTPUT
+          bash ./scripts/resolve-tag-image.sh "${{ inputs.push_image }}" "${{ inputs.release }}"  "${{ inputs.release_tag }}"
           echo docker_repo=ghcr.io/${{ github.repository_owner }}/sealos-${{ matrix.module }}-controller >> $GITHUB_OUTPUT
 
       - # Add support for more platforms with QEMU (optional)
@@ -121,47 +126,36 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
-        if: ${{ (github.event_name == 'push') || (inputs.push_image == true) }}
+        if: ${{ (github.event_name == 'push') || (inputs.push_image == true) || (inputs.release == true) }}
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GH_PAT }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/sealos-${{ env.MODULE_NAME }}-controllers
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=dev,enable=true
+            type=raw,value=${{ steps.prepare.outputs.tag_name }},enable=true
 
       - name: build (and publish) ${{ matrix.module }} main image
-        if: ${{ (github.event_name == 'push') || (inputs.push_image == true) }}
-        env:
-          # fork friendly ^^
-          DOCKER_REPO: ghcr.io/${{ github.repository_owner }}/sealos-${{ matrix.module }}-controller
-        working-directory: controllers/${{ matrix.module }}
-        run: |
-          docker buildx build \
-          --platform linux/amd64,linux/arm64 \
-          --label "org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/sealos" \
-          --label "org.opencontainers.image.description=sealos-${{ matrix.module }}-controller container image" \
-          --label "org.opencontainers.image.licenses=MIT" \
-          --push \
-          -t ${DOCKER_REPO}:${{ steps.prepare.outputs.tag_name }} \
-          -f Dockerfile \
-          .
-      - name: build  ${{ matrix.module }} image
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          # fork friendly ^^
-          DOCKER_REPO: ghcr.io/${{ github.repository_owner }}/sealos-${{ matrix.module }}-controller
-        working-directory: controllers/${{ matrix.module }}
-        run: |
-          docker buildx build \
-          --platform linux/amd64,linux/arm64 \
-          --label "org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/sealos" \
-          --label "org.opencontainers.image.description=sealos-${{ matrix.module }}-controller container image" \
-          --label "org.opencontainers.image.licenses=MIT" \
-          -t ${DOCKER_REPO}:${{ steps.prepare.outputs.tag_name }} \
-          -f Dockerfile \
-          .
+        uses: docker/build-push-action@v4
+        with:
+          context: ./controllers/${{ matrix.module }}
+          file: ./controllers/${{ matrix.module }}/Dockerfile
+          # Push if it's a push event or if push_image is true
+          push: ${{ (github.event_name == 'push') || (inputs.push_image == true) || (inputs.release == true) }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
   save-sealos:
     uses: ./.github/workflows/import-save-sealos.yml
   build-cluster-image:
-    if: ${{ (github.event_name == 'push') || (inputs.push_image == true) }}
+    if: ${{ (github.event_name == 'push') || (inputs.push_image == true) || (inputs.release == true) }}
     needs:
       - image-build
       - save-sealos
@@ -181,9 +175,7 @@ jobs:
       - name: Prepare
         id: prepare
         run: |
-          SHA_TAG=${GIT_COMMIT_SHORT_SHA}
-          tag_name=$(if [ ${{ inputs.push_image }} ]; then echo "${{ inputs.release_tag }}"; else echo "$SHA_TAG"; fi);
-          echo tag_name=$tag_name >> $GITHUB_OUTPUT
+          bash ./scripts/resolve-tag-image.sh "${{ inputs.push_image }}" "${{ inputs.release }}"  "${{ inputs.release_tag }}"
           echo old_docker_repo=ghcr.io/labring/sealos-${{ matrix.module }}-controller >> $GITHUB_OUTPUT          
           echo new_docker_repo=ghcr.io/${{ github.repository_owner }}/sealos-${{ matrix.module }}-controller >> $GITHUB_OUTPUT
           echo cluster_repo=ghcr.io/${{ github.repository_owner }}/sealos-cloud-${{ matrix.module }}-controller >> $GITHUB_OUTPUT

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,12 +1,19 @@
 name: Build Frontend Image
 
 on:
+  workflow_call:
+    inputs:
+      release:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       push_image:
         description: 'Push images'
         required: false
         type: boolean
+        default: false
       release_tag:
         description: 'Release images'
         default: 'dev'
@@ -50,9 +57,7 @@ jobs:
       - name: Prepare
         id: prepare
         run: |
-          SHA_TAG=${GIT_COMMIT_SHORT_SHA}
-          tag_name=$(if [ ${{ inputs.push_image }} ]; then echo "${{ inputs.release_tag }}"; else echo "$SHA_TAG"; fi);
-          echo tag_name=$tag_name >> $GITHUB_OUTPUT
+          bash ./scripts/resolve-tag-image.sh "${{ inputs.push_image }}" "${{ inputs.release }}"  "${{ inputs.release_tag }}"
       - name: Extract module name
         id: module_name
         run: |
@@ -77,7 +82,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Login to Github Container Hub
-        if: ${{ (github.event_name == 'push') || (inputs.push_image == true) }}
+        if: ${{ (github.event_name == 'push') || (inputs.push_image == true) || (inputs.release == true) }}
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -90,13 +95,13 @@ jobs:
           context: ./frontend/${{ matrix.module }}
           file: ./frontend/${{ matrix.module }}/Dockerfile
           # Push if it's a push event or if push_image is true
-          push: ${{ (github.event_name == 'push') || (inputs.push_image == true) }}
+          push: ${{ (github.event_name == 'push') || (inputs.push_image == true) || (inputs.release == true) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
   save-sealos:
     uses: ./.github/workflows/import-save-sealos.yml
   cluster-image-build:
-    if: ${{ (github.event_name == 'push') || (inputs.push_image == true) || (inputs.build_dev == true)}}
+    if: ${{ (github.event_name == 'push') || (inputs.push_image == true) || (inputs.release == true) }}
     needs:
       - image-build
       - save-sealos
@@ -121,9 +126,7 @@ jobs:
       - name: Prepare
         id: prepare
         run: |
-          SHA_TAG=${GIT_COMMIT_SHORT_SHA}
-          tag_name=$(if [ ${{ inputs.push_image }} ]; then echo "${{ inputs.release_tag }}"; else echo "$SHA_TAG"; fi);
-          echo tag_name=$tag_name >> $GITHUB_OUTPUT
+          bash ./scripts/resolve-tag-image.sh "${{ inputs.push_image }}" "${{ inputs.release }}"  "${{ inputs.release_tag }}"
           echo old_docker_repo=ghcr.io/labring/sealos-${{ env.MODULE_NAME }}-frontend >> $GITHUB_OUTPUT 
           echo old_docker_image=ghcr.io/labring/sealos-${{ env.MODULE_NAME }}-frontend:dev >> $GITHUB_OUTPUT
           echo new_docker_repo=ghcr.io/${{ github.repository_owner }}/sealos-${{ env.MODULE_NAME }}-frontend >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,18 @@ on:
       - "*"
 
 jobs:
+  workflow-frontend:
+    uses: ./.github/workflows/frontend.yml
+    with:
+      release: true
+  workflow-services:
+    uses: ./.github/workflows/services.yml
+    with:
+      release: true
+  workflow-controllers:
+    uses: ./.github/workflows/controllers.yml
+    with:
+      release: true
   goreleaser:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/services.yml
+++ b/.github/workflows/services.yml
@@ -2,12 +2,19 @@ name: Build Services image
 
 
 on:
+  workflow_call:
+    inputs:
+      release:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       push_image:
         description: 'Push images'
         required: false
         type: boolean
+        default: false
       release_tag:
         description: 'Release images'
         default: 'dev'
@@ -106,9 +113,7 @@ jobs:
       - name: Prepare
         id: prepare
         run: |
-          SHA_TAG=${GIT_COMMIT_SHORT_SHA}
-          tag_name=$(if [ ${{ inputs.push_image }} ]; then echo "${{ inputs.release_tag }}"; else echo "$SHA_TAG"; fi);
-          echo tag_name=$tag_name >> $GITHUB_OUTPUT
+          bash ./scripts/resolve-tag-image.sh "${{ inputs.push_image }}" "${{ inputs.release }}"  "${{ inputs.release_tag }}"
           echo docker_repo=ghcr.io/${{ github.repository_owner }}/sealos-${{ matrix.module }}-service >> $GITHUB_OUTPUT
 
       - # Add support for more platforms with QEMU (optional)
@@ -122,47 +127,38 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
-        if: ${{ (github.event_name == 'push') || (inputs.push_image == true) }}
+        if: ${{ (github.event_name == 'push') || (inputs.push_image == true) || (inputs.release == true) }}
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GH_PAT }}
 
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/sealos-${{ env.MODULE_NAME }}-service
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=dev,enable=true
+            type=raw,value=${{ steps.prepare.outputs.tag_name }},enable=true
+
       - name: build (and publish) ${{ matrix.module }} main image
-        if: ${{ (github.event_name == 'push') || (inputs.push_image == true) }}
-        env:
-          # fork friendly ^^
-          DOCKER_REPO: ghcr.io/${{ github.repository_owner }}/sealos-${{ matrix.module }}-service
-        working-directory: service/${{ matrix.module }}
-        run: |
-          docker buildx build \
-          --platform linux/amd64,linux/arm64 \
-          --label "org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/sealos" \
-          --label "org.opencontainers.image.description=sealos-${{ matrix.module }}-service container image" \
-          --label "org.opencontainers.image.licenses=MIT" \
-          --push \
-          -t ${DOCKER_REPO}:${{ steps.prepare.outputs.tag_name }} \
-          -f Dockerfile \
-          .
-      - name: build ${{ matrix.module }} image
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          # fork friendly ^^
-          DOCKER_REPO: ghcr.io/${{ github.repository_owner }}/sealos-${{ matrix.module }}-service
-        working-directory: service/${{ matrix.module }}
-        run: |
-          docker buildx build \
-          --platform linux/amd64,linux/arm64 \
-          --label "org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/sealos" \
-          --label "org.opencontainers.image.description=sealos-${{ matrix.module }}-service container image" \
-          --label "org.opencontainers.image.licenses=MIT" \
-          -t ${DOCKER_REPO}:${{ steps.prepare.outputs.tag_name }} \
-          -f Dockerfile \
-          .
+        uses: docker/build-push-action@v4
+        with:
+          context: ./service/${{ matrix.module }}
+          file: ./service/${{ matrix.module }}/Dockerfile
+          # Push if it's a push event or if push_image is true
+          push: ${{ (github.event_name == 'push') || (inputs.push_image == true) || (inputs.release == true) }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+
   save-sealos:
     uses: ./.github/workflows/import-save-sealos.yml
   build-cluster-image:
-    if: ${{ (github.event_name == 'push') || (inputs.push_image == true) }}
+    if: ${{ (github.event_name == 'push') || (inputs.push_image == true) || (inputs.release == true) }}
     needs:
       - image-build
       - save-sealos
@@ -182,9 +178,7 @@ jobs:
       - name: Prepare
         id: prepare
         run: |
-          SHA_TAG=${GIT_COMMIT_SHORT_SHA}
-          tag_name=$(if [ ${{ inputs.push_image }} ]; then echo "${{ inputs.release_tag }}"; else echo "$SHA_TAG"; fi);
-          echo tag_name=$tag_name >> $GITHUB_OUTPUT          
+          bash ./scripts/resolve-tag-image.sh "${{ inputs.push_image }}" "${{ inputs.release }}"  "${{ inputs.release_tag }}"
           echo old_docker_repo=ghcr.io/labring/sealos-${{ matrix.module }}-service >> $GITHUB_OUTPUT
           echo new_docker_repo=ghcr.io/${{ github.repository_owner }}/sealos-${{ matrix.module }}-service >> $GITHUB_OUTPUT
           echo cluster_repo=ghcr.io/${{ github.repository_owner }}/sealos-cloud-${{ matrix.module }}-service >> $GITHUB_OUTPUT

--- a/scripts/resolve-tag-image.sh
+++ b/scripts/resolve-tag-image.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -ex
+SHA_TAG=${GIT_COMMIT_SHORT_SHA}
+tag_name="$SHA_TAG"
+
+push_image=${1:-false}
+release=${2:-false}
+
+if [[ "$push_image" == true ]]; then
+  tag_name=${3}
+elif [[ "$release" == true ]]; then
+  tag_name=${GITHUB_REF#refs/tags/}
+fi
+
+echo "tag_name=$tag_name" >> $GITHUB_OUTPUT


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 134d358</samp>

### Summary
🚀🐳📜

<!--
1.  🚀 This emoji represents the release event trigger and the release tag name for the images, indicating that the changes are related to deploying the application to production.
2.  🐳 This emoji represents the docker actions and the image building and pushing steps, indicating that the changes are related to the containerization of the application modules.
3.  📜 This emoji represents the bash script and the input parameters, indicating that the changes are related to the configuration and logic of the workflows.
-->
This pull request refactors and updates the GitHub workflows for building and pushing the images for the frontend, services, and controllers modules. It adds support for release events, uses actions and a common script to simplify the code and generate tags and labels, and invokes the workflows as reusable components from a new `release.yml` workflow.

> _We unleash the fury of the `release.yml`_
> _We invoke the workflows of doom_
> _We build and push the images of fire_
> _We use the script to resolve the `tag_name`_

### Walkthrough
*  Add a new input parameter `release` to the `workflow_call` sections of the `frontend.yml`, `services.yml`, and `controllers.yml` workflows, indicating whether the workflows are triggered by a release event ([link](https://github.com/labring/sealos/pull/3063/files?diff=unified&w=0#diff-8e0e4903d4e4f8b8844d36370ca2d71c7c72d03ddb7a9cdcedc6328dfc5da8faR4-R9), [link](https://github.com/labring/sealos/pull/3063/files?diff=unified&w=0#diff-ffe3a297ed15e9a79846161a3731a580511bf13c6b5cc5a9e03ddcbd8515fdeeR4-R9), [link](https://github.com/labring/sealos/pull/3063/files?diff=unified&w=0#diff-48839d65f7bfedd91312ee406fd94da103ede7d3c7e791eb2c1657f46afdea00R5-R10))
*  Add a default value of false to the existing input parameter `push_image` in the `workflow_call` sections of the `frontend.yml`, `services.yml`, and `controllers.yml` workflows, indicating whether the workflows should push the images to the registry ([link](https://github.com/labring/sealos/pull/3063/files?diff=unified&w=0#diff-8e0e4903d4e4f8b8844d36370ca2d71c7c72d03ddb7a9cdcedc6328dfc5da8faR16), [link](https://github.com/labring/sealos/pull/3063/files?diff=unified&w=0#diff-ffe3a297ed15e9a79846161a3731a580511bf13c6b5cc5a9e03ddcbd8515fdeeR16), [link](https://github.com/labring/sealos/pull/3063/files?diff=unified&w=0#diff-48839d65f7bfedd91312ee406fd94da103ede7d3c7e791eb2c1657f46afdea00R17))
*  Replace the original code that sets the `tag_name` variable based on the `push_image` input parameter with a call to the bash script `./scripts/resolve-tag-image.sh` in the `frontend.yml`, `services.yml`, and `controllers.yml` workflows, simplifying and unifying the logic of determining the tag name for the images based on different scenarios ([link](https://github.com/labring/sealos/pull/3063/files?diff=unified&w=0#diff-8e0e4903d4e4f8b8844d36370ca2d71c7c72d03ddb7a9cdcedc6328dfc5da8faL108-R115), [link](https://github.com/labring/sealos/pull/3063/files?diff=unified&w=0#diff-8e0e4903d4e4f8b8844d36370ca2d71c7c72d03ddb7a9cdcedc6328dfc5da8faL184-R178), [link](https://github.com/labring/sealos/pull/3063/files?diff=unified&w=0#diff-ffe3a297ed15e9a79846161a3731a580511bf13c6b5cc5a9e03ddcbd8515fdeeL53-R60), [link](https://github.com/labring/sealos/pull/3063/files?diff=unified&w=0#diff-ffe3a297ed15e9a79846161a3731a580511bf13c6b5cc5a9e03ddcbd8515fdeeL124-R129), [link](https://github.com/labring/sealos/pull/3063/files?diff=unified&w=0#diff-48839d65f7bfedd91312ee406fd94da103ede7d3c7e791eb2c1657f46afdea00L109-R116), [link](https://github.com/labring/sealos/pull/3063/files?diff=unified&w=0#diff-48839d65f7bfedd91312ee406fd94da103ede7d3c7e791eb2c1657f46afdea00L185-R181))
*  Add the `docker/build-push-action@v4` and the `docker/metadata-action@v4` actions to the `frontend.yml`, `services.yml`, and `controllers.yml` workflows, leveraging their functionality to generate metadata labels and tags for the images, and caching layers ([link](https://github.com/labring/sealos/pull/3063/files?diff=unified&w=0#diff-8e0e4903d4e4f8b8844d36370ca2d71c7c72d03ddb7a9cdcedc6328dfc5da8faL124-R158), [link](https://github.com/labring/sealos/pull/3063/files?diff=unified&w=0#diff-ffe3a297ed15e9a79846161a3731a580511bf13c6b5cc5a9e03ddcbd8515fdeeL93-R98), [link](https://github.com/labring/sealos/pull/3063/files?diff=unified&w=0#diff-48839d65f7bfedd91312ee406fd94da103ede7d3c7e791eb2c1657f46afdea00L131-R161))
*  Add new conditions to the `if` statements that check whether the workflows should login to the Docker Hub and build the cluster image, enabling the workflows to push the images to the registry and build the cluster image when the `release` input parameter is true ([link](https://github.com/labring/sealos/pull/3063/files?diff=unified&w=0#diff-ffe3a297ed15e9a79846161a3731a580511bf13c6b5cc5a9e03ddcbd8515fdeeL80-R85), [link](https://github.com/labring/sealos/pull/3063/files?diff=unified&w=0#diff-ffe3a297ed15e9a79846161a3731a580511bf13c6b5cc5a9e03ddcbd8515fdeeL99-R104), [link](https://github.com/labring/sealos/pull/3063/files?diff=unified&w=0#diff-48839d65f7bfedd91312ee406fd94da103ede7d3c7e791eb2c1657f46afdea00L125-R130))
*  Add three new sections to the `release.yml` workflow, invoking the `frontend.yml`, `services.yml`, and `controllers.yml` workflows as reusable components, passing the `release` input parameter as true, triggering the workflows that build and push the images for the frontend, services, and controllers modules when a release event occurs, using the release tag as the tag name for the images ([link](https://github.com/labring/sealos/pull/3063/files?diff=unified&w=0#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R16-R27))
*  Add a new bash script `./scripts/resolve-tag-image.sh` that takes three arguments: `push_image`, `release`, and `release_tag`, and sets the `tag_name` variable accordingly, echoing the `tag_name` variable to the `GITHUB_OUTPUT` file ([link](https://github.com/labring/sealos/pull/3063/files?diff=unified&w=0#diff-3e2e6905979550785d12da919a7cc4f24ebb1b87ddc84c8ce6fb785358ef1c52R1-R15))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
