### PR TITLE
refactor(main): remove compression registry

### DIFF
--- a/test/e2e/suites/operators/image.go
+++ b/test/e2e/suites/operators/image.go
@@ -91,7 +91,6 @@ func (f *fakeImageClient) BuildImage(image, context string, opts BuildOptions) e
 		Tag:          image,
 		SaveImage:    opts.SaveImage,
 		Context:      context,
-		Compression:  opts.Compression,
 		MaxPullProcs: opts.MaxPullProcs,
 		Pull:         opts.Pull,
 		Debug:        true,

--- a/test/e2e/suites/operators/interface.go
+++ b/test/e2e/suites/operators/interface.go
@@ -28,7 +28,6 @@ type DisplayImage struct {
 }
 type BuildOptions struct {
 	Compress     bool
-	Compression  string
 	MaxPullProcs int
 	Pull         string
 	SaveImage    bool

--- a/test/e2e/testhelper/cmd/sealosCmdOpts.go
+++ b/test/e2e/testhelper/cmd/sealosCmdOpts.go
@@ -73,7 +73,6 @@ type BuildOptions struct {
 	BuildContext       []string
 	BuildArg           []string
 	CertDir            string
-	Compression        string
 	Creds              string
 	Context            string
 	DisableCompression bool
@@ -157,7 +156,6 @@ func (bo *BuildOptions) Args() []string {
 		appendFlagsWithValues("--debug", bo.Debug).
 		appendFlagsWithValues("--build-context", bo.BuildContext).
 		appendFlagsWithValues("--cert-dir", bo.CertDir).
-		appendFlagsWithValues("--compression", bo.Compression).
 		appendFlagsWithValues("--creds", bo.Creds).
 		appendFlagsWithValues("--disable-compression", bo.DisableCompression).
 		appendFlagsWithValues("--dns", bo.DNS).


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 43f39a9</samp>

### Summary
🗑️🚀🛠️

<!--
1.  🗑️ - This emoji represents the removal or deletion of something, such as a feature, a field, or a dependency. It can be used to indicate that the changes reduce the code size or complexity, or that they eliminate unused or unnecessary components.
2.  🚀 - This emoji represents the improvement or enhancement of something, such as the performance, the speed, or the efficiency. It can be used to indicate that the changes make the project faster, lighter, or more reliable, or that they optimize the resource usage or the user experience.
3.  🛠️ - This emoji represents the fixing or repairing of something, such as a bug, a flaw, or a vulnerability. It can be used to indicate that the changes resolve an issue, improve the quality, or increase the security of the project.
-->
Removed the compression feature from the `buildah`, `registry`, and `sealos` packages and their tests. This feature was not used by the sealos project and simplified the code and improved the performance.

> _No more compression, no more waste_
> _We tear down the code that we hate_
> _Simplify the sealos, make it fast and lean_
> _We build the images of our dreams_

### Walkthrough
*  Remove compression feature from `buildah` package and related packages ([link](https://github.com/labring/sealos/pull/3166/files?diff=unified&w=0#diff-8fecdf546a08e5fe09cd5106811fb7016c57d83b6873b81d9ac02903d996bcbdL19-L20), [link](https://github.com/labring/sealos/pull/3166/files?diff=unified&w=0#diff-8fecdf546a08e5fe09cd5106811fb7016c57d83b6873b81d9ac02903d996bcbdL31), [link](https://github.com/labring/sealos/pull/3166/files?diff=unified&w=0#diff-8fecdf546a08e5fe09cd5106811fb7016c57d83b6873b81d9ac02903d996bcbdL38-R35), [link](https://github.com/labring/sealos/pull/3166/files?diff=unified&w=0#diff-8fecdf546a08e5fe09cd5106811fb7016c57d83b6873b81d9ac02903d996bcbdL47), [link](https://github.com/labring/sealos/pull/3166/files?diff=unified&w=0#diff-8fecdf546a08e5fe09cd5106811fb7016c57d83b6873b81d9ac02903d996bcbdL53), [link](https://github.com/labring/sealos/pull/3166/files?diff=unified&w=0#diff-8fecdf546a08e5fe09cd5106811fb7016c57d83b6873b81d9ac02903d996bcbdL62-R57), [link](https://github.com/labring/sealos/pull/3166/files?diff=unified&w=0#diff-8fecdf546a08e5fe09cd5106811fb7016c57d83b6873b81d9ac02903d996bcbdL109-R71), [link](https://github.com/labring/sealos/pull/3166/files?diff=unified&w=0#diff-761edccdbc8a702a3f214513a0ac4448b9d8c03b41557eb4742aea2170b498d5L21-L23), [link](https://github.com/labring/sealos/pull/3166/files?diff=unified&w=0#diff-761edccdbc8a702a3f214513a0ac4448b9d8c03b41557eb4742aea2170b498d5L32), [link](https://github.com/labring/sealos/pull/3166/files?diff=unified&w=0#diff-761edccdbc8a702a3f214513a0ac4448b9d8c03b41557eb4742aea2170b498d5L59-R55), [link](https://github.com/labring/sealos/pull/3166/files?diff=unified&w=0#diff-761edccdbc8a702a3f214513a0ac4448b9d8c03b41557eb4742aea2170b498d5L74-L84), [link](https://github.com/labring/sealos/pull/3166/files?diff=unified&w=0#diff-ca97db7f080c56b85f2bc27ed20cb30955a9848a07a5c09de6f655f849f05f59L94), [link](https://github.com/labring/sealos/pull/3166/files?diff=unified&w=0#diff-485bdba6d66188ab41347b140493ad4abf1a2bcb01b2a69cbbe8cf835e782680L31), [link](https://github.com/labring/sealos/pull/3166/files?diff=unified&w=0#diff-33878949d785e36ba4e928b079589d4b9d40f6ebe94d319d0febe48fba2ddef3L76), [link](https://github.com/labring/sealos/pull/3166/files?diff=unified&w=0#diff-33878949d785e36ba4e928b079589d4b9d40f6ebe94d319d0febe48fba2ddef3L160))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
