### PR TITLE
Move apps.displayType to spec.

### DIFF
--- a/controllers/app/api/v1/app_types.go
+++ b/controllers/app/api/v1/app_types.go
@@ -51,7 +51,7 @@ const (
 
 // AppStatus defines the observed state of App
 type AppStatus struct {
-	//+kubebuilder:validation:Enum={ normal, more, hidden }
+	//+kubebuilder:validation:Enum={ normal, more, hidden, }
 	//+kubebuilder:validation:Optional
 	DisplayStatus DisplayStatusType `json:"displayStatus,omitempty"`
 }

--- a/controllers/app/api/v1/app_types.go
+++ b/controllers/app/api/v1/app_types.go
@@ -40,8 +40,20 @@ type AppSpec struct {
 	MenuData MenuData `json:"menuData,omitempty"`
 }
 
+type DisplayStatusType string
+
+// data types
+const (
+	DisplayStatusNormal DisplayStatusType = "normal"
+	DisplayStatusMore   DisplayStatusType = "more"
+	DisplayStatusHidden DisplayStatusType = "hidden"
+)
+
 // AppStatus defines the observed state of App
 type AppStatus struct {
+	//+kubebuilder:validation:Enum={ normal, more, hidden }
+	//+kubebuilder:validation:Optional
+	DisplayStatus DisplayStatusType `json:"displayStatus,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/controllers/app/api/v1/app_types.go
+++ b/controllers/app/api/v1/app_types.go
@@ -31,29 +31,31 @@ type MenuData struct {
 	HelpDocs     string `json:"helpDocs,omitempty"`
 }
 
+type DisplayType string
+
+// data types
+const (
+	DisplayNormal DisplayType = "normal"
+	DisplayMore   DisplayType = "more"
+	DisplayHidden DisplayType = "hidden"
+)
+
 // AppSpec defines the desired state of App
 type AppSpec struct {
-	Name     string   `json:"name,omitempty"`
-	Icon     string   `json:"icon,omitempty"`
-	Type     string   `json:"type,omitempty"`
+	Name string `json:"name,omitempty"`
+	Icon string `json:"icon,omitempty"`
+	Type string `json:"type,omitempty"`
+
+	//+kubebuilder:validation:Enum={ normal, more, hidden, }
+	//+kubebuilder:validation:Optional
+	DisplayType DisplayType `json:"displayType,omitempty"`
+
 	Data     Data     `json:"data,omitempty"`
 	MenuData MenuData `json:"menuData,omitempty"`
 }
 
-type DisplayStatusType string
-
-// data types
-const (
-	DisplayStatusNormal DisplayStatusType = "normal"
-	DisplayStatusMore   DisplayStatusType = "more"
-	DisplayStatusHidden DisplayStatusType = "hidden"
-)
-
 // AppStatus defines the observed state of App
 type AppStatus struct {
-	//+kubebuilder:validation:Enum={ normal, more, hidden, }
-	//+kubebuilder:validation:Optional
-	DisplayStatus DisplayStatusType `json:"displayStatus,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/controllers/app/config/crd/bases/app.sealos.io_apps.yaml
+++ b/controllers/app/config/crd/bases/app.sealos.io_apps.yaml
@@ -60,6 +60,13 @@ spec:
             type: object
           status:
             description: AppStatus defines the observed state of App
+            properties:
+              displayStatus:
+                enum:
+                - normal
+                - more
+                - ""
+                type: string
             type: object
         type: object
     served: true

--- a/controllers/app/config/crd/bases/app.sealos.io_apps.yaml
+++ b/controllers/app/config/crd/bases/app.sealos.io_apps.yaml
@@ -42,6 +42,12 @@ spec:
                   url:
                     type: string
                 type: object
+              displayType:
+                enum:
+                - normal
+                - more
+                - hidden
+                type: string
               icon:
                 type: string
               menuData:
@@ -60,13 +66,6 @@ spec:
             type: object
           status:
             description: AppStatus defines the observed state of App
-            properties:
-              displayStatus:
-                enum:
-                - normal
-                - more
-                - hidden
-                type: string
             type: object
         type: object
     served: true

--- a/controllers/app/config/crd/bases/app.sealos.io_apps.yaml
+++ b/controllers/app/config/crd/bases/app.sealos.io_apps.yaml
@@ -65,7 +65,7 @@ spec:
                 enum:
                 - normal
                 - more
-                - ""
+                - hidden
                 type: string
             type: object
         type: object


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 687d2b7</samp>

### Summary
🆕🎛️📄

<!--
1.  🆕 - This emoji represents the addition of a new field or feature, and can be used to highlight the `DisplayType` field in the `AppSpec` struct.
2.  🎛️ - This emoji represents a setting or configuration option, and can be used to highlight the `displayType` property in the CRD, which allows users to adjust how the App is displayed in the UI.
3.  📄 - This emoji represents a document or file, and can be used to highlight the CRD itself, which defines the schema and validation of the App resource.
-->
This pull request adds a new `DisplayType` field to the `AppSpec` struct and the corresponding CRD for the App resource. This field allows users to control how the App is displayed in the UI.

> _`AppSpec` has new field_
> _`DisplayType` for the UI_
> _Winter of choices_

### Walkthrough
*  Add `DisplayType` field to `AppSpec` struct to control UI display ([link](https://github.com/labring/sealos/pull/3133/files?diff=unified&w=0#diff-acb4f8c70b8c1d94cdd3eb454815074886893350eed3af3a2276ccdf0a5ed64bL34-R52))
*  Update CRD for App resource to include `displayType` property and enum values ([link](https://github.com/labring/sealos/pull/3133/files?diff=unified&w=0#diff-9588b92788f59aaac8aa7fc6af0a3101e5741635fdcb61ec8bd5f5d42745a95aR45-R50))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
