### PR TITLE
Add type status hide/show system app.

### DIFF
--- a/controllers/app/api/v1/app_types.go
+++ b/controllers/app/api/v1/app_types.go
@@ -51,7 +51,7 @@ const (
 
 // AppStatus defines the observed state of App
 type AppStatus struct {
-	//+kubebuilder:validation:Enum={ normal, more, hidden }
+	//+kubebuilder:validation:Enum={ normal, more, hidden, }
 	//+kubebuilder:validation:Optional
 	DisplayStatus DisplayStatusType `json:"displayStatus,omitempty"`
 }

--- a/controllers/app/api/v1/app_types.go
+++ b/controllers/app/api/v1/app_types.go
@@ -40,8 +40,20 @@ type AppSpec struct {
 	MenuData MenuData `json:"menuData,omitempty"`
 }
 
+type DisplayStatusType string
+
+// data types
+const (
+	DisplayStatusNormal DisplayStatusType = "normal"
+	DisplayStatusMore   DisplayStatusType = "more"
+	DisplayStatusHidden DisplayStatusType = "hidden"
+)
+
 // AppStatus defines the observed state of App
 type AppStatus struct {
+	//+kubebuilder:validation:Enum={ normal, more, hidden }
+	//+kubebuilder:validation:Optional
+	DisplayStatus DisplayStatusType `json:"displayStatus,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/controllers/app/config/crd/bases/app.sealos.io_apps.yaml
+++ b/controllers/app/config/crd/bases/app.sealos.io_apps.yaml
@@ -60,6 +60,13 @@ spec:
             type: object
           status:
             description: AppStatus defines the observed state of App
+            properties:
+              displayStatus:
+                enum:
+                - normal
+                - more
+                - ""
+                type: string
             type: object
         type: object
     served: true

--- a/controllers/app/config/crd/bases/app.sealos.io_apps.yaml
+++ b/controllers/app/config/crd/bases/app.sealos.io_apps.yaml
@@ -65,7 +65,7 @@ spec:
                 enum:
                 - normal
                 - more
-                - ""
+                - hidden
                 type: string
             type: object
         type: object


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c509e2e</samp>

### Summary
:sparkles::wrench::hammer:

<!--
1.  :sparkles: This emoji represents the addition of a new feature or enhancement, which is the new `displayStatus` field for the `AppStatus` struct.
2.  :wrench: This emoji represents the modification or update of an existing feature or functionality, which is the CRD schema for the `App` resource.
3.  :hammer: This emoji represents the building or generation of a project component, which is the CRD manifest file that is produced by running `make manifests`.
-->
This pull request adds a new optional field `displayStatus` to the `AppStatus` struct and the `App` CRD, which allows controlling how apps are displayed in the sealos dashboard.

> _`AppStatus` has_
> _a new field for display_
> _optional, `more` or `less`_

### Walkthrough
* Add a new optional field `displayStatus` to the `AppStatus` struct to represent the display status of an app in the sealos dashboard ([link](https://github.com/labring/sealos/pull/3127/files?diff=unified&w=0#diff-acb4f8c70b8c1d94cdd3eb454815074886893350eed3af3a2276ccdf0a5ed64bL43-R56))
* Validate the `displayStatus` field with kubebuilder annotations and generate the corresponding CRD schema in `app_types.go` ([link](https://github.com/labring/sealos/pull/3127/files?diff=unified&w=0#diff-acb4f8c70b8c1d94cdd3eb454815074886893350eed3af3a2276ccdf0a5ed64bL43-R56))
* Update the CRD schema for the `App` resource in `bases/app.sealos.io_apps.yaml` to include the new `displayStatus` field and its possible values ([link](https://github.com/labring/sealos/pull/3127/files?diff=unified&w=0#diff-9588b92788f59aaac8aa7fc6af0a3101e5741635fdcb61ec8bd5f5d42745a95aR63-R69))

