### PR TITLE
refactor(main): add registry docs and fix registry save bug

### DIFF
--- a/docs/4.0/docs/design/sealctl-usage.md
+++ b/docs/4.0/docs/design/sealctl-usage.md
@@ -161,34 +161,31 @@ sealctl hosts list --path /custom/path/hosts
 
 ### registry save Command
 
-The `registry save`  command is used to pull remote Docker images to the local machine and save them in a specified directory. This is especially useful for deploying container images in offline or internal network environments. It supports two modes: default and raw.
-
-- The `default` mode automatically fetches images based on the parsed image list. These image lists are sourced from the charts directory, manifests directory, and images directory.
-- The `raw` mode allows users to directly specify the list of images to be saved.
+The `registry save`  command is used to pull remote Docker images to the local machine and save them in a specified directory. This is especially useful for deploying container images in offline or internal network environments.
 
 When executing the `registry save` command, the authentication information from `sealos login` will be automatically obtained for repository authentication.
 
-**Subcommands**
+**Usage**
 
-1. `default [CONTEXT]`
+1. Using context lookup images
 
    Pull and save images using the default method. This mode automatically parses the `charts` directory, `manifests` directory, and `images` directory to obtain the image list.
 
    **Usage Example**
 
  ```shell
- sealctl registry save default my-context
+ sealctl registry save --registry-dir=/tmp/registry1 my-context
  ```
 
 
-2. `raw`
+2. Using images args
 
-   Pull and save images using the raw method.
+   Pull and save images using the specified image list.
 
    **Usage Example**
 
   ```shell
-  sealctl registry save raw --images my-image:latest
+  sealctl registry save --registry-dir=/tmp/registry2 --images=docker.io/library/busybox:latest
   ```
 
 **Options**
@@ -198,32 +195,8 @@ The following options apply to the `save` command and its subcommands:
 - `--max-procs`: The maximum number of parallel processes to use when pulling images.
 - `--registry-dir`: The local directory to save the images.
 - `--arch`: The target architecture of the images, such as: amd64, arm64, etc.
-
-For the `raw` subcommand, there are also the following additional options:
-
 - `--images`:  The list of images to pull and save, separated by commas. For example: "my-image1:latest,my-image2:v1.0".
 
-**Usage Documentation**
-
-To use the  `sealctl registry save` command, follow these steps:
-
-1. Choose a subcommand (`default` or `raw`) as needed.
-2. Provide the necessary options and parameters for the subcommand.
-3. Execute the command, and the images will be pulled from the remote repository and saved to the specified local directory.
-
-**Examples**
-
-Save images from the default context:
-
-```shell
-sealctl registry save default my-context
-```
-
-Save a specified image using the raw method:
-
-```shell
-sealctl registry save raw --images my-image:latest
-```
 
 ### ipvs Configuration Management Command
 

--- a/docs/4.0/i18n/zh-Hans/design/sealctl-usage.md
+++ b/docs/4.0/i18n/zh-Hans/design/sealctl-usage.md
@@ -167,34 +167,31 @@ sealctl hosts list --path /custom/path/hosts
 
 ### registry保存命令
 
-`registry save` 命令用于将远程的 Docker 镜像拉取到本地并保存在指定的目录中。这对于在离线或者内网环境中部署容器镜像特别有用。它支持两种模式：`default` 和 `raw`。
-
-- `default` 模式会根据解析出的镜像列表自动获取镜像。这些镜像列表来源于 charts 目录、manifests 目录和 images 目录。
-- `raw` 模式允许用户直接指定要保存的镜像列表。
+`registry save` 命令用于将远程的 Docker 镜像拉取到本地并保存在指定的目录中。这对于在离线或者内网环境中部署容器镜像特别有用。
 
 在执行 `registry save` 命令时，将自动获取 `sealos login` 认证信息进行仓库认证。
 
-**子命令**
+**使用说明**
 
-1. `default [CONTEXT]`
+1. 使用context自动获取镜像
 
    使用默认方式拉取并保存镜像。这种模式会自动解析 `charts` 目录、`manifests` 目录和 `images` 目录以获取镜像列表。
 
    **使用示例**
 
  ```shell
- sealctl registry save default my-context
+ sealctl registry save --registry-dir=/tmp/registry1 my-context
  ```
 
 
-2. `raw`
+2. 指定镜像列表方式
 
-   使用原始方式拉取并保存镜像。
+   使用参数传入镜像列表
 
    **使用示例**
 
   ```shell
-  sealctl registry save raw --images my-image:latest
+  sealctl registry save --registry-dir=/tmp/registry2 --images=docker.io/library/busybox:latest
   ```
 
 **选项**
@@ -204,32 +201,7 @@ sealctl hosts list --path /custom/path/hosts
 - `--max-procs`: 拉取镜像时使用的最大并行进程数。
 - `--registry-dir`: 保存镜像的本地目录。
 - `--arch`: 镜像的目标架构，例如：`amd64`、`arm64` 等。
