### PR TITLE
fix ingress's backend error

### DIFF
--- a/frontend/providers/applaunchpad/deploy/manifests/ingress.yaml.tmpl
+++ b/frontend/providers/applaunchpad/deploy/manifests/ingress.yaml.tmpl
@@ -42,7 +42,7 @@ metadata:
         expires 30d;
         add_header Cache-Control "public";
       }
-  name: applaunchpad-manager
+  name: sealos-applaunchpad
   namespace: applaunchpad-frontend
 spec:
   rules:
@@ -53,7 +53,7 @@ spec:
             path: /
             backend:
               service:
-                name: applaunchpad-manager-frontend
+                name: applaunchpad-frontend
                 port:
                   number: 3000
   tls:

--- a/frontend/providers/terminal/deploy/manifests/ingress.yaml.tmpl
+++ b/frontend/providers/terminal/deploy/manifests/ingress.yaml.tmpl
@@ -33,7 +33,7 @@ metadata:
         expires 30d;
         add_header Cache-Control "public";
       }
-  name: terminal-cloud-sealos-io
+  name: sealos-terminal
   namespace: terminal-frontend
 spec:
   rules:

--- a/service/auth/deploy/manifests/ingress.yaml.tmpl
+++ b/service/auth/deploy/manifests/ingress.yaml.tmpl
@@ -32,7 +32,7 @@ spec:
             path: /service/auth(/|$)(.*)
             backend:
               service:
-                name: service-auth
+                name: auth-service
                 port:
                   number: 8080
   tls:

--- a/service/auth/deploy/manifests/ingress.yaml.tmpl
+++ b/service/auth/deploy/manifests/ingress.yaml.tmpl
@@ -32,7 +32,7 @@ spec:
             path: /service/auth(/|$)(.*)
             backend:
               service:
-                name: auth-service
+                name: auth-service-manager
                 port:
                   number: 8080
   tls:


### PR DESCRIPTION
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2c5e599</samp>

> _`service-auth` renamed_
> _to match the convention_
> _ingress cut by `/auth`_