### PR TITLE
fix: invalid reference format

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -116,6 +116,7 @@ cloud.google.com/go/compute v1.12.0/go.mod h1:e8yNOBcBONZU1vJKCvCoDw/4JQsA0dpM4x
 cloud.google.com/go/compute v1.12.1/go.mod h1:e8yNOBcBONZU1vJKCvCoDw/4JQsA0dpM4x/6PIIOocU=
 cloud.google.com/go/compute v1.13.0/go.mod h1:5aPTS0cUNMIc1CE546K+Th6weJUNQErARyZtRXDJ8GE=
 cloud.google.com/go/compute v1.15.1/go.mod h1:bjjoF/NtFUrkD/urWfdHaKuOPDR5nWIs63rR+SXhcpA=
+cloud.google.com/go/compute v1.18.0 h1:FEigFqoDbys2cvFkZ9Fjq4gnHBP55anJ0yQyau2f9oY=
 cloud.google.com/go/compute v1.18.0/go.mod h1:1X7yHxec2Ga+Ss6jPyjxRxpu2uu7PLgsOVXvgU0yacs=
 cloud.google.com/go/compute/metadata v0.1.0/go.mod h1:Z1VN+bulIf6bt4P/C37K4DyZYZEXYonfTBHHFPO/4UU=
 cloud.google.com/go/compute/metadata v0.2.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
@@ -685,6 +686,7 @@ github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/miekg/dns v1.1.25/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.43/go.mod h1:+evo5L0630/F6ca/Z9+GAqzhjGyn8/c+TBaOyfEl0V4=
 github.com/minio/sha256-simd v1.0.0/go.mod h1:OuYzVNI5vcoYIAmbIvHPl3N3jUzVedXbKy5RFepssQM=
+github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible h1:aKW/4cBs+yK6gpqU3K/oIwk9Q/XICqd3zOX/UFuvqmk=
 github.com/moby/sys/mount v0.2.0/go.mod h1:aAivFE2LB3W4bACsUXChRHQ0qKWsetY4Y9V7sxOougM=
 github.com/moby/sys/mount v0.3.3/go.mod h1:PBaEorSNTLG5t/+4EgukEQVlAvVEc6ZjTySwKdqp5K0=
 github.com/moby/sys/signal v0.6.0/go.mod h1:GQ6ObYZfqacOwTtlXvcmh9A26dVRul/hbOZn88Kg8Tg=

--- a/pkg/buildah/runtime.go
+++ b/pkg/buildah/runtime.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/common/libimage"
@@ -98,6 +99,9 @@ func (r *Runtime) pullOrLoadImages(ctx context.Context, args ...string) ([]strin
 		}
 		switch tr.Name() {
 		case TransportDocker, TransportContainersStorage:
+			if tr.Name() == TransportDocker {
+				ref = strings.TrimPrefix(ref, "//")
+			}
 			pullImages, err := r.Runtime.Pull(ctx, ref, config.PullPolicyMissing, &libimage.PullOptions{
 				CopyOptions: libimage.CopyOptions{
 					Writer: os.Stderr,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f277021</samp>

### Summary
🆙🔒🐛

<!--
1.  🆙 - This emoji can be used to indicate that dependencies have been updated or upgraded to newer versions. It conveys the idea of moving up or improving something.
2.  🔒 - This emoji can be used to indicate that checksums have been added or verified for security or integrity purposes. It conveys the idea of locking or protecting something.
3.  🐛 - This emoji can be used to indicate that a bug has been fixed or resolved. It conveys the idea of squashing or eliminating something.
-->
Update dependencies and fix image pulling bug. This pull request updates the `go.sum` file with new module versions and checksums, and fixes a bug in `pkg/buildah/runtime.go` that prevents pulling images from a docker transport by removing the "//" prefix from docker references.

> _Sing, O Muse, of the skillful coder who updated the dependencies_
> _Of the project that builds containers with the help of the modules_
> _That the cloud-born Google and the ZFS-loving Mistifyio provide_
> _And who fixed the bug that hindered the docker transport with strings applied_

### Walkthrough
*  Fix a bug in pulling images from docker transport by removing "//" prefix from reference ([link](https://github.com/labring/sealos/pull/3070/files?diff=unified&w=0#diff-9b69fba85c5f5b22f133aa0d78d11f61fd73004aeede141ef7bb0c737addca75R102-R104))
*  Add strings package to import list to use strings.TrimPrefix function ([link](https://github.com/labring/sealos/pull/3070/files?diff=unified&w=0#diff-9b69fba85c5f5b22f133aa0d78d11f61fd73004aeede141ef7bb0c737addca75R22))
*  Update dependencies of the project to use newer versions of modules and add checksums to `go.sum` file ([link](https://github.com/labring/sealos/pull/3070/files?diff=unified&w=0#diff-20cee3a725d1c5d2c595ff5372e6593d3bcaa7aebd8319866f65e90c6924f247R119), [link](https://github.com/labring/sealos/pull/3070/files?diff=unified&w=0#diff-20cee3a725d1c5d2c595ff5372e6593d3bcaa7aebd8319866f65e90c6924f247R689))

