### PR TITLE
feat: add registry sync command

### DIFF
--- a/cmd/sealctl/cmd/registry.go
+++ b/cmd/sealctl/cmd/registry.go
@@ -26,7 +26,6 @@ func newRegistryCmd() *cobra.Command {
 		Use:   "registry",
 		Short: "registry related",
 	}
-	cmd.AddCommand(commands.NewRegistryImageSaveCmd())
 	cmd.AddCommand(commands.NewServeRegistryCommand())
 	return cmd
 }

--- a/cmd/sealos/cmd/registry.go
+++ b/cmd/sealos/cmd/registry.go
@@ -30,6 +30,6 @@ func newRegistryCmd() *cobra.Command {
 	cmd.AddCommand(commands.NewRegistryPasswdCmd())
 	cmd.AddCommand(commands.NewRegistryImageSaveCmd())
 	cmd.AddCommand(commands.NewSyncRegistryCommand())
-
+	cmd.AddCommand(commands.NewServeRegistryCommand())
 	return cmd
 }

--- a/cmd/sealos/cmd/registry.go
+++ b/cmd/sealos/cmd/registry.go
@@ -28,5 +28,8 @@ func newRegistryCmd() *cobra.Command {
 		Short: "registry related",
 	}
 	cmd.AddCommand(commands.NewRegistryPasswdCmd())
+	cmd.AddCommand(commands.NewRegistryImageSaveCmd())
+	cmd.AddCommand(commands.NewSyncRegistryCommand())
+
 	return cmd
 }

--- a/pkg/registry/commands/sync.go
+++ b/pkg/registry/commands/sync.go
@@ -42,14 +42,9 @@ func NewSyncRegistryCommand() *cobra.Command {
 }
 
 func runSync(ctx context.Context, source, dst string) error {
-	sep, err := sync.ParseRegistryAddress(source)
-	if err != nil {
-		return err
-	}
-	dep, err := sync.ParseRegistryAddress(dst)
-	if err != nil {
-		return err
-	}
+	sep := sync.ParseRegistryAddress(source)
+	dep := sync.ParseRegistryAddress(dst)
+
 	eg, _ := errgroup.WithContext(ctx)
 	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()

--- a/pkg/registry/commands/sync.go
+++ b/pkg/registry/commands/sync.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2023 fengxsong@outlook.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package commands
+
+import (
+	"context"
+	"time"
+
+	imagecopy "github.com/containers/image/v5/copy"
+	"github.com/containers/image/v5/types"
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/labring/sealos/pkg/registry/sync"
+	httputils "github.com/labring/sealos/pkg/utils/http"
+)
+
+func NewSyncRegistryCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "sync source dst",
+		Aliases: []string{"copy"},
+		Short:   "sync all images from one registry to another",
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSync(cmd.Context(), args[0], args[1])
+		},
+	}
+	return cmd
+}
+
+func runSync(ctx context.Context, source, dst string) error {
+	sep, err := sync.ParseRegistryAddress(source)
+	if err != nil {
+		return err
+	}
+	dep, err := sync.ParseRegistryAddress(dst)
+	if err != nil {
+		return err
+	}
+	eg, _ := errgroup.WithContext(ctx)
+	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	eg.Go(func() error {
+		return httputils.WaitUntilEndpointAlive(probeCtx, sep)
+	})
+	eg.Go(func() error {
+		return httputils.WaitUntilEndpointAlive(probeCtx, dep)
+	})
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+
+	sysCtx := &types.SystemContext{
+		DockerInsecureSkipTLSVerify: types.OptionalBoolTrue,
+	}
+	return sync.ToRegistry(ctx, sysCtx, sep, dep, imagecopy.CopySystemImage)
+}

--- a/pkg/registry/save/registry_save.go
+++ b/pkg/registry/save/registry_save.go
@@ -15,24 +15,22 @@
 package save
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	stdsync "sync"
 	"time"
 
-	"github.com/containers/image/v5/transports/alltransports"
-
-	"github.com/google/go-containerregistry/pkg/name"
-
 	"github.com/containers/image/v5/copy"
+	"github.com/containers/image/v5/transports/alltransports"
 	itype "github.com/containers/image/v5/types"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/labring/sealos/pkg/registry/handler"
 	"github.com/labring/sealos/pkg/registry/sync"
