### PR TITLE
feat: more apps and hover ball

### DIFF
--- a/frontend/desktop/src/components/app_window/index.module.scss
+++ b/frontend/desktop/src/components/app_window/index.module.scss
@@ -40,10 +40,10 @@
   }
 
   &[data-size='minimize'] {
-    left: 20%;
-    height: 80%;
-    width: 60%;
-    top: calc(100% + 10px);
+    left: 50%;
+    height: 0px;
+    width: 0px;
+    top: 90%;
     transform: scale(0.6);
     transform-origin: bottom;
     opacity: 0;

--- a/frontend/desktop/src/components/app_window/index.module.scss
+++ b/frontend/desktop/src/components/app_window/index.module.scss
@@ -13,7 +13,7 @@
   width: 100%;
   height: 100%;
   border-radius: 6px;
-  transition: all cubic-bezier(0.85, 0.14, 0.14, 0.85) 250ms;
+  transition: all cubic-bezier(0.85, 0.14, 0.14, 0.85) 150ms;
   transform-origin: center;
   display: flex;
   flex-direction: column;
@@ -40,11 +40,11 @@
   }
 
   &[data-size='minimize'] {
-    left: 50%;
-    height: 0px;
-    width: 0px;
-    top: 90%;
-    transform: scale(0.6);
+    top: 10%;
+    left: 20%;
+    width: 60%;
+    height: 80%;
+    transform: scale(0.1) translate(0, 0) !important;
     transform-origin: bottom;
     opacity: 0;
     pointer-events: none;

--- a/frontend/desktop/src/components/desktop_content/index.module.scss
+++ b/frontend/desktop/src/components/desktop_content/index.module.scss
@@ -2,6 +2,7 @@
   position: relative;
   width: 100%;
   height: 100%;
+  overflow: hidden;
 }
 
 .iframeContainer {

--- a/frontend/desktop/src/components/desktop_content/index.tsx
+++ b/frontend/desktop/src/components/desktop_content/index.tsx
@@ -18,6 +18,7 @@ const UserMenu = dynamic(() => import('@/components/user_menu'), {
 
 export default function DesktopContent(props: any) {
   const { installedApps: apps, runningInfo, openApp, setToHighestLayerById } = useAppStore();
+  const renderApps = apps.filter((item: TApp) => item?.displayType === 'normal');
   const [maxItems, setMaxItems] = useState(10);
   const handleDoubleClick = (e: MouseEvent<HTMLDivElement>, item: TApp) => {
     e.preventDefault();
@@ -77,8 +78,8 @@ export default function DesktopContent(props: any) {
           templateColumns={'repeat(5, 72px)'}
           gap={'36px'}
         >
-          {apps &&
-            apps.slice(0, maxItems).map((item: TApp, index) => (
+          {renderApps &&
+            renderApps.slice(0, maxItems).map((item: TApp, index) => (
               <GridItem
                 w="72px"
                 h="100px"

--- a/frontend/desktop/src/components/desktop_content/index.tsx
+++ b/frontend/desktop/src/components/desktop_content/index.tsx
@@ -4,7 +4,7 @@ import useAppStore from '@/stores/app';
 import { TApp } from '@/types';
 import { Box, Flex, Grid, GridItem, Image, Text } from '@chakra-ui/react';
 import dynamic from 'next/dynamic';
-import { MouseEvent, useCallback, useEffect } from 'react';
+import { MouseEvent, useCallback, useEffect, useState } from 'react';
 import { createMasterAPP, masterApp } from 'sealos-desktop-sdk/master';
 import IframeWindow from './iframe_window';
 import styles from './index.module.scss';
@@ -18,7 +18,7 @@ const UserMenu = dynamic(() => import('@/components/user_menu'), {
 
 export default function DesktopContent(props: any) {
   const { installedApps: apps, runningInfo, openApp, setToHighestLayerById } = useAppStore();
-
+  const [maxItems, setMaxItems] = useState(10);
   const handleDoubleClick = (e: MouseEvent<HTMLDivElement>, item: TApp) => {
     e.preventDefault();
     if (item?.name) {
@@ -78,7 +78,7 @@ export default function DesktopContent(props: any) {
           gap={'36px'}
         >
           {apps &&
-            apps.map((item: TApp, index) => (
+            apps.slice(0, maxItems).map((item: TApp, index) => (
               <GridItem
                 w="72px"
                 h="100px"

--- a/frontend/desktop/src/components/floating_button/index.tsx
+++ b/frontend/desktop/src/components/floating_button/index.tsx
@@ -122,6 +122,14 @@ export default function Index(props: any) {
           id="floatButtonNav"
           className={clsx(styles.container, dragging ? styles.notrans : '')}
           data-open={isOpen}
+          onMouseEnter={(e) => {
+            if (suction !== Suction.None) return;
+            onOpen();
+          }}
+          onMouseLeave={(e) => {
+            if (suction !== Suction.None) return;
+            onClose();
+          }}
         >
           <div
             className={clsx(styles.floatBtn, dragging ? styles.notrans : '')}

--- a/frontend/desktop/src/components/layout/index.module.scss
+++ b/frontend/desktop/src/components/layout/index.module.scss
@@ -1,5 +1,6 @@
 .desktopContainer {
+  position: relative;
   width: 100vw;
   height: 100vh;
-  position: relative;
+  overflow: hidden;
 }

--- a/frontend/desktop/src/components/layout/index.tsx
+++ b/frontend/desktop/src/components/layout/index.tsx
@@ -3,12 +3,18 @@ import DesktopContent from '@/components/desktop_content';
 import FloatButton from '@/components/floating_button';
 import useAppStore from '@/stores/app';
 import Head from 'next/head';
-import { useEffect } from 'react';
+import { createContext, useEffect, useState } from 'react';
 import styles from './index.module.scss';
+import MoreApps from '@/components/more_apps';
+interface IMoreAppsContext {
+  showMoreApps: boolean;
+  setShowMoreApps: (value: boolean) => void;
+}
+export const MoreAppsContext = createContext<IMoreAppsContext | null>(null);
 
 export default function Layout(props: any) {
   const { init } = useAppStore((state) => state);
-
+  const [showMoreApps, setShowMoreApps] = useState(false);
   useEffect(() => {
     (async () => {
       // Initialize, get user information, install application information, etc.
@@ -22,11 +28,14 @@ export default function Layout(props: any) {
         <title>sealos Cloud</title>
         <meta name="description" content="sealos cloud dashboard" />
       </Head>
-      <div className={styles.desktopContainer}>
-        <Background />
-        <DesktopContent />
-        <FloatButton />
-      </div>
+      <MoreAppsContext.Provider value={{ showMoreApps, setShowMoreApps }}>
+        <div className={styles.desktopContainer}>
+          <Background />
+          <DesktopContent />
+          <FloatButton />
+          <MoreApps />
+        </div>
+      </MoreAppsContext.Provider>
     </>
   );
 }

--- a/frontend/desktop/src/components/more_apps/index.module.scss
+++ b/frontend/desktop/src/components/more_apps/index.module.scss
@@ -1,0 +1,44 @@
+.container {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 88px 52px 48px 52px;
+  backdrop-filter: blur(150px);
+  transition: all 0.5s cubic-bezier(0.39, 0.575, 0.565, 1);
+
+  &[data-show='true'] {
+    visibility: visible;
+    opacity: 1;
+  }
+
+  &[data-show='false'] {
+    opacity: 0;
+    visibility: hidden;
+    z-index: -5;
+    transform: scale(0.1);
+  }
+}
+
+.appsContainer {
+  grid-column-gap: 126px;
+  grid-row-gap: 48px;
+}
+@media screen and (max-width: 1200px) {
+  .appsContainer {
+    grid-column-gap: 50px;
+    grid-row-gap: 48px;
+  }
+}
+
+@media screen and (max-width: 778px) {
+  .appsContainer {
+    grid-column-gap: 20px;
+    grid-row-gap: 48px;
+  }
+  .container {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}

--- a/frontend/desktop/src/components/more_apps/index.tsx
+++ b/frontend/desktop/src/components/more_apps/index.tsx
@@ -1,0 +1,159 @@
+import { Box, Flex, Grid, GridItem, Text, Image } from '@chakra-ui/react';
+import { useContext, MouseEvent, useState } from 'react';
+import { MoreAppsContext } from '@/components/layout';
+import useAppStore from '@/stores/app';
+import { TApp } from '@/types';
+import Iconfont from '../iconfont';
+import styles from './index.module.scss';
+import clsx from 'clsx';
+
+export default function Index() {
+  const moreAppsContent = useContext(MoreAppsContext);
+  const { installedApps: apps, runningInfo, openApp, setToHighestLayerById } = useAppStore();
+  const itemsPerPage = 30; // Number of apps per page
+  const [currentPage, setCurrentPage] = useState(1);
+  const startIndex = (currentPage - 1) * itemsPerPage;
+  const endIndex = startIndex + itemsPerPage;
+  const paginatedApps = apps?.slice(startIndex, endIndex);
+  const totalPages = Math.ceil((apps?.length || 0) / itemsPerPage);
+
+  const handleDoubleClick = (e: MouseEvent<HTMLDivElement>, item: TApp) => {
+    e.preventDefault();
+    if (item?.name) {
+      openApp(item);
+    }
+  };
+
+  return (
+    <Box
+      data-show={moreAppsContent?.showMoreApps}
+      className={clsx(styles.container)}
+      onClick={() => {
+        moreAppsContent?.setShowMoreApps(false);
+      }}
+    >
+      <Flex justifyContent={'center'}>
+        <Text
+          fontWeight={500}
+          fontSize={'24px'}
+          color={'#FFFFFF'}
+          textShadow={'0px 1px 2px rgba(0, 0, 0, 0.4)'}
+          lineHeight={'140%'}
+        >
+          更多应用
+        </Text>
+      </Flex>
+      <Flex alignItems={'center'}>
+        <Flex
+          alignItems={'center'}
+          justifyContent={'center'}
+          w="60px"
+          h="60px"
+          borderRadius={'50%'}
+          cursor={'pointer'}
+          _hover={{
+            background: 'rgba(255, 255, 255, 0.3)'
+          }}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (currentPage <= 1) return;
+            console.log(1);
+            setCurrentPage((state) => state - 1);
+          }}
+        >
+          <Iconfont
+            iconName="icon-more-right"
+            width={24}
+            height={24}
+            color={currentPage === 1 ? '#9cc2d1' : '#FFFFFF'}
+          ></Iconfont>
+        </Flex>
+        <Grid
+          className={styles.appsContainer}
+          mt="68px"
+          maxW={'868px'}
+          mx="auto"
+          templateRows={'repeat(2, 100px)'}
+          templateColumns={'repeat(5, 72px)'}
+        >
+          {paginatedApps &&
+            paginatedApps.map((item: TApp, index) => (
+              <GridItem
+                w="72px"
+                h="100px"
+                key={index}
+                userSelect="none"
+                cursor={'pointer'}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleDoubleClick(e, item);
+                }}
+              >
+                <Box
+                  w="72px"
+                  h="72px"
+                  p={'15px'}
+                  border={'1px solid #FFFFFF'}
+                  borderRadius={8}
+                  boxShadow={'0px 1.16667px 2.33333px rgba(0, 0, 0, 0.2)'}
+                  backgroundColor={'rgba(244, 246, 248, 0.9)'}
+                >
+                  <Image
+                    width="100%"
+                    height="100%"
+                    src={item?.icon}
+                    fallbackSrc="/images/sealos.svg"
+                    alt="user avator"
+                  />
+                </Box>
+                <Text
+                  textShadow={'0px 1px 2px rgba(0, 0, 0, 0.4)'}
+                  textAlign={'center'}
+                  mt="8px"
+                  color={'#FFFFFF'}
+                  fontSize={'10px'}
+                  lineHeight={'16px'}
+                >
+                  {item?.name}
+                </Text>
+              </GridItem>
+            ))}
+        </Grid>
+        <Flex
+          alignItems={'center'}
+          justifyContent={'center'}
+          w="60px"
+          h="60px"
+          borderRadius={'50%'}
+          _hover={{
+            background: 'rgba(255, 255, 255, 0.3)'
+          }}
+          cursor={'pointer'}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (currentPage >= totalPages) return;
+            console.log(1);
+            setCurrentPage((state) => state + 1);
+          }}
+        >
+          <Iconfont
+            iconName="icon-more-left"
+            width={24}
+            height={24}
+            color={currentPage === totalPages ? '#9cc2d1' : '#FFFFFF'}
+          ></Iconfont>
+        </Flex>
+      </Flex>
+      <Flex
+        justifyContent={'center'}
+        position={'absolute'}
+        bottom={'48px'}
+        left={'50%'}
+        transform={' translateX(-50%)'}
+      >
+        <Text color={'#FFFFFF'}>{currentPage}</Text>
+        <Text color={'#b8d5e1'}>&nbsp;/&nbsp;{totalPages}</Text>
+      </Flex>
+    </Box>
+  );
+}

--- a/frontend/desktop/src/components/more_button/index.tsx
+++ b/frontend/desktop/src/components/more_button/index.tsx
@@ -1,9 +1,15 @@
-import { Flex, Text, Box } from '@chakra-ui/react';
+import { MoreAppsContext } from '@/components/layout';
+import { Box, Flex, Text } from '@chakra-ui/react';
+import { useContext } from 'react';
 import Iconfont from '../iconfont';
-
 export default function Index() {
+  const moreAppsContent = useContext(MoreAppsContext);
   return (
     <Flex
+      onClick={() => {
+        moreAppsContent?.setShowMoreApps(true);
+      }}
+      cursor={'pointer'}
       justifyContent={'center'}
       alignItems={'center'}
       w="110px"
@@ -13,6 +19,7 @@ export default function Index() {
       position={'absolute'}
       bottom={'80px'}
       borderRadius={'8px'}
+      userSelect={'none'}
     >
       <Box pt={'1px'} pr={'6px'}>
         <Iconfont iconName="icon-apps" width={20} height={20} color="#ffffff"></Iconfont>

--- a/frontend/desktop/src/pages/api/desktop/getInstalledApps.ts
+++ b/frontend/desktop/src/pages/api/desktop/getInstalledApps.ts
@@ -3,6 +3,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { authSession } from '@/services/backend/auth';
 import { GetUserDefaultNameSpace, K8sApi, ListCRD } from '../../../services/backend/kubernetes';
 import { jsonRes } from '@/services/backend/response';
+import { TApp } from '@/types';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
@@ -36,10 +37,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     });
     //@ts-ignore
     const userArr = userResult?.body?.items.map((item: any) => {
-      return { key: `user-${item.metadata.name}`, ...item.spec };
+      return { key: `user-${item.metadata.name}`, ...item.spec, displayType: 'normal' };
     });
 
-    let apps = [...defaultArr, ...userArr];
+    let apps = [...defaultArr, ...userArr].filter((item: TApp) => item.displayType !== 'hidden');
 
     jsonRes(res, { data: apps });
   } catch (err) {

--- a/frontend/desktop/src/stores/app.ts
+++ b/frontend/desktop/src/stores/app.ts
@@ -31,6 +31,7 @@ export class AppInfo {
     helpDropDown: boolean;
     helpDocs: boolean | string;
   };
+  displayType: 'normal' | 'hidden' | 'more ';
   constructor(app: TApp, pid: number) {
     this.isShow = false;
     this.zIndex = 1;
@@ -47,6 +48,7 @@ export class AppInfo {
     this.name = app.name;
     this.key = app.key;
     this.pid = pid;
+    this.displayType = app.displayType;
   }
 }
 

--- a/frontend/desktop/src/types/app.ts
+++ b/frontend/desktop/src/types/app.ts
@@ -46,6 +46,7 @@ export type TAppConfig = {
     helpDropDown: boolean;
     helpDocs: boolean | string;
   };
+  displayType: 'normal' | 'hidden' | 'more ';
 };
 
 export type TApp = TAppConfig & TAppFront & { pid: number };


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0866be1</samp>

### Summary
:sparkles::lipstick::zap:

<!--
1.  :sparkles: This emoji represents the addition of a new feature or enhancement to the existing functionality. In this case, the more apps component is a new feature that allows users to access more apps from a pop-up component.
2.  :lipstick: This emoji represents the improvement or update of the UI or style files. In this case, the CSS properties of the app window element, the desktop content element, and the desktop container element are changed to improve the appearance and behavior of the UI elements. The CSS module for the more apps component is also created and contains the styles for the component.
3.  :zap: This emoji represents the improvement or update of the performance or speed. In this case, the state variable that limits the number of apps displayed on the desktop and filters out some apps based on their keys improves the performance and usability of the desktop component.
-->
This pull request adds a new feature to the frontend that allows users to access more apps from a pop-up component on the desktop. It also improves the performance and usability of the desktop component by limiting and filtering the number of apps displayed, hiding the minimized app windows, and adding mouse hover events to the floating button. It modifies the files `frontend/desktop/src/components/desktop_content/index.tsx`, `frontend/desktop/src/components/layout/index.tsx`, `frontend/desktop/src/components/more_button/index.tsx`, `frontend/desktop/src/components/app_window/index.module.scss`, `frontend/desktop/src/components/desktop_content/index.module.scss`, `frontend/desktop/src/components/floating_button/index.tsx`, `frontend/desktop/src/components/layout/index.module.scss`, and creates the files `frontend/desktop/src/components/more_apps/index.module.scss` and `frontend/desktop/src/components/more_apps/index.tsx`.

> _Sing, O Muse, of the skillful coder who devised_
> _A wondrous feature for the frontend layout of his app,_
> _That users might access more apps from a pop-up grid_
> _With ease and joy, as Zeus commands the thunderclap._

### Walkthrough
*  Add more apps feature to show paginated apps grid when more button is clicked or floating button is hovered over ([link](https://github.com/labring/sealos/pull/3126/files?diff=unified&w=0#diff-4ae759586b8ce6e86c0d3949c7e588f4dcfd84aa3232cf567704c324c85196abL6-R17), [link](https://github.com/labring/sealos/pull/3126/files?diff=unified&w=0#diff-4ae759586b8ce6e86c0d3949c7e588f4dcfd84aa3232cf567704c324c85196abL25-R38), [link](https://github.com/labring/sealos/pull/3126/files?diff=unified&w=0#diff-942cf93ff546b74643d32be5bdb582b156157a33ace9bb5bf07ca080c1336c60R1-R159), [link](https://github.com/labring/sealos/pull/3126/files?diff=unified&w=0#diff-322ecb0d4c3fbb372838a948e5d24b716b5ec69c8b50fcf308b74fba2f468bb3L1-R12), [link](https://github.com/labring/sealos/pull/3126/files?diff=unified&w=0#diff-322ecb0d4c3fbb372838a948e5d24b716b5ec69c8b50fcf308b74fba2f468bb3R22), [link](https://github.com/labring/sealos/pull/3126/files?diff=unified&w=0#diff-8196135e2362a94ba0b40f0513694fea50da4a2c03feefac99ab2055a224faf6R125-R132))
*  Hide app windows when they are minimized instead of showing them at the bottom of the screen ([link](https://github.com/labring/sealos/pull/3126/files?diff=unified&w=0#diff-64502e6ad437dbedbb812459d8495a26ec2e04d70664faaebe52ab5b57b1929dL43-R46))
*  Prevent app windows from overflowing the desktop container when they are resized or dragged by adding `overflow: hidden` property to the desktop content and layout elements ([link](https://github.com/labring/sealos/pull/3126/files?diff=unified&w=0#diff-1c97516be681b4b519dd710aeef7467a16137b8b4b35820155ec82d0b929754cR5), [link](https://github.com/labring/sealos/pull/3126/files?diff=unified&w=0#diff-ae164d3e3a847d43f1b3a7756591b16f51c07b8f819bd790c99e14a319a076c9L2-R5))
*  Limit the number of apps to render on the desktop based on a state variable and filter out the apps that should not be rendered ([link](https://github.com/labring/sealos/pull/3126/files?diff=unified&w=0#diff-6eec7bb4fac557f6da1a4c82880637cbb656e3b08ab0b2adcc12d6d9777aa028L7-R7), [link](https://github.com/labring/sealos/pull/3126/files?diff=unified&w=0#diff-6eec7bb4fac557f6da1a4c82880637cbb656e3b08ab0b2adcc12d6d9777aa028L21-R23), [link](https://github.com/labring/sealos/pull/3126/files?diff=unified&w=0#diff-6eec7bb4fac557f6da1a4c82880637cbb656e3b08ab0b2adcc12d6d9777aa028L80-R83))
*  Add transitions, visibility, opacity, grid gaps, and media queries to the more apps component styles in `frontend/desktop/src/components/more_apps/index.module.scss` ([link](https://github.com/labring/sealos/pull/3126/files?diff=unified&w=0#diff-7cb46b489f9c9f7ca96b8880ceb56edb9cdfb0a1599a30c8b62371be5fc4fd8dR1-R44))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
