### PR TITLE
docs(main): update latest sealos version

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ Some Screen Shots of `Sealos Desktop`:
 
 > Installing a highly available Kubernetes cluster with Calico as the container network interface (CNI).
 
-Here, the Cluster images `kubernetes:v1.24.0` and `calico:v3.24.1` stored in the registry are fully compliant with the OCI standard. However, if you prefer to use flannel, it is also an option.
+Here, the Cluster images `kubernetes:v1.24.0-4.2.0` and `calico:v3.24.1` stored in the registry are fully compliant with the OCI standard. However, if you prefer to use flannel, it is also an option.
 
 ```bash
 # Download and install Sealos, which is a binary tool written in Golang. Simply download it and copy it to the bin directory. You can also download it from the release page.
-$ wget  https://github.com/labring/sealos/releases/download/v4.1.4/sealos_4.1.4_linux_amd64.tar.gz  && \
-    tar -zxvf sealos_4.1.4_linux_amd64.tar.gz sealos &&  chmod +x sealos && mv sealos /usr/bin 
+$ wget  https://github.com/labring/sealos/releases/download/v4.2.0/sealos_4.2.0_linux_amd64.tar.gz  && \
+    tar -zxvf sealos_4.2.0_linux_amd64.tar.gz sealos &&  chmod +x sealos && mv sealos /usr/bin 
 # Create a cluster
-$ sealos run labring/kubernetes:v1.25.0 labring/helm:v3.8.2 labring/calico:v3.24.1 \
+$ sealos run labring/kubernetes:v1.25.0-4.2.0 labring/helm:v3.8.2 labring/calico:v3.24.1 \
      --masters 192.168.64.2,192.168.64.22,192.168.64.20 \
      --nodes 192.168.64.21,192.168.64.19 -p [your-ssh-passwd]
 ```
@@ -88,7 +88,7 @@ $ sealos run labring/kubernetes:v1.25.0 labring/helm:v3.8.2 labring/calico:v3.24
 > Single host
 
 ```bash
-$ sealos run labring/kubernetes:v1.25.0 labring/helm:v3.8.2 labring/calico:v3.24.1
+$ sealos run labring/kubernetes:v1.25.0-4.2.0 labring/helm:v3.8.2 labring/calico:v3.24.1
 ```
 
 > Building a custom Cluster image
@@ -111,7 +111,7 @@ And now everything is ready.
 ## Use Kubernetes Cluster image with cri-docker runtime
 
 ```bash
-sealos run labring/kubernetes-docker:v1.20.8-4.1.4 labring/calico:v3.22.1 \
+sealos run labring/kubernetes-docker:v1.20.8-4.2.0 labring/calico:v3.22.1 \
      --masters 192.168.64.2,192.168.64.22,192.168.64.20 \
      --nodes 192.168.64.21,192.168.64.19 -p [your-ssh-passwd]
 ```

--- a/docs/4.0/docs/getting-started/installation.md
+++ b/docs/4.0/docs/getting-started/installation.md
@@ -13,16 +13,16 @@ import TabItem from '@theme/TabItem';
   <TabItem value="amd64" label="amd64" default>
 
 ```bash
-$ wget https://github.com/labring/sealos/releases/download/v4.1.4/sealos_4.1.4_linux_amd64.tar.gz \
-   && tar zxvf sealos_4.1.4_linux_amd64.tar.gz sealos && chmod +x sealos && mv sealos /usr/bin
+$ wget https://github.com/labring/sealos/releases/download/v4.2.0/sealos_4.2.0_linux_amd64.tar.gz \
+   && tar zxvf sealos_4.2.0_linux_amd64.tar.gz sealos && chmod +x sealos && mv sealos /usr/bin
 ```
 
   </TabItem>
   <TabItem value="arm64" label="arm64">
 
 ```bash
-$ wget https://github.com/labring/sealos/releases/download/v4.1.4/sealos_4.1.4_linux_arm64.tar.gz \
-   && tar zxvf sealos_4.1.4_linux_arm64.tar.gz sealos && chmod +x sealos && mv sealos /usr/bin
+$ wget https://github.com/labring/sealos/releases/download/v4.2.0/sealos_4.2.0_linux_arm64.tar.gz \
+   && tar zxvf sealos_4.2.0_linux_arm64.tar.gz sealos && chmod +x sealos && mv sealos /usr/bin
 ```
 
   </TabItem>

