### PR TITLE
fix: fix loop call which occur in throw error in onmessage callback

### DIFF
--- a/frontend/client-sdk/src/master.ts
+++ b/frontend/client-sdk/src/master.ts
@@ -21,7 +21,8 @@ class MasterSDK {
     message = '',
     data = {}
   }: MasterReplyMessageType) {
-    if (!source) return;
+    // if not define source or source is self(Not need send message to self). Skip it
+    if (!source || source === window) return;
 
     source.postMessage(
       {


### PR DESCRIPTION
if `source` is self, will occur loop in
windowMessage -> replyAppMessage -> (send to self) -> windowMessage

## Preview

before:

![image](https://github.com/labring/sealos/assets/6964737/e8b41ad4-8de5-493b-a573-fae7159fcf0a)

yes, its endless loop

after:

![image](https://github.com/labring/sealos/assets/6964737/118b747d-9712-45fe-a621-9e1354f26f36)


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e5533d4</samp>

### Summary
🛡️🗣️🚫

<!--
1.  🛡️ - This emoji can represent the idea of adding a condition or a guard to prevent unwanted or invalid messages from being processed or replied to. It can also suggest a security or protection aspect of the change.
2.  🗣️ - This emoji can represent the idea of communication or messaging between different sources or parties. It can also suggest a dialogue or a conversation aspect of the change.
3.  🚫 - This emoji can represent the idea of rejecting or denying something that does not meet the criteria or expectations. It can also suggest a negative or error aspect of the change.
-->
Fix a bug in `frontend/client-sdk/src/master.ts` that caused the master SDK to reply with an error message to its own app messages. This improves the communication between the master SDK and the app SDK.

> _`source` and `window`_
> _must not be the same, or else_
> _error in autumn_

### Walkthrough
*  Add a condition to avoid sending error messages to the same window that originated the app request ([link](https://github.com/labring/sealos/pull/3150/files?diff=unified&w=0#diff-a6c87f8f20ac55bd024ec33bffb6c4c5358b48e6b3083a702281ccb19de0212dL58-R78))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
