### PR TITLE
Fix demo usage of side-login ingress.

### DIFF
--- a/deploy/cloud/manifests/ingress-nginx/side-login.yaml
+++ b/deploy/cloud/manifests/ingress-nginx/side-login.yaml
@@ -49,8 +49,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/rewrite-target: /$2
-    cert-manager.io/issuer: cluster-issuer-login
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
   name: login-sealos-io
   namespace: sealos
 spec:


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 18e8ed4</samp>

### Summary
:lock::wrench::heavy_check_mark:

<!--
1.  :lock: - This emoji represents the removal of the cert-manager annotation and the change in the backend protocol, which both affect the security and encryption of the traffic to the login service.
2.  :wrench: - This emoji represents the fact that this change was a fix for an existing issue, and that it involved modifying the configuration of the ingress resource.
3.  :heavy_check_mark: - This emoji represents the positive outcome of this change, which resolved the issue and made the login service functional again.
-->
Removed cert-manager annotation and changed backend protocol for `login.sealos.io` ingress. This fixes the TLS certificate issue for the login service.

> _`cert-manager` gone_
> _ingress talks HTTP now_
> _login service fixed_

### Walkthrough
* Remove cert-manager annotation and change backend protocol for login ingress ([link](https://github.com/labring/sealos/pull/3072/files?diff=unified&w=0#diff-04dd70c037058091bd4ba2482c3829ba7bfd06271189920e79f4926fbd601dc1L52-R52))

