### PR TITLE
fix terminal and applaunchpad deploy yaml

### DIFF
--- a/frontend/providers/applaunchpad/deploy/manifests/deploy.yaml.tmpl
+++ b/frontend/providers/applaunchpad/deploy/manifests/deploy.yaml.tmpl
@@ -32,6 +32,10 @@ spec:
         app: applaunchpad-frontend
     spec:
       containers:
+        - env:
+            - name: SEALOS_DOMAIN
+              value: {{ .cloudDomain }}
+            - name: FASTGPT_KEY
         - name: applaunchpad-frontend
           securityContext:
             runAsNonRoot: true

--- a/frontend/providers/applaunchpad/deploy/manifests/ingress.yaml.tmpl
+++ b/frontend/providers/applaunchpad/deploy/manifests/ingress.yaml.tmpl
@@ -1,32 +1,17 @@
-#apiVersion: cert-manager.io/v1
-#kind: ClusterIssuer
-#metadata:
-#  name: applaunchpad-cluster-issuer
-#  namespace: applaunchpad-frontend
-#spec:
-#  acme:
-#    server: https://acme-v02.api.letsencrypt.org/directory
-#    email: admin@sealos.io
-#    privateKeySecretRef:
-#      name: letsencrypt-prod
-#    solvers:
-#      - http01:
-#          ingress:
-#            class: nginx
-#---
-#apiVersion: cert-manager.io/v1
-#kind: Certificate
-#metadata:
-#  name: applaunchpad-cert
-#  namespace: applaunchpad-frontend
-#spec:
-#  secretName: applaunchpad-cert-secret
-#  dnsNames:
-#    - applaunchpad.{{ .cloudDomain }}
-#  issuerRef:
-#    name: applaunchpad-cluster-issuer
-#    kind: ClusterIssuer
----
+# Copyright © 2022 sealos.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -35,7 +20,7 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_clear_headers "X-Frame-Options:";
-      more_set_headers "Content-Security-Policy: default-src * blob: data: *.{{ .cloudDomain }} {{ .cloudDomain }}; img-src * data: blob: resource: *.{{ .cloudDomain }} {{ .cloudDomain }}; connect-src * wss: blob: resource:; style-src 'self' 'unsafe-inline' blob: *.{{ .cloudDomain }} {{ .cloudDomain }} resource:; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: *.{{ .cloudDomain }} {{ .cloudDomain }} resource: *.baidu.com *.bdstatic.com; frame-src 'self' {{ .cloudDomain }} mailto: tel: weixin: mtt: *.baidu.com; frame-ancestors 'self' https://{{ .cloudDomain }} https://*.{{ .cloudDomain }}";
+      more_set_headers "Content-Security-Policy: default-src * blob: data: *.{{ .cloudDomain }} {{ .cloudDomain }}; img-src * data: blob: resource: *.{{ .cloudDomain }} {{ .cloudDomain }}; connect-src * wss: blob: resource:; style-src 'self' 'unsafe-inline' blob: *.{{ .cloudDomain }} {{ .cloudDomain }} resource:; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: *.{{ .cloudDomain }} {{ .cloudDomain }} resource: *.baidu.com *.bdstatic.com; frame-src 'self' *.{{ .cloudDomain }} {{ .cloudDomain }} mailto: tel: weixin: mtt: *.baidu.com; frame-ancestors 'self' https://{{ .cloudDomain }} https://*.{{ .cloudDomain }}";
       more_set_headers "X-Xss-Protection: 1; mode=block";
 
       if ($request_uri ~* \.(js|css|gif|jpe?g|png)) {

--- a/frontend/providers/terminal/deploy/manifests/ingress.yaml.tmpl
+++ b/frontend/providers/terminal/deploy/manifests/ingress.yaml.tmpl
@@ -26,7 +26,7 @@ metadata:
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_clear_headers "X-Frame-Options:";
-      more_set_headers "Content-Security-Policy: default-src * blob: data: *.{{ .cloudDomain }} {{ .cloudDomain }}; img-src * data: blob: resource: *.{{ .cloudDomain }} {{ .cloudDomain }}; connect-src * wss: blob: resource:; style-src 'self' 'unsafe-inline' blob: *.{{ .cloudDomain }} {{ .cloudDomain }} resource:; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: *.{{ .cloudDomain }} {{ .cloudDomain }} resource: *.baidu.com *.bdstatic.com; frame-src 'self' {{ .cloudDomain }} mailto: tel: weixin: mtt: *.baidu.com; frame-ancestors 'self' https://{{ .cloudDomain }} https://*.{{ .cloudDomain }}";
+      more_set_headers "Content-Security-Policy: default-src * blob: data: *.{{ .cloudDomain }} {{ .cloudDomain }}; img-src * data: blob: resource: *.{{ .cloudDomain }} {{ .cloudDomain }}; connect-src * wss: blob: resource:; style-src 'self' 'unsafe-inline' blob: *.{{ .cloudDomain }} {{ .cloudDomain }} resource:; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: *.{{ .cloudDomain }} {{ .cloudDomain }} resource: *.baidu.com *.bdstatic.com; frame-src 'self' *.{{ .cloudDomain }} {{ .cloudDomain }} mailto: tel: weixin: mtt: *.baidu.com; frame-ancestors 'self' https://{{ .cloudDomain }} https://*.{{ .cloudDomain }}";
       more_set_headers "X-Xss-Protection: 1; mode=block";
 
       if ($request_uri ~* \.(js|css|gif|jpe?g|png)) {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at db4f930</samp>

### Summary
:sparkles::wrench::recycle:

<!--
1.  :sparkles: This emoji represents the addition of a new feature or enhancement, which is the case for the first change that adds the environment variables for the FastGPT service. This change enables the applaunchpad frontend to use natural language generation capabilities, which is a significant improvement for the user experience and functionality of the web application.
2.  :wrench: This emoji represents a fix or improvement of something that was broken or not working well, which is the case for the second change that modifies the Content-Security-Policy header for the terminal ingress. This change fixes the issue of the terminal service not being able to be embedded as an iframe by the applaunchpad frontend, which is a bug that affects the usability and integration of the two services.
3.  :recycle: This emoji represents a refactor or cleanup of the code or configuration, which is the case for the third change that simplifies the ingress resource definition and relaxes the Content-Security-Policy header for the applaunchpad frontend. This change does not add or fix any functionality, but it makes the deployment process easier and more consistent, and it allows more flexibility for the iframe embedding of the applaunchpad frontend.
-->
This pull request updates the ingress resources and the deployment environment variables for the applaunchpad frontend and the terminal service. The main goals are to enable iframe embedding of the terminal service by the applaunchpad frontend, and to integrate the FastGPT service for natural language generation.

> _To make the frontend more appealing_
> _We added some FastGPT and SEALOS_
> _But to embed the terminal_
> _We had to be liberal_
> _With the `Content-Security-Policy` and `ingress`_

### Walkthrough
*  Add environment variables for FastGPT service to applaunchpad frontend deployment ([link](https://github.com/labring/sealos/pull/3091/files?diff=unified&w=0#diff-4a0a2039e5ccec7cfbebd9819eb00bcb2dc38097079136dd81342f30f4b5b879R35-R38))
* Move ingress resource definition from `ingress.yaml.tmpl` to `deploy.yaml.tmpl` and remove cert-manager resources ([link](https://github.com/labring/sealos/pull/3091/files?diff=unified&w=0#diff-98152272443968804cab1a8adb158cd8a8cd6e7ce5679ab0e0388ffec7692390L1-R14))
* Add wildcard (*) to frame-src directive of Content-Security-Policy header for both applaunchpad frontend and terminal ingresses ([link](https://github.com/labring/sealos/pull/3091/files?diff=unified&w=0#diff-98152272443968804cab1a8adb158cd8a8cd6e7ce5679ab0e0388ffec7692390L38-R23), [link](https://github.com/labring/sealos/pull/3091/files?diff=unified&w=0#diff-47695228e3b26a0a56ef442536051acd5d68452449b38da7d816f6175ecb4a9cL29-R29))