-
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-
+	httputils "github.com/labring/sealos/pkg/utils/http"
 	"github.com/labring/sealos/pkg/utils/logger"
 )
 
@@ -51,9 +49,13 @@ func (is *tmpRegistryImage) SaveImages(images []string, dir string, platform v1.
 		return nil, err
 	}
 	errCh := handler.Run(is.ctx, config)
-	if err = sync.WaitUntilHTTPListen("http://"+ep, time.Second*3); err != nil {
+
+	probeCtx, cancel := context.WithTimeout(is.ctx, time.Second*3)
+	defer cancel()
+	if err = httputils.WaitUntilEndpointAlive(probeCtx, "http://"+ep); err != nil {
 		return nil, err
 	}
+
 	if platform.OS == "" {
 		platform.OS = "linux"
 	}

--- a/pkg/registry/save/registry_save.go
+++ b/pkg/registry/save/registry_save.go
@@ -44,14 +44,11 @@ func (is *tmpRegistryImage) SaveImages(images []string, dir string, platform v1.
 		return nil, err
 	}
 	config.Log.AccessLog.Disabled = true
-	ep, err := sync.ParseRegistryAddress(localhost, config.HTTP.Addr)
-	if err != nil {
-		return nil, err
-	}
 	errCh := handler.Run(is.ctx, config)
 
 	probeCtx, cancel := context.WithTimeout(is.ctx, time.Second*3)
 	defer cancel()
+	ep := sync.ParseRegistryAddress(localhost, config.HTTP.Addr)
 	if err = httputils.WaitUntilEndpointAlive(probeCtx, "http://"+ep); err != nil {
 		return nil, err
 	}

--- a/pkg/registry/sync/sync.go
+++ b/pkg/registry/sync/sync.go
@@ -185,24 +185,19 @@ func getImageTags(ctx context.Context, sysCtx *types.SystemContext, repoRef refe
 	return tags, nil
 }
 
-func ParseRegistryAddress(s string, args ...string) (string, error) {
+func ParseRegistryAddress(s string, args ...string) string {
+	if strings.Contains(s, ":") {
+		return s
+	}
+
 	var portStr string
 	if len(args) > 0 {
 		portStr = args[0]
+	} else {
+		portStr = defaultPort
 	}
-	if strings.Contains(s, ":") {
-		var err error
-		s, portStr, err = net.SplitHostPort(s)
-		if err != nil {
-			return "", err
-		}
-	}
-
 	if idx := strings.Index(portStr, ":"); idx >= 0 {
 		portStr = portStr[idx+1:]
 	}
-	if portStr == "" {
-		portStr = defaultPort
-	}
-	return net.JoinHostPort(s, portStr), nil
+	return net.JoinHostPort(s, portStr)
 }

--- a/pkg/utils/http/url.go
+++ b/pkg/utils/http/url.go
@@ -17,11 +17,16 @@ limitations under the License.
 package http
 
 import (
+	"context"
 	"crypto/tls"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
+
+	"github.com/labring/sealos/pkg/utils/logger"
 )
 
 func IsURL(u string) (*url.URL, bool) {
@@ -29,6 +34,36 @@ func IsURL(u string) (*url.URL, bool) {
 		return uu, true
 	}
 	return nil, false
+}
+
+func WaitUntilEndpointAlive(ctx context.Context, endpoint string) error {
+	if !strings.HasPrefix(endpoint, "http") {
+		endpoint = "http://" + endpoint
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return err
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return err
+		default:
+			var resp *http.Response
+			resp, err = DefaultClient.Get(u.String())
+			if err == nil {
+				_, _ = io.Copy(io.Discard, resp.Body)
+				resp.Body.Close()
+				logger.Debug("http endpoint %s is alive", u.String())
+				return nil
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+}
+
+var DefaultClient = &http.Client{
+	Transport: DefaultSkipVerify,
 }
 
 var DefaultSkipVerify = &http.Transport{


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fc69689</samp>

This pull request refactors and improves the registry commands and features in `sealos`. It adds new commands for saving and syncing images between registries, and enhances the context management, error handling, and HTTP utilities of the existing commands. It also removes a duplicate command and follows the code style and formatting conventions.