-
-对于 `raw` 子命令，还有以下额外选项：
-
 - `--images`: 需要拉取并保存的镜像列表，以逗号分隔。例如："my-image1:latest,my-image2:v1.0"。
-
-**使用文档**
-
-要使用 `sealctl registry save` 命令，请按照以下步骤操作：
-
-1. 根据需要选择子命令（`default` 或 `raw`）。
-2. 为子命令提供必要的选项和参数。
-3. 执行命令，镜像将从远程仓库拉取并保存到指定的本地目录。
-
-**示例**
-
-保存默认上下文中的镜像：
-
-```shell
-sealctl registry save default my-context
-```
-
-使用原始方式保存指定镜像：
-
-```shell
-sealctl registry save raw --images my-image:latest
-```
 
 ### ipvs配置管理命令
 

--- a/pkg/buildimage/images.go
+++ b/pkg/buildimage/images.go
@@ -34,7 +34,7 @@ import (
 
 func ParseYamlImages(dir string) ([]string, error) {
 	if !file.IsExist(dir) {
-		logger.Debug("path %s is not exists", dir)
+		logger.Debug("path %s is not exists,skip", dir)
 		return nil, nil
 	}
 	list := sets.NewString()
@@ -77,6 +77,7 @@ func formalizeImages(images []string) (res []string) {
 
 func ParseShimImages(dir string) ([]string, error) {
 	if dir == "" || !file.IsExist(dir) {
+		logger.Debug("path %s is not exists,skip", dir)
 		return nil, nil
 	}
 	list := sets.NewString()
@@ -110,7 +111,6 @@ func List(dir string) ([]string, error) {
 	if err != nil {
 		return nil, wrapGetImageErr(err, yamlDir)
 	}
-
 	shimDir := path.Join(dir, constants.ImagesDirName, constants.ImageShimDirName)
 	shimImgs, err := ParseShimImages(shimDir)
 	if err != nil {

--- a/pkg/registry/commands/flags.go
+++ b/pkg/registry/commands/flags.go
@@ -37,7 +37,7 @@ type registrySaveResults struct {
 func (opts *registrySaveResults) RegisterFlags(fs *pflag.FlagSet) {
 	fs.SetInterspersed(false)
 	fs.StringVar(&opts.registryPullArch, "arch", runtime.GOARCH, "pull images arch")
-	fs.StringVar(&opts.registryPullRegistryDir, "data-dir", "/var/lib/registry", "registry data dir path")
+	fs.StringVar(&opts.registryPullRegistryDir, "registry-dir", "/var/lib/registry", "registry data dir path")
 	fs.IntVar(&opts.registryPullMaxPullProcs, "max-pull-procs", 5, "maximum number of goroutines for pulling")
 }
 

--- a/pkg/registry/commands/password.go
+++ b/pkg/registry/commands/password.go
@@ -37,6 +37,7 @@ func NewRegistryPasswdCmd() *cobra.Command {
 				return err
 			}
 			if cluster == nil {
+				logger.Error("registry passwd apply error: cluster is nil")
 				return nil
 			}
 			if err := flagsResults.Apply(cluster); err != nil {

--- a/pkg/registry/commands/save.go
+++ b/pkg/registry/commands/save.go
@@ -38,6 +38,9 @@ func NewRegistryImageSaveCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "save",
 		Short: "save images to local registry dir",
+		Example: `
+sealctl registry save --registry-dir=/tmp/registry .
+sealctl registry save --registry-dir=/tmp/registry --images=docker.io/library/busybox:latest`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			is := registry.NewImageSaver(context.Background(), flagsResults.registryPullMaxPullProcs, auth)
 			outImages, err := is.SaveImages(images, flagsResults.registryPullRegistryDir, v1.Platform{OS: "linux", Architecture: flagsResults.registryPullArch})
@@ -48,7 +51,7 @@ func NewRegistryImageSaveCmd() *cobra.Command {
 			return nil
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 || len(flagsResults.images) == 0 {
+			if len(args) == 0 && len(flagsResults.images) == 0 {
 				return errors.New("'--images' and args cannot be empty at the same time")
 			}
 			var err error

--- a/pkg/registry/password/apply.go
+++ b/pkg/registry/password/apply.go
@@ -24,7 +24,6 @@ import (
 	"github.com/labring/sealos/pkg/clusterfile"
 
 	"github.com/modood/table"
-	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"github.com/labring/sealos/pkg/constants"
@@ -52,8 +51,6 @@ func (r *RegistryPasswdResults) RegisterFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&r.ClusterName, "cluster-name", "c", "default", "cluster name")
 	fs.StringVarP(&r.HtpasswdPath, "htpasswd-path", "p", "/etc/registry/registry_htpasswd", "registry passwd file path")
 	fs.StringVarP(&r.ImageCRIShimFilePath, "cri-shim-file-path", "f", "/etc/image-cri-shim.yaml", "image cri shim file path,if empty will not update image cri shim file")
-	_ = cobra.MarkFlagRequired(fs, "cluster-name")
-	_ = cobra.MarkFlagRequired(fs, "htpasswd-path")
 }
 
 type confirmPrint struct {
@@ -63,6 +60,12 @@ type confirmPrint struct {
 }
 
 func (r *RegistryPasswdResults) Validate() (*v1beta1.Cluster, error) {
+	if r.ClusterName == "" {
+		return nil, errors.New("cluster name is empty")
+	}
+	if r.HtpasswdPath == "" {
+		return nil, errors.New("htpasswd path is empty")
+	}
 	clusterPath := constants.Clusterfile(r.ClusterName)
 	if !fileutil.IsExist(clusterPath) {
 		logger.Warn("cluster %s not exist", r.ClusterName)


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6b95139</samp>

### Summary
🚚🐛📝

<!--
1.  🚚 This emoji means "moving" or "renaming" and can be used to indicate the change of the flag name from `--data-dir` to `--registry-dir`.
2. 🐛 This emoji means "bug" or "fixing" and can be used to indicate the addition of the error log message to handle the nil cluster case.
3. 📝 This emoji means "writing" or "documenting" and can be used to indicate the various improvements and updates to the documentation of the command.
-->
This pull request enhances the `registry save` command and its documentation, as well as the related `buildimage` and `password` packages. It fixes some bugs, simplifies some logic, and improves the clarity and consistency of the code and the docs. It also renames the `--data-dir` flag to `--registry-dir` in `registry save`.

> _The `registry save` command got a makeover_
> _With better docs, flags, and error cover_
> _The `buildimage` package_
> _Got some logging and format baggage_
> _And the `password` package removed some leftover_

### Walkthrough
*  Simplify and update the `registry save` command and its documentation ([link](https://github.com/labring/sealos/pull/3124/files?diff=unified&w=0#diff-e8d2464bcc4183467efc22c216ce00f9f3d4a352086cc9362b1fabc27809c9fbL164-R170), [link](https://github.com/labring/sealos/pull/3124/files?diff=unified&w=0#diff-e8d2464bcc4183467efc22c216ce00f9f3d4a352086cc9362b1fabc27809c9fbL180-R188), [link](https://github.com/labring/sealos/pull/3124/files?diff=unified&w=0#diff-e8d2464bcc4183467efc22c216ce00f9f3d4a352086cc9362b1fabc27809c9fbL201-R200), [link](https://github.com/labring/sealos/pull/3124/files?diff=unified&w=0#diff-0e749b6ee01102a3b27fff69bc7712865829336f0f9aefd67ba5ca7f6b452881L170-R176), [link](https://github.com/labring/sealos/pull/3124/files?diff=unified&w=0#diff-0e749b6ee01102a3b27fff69bc7712865829336f0f9aefd67ba5ca7f6b452881L186-R194), [link](https://github.com/labring/sealos/pull/3124/files?diff=unified&w=0#diff-0e749b6ee01102a3b27fff69bc7712865829336f0f9aefd67ba5ca7f6b452881L207-R205), [link](https://github.com/labring/sealos/pull/3124/files?diff=unified&w=0#diff-55f375c2b976f6fc3bedd745cf7de02ecaf5c2736370ddd702465993a368a9d2L40-R40), [link](https://github.com/labring/sealos/pull/3124/files?diff=unified&w=0#diff-40842ce77ff674f441713045ba15b361515aef3c96aaa33e0d1f66e203b5ef1aR41-R43), [link](https://github.com/labring/sealos/pull/3124/files?diff=unified&w=0#diff-40842ce77ff674f441713045ba15b361515aef3c96aaa33e0d1f66e203b5ef1aL51-R54))
* Add error and debug log messages to the `buildimage` and `registry` packages ([link](https://github.com/labring/sealos/pull/3124/files?diff=unified&w=0#diff-130eebefef11b9208b2b0b1d90fdd824ad6420e163a3b6e7cf4e0805d2ceecfdR79), [link](https://github.com/labring/sealos/pull/3124/files?diff=unified&w=0#diff-dc5736c40a26b9df1dfaaeac9ef8829f1aab9be01ae56db00e57b89f6b992592R40), [link](https://github.com/labring/sealos/pull/3124/files?diff=unified&w=0#diff-a359b5dc4fd98c18922db1e0ffd551ae0021d9f6a51b220e7b36d345c40b3b94R63-R68))
* Remove unused and unnecessary code from the `buildimage` and `password` packages ([link](https://github.com/labring/sealos/pull/3124/files?diff=unified&w=0#diff-130eebefef11b9208b2b0b1d90fdd824ad6420e163a3b6e7cf4e0805d2ceecfdL113), [link](https://github.com/labring/sealos/pull/3124/files?diff=unified&w=0#diff-a359b5dc4fd98c18922db1e0ffd551ae0021d9f6a51b220e7b36d345c40b3b94L27), [link](https://github.com/labring/sealos/pull/3124/files?diff=unified&w=0#diff-a359b5dc4fd98c18922db1e0ffd551ae0021d9f6a51b220e7b36d345c40b3b94L55-L56))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
