### PR TITLE
feat: add more verbose output while syncing registry

### DIFF
--- a/pkg/filesystem/registry/sync.go
+++ b/pkg/filesystem/registry/sync.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	stdsync "sync"
@@ -113,7 +114,7 @@ func (s *syncMode) Sync(ctx context.Context, hosts ...string) error {
 					if err = httputils.WaitUntilEndpointAlive(probeCtx, "http://"+src); err != nil {
 						return err
 					}
-					return sync.ToRegistry(inner, sys, src, dst, copy.CopySystemImage)
+					return sync.ToRegistry(inner, sys, src, dst, os.Stdout, copy.CopySystemImage)
 				})
 			}
 			go func() {

--- a/pkg/registry/sync/sync.go
+++ b/pkg/registry/sync/sync.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -41,7 +42,7 @@ const (
 	defaultPort = "5000"
 )
 
-func ToRegistry(ctx context.Context, sys *types.SystemContext, src, dst string, selection copy.ImageListSelection) error {
+func ToRegistry(ctx context.Context, sys *types.SystemContext, src, dst string, reportWriter io.Writer, selection copy.ImageListSelection) error {
 	policyContext, err := getPolicyContext()
 	if err != nil {
 		return err
@@ -53,6 +54,9 @@ func ToRegistry(ctx context.Context, sys *types.SystemContext, src, dst string, 
 	}
 	if len(repos) == 0 {
 		return nil
+	}
+	if reportWriter == nil {
+		reportWriter = io.Discard
 	}
 	for i := range repos {
 		named, err := parseRepositoryReference(fmt.Sprintf("%s/%s", src, repos[i].Name))
@@ -76,6 +80,7 @@ func ToRegistry(ctx context.Context, sys *types.SystemContext, src, dst string, 
 					SourceCtx:          sys,
 					DestinationCtx:     sys,
 					ImageListSelection: selection,
+					ReportWriter:       reportWriter,
 				})
 				return err
 			}, getRetryOptions())

--- a/pkg/utils/http/url.go
+++ b/pkg/utils/http/url.go
@@ -44,6 +44,7 @@ func WaitUntilEndpointAlive(ctx context.Context, endpoint string) error {
 	if err != nil {
 		return err
 	}
+	logger.Debug("checking if endpoint %s is alive", u.String())
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b9a347d</samp>

This pull request enhances the `registry` package to show the progress of image copying to the standard output. It modifies the `ToRegistry` function in the `sync` package to accept an `io.Writer` for reporting, and updates the `runSync` function in the `commands` package to use the command's context and output stream. It also adds a debug log message to the `WaitUntilEndpointAlive` function in the `utils` package.