### PR TITLE
feat. fix cloud cluster image

### DIFF
--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Build sealos cloud cluster image
         working-directory: deploy/cloud
         run: |
-          sudo sealos build -t ${{ steps.prepare.outputs.repo }}:${{ steps.prepare.outputs.tag_name }} -f Kubefile
+          sudo sealos build --isolation=chroot  -t ${{ steps.prepare.outputs.repo }}:${{ steps.prepare.outputs.tag_name }} -f Kubefile
           sudo sealos push ${{ steps.prepare.outputs.repo }}:${{ steps.prepare.outputs.tag_name }}
 
       # todo: build multi-arch images

--- a/deploy/cloud/Kubefile
+++ b/deploy/cloud/Kubefile
@@ -1,5 +1,16 @@
-FROM scratch
+FROM ghcr.io/labring/sealos:v4.2.0 as builder
+WORKDIR /
+USER root
+RUN mkdir -p tars && sealos save -o tars/user.tar ghcr.io/labring/sealos-cloud-user-controller:dev && \
+    sealos save -o tars/terminal.tar ghcr.io/labring/sealos-cloud-terminal-controller:dev && \
+    sealos save -o tars/app.tar ghcr.io/labring/sealos-cloud-app-controller:dev && \
+    sealos save -o tars/frontend-desktop.tar  ghcr.io/labring/sealos-cloud-desktop-frontend:dev && \
+    sealos save -o tars/frontend-terminal.tar  ghcr.io/labring/sealos-cloud-terminal-frontend:dev && \
+    sealos save -o tars/frontend-applaunchpad.tar ghcr.io/labring/sealos-cloud-applaunchpad-frontend:dev && \
+    sealos save -o tars/auth.tar ghcr.io/labring/sealos-cloud-auth-service:dev
 
+FROM scratch
+COPY --from=builder /tars .
 COPY etc etc
 COPY scripts scripts
 COPY registry registry

--- a/deploy/cloud/images/shim/controller
+++ b/deploy/cloud/images/shim/controller
@@ -1,3 +1,0 @@
-ghcr.io/labring/sealos-cloud-user-controller:dev
-ghcr.io/labring/sealos-cloud-terminal-controller:dev
-ghcr.io/labring/sealos-cloud-app-controller:dev

--- a/deploy/cloud/images/shim/frontend
+++ b/deploy/cloud/images/shim/frontend
@@ -1,3 +1,0 @@
-ghcr.io/labring/sealos-cloud-desktop-frontend:dev
-ghcr.io/labring/sealos-cloud-terminal-frontend:dev
-ghcr.io/labring/sealos-cloud-applaunchpad-frontend:dev

--- a/deploy/cloud/images/shim/service
+++ b/deploy/cloud/images/shim/service
@@ -1,1 +1,0 @@
-ghcr.io/labring/sealos-cloud-auth-service:dev

