### PR TITLE
Fix adminer connect driver name.

### DIFF
--- a/frontend/providers/adminer/src/interfaces/kubeblock.ts
+++ b/frontend/providers/adminer/src/interfaces/kubeblock.ts
@@ -34,7 +34,7 @@ const clusterTypeMap: Record<string, KubeBlockClusterType> = {
     driver: 'mysql'
   },
   mongodb: {
-    driver: 'mongodb'
+    driver: 'mongo'
   }
 };
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 602fd84</samp>

### Summary
🐛🗄️🚀

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change. The typo in the driver name was a bug that prevented adminer from working with mongodb clusters.
2.  🗄️ - This emoji represents a database, which is the domain of the change. The change affects how adminer interacts with different database types and drivers.
3.  🚀 - This emoji represents an improvement or enhancement, which is the outcome of the change. The change improves the user experience and functionality of adminer by enabling it to connect to mongodb clusters.
-->
Fix typo in adminer driver name for mongodb clusters. This change affects the `clusterTypeMap` object in the `frontend/providers/adminer/src/interfaces/kubeblock.ts` file.

> _`clusterTypeMap` fixed_
> _mongo driver name typo_
> _adminer connects_

### Walkthrough
* Fix typo in driver name for mongodb cluster type in `clusterTypeMap` object ([link](https://github.com/labring/sealos/pull/3230/files?diff=unified&w=0#diff-a5bc3a0ee5f70c098cc94e83d3d8736d655eb3aa9ae63e6f90990adaaced876aL37-R37))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