--- a/docs/4.0/i18n/zh-Hans/getting-started/installation.md
+++ b/docs/4.0/i18n/zh-Hans/getting-started/installation.md
@@ -13,16 +13,16 @@ import TabItem from '@theme/TabItem';
   <TabItem value="amd64" label="amd64" default>
 
 ```bash
-$ wget https://github.com/labring/sealos/releases/download/v4.1.4/sealos_4.1.4_linux_amd64.tar.gz \
-   && tar zxvf sealos_4.1.4_linux_amd64.tar.gz sealos && chmod +x sealos && mv sealos /usr/bin
+$ wget https://github.com/labring/sealos/releases/download/v4.2.0/sealos_4.2.0_linux_amd64.tar.gz \
+   && tar zxvf sealos_4.2.0_linux_amd64.tar.gz sealos && chmod +x sealos && mv sealos /usr/bin
 ```
 
   </TabItem>
   <TabItem value="arm64" label="arm64">
 
 ```bash
-$ wget https://github.com/labring/sealos/releases/download/v4.1.4/sealos_4.1.4_linux_arm64.tar.gz \
-   && tar zxvf sealos_4.1.4_linux_arm64.tar.gz sealos && chmod +x sealos && mv sealos /usr/bin
+$ wget https://github.com/labring/sealos/releases/download/v4.2.0/sealos_4.2.0_linux_arm64.tar.gz \
+   && tar zxvf sealos_4.2.0_linux_arm64.tar.gz sealos && chmod +x sealos && mv sealos /usr/bin
 ```
 
   </TabItem>


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4dd0568</samp>

### Summary
📝🚀🐳

<!--
1.  📝 - This emoji represents documentation updates or changes, and can be used for the first and second bullet points.
2.  🚀 - This emoji represents a new feature or improvement, and can be used for the second bullet point to indicate the new version of sealos.
3.  🐳 - This emoji represents Docker or Kubernetes related changes, and can be used for the third bullet point to indicate the new cluster image versions.
-->
This pull request updates the documentation and the README.md file to use the latest sealos tool version `v4.2.0` and the corresponding Kubernetes cluster image versions. This improves the user experience and the reliability of the sealos tool.

> _Oh, we are the sealos crew, and we have a job to do_
> _We update the docs and the code, to match the latest release_
> _So heave away, me hearties, heave away with `v4.2.0`_
> _We'll make the clusters run so smooth, with sealos and Kubernetes_

### Walkthrough
*  Update the sealos binary version from `v4.1.4` to `v4.2.0` in the installation instructions for both amd64 and arm64 architectures ([link](https://github.com/labring/sealos/pull/3104/files?diff=unified&w=0#diff-dd042a897dd5803ec6878d9fe99beeeab202ac47cb68d4b53b7436e81c8cd729L16-R17), [link](https://github.com/labring/sealos/pull/3104/files?diff=unified&w=0#diff-dd042a897dd5803ec6878d9fe99beeeab202ac47cb68d4b53b7436e81c8cd729L24-R25), [link](https://github.com/labring/sealos/pull/3104/files?diff=unified&w=0#diff-04791ad8aafa40336d670bacc26e634b55adda7fc99f22c117d26538294b2b78L16-R17), [link](https://github.com/labring/sealos/pull/3104/files?diff=unified&w=0#diff-04791ad8aafa40336d670bacc26e634b55adda7fc99f22c117d26538294b2b78L24-R25))
*  Update the Kubernetes cluster image version from `v1.24.0` to `v1.24.0-4.2.0` in the quickstart and create a cluster examples in the `README.md` file ([link](https://github.com/labring/sealos/pull/3104/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L73-R80), [link](https://github.com/labring/sealos/pull/3104/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L91-R91))
*  Update the Kubernetes cluster image version with cri-docker runtime from `v1.20.8-4.1.4` to `v1.20.8-4.2.0` in the use Kubernetes cluster image with cri-docker runtime example in the `README.md` file ([link](https://github.com/labring/sealos/pull/3104/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L114-R114))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
