### PR TITLE
feat: add max limit in podline chart

### DIFF
--- a/frontend/providers/applaunchpad/src/components/PodLineChart/index.tsx
+++ b/frontend/providers/applaunchpad/src/components/PodLineChart/index.tsx
@@ -38,6 +38,7 @@ const PodLineChart = ({
         global: false // 缺省为 false
       },
       lineColor: '#36ADEF',
+      max: 100,
       formatter: (e: any[]) => `${((e[0].value / cpu) * 100).toFixed(2)}%`
     },
     memory: {
@@ -82,6 +83,7 @@ const PodLineChart = ({
         global: false // 缺省为 false
       },
       lineColor: '#00A9A6',
+      max: 100,
       formatter: (e: any[]) => `${((e[0].value / cpu) * 100).toFixed(2)}%`
     },
     deepBlue: {
@@ -118,7 +120,8 @@ const PodLineChart = ({
     yAxis: {
       type: 'value',
       show: false,
-      boundaryGap: false
+      boundaryGap: false,
+      max: map[type].max
     },
     grid: {
       show: false,


### PR DESCRIPTION
Add max limit for cpu because cpu has limit(100%)

Its useful to found which service is busy

## Preview

before:
![image](https://github.com/labring/sealos/assets/6964737/d8ae57a7-c0d4-46fd-9571-61f25aaf6724)

after:
![image](https://github.com/labring/sealos/assets/6964737/d5ca61fb-a085-46f7-8243-3b6f3f633450)

## Test plan

Seriously, I didn't test this feature on a real local environment. Because it's too much trouble for frontend development (some style adjustments).

Because my changes are limited to a fixed file on the front end, I use the overrides function of chrome to directly modify the file that loads js, and it seems that there is no problem. If you are worried, you can test it again.


## Another problem

- I have no idea add memory limit, maybe we should append `max` into props and get external incoming? 
- Some value cannot found different, maybe we should hide/not render zero value? because its means nothing.

## Reference

https://echarts.apache.org/en/option.html#yAxis.max

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 39cd714</samp>

### Summary
📈🎛️📊

<!--
1.  📈 This emoji represents the scaling or adjustment of the y-axis values for the charts, as well as the improvement in accuracy and readability of the data.
2.  🎛️ This emoji represents the component or element that is being modified, which is the `PodLineChart` that displays the pod usage charts.
3.  📊 This emoji represents the type of data or visualization that is being affected, which is the charts or graphs that show the pod usage metrics.
-->
This pull request fixes the y-axis scaling of the pod usage charts in the `frontend/providers/applaunchpad/src/components/PodLineChart/index.tsx` file. It improves the accuracy and readability of the charts for CPU, memory, and network usage.

> _The pod usage charts were a mess_
> _They showed wrong values and excess_
> _So `PodLineChart` got a fix_
> _To scale the y-axis right and quick_
> _And handle different network metrics_

### Walkthrough
*  Set the maximum values of the y-axes for the CPU, memory, and network usage charts to reflect the appropriate units and scales ([link](https://github.com/labring/sealos/pull/3140/files?diff=unified&w=0#diff-95713470394138dbc1827aff3c65db1b6e26de8b2e05dbaeccd7e707481bc700R41), [link](https://github.com/labring/sealos/pull/3140/files?diff=unified&w=0#diff-95713470394138dbc1827aff3c65db1b6e26de8b2e05dbaeccd7e707481bc700R86), [link](https://github.com/labring/sealos/pull/3140/files?diff=unified&w=0#diff-95713470394138dbc1827aff3c65db1b6e26de8b2e05dbaeccd7e707481bc700L121-R124)) in `frontend/providers/applaunchpad/src/components/PodLineChart/index.tsx`


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
