### PR TITLE
fix: if a command requires buildah module, call SetRequireBuildahAnnotation explicitly

### DIFF
--- a/cmd/sealos/cmd/add.go
+++ b/cmd/sealos/cmd/add.go
@@ -59,6 +59,7 @@ func newAddCmd() *cobra.Command {
 			logger.Info(getContact())
 		},
 	}
+	setRequireBuildahAnnotation(addCmd)
 	addArgs.RegisterFlags(addCmd.Flags(), "be joined", "join")
 	return addCmd
 }

--- a/cmd/sealos/cmd/apply.go
+++ b/cmd/sealos/cmd/apply.go
@@ -42,6 +42,7 @@ func newApplyCmd() *cobra.Command {
 			logger.Info(getContact())
 		},
 	}
+	setRequireBuildahAnnotation(applyCmd)
 	applyCmd.Flags().StringVarP(&clusterFile, "Clusterfile", "f", "Clusterfile", "apply a kubernetes cluster")
 	applyArgs.RegisterFlags(applyCmd.Flags())
 	return applyCmd

--- a/cmd/sealos/cmd/cert.go
+++ b/cmd/sealos/cmd/cert.go
@@ -73,6 +73,5 @@ func newCertCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&clusterName, "cluster", "c", "default", "name of cluster to applied exec action")
 	cmd.Flags().StringVar(&altNames, "alt-names", "", "add domain or ip in certs, sealos.io or 10.103.97.2")
-	setCommandUnrelatedToBuildah(cmd)
 	return cmd
 }

--- a/cmd/sealos/cmd/delete.go
+++ b/cmd/sealos/cmd/delete.go
@@ -71,6 +71,7 @@ func newDeleteCmd() *cobra.Command {
 			logger.Info(getContact())
 		},
 	}
+	setRequireBuildahAnnotation(deleteCmd)
 	deleteArgs.RegisterFlags(deleteCmd.Flags(), "removed", "remove")
 	deleteCmd.Flags().BoolVar(&processor.ForceDelete, "force", false, "we also can input an --force flag to delete cluster by force")
 	return deleteCmd

--- a/cmd/sealos/cmd/docs.go
+++ b/cmd/sealos/cmd/docs.go
@@ -32,7 +32,6 @@ func newDocsCmd() *cobra.Command {
 		},
 	}
 	docsCmd.Flags().StringVarP(&docsPath, "path", "p", "./docs/api", "path to output docs")
-	setCommandUnrelatedToBuildah(docsCmd)
 	return docsCmd
 }
 

--- a/cmd/sealos/cmd/exec.go
+++ b/cmd/sealos/cmd/exec.go
@@ -72,6 +72,5 @@ func newExecCmd() *cobra.Command {
 	execCmd.Flags().StringVarP(&clusterName, "cluster", "c", "default", "name of cluster to applied exec action")
 	execCmd.Flags().StringVarP(&roles, "roles", "r", "", "run command on nodes with role")
 	execCmd.Flags().StringSliceVar(&ips, "ips", []string{}, "run command on nodes with ip address")
-	setCommandUnrelatedToBuildah(execCmd)
 	return execCmd
 }

--- a/cmd/sealos/cmd/gen.go
+++ b/cmd/sealos/cmd/gen.go
@@ -75,6 +75,7 @@ func newGenCmd() *cobra.Command {
 			return err
 		},
 	}
+	setRequireBuildahAnnotation(genCmd)
 	genArgs.RegisterFlags(genCmd.Flags())
 	genCmd.Flags().StringVarP(&out, "output", "o", "", "print output to named file")
 	return genCmd

--- a/cmd/sealos/cmd/reset.go
+++ b/cmd/sealos/cmd/reset.go
@@ -57,6 +57,7 @@ func newResetCmd() *cobra.Command {
 			logger.Info(getContact())
 		},
 	}
+	setRequireBuildahAnnotation(resetCmd)
 	resetArgs.RegisterFlags(resetCmd.Flags())
 	resetCmd.Flags().BoolVar(&processor.ForceDelete, "force", false, "we also can input an --force flag to reset cluster by force")
 	return resetCmd

--- a/cmd/sealos/cmd/root.go
+++ b/cmd/sealos/cmd/root.go
@@ -99,9 +99,8 @@ func init() {
 	rootCmd.AddCommand(system.NewEnvCmd())
 }
 
-// add unrelated command names that don't required buildah sdk.
-func setCommandUnrelatedToBuildah(cmd *cobra.Command) {
-	buildah.AddUnrelatedCommandNames(cmd.Name())
+func setRequireBuildahAnnotation(cmd *cobra.Command) {
+	buildah.SetRequireBuildahAnnotation(cmd)
 }
 
 func onBootOnDie() {

--- a/cmd/sealos/cmd/run.go
+++ b/cmd/sealos/cmd/run.go
@@ -83,6 +83,7 @@ func newRunCmd() *cobra.Command {
 			logger.Info(getContact())
 		},
 	}
+	setRequireBuildahAnnotation(runCmd)
 	runArgs.RegisterFlags(runCmd.Flags())
 	runCmd.Flags().BoolVar(new(bool), "single", false, "run cluster in single mode")
 	if err := runCmd.Flags().MarkDeprecated("single", "it defaults to running cluster in single mode when there are no master and node"); err != nil {

--- a/cmd/sealos/cmd/scp.go
+++ b/cmd/sealos/cmd/scp.go
@@ -73,6 +73,5 @@ func newScpCmd() *cobra.Command {
 	scpCmd.Flags().StringVarP(&clusterName, "cluster", "c", "default", "name of cluster to applied scp action")
 	scpCmd.Flags().StringVarP(&roles, "roles", "r", "", "copy file to nodes with role")
 	scpCmd.Flags().StringSliceVar(&ips, "ips", []string{}, "copy file to nodes with ip address")
-	setCommandUnrelatedToBuildah(scpCmd)
 	return scpCmd
 }

--- a/cmd/sealos/cmd/status.go
+++ b/cmd/sealos/cmd/status.go
@@ -39,6 +39,5 @@ func newStatusCmd() *cobra.Command {
 		},
 	}
 	checkCmd.Flags().StringVarP(&clusterName, "cluster", "c", "default", "name of cluster to applied status action")
-	setCommandUnrelatedToBuildah(checkCmd)
 	return checkCmd
 }

--- a/cmd/sealos/cmd/version.go
+++ b/cmd/sealos/cmd/version.go
@@ -52,7 +52,6 @@ func newVersionCmd() *cobra.Command {
 	}
 	versionCmd.Flags().BoolVar(&shortPrint, "short", false, "if true, print just the version number.")
 	versionCmd.Flags().StringVarP(&output, "output", "o", "yaml", "One of 'yaml' or 'json'")
-	setCommandUnrelatedToBuildah(versionCmd)
 	return versionCmd
 }
 


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4e59710</samp>

This pull request refactors the sealos command-line interface to use annotations to indicate which commands require the buildah module dependency. This simplifies the code and avoids hard-coding the command names in the `buildah` package. The `setRequireBuildahAnnotation` function is added to the `cmd` package and called by the commands that need the buildah module. The `setCommandUnrelatedToBuildah` function and the list of commands that do not need the buildah module are removed.
