### PR TITLE
add cert prepare readme

### DIFF
--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -6,6 +6,27 @@
 1. A cloud domain and dns to your k8s cluster. Suppose your domain name is `cloud.example.io`.
 2. A TLS cert that resolves `cloud.example.io` and `*.cloud.example.io`
 
+Here is one way to get a TLS cert by using acme.sh with alidns.
+
+1. install [acme.sh](https://github.com/acmesh-official/acme.sh)
+2. get your alidns access key and secret key
+3. run following command to get a TLS cert
+
+    ```shell
+    export Ali_Key="<your ali key>"
+    export Ali_Secret="<your ali secret>"
+    
+    acme.sh --issue --dns dns_ali -d "cloud.example.io" -d "*.cloud.example.io"
+    ```
+
+4. base64 encode your cert and key, and save the output which will be used in the next step
+    ```shell
+        base64 -w 0 ~/.acme.sh/${<your domian path>}/fullchain.cer
+        base64 -w 0 ~/.acme.sh/${<your domian path>}/${<your domian>}.key
+    ```
+
+Other dns api please read: https://github.com/acmesh-official/acme.sh/wiki/dnsapi
+
 ### kubernetes cluster
 ```shell
 sealos gen labring/kubernetes:v1.25.6 \
@@ -59,16 +80,16 @@ metadata:
   name: secret
 spec:
   path: manifests/tls-secret.yaml
-  match: ghcr.io/labring/sealos-cloud:dev
+  match: docker.io/labring/sealos-cloud:dev
   strategy: merge
   data: |
     data:
-      tls.crt: <your-tls.crt-base64>
-      tls.key: <your-tls.key-base64>
+      tls.crt: <your-fullchain.cer-base64>
+      tls.key: <your-${your domain}.key-base64>
 ```
 
 ------
 ## run sealos cloud cluster image
 ```shell
-sealos run ghcr.io/labring/sealos-cloud:dev --config-file tls-secret.yaml --env cloudDomain="cloud.example.com"
+sealos run docker.io/labring/sealos-cloud:dev --env cloudDomain="cloud.example.com" --config-file tls-secret.yaml
 ```


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 69ab747</samp>

### Summary
📝☁️🌐

<!--
1.  📝 - This emoji can be used to indicate that the README.md file was updated with documentation or instructions.
2.  ☁️ - This emoji can be used to indicate that the changes are related to cloud cluster deployment or cloud services.
3.  🌐 - This emoji can be used to indicate that the changes involve DNS or networking configuration.
-->
This pull request improves the documentation and usability of the sealos cloud cluster deployment. It supports alidns as a DNS provider and fixes the image source and argument order for the `sealos run` command in `deploy/cloud/README.md`.

> _Sing, O Muse, of the sealos cloud cluster, the mighty work of code_
> _That guides the users to deploy their pods on Alibaba's abode_
> _And how they learned to use alidns, the swift and clever tool_
> _That links their names with IP addresses, following the rule_

### Walkthrough
*  Add instructions for getting a TLS certificate with alidns and base64 encoding it ([link](https://github.com/labring/sealos/pull/3100/files?diff=unified&w=0#diff-e5a74fab87ec2353240365589f23b63386a45bbcdbf1512850a1fb07eee48742R9-R29))
*  Update image name and data fields for tls-secret.yaml file ([link](https://github.com/labring/sealos/pull/3100/files?diff=unified&w=0#diff-e5a74fab87ec2353240365589f23b63386a45bbcdbf1512850a1fb07eee48742L62-R88), [link](https://github.com/labring/sealos/pull/3100/files?diff=unified&w=0#diff-e5a74fab87ec2353240365589f23b63386a45bbcdbf1512850a1fb07eee48742L73-R94))
*  Update image name and argument order for sealos run command in `deploy/cloud/README.md` ([link](https://github.com/labring/sealos/pull/3100/files?diff=unified&w=0#diff-e5a74fab87ec2353240365589f23b63386a45bbcdbf1512850a1fb07eee48742L73-R94))


