### PR TITLE
style: return error instead of bool type

### DIFF
--- a/pkg/filesystem/registry/sync.go
+++ b/pkg/filesystem/registry/sync.go
@@ -53,7 +53,7 @@ func (s *syncMode) Sync(ctx context.Context, hosts ...string) error {
 	sys := &types.SystemContext{
 		DockerInsecureSkipTLSVerify: types.OptionalBoolTrue,
 	}
-	logger.Info("using syncMode syncing registry images to hosts %v", hosts)
+	logger.Info("using sync mode syncing images to hosts %v", hosts)
 	// run `sealctl registry serve` to start a temporary registry
 	for i := range hosts {
 		ctx, cancel := context.WithCancel(ctx)
@@ -73,8 +73,8 @@ func (s *syncMode) Sync(ctx context.Context, hosts ...string) error {
 		if err != nil {
 			return err
 		}
-		if !sync.WaitUntilHTTPListen("http://"+ep, time.Second*3) {
-			return fmt.Errorf("cannot detect whether registry %s is listening, check manually", ep)
+		if err = sync.WaitUntilHTTPListen("http://"+ep, time.Second*3); err != nil {
+			return err
 		}
 		endpoints = append(endpoints, ep)
 	}
@@ -98,8 +98,8 @@ func (s *syncMode) Sync(ctx context.Context, hosts ...string) error {
 					if err != nil {
 						return err
 					}
-					if !sync.WaitUntilHTTPListen("http://"+src, time.Second*3) {
-						return fmt.Errorf("cannot detect whether registry %s is listening, check manually", src)
+					if err = sync.WaitUntilHTTPListen("http://"+src, time.Second*3); err != nil {
+						return err
 					}
 					return sync.ToRegistry(ctx, sys, src, dst, copy.CopySystemImage)
 				})

--- a/pkg/registry/save/registry_save.go
+++ b/pkg/registry/save/registry_save.go
@@ -51,8 +51,8 @@ func (is *tmpRegistryImage) SaveImages(images []string, dir string, platform v1.
 		return nil, err
 	}
 	errCh := handler.Run(is.ctx, config)
-	if !sync.WaitUntilHTTPListen("http://"+ep, time.Second*3) {
-		return nil, fmt.Errorf("cannot detect whether registry %s is listening, check manually", ep)
+	if err = sync.WaitUntilHTTPListen("http://"+ep, time.Second*3); err != nil {
+		return nil, err
 	}
 	if platform.OS == "" {
 		platform.OS = "linux"

--- a/pkg/registry/sync/sync.go
+++ b/pkg/registry/sync/sync.go
@@ -190,20 +190,21 @@ func getImageTags(ctx context.Context, sysCtx *types.SystemContext, repoRef refe
 	return tags, nil
 }
 
-func WaitUntilHTTPListen(endpoint string, tw time.Duration) bool {
+func WaitUntilHTTPListen(endpoint string, tw time.Duration) error {
+	var err error
 	for {
 		select {
 		case <-time.After(tw):
-			return false
+			return err
 		default:
-			resp, err := http.DefaultClient.Get(endpoint)
+			var resp *http.Response
+			resp, err = http.DefaultClient.Get(endpoint)
 			if err == nil {
 				_, _ = io.Copy(io.Discard, resp.Body)
 				resp.Body.Close()
-				logger.Info("registry %s is listening , connect success", endpoint)
-				return true
+				logger.Debug("connect to registry %s successfully", endpoint)
+				return nil
 			}
-			logger.Warn("connect to %s error: %v", endpoint, err)
 			time.Sleep(100 * time.Millisecond)
 		}
 	}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f99c14</samp>

Moved and refactored registry save code to `pkg/filesystem/registry/sync.go`. Improved error handling and logging for registry sync operations.