--- a/deploy/cloud/scripts/init.sh
+++ b/deploy/cloud/scripts/init.sh
@@ -24,30 +24,30 @@ function mock_tls {
 
 function sealos_run_controller {
   # run user controller
-  sealos run sealos.hub:5000/labring/sealos-cloud-user-controller:dev
+  sealos run tars/user.tar
   # \ 1 > /dev/null
 
   # run terminal controller
-  sealos run sealos.hub:5000/labring/sealos-cloud-terminal-controller:dev --env cloudDomain=$cloudDomain --env userNamespace="user-system" --env wildcardCertSecretName="wildcard-secret" --env wildcardCertSecretNamespace="sealos-system"
+  sealos run tars/terminal.tar --env cloudDomain=$cloudDomain --env userNamespace="user-system" --env wildcardCertSecretName="wildcard-secret" --env wildcardCertSecretNamespace="sealos-system"
   # \ 1 > /dev/null
 
   # run app controller
-  sealos run sealos.hub:5000/labring/sealos-cloud-app-controller:dev
+  sealos run tars/app.tar
   # \ 1 > /dev/null
 }
 
 function sealos_run_service {
   # run auth service
-  sealos run sealos.hub:5000/labring/sealos-cloud-auth-service:dev --env cloudDomain=$cloudDomain --env certSecretName="wildcard-secret" --env callbackUrl="$cloudDomain/login/callback" --env ssoEndpoint="login.$cloudDomain" --env casdoorMysqlRootPassword="$(tr -cd 'a-z0-9' </dev/urandom | head -c16)"
+  sealos run tars/auth.tar --env cloudDomain=$cloudDomain --env certSecretName="wildcard-secret" --env callbackUrl="$cloudDomain/login/callback" --env ssoEndpoint="login.$cloudDomain" --env casdoorMysqlRootPassword="$(tr -cd 'a-z0-9' </dev/urandom | head -c16)"
   # \ 1 > /dev/null
 }
 
 function sealos_run_frontend {
-  sealos run sealos.hub:5000/labring/sealos-cloud-desktop-frontend:dev --env cloudDomain=$cloudDomain --env certSecretName="wildcard-secret"
+  sealos run tars/frontend-desktop.tar --env cloudDomain=$cloudDomain --env certSecretName="wildcard-secret"
 
-  sealos run sealos.hub:5000/labring/sealos-cloud-applaunchpad-frontend:dev --env cloudDomain=$cloudDomain --env certSecretName="wildcard-secret"
+  sealos run tars/frontend-applaunchpad.tar --env cloudDomain=$cloudDomain --env certSecretName="wildcard-secret"
 
-  sealos run sealos.hub:5000/labring/sealos-cloud-terminal-frontend:dev --env cloudDomain=$cloudDomain --env certSecretName="wildcard-secret"
+  sealos run tars/frontend-terminal.tar --env cloudDomain=$cloudDomain --env certSecretName="wildcard-secret"
 }
 
 
@@ -57,8 +57,6 @@ function install {
   mock_tls $cloudDomain
   # kubectl apply namespace and secret
   kubectl apply -f manifests
-  # sealos login
-  sealos login -u admin -p passw0rd sealos.hub:5000
   # sealos run controllers
   sealos_run_controller
   # sealos run services


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1e43528</samp>

### Summary
🛠️🏗️🚀

<!--
1.  🛠️ for adding the `--isolation=chroot` flag as a workaround for a bug
2.  🏗️ for using a multi-stage build to improve the image size and quality
3.  🚀 for using local tar files to speed up and stabilize the deployment process
-->
This pull request improves the deployment speed and stability of sealos-cloud by using local tar files instead of pulling images from the sealos hub registry. It also fixes a bug in the GitHub Actions workflow that prevented using docker for building the image.

> _`sealos build` fixes_
> _docker bug with chroot flag_
> _autumn workaround_

### Walkthrough
*  Add `--isolation=chroot` flag to `sealos build` command to avoid docker bug in GitHub Actions ([link](https://github.com/labring/sealos/pull/3087/files?diff=unified&w=0#diff-7e4159d358d73ce740ffdf0b5737ccb6965692a7d3cea96bbb2a1ba054ea229eL84-R84))
*  Use multi-stage build in `Kubefile` to copy sealos-cloud components from builder image and reduce final image size and complexity ([link](https://github.com/labring/sealos/pull/3087/files?diff=unified&w=0#diff-e4247ffa6d74e55ecb0294d7d215212f8cdca29bc743c86c769a0f257cb0e597L1-R13))
*  Delete unused shim files for controller, service and frontend ([link](https://github.com/labring/sealos/pull/3087/files?diff=unified&w=0#diff-a459e3b6355f1fae43b251534a5887ae295382cf2d3711398e8c77646971c112), [link](https://github.com/labring/sealos/pull/3087/files?diff=unified&w=0#diff-0ff1a52beaadcbc39c9dfd14429c3d71305a7f819d9a9975f4cba7f6893ebb49), [link](https://github.com/labring/sealos/pull/3087/files?diff=unified&w=0#diff-edca07d575648ebc4c9846ea58fdd34df49c9c2a2526ab0699dc55e6e3e9c285))
*  Modify `init.sh` script to use local tar files instead of remote images for running sealos-cloud components and improve performance and reliability ([link](https://github.com/labring/sealos/pull/3087/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844L27-R35), [link](https://github.com/labring/sealos/pull/3087/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844L41-R50), [link](https://github.com/labring/sealos/pull/3087/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844L60-L61))
*  Remove `sealos login` command from `init.sh` script as it is no longer needed ([link](https://github.com/labring/sealos/pull/3087/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844L60-L61))

