### PR TITLE
move registry save command to sealctl

### DIFF
--- a/cmd/sealctl/cmd/registry.go
+++ b/cmd/sealctl/cmd/registry.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2022 cuisongliu@qq.com.
+Copyright 2023 fengxsong@outlook.com
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,19 +13,23 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-package commands
+package cmd
 
 import (
-	"os"
-
-	"github.com/containers/buildah/pkg/parse"
 	"github.com/spf13/cobra"
+
+	"github.com/labring/sealos/pkg/registry/commands"
 )
 
-func RegisterRootCommand(cmd *cobra.Command, _ *cobra.Command) {
-	os.Setenv("TMPDIR", parse.GetTempDir())
-	cmd.SilenceUsage = true
-	cmd.AddCommand(NewRegistryImageSaveCmd())
-	cmd.AddCommand(NewRegistryPasswdCmd())
+func newRegistryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "registry",
+		Short: "registry related",
+	}
+	cmd.AddCommand(commands.NewRegistryImageSaveCmd())
+	return cmd
+}
+
+func init() {
+	rootCmd.AddCommand(newRegistryCmd())
 }

--- a/cmd/sealos/cmd/registry.go
+++ b/cmd/sealos/cmd/registry.go
@@ -23,10 +23,10 @@ import (
 )
 
 func newRegistryCmd() *cobra.Command {
-	var registryImageCmd = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:   "registry",
-		Short: "registry images manager",
+		Short: "registry related",
 	}
-	commands.RegisterRootCommand(registryImageCmd, rootCmd)
-	return registryImageCmd
+	cmd.AddCommand(commands.NewRegistryPasswdCmd())
+	return cmd
 }

--- a/pkg/registry/commands/flags.go
+++ b/pkg/registry/commands/flags.go
@@ -61,11 +61,3 @@ func (opts *registrySaveRawResults) RegisterFlags(fs *pflag.FlagSet) {
 	opts.registrySaveResults.RegisterFlags(fs)
 	fs.StringSliceVar(&opts.images, "images", []string{}, "images list")
 }
-
-type registrySaveDefaultResults struct {
-	*registrySaveResults
-}
-
-func (opts *registrySaveDefaultResults) RegisterFlags(fs *pflag.FlagSet) {
-	opts.registrySaveResults.RegisterFlags(fs)
-}

--- a/pkg/registry/commands/password.go
+++ b/pkg/registry/commands/password.go
@@ -17,35 +17,32 @@ limitations under the License.
 package commands
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
 
 	"github.com/labring/sealos/pkg/registry/password"
-	v2 "github.com/labring/sealos/pkg/types/v1beta1"
 	"github.com/labring/sealos/pkg/utils/logger"
 )
 
-func newRegistryPasswdCmd() *cobra.Command {
+func NewRegistryPasswdCmd() *cobra.Command {
 	flagsResults := password.RegistryPasswdResults{}
-	var cluster *v2.Cluster
 
 	var registryPasswdCmd = &cobra.Command{
 		Use:   "passwd",
-		Short: "update registry password",
+		Short: "configure registry password",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cluster, err := flagsResults.Validate()
+			if err != nil {
+				return err
+			}
+			if cluster == nil {
+				return nil
+			}
 			if err := flagsResults.Apply(cluster); err != nil {
 				return fmt.Errorf("registry passwd apply error: %v", err)
 			}
 			logger.Info("registry passwd apply success")
-			return nil
-		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			cluster = flagsResults.Validate()
-			if cluster == nil {
-				return errors.New("registry passwd validate error")
-			}
 			return nil
 		},
 	}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0bca8b7</samp>

This pull request refactors the registry commands in the `pkg/registry/commands` package and the `sealctl` and `sealos` command-line tools to make them more consistent and user-friendly. It simplifies the code, removes unused or redundant components, exports some functions for external use, and uses the `cobra` package for flag validation and error handling. It also adds a new file `cmd/sealctl/cmd/registry.go` to contain the registry-related commands for the `sealctl` tool.