### PR TITLE
feat: make manifest command visible

### DIFF
--- a/cmd/sealos/cmd/root.go
+++ b/cmd/sealos/cmd/root.go
@@ -96,7 +96,7 @@ func init() {
 	groups.Add(rootCmd)
 	filters := []string{}
 	templates.ActsAsRootCommand(rootCmd, filters, groups...)
-	rootCmd.AddCommand(system.NewEnvCmd())
+	rootCmd.AddCommand(system.NewEnvCmd(constants.AppName))
 }
 
 func setRequireBuildahAnnotation(cmd *cobra.Command) {

--- a/pkg/buildah/buildah.go
+++ b/pkg/buildah/buildah.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/labring/sealos/pkg/system"
 	"github.com/labring/sealos/pkg/utils/logger"
 )
 
@@ -306,6 +307,9 @@ func init() {
 }
 
 func maybeSetupLogrusLogger() (err error) {
+	if logLevelVal, _ := system.Get(system.BuildahLogLevelConfigKey); logLevelVal != "" {
+		globalFlagResults.LogLevel = logLevelVal
+	}
 	logrusLvl, err := logrus.ParseLevel(globalFlagResults.LogLevel)
 	if err != nil {
 		return fmt.Errorf("unable to parse log level: %w", err)

--- a/pkg/buildah/manifest.go
+++ b/pkg/buildah/manifest.go
@@ -123,10 +123,9 @@ func newManifestCommand() *cobra.Command {
 		manifestPushOpts            pushOptions
 	)
 	manifestCommand := &cobra.Command{
-		Use:    "manifest",
-		Hidden: true,
-		Short:  "Manipulate manifest lists and image indexes",
-		Long:   manifestDescription,
+		Use:   "manifest",
+		Short: "Manipulate manifest lists and image indexes",
+		Long:  manifestDescription,
 		Example: fmt.Sprintf(`%[1]s manifest create localhost/list
   %[1]s manifest add localhost/list localhost/image
   %[1]s manifest annotate --annotation A=B localhost/list localhost/image

--- a/pkg/system/env.go
+++ b/pkg/system/env.go
@@ -78,13 +78,18 @@ var configOptions = []ConfigOption{
 		OSEnv:        BuildahFormatConfigKey,
 	},
 	{
+		Key:         BuildahLogLevelConfigKey,
+		Description: `the log level to be used in buildah modules, either "trace", "debug", "info", "warn", "error", "fatal", or "panic".`,
+		OSEnv:       BuildahLogLevelConfigKey,
+	},
+	{
 		Key:          ScpChecksumConfigKey,
-		Description:  "whether to check the md5sum value is consistent during the copy process",
+		Description:  "whether to check the md5sum value is consistent during the copy process.",
 		DefaultValue: "yes",
 	},
 	{
 		Key:          RegistrySyncExperimentalConfigKey,
-		Description:  "enable registry sync experimental feature",
+		Description:  "enable registry sync experimental feature.",
 		DefaultValue: "false",
 	},
 }
@@ -94,6 +99,7 @@ const (
 	RuntimeRootConfigKey              = "RUNTIME_ROOT"
 	DataRootConfigKey                 = "DATA_ROOT"
 	BuildahFormatConfigKey            = "BUILDAH_FORMAT"
+	BuildahLogLevelConfigKey          = "BUILDAH_LOG_LEVEL"
 	ScpChecksumConfigKey              = "SCP_CHECKSUM"
 	RegistrySyncExperimentalConfigKey = "REGISTRY_SYNC_EXPERIMENTAL"
 )

--- a/pkg/system/env_cmd.go
+++ b/pkg/system/env_cmd.go
@@ -18,25 +18,31 @@ package system
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 )
 
-func NewEnvCmd() *cobra.Command {
-	var configCmd = &cobra.Command{
+func NewEnvCmd(appName string) *cobra.Command {
+	var verbose bool
+	var cmd = &cobra.Command{
 		Use:   "env",
-		Short: "Display all envs for sealos",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Short: fmt.Sprintf("prints out all the environment information in use by %s", appName),
+		Run: func(cmd *cobra.Command, args []string) {
 			list := ConfigOptions()
 			for _, v := range list {
 				data, _ := GetConfig(v.Key)
 				if data == nil {
 					continue
 				}
-				println(fmt.Sprintf("%s=%s", data.OSEnv, data.DefaultValue))
+				fmt.Fprintf(os.Stdout, "%s=%s", data.OSEnv, data.DefaultValue)
+				if verbose {
+					fmt.Fprintf(os.Stdout, "\t# %s", data.Description)
+				}
+				fmt.Fprintf(os.Stdout, "\n")
 			}
-			return nil
 		},
 	}
-	return configCmd
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "more verbose output")
+	return cmd
 }


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 84baab3</samp>

Added a configuration option for buildah log level and exposed the manifest command. The `env` command was improved to accept an application name and a verbosity flag. The files `pkg/buildah/buildah.go`, `pkg/system/env_cmd.go`, `pkg/system/env.go`, `cmd/sealos/cmd/root.go`, and `pkg/buildah/manifest.go` were modified to implement these changes.