### PR TITLE
refactor(main): enable build flags isolation

### DIFF
--- a/pkg/buildah/common.go
+++ b/pkg/buildah/common.go
@@ -84,7 +84,6 @@ func flagsInBuildCommandToBeHidden() []string {
 		"identity-label",
 		"iidfile",
 		"ipc",
-		"isolation",
 		"logfile",
 		"logsplit",
 		"memory",


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at dcb3296</samp>

### Summary
🚫🛠️🐳

<!--
1.  🚫 - This emoji can be used to indicate that something was removed or deleted, such as the `isolation` flag.
2.  🛠️ - This emoji can be used to indicate that something was fixed or improved, such as the build command.
3.  🐳 - This emoji can be used to indicate that something is related to containers or Docker, such as the isolation technology.
-->
Removed `isolation` flag from build command in `pkg/buildah/common.go`. This flag is not needed for sealos, which uses Kubernetes for container management.

> _`isolation` flag_
> _gone from build command list_
> _sealos uses k8s_

### Walkthrough
* Remove `isolation` flag from hidden flags in build command ([link](https://github.com/labring/sealos/pull/3086/files?diff=unified&w=0#diff-72235052288a2edb31f865993dc1ac1b76ca41f9380b446fa049677787b9df5cL87)) to avoid confusion and unnecessary complexity for sealos users


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
