### PR TITLE
refactor(main): add skip error for sync

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -75,8 +75,8 @@ area/cloud:
 area/lifecycle-management:
   - any: [ 'pkg/**/*' ]
   - any: [ 'staging/**/*' ]
-  - any: [ 'docs/4.0/docs/lifecycle-management/*' ]
-  - any: [ 'docs/4.0/i18n/zh-Hans/lifecycle-management/*' ]
+  - any: [ 'docs/4.0/docs/lifecycle-management/**/*' ]
+  - any: [ 'docs/4.0/i18n/zh-Hans/lifecycle-management/**/*' ]
 
 
 area/frontend:
@@ -91,4 +91,4 @@ area/ci:
   - 'Makefile'
 
 area/workflow:
-  - any: [ '.github/**' ]
+  - any: [ '.github/**/*' ]

--- a/cmd/sealos/cmd/registry.go
+++ b/cmd/sealos/cmd/registry.go
@@ -27,9 +27,11 @@ func newRegistryCmd() *cobra.Command {
 		Use:   "registry",
 		Short: "registry related",
 	}
+	commands.SetRootCommand(rootCmd)
 	cmd.AddCommand(commands.NewRegistryPasswdCmd())
+	cmd.AddCommand(commands.NewServeRegistryCommand())
 	cmd.AddCommand(commands.NewRegistryImageSaveCmd())
 	cmd.AddCommand(commands.NewSyncRegistryCommand())
-	cmd.AddCommand(commands.NewServeRegistryCommand())
+	cmd.AddCommand(commands.NewCopyRegistryCommand())
 	return cmd
 }

--- a/docs/4.0/docs/lifecycle-management/reference/sealos/commands/registry.md
+++ b/docs/4.0/docs/lifecycle-management/reference/sealos/commands/registry.md
@@ -134,31 +134,101 @@ sealos registry passwd
 
 
 
-## Sealos：sealos registry sync 命令详解与使用指南
+## Sealos：`sealos registry sync` 命令详解与使用指南
 
-Sealos 的 `registry sync` 命令主要用于将所有镜像从一个 registry 同步到另一个 registry。这可以帮助用户在不同的 registry 之间进行镜像的迁移或备份。
+Sealos 的 `registry sync` 命令可帮助您在两个 registry 之间同步所有镜像。这不仅可以用于镜像的迁移，还可以备份您的镜像。
 
-## 基本用法
+### 命令基本用法
 
-使用 `sealos registry sync` 命令来进行镜像的同步。
+执行 `sealos registry sync` 命令来进行镜像同步：
 
 ```bash
 sealos registry sync source dst
 ```
-`source` 是源 registry 的地址，`dst` 是目标 registry 的地址。
 
-例如，要将所有镜像从地址为 127.0.0.1:41669 的 registry 同步到地址为 sealos.hub:5000 的 registry，可以执行以下命令：
+这里的 `source` 表示源 registry 的地址，而 `dst` 是目标 registry 的地址。
+
+例如，您想将地址为 127.0.0.1:41669 的 registry 中的所有镜像同步到地址为 sealos.hub:5000 的 registry，您应执行以下命令：
 
 ```bash
 sealos registry sync 127.0.0.1:41669 sealos.hub:5000
 ```
 
-## 注意事项
+### 认证与权限
 
-在执行 `sealos registry sync` 命令之前，请确保你有权限访问源 registry 和目标 registry。如果 registry 需要身份验证，你需要提供正确的用户名和密码。
+在执行 `sealos registry sync` 命令之前，请确保您具有访问源 registry 和目标 registry 的权限。可以使用`sealos login`对registry进行认证登录。
 
-此外，同步镜像可能需要一些时间，具体取决于镜像的数量和大小，以及网络的速度。在同步期间，请保持网络的连通性，并确保在同步完成之前不要中断命令的执行。
+### 同步过程
 
-**但，这种方式可以做到增量镜像同步，已经存在的镜像不会重新同步!!!**
+请注意，镜像同步可能需要一些时间，这取决于镜像的数量和大小，以及网络的速度。在同步过程中，请保持网络的连通性，并确保在同步完成之前不要中断命令的执行。
+
+重要的是，`sealos registry sync` 命令支持增量同步，已经存在于目标 registry 的镜像不会重新同步。
+
+### 参数选项
+
+`sealos registry sync` 命令还提供了一些参数选项，允许您更精细地控制同步过程：
+
+- `--override-arch ARCH`：使用指定的 `ARCH` 替代当前机器的架构来选择镜像。
+
+- `--override-os OS`：使用指定的 `OS` 替代当前操作系统来选择镜像。
+
+- `--override-variant VARIANT`：使用指定的 `VARIANT` 替代当前的架构变种来选择镜像。
+
+- `-a` 或 `--all`：如果源镜像是一个列表，同步所有镜像。这对异构环境下特别有用，因为默认情况下，只会同步当前架构的镜像。
+
+例如，如果您想同步所有架构的镜像，可以添加 `-a` 参数：
+
+```bash
+sealos registry sync -a 127.0.0.1:41669 sealos.hub:5000
+```
+
+以上就是 `sealos registry sync` 命令的详细说明与使用指南。希望这些信息能帮助您更好地理解和使用这个命令。如果您在使用过程中遇到任何问题，欢迎随时提问。
+
+## Sealos：`sealos registry copy` 命令详解与使用指南
+
+Sealos 的 `registry copy` 命令用于将指定镜像从一个 registry 复制到另一个 registry。这能帮助您在不同的 registry 之间进行镜像的迁移或备份。
+
+### 命令基本用法
+
+使用 `sealos registry copy` 命令来进行镜像的复制：
+
+```bash
+sealos registry copy source-image dst
+```
+
+这里的 `source-image` 表示源镜像的全名（包括地址和镜像名），`dst` 是目标 registry 的地址。
+
+例如，要将名为 `127.0.0.1:41669/my-image:tag` 的镜像复制到地址为 `sealos.hub:5000` 的 registry，您可以执行以下命令：
+
+```bash
+sealos registry copy 127.0.0.1:41669/my-image:tag sealos.hub:5000
+```
+
+### 认证与权限
+
+在执行 `sealos registry copy` 命令之前，请确保您具有访问源镜像和目标 registry 的权限。可以使用`sealos login`对registry进行认证登录。
+
+### 复制过程
+
+请注意，镜像复制可能需要一些时间，这取决于镜像的大小，以及网络的速度。在复制过程中，请保持网络的连通性，并确保在复制完成之前不要中断命令的执行。
+
+### 参数选项
+
+`sealos registry copy` 命令提供了一些参数选项，允许您更精细地控制复制过程：
+
+- `--override-arch ARCH`：使用指定的 `ARCH` 替代当前机器的架构来选择镜像。
+
+- `--override-os OS`：使用指定的 `OS` 替代当前操作系统来选择镜像。
+
+- `--override-variant VARIANT`：使用指定的 `VARIANT` 替代当前的架构变种来选择镜像。
+
+- `-a` 或 `--all`：如果源镜像是一个列表，复制所有镜像。这对异构环境下特别有用，因为默认情况下，只会复制当前架构的镜像。
+
+例如，如果您想复制所有架构的镜像，可以添加 `-a` 参数：
+
+```bash
+sealos registry copy -a 127.0.0.1:41669/my-image:tag sealos.hub:5000
+```
+
 
 以上就是 `sealos registry` 命令的使用指南，希望对你有所帮助。如果你在使用过程中遇到任何问题，欢迎向我们提问。

--- a/docs/4.0/i18n/zh-Hans/lifecycle-management/reference/sealos/commands/registry.md
+++ b/docs/4.0/i18n/zh-Hans/lifecycle-management/reference/sealos/commands/registry.md
@@ -134,31 +134,101 @@ sealos registry passwd
 
 
 
-## Sealos：sealos registry sync 命令详解与使用指南
+## Sealos：`sealos registry sync` 命令详解与使用指南
 
-Sealos 的 `registry sync` 命令主要用于将所有镜像从一个 registry 同步到另一个 registry。这可以帮助用户在不同的 registry 之间进行镜像的迁移或备份。
+Sealos 的 `registry sync` 命令可帮助您在两个 registry 之间同步所有镜像。这不仅可以用于镜像的迁移，还可以备份您的镜像。
 
-## 基本用法
+### 命令基本用法
 
-使用 `sealos registry sync` 命令来进行镜像的同步。
+执行 `sealos registry sync` 命令来进行镜像同步：
 
 ```bash
 sealos registry sync source dst
 ```
-`source` 是源 registry 的地址，`dst` 是目标 registry 的地址。
 
-例如，要将所有镜像从地址为 127.0.0.1:41669 的 registry 同步到地址为 sealos.hub:5000 的 registry，可以执行以下命令：
+这里的 `source` 表示源 registry 的地址，而 `dst` 是目标 registry 的地址。
+
+例如，您想将地址为 127.0.0.1:41669 的 registry 中的所有镜像同步到地址为 sealos.hub:5000 的 registry，您应执行以下命令：
 
 ```bash
 sealos registry sync 127.0.0.1:41669 sealos.hub:5000
 ```
 
-## 注意事项
+### 认证与权限
 
-在执行 `sealos registry sync` 命令之前，请确保你有权限访问源 registry 和目标 registry。如果 registry 需要身份验证，你需要提供正确的用户名和密码。
+在执行 `sealos registry sync` 命令之前，请确保您具有访问源 registry 和目标 registry 的权限。可以使用`sealos login`对registry进行认证登录。
 
-此外，同步镜像可能需要一些时间，具体取决于镜像的数量和大小，以及网络的速度。在同步期间，请保持网络的连通性，并确保在同步完成之前不要中断命令的执行。
+### 同步过程
 
-**但，这种方式可以做到增量镜像同步，已经存在的镜像不会重新同步!!!**
+请注意，镜像同步可能需要一些时间，这取决于镜像的数量和大小，以及网络的速度。在同步过程中，请保持网络的连通性，并确保在同步完成之前不要中断命令的执行。
+
+重要的是，`sealos registry sync` 命令支持增量同步，已经存在于目标 registry 的镜像不会重新同步。
+
+### 参数选项
+
+`sealos registry sync` 命令还提供了一些参数选项，允许您更精细地控制同步过程：
+
+- `--override-arch ARCH`：使用指定的 `ARCH` 替代当前机器的架构来选择镜像。
+
+- `--override-os OS`：使用指定的 `OS` 替代当前操作系统来选择镜像。
+
+- `--override-variant VARIANT`：使用指定的 `VARIANT` 替代当前的架构变种来选择镜像。
+
+- `-a` 或 `--all`：如果源镜像是一个列表，同步所有镜像。这对异构环境下特别有用，因为默认情况下，只会同步当前架构的镜像。
+
+例如，如果您想同步所有架构的镜像，可以添加 `-a` 参数：
+
+```bash
+sealos registry sync -a 127.0.0.1:41669 sealos.hub:5000
+```
+
+以上就是 `sealos registry sync` 命令的详细说明与使用指南。希望这些信息能帮助您更好地理解和使用这个命令。如果您在使用过程中遇到任何问题，欢迎随时提问。
+
+## Sealos：`sealos registry copy` 命令详解与使用指南
+
+Sealos 的 `registry copy` 命令用于将指定镜像从一个 registry 复制到另一个 registry。这能帮助您在不同的 registry 之间进行镜像的迁移或备份。
+
+### 命令基本用法
+
+使用 `sealos registry copy` 命令来进行镜像的复制：
+
+```bash
+sealos registry copy source-image dst
+```
+
+这里的 `source-image` 表示源镜像的全名（包括地址和镜像名），`dst` 是目标 registry 的地址。
+
+例如，要将名为 `127.0.0.1:41669/my-image:tag` 的镜像复制到地址为 `sealos.hub:5000` 的 registry，您可以执行以下命令：
+
+```bash
+sealos registry copy 127.0.0.1:41669/my-image:tag sealos.hub:5000
+```
+
+### 认证与权限
+
+在执行 `sealos registry copy` 命令之前，请确保您具有访问源镜像和目标 registry 的权限。可以使用`sealos login`对registry进行认证登录。
+
+### 复制过程
+
+请注意，镜像复制可能需要一些时间，这取决于镜像的大小，以及网络的速度。在复制过程中，请保持网络的连通性，并确保在复制完成之前不要中断命令的执行。
+
+### 参数选项
+
+`sealos registry copy` 命令提供了一些参数选项，允许您更精细地控制复制过程：
+
+- `--override-arch ARCH`：使用指定的 `ARCH` 替代当前机器的架构来选择镜像。
+
+- `--override-os OS`：使用指定的 `OS` 替代当前操作系统来选择镜像。
+
+- `--override-variant VARIANT`：使用指定的 `VARIANT` 替代当前的架构变种来选择镜像。
+
+- `-a` 或 `--all`：如果源镜像是一个列表，复制所有镜像。这对异构环境下特别有用，因为默认情况下，只会复制当前架构的镜像。
+
+例如，如果您想复制所有架构的镜像，可以添加 `-a` 参数：
+
+```bash
+sealos registry copy -a 127.0.0.1:41669/my-image:tag sealos.hub:5000
+```
+
 
 以上就是 `sealos registry` 命令的使用指南，希望对你有所帮助。如果你在使用过程中遇到任何问题，欢迎向我们提问。

--- a/pkg/filesystem/registry/sync.go
+++ b/pkg/filesystem/registry/sync.go
@@ -120,7 +120,6 @@ func (s *syncMode) Sync(ctx context.Context, hosts ...string) error {
 						Target:    dst,
 						Writer:    os.Stdout,
 						Selection: copy.CopySystemImage,
-						SkipError: false,
 					}
 					return sync.ToRegistry(inner, opts)
 				})

--- a/pkg/filesystem/registry/sync.go
+++ b/pkg/filesystem/registry/sync.go
@@ -114,7 +114,15 @@ func (s *syncMode) Sync(ctx context.Context, hosts ...string) error {
 					if err = httputils.WaitUntilEndpointAlive(probeCtx, "http://"+src); err != nil {
 						return err
 					}
-					return sync.ToRegistry(inner, sys, src, dst, os.Stdout, copy.CopySystemImage)
+					opts := &sync.Options{
+						Sys:       sys,
+						Source:    src,
+						Target:    dst,
+						Writer:    os.Stdout,
+						Selection: copy.CopySystemImage,
+						SkipError: false,
+					}
+					return sync.ToRegistry(inner, opts)
 				})
 			}
 			go func() {

--- a/pkg/registry/commands/copy.go
+++ b/pkg/registry/commands/copy.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2023 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/pflag"
+
+	imagecopy "github.com/containers/image/v5/copy"
+	"github.com/containers/image/v5/types"
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/labring/sealos/pkg/registry/crane"
+
+	"github.com/labring/sealos/pkg/registry/sync"
+	httputils "github.com/labring/sealos/pkg/utils/http"
+)
+
+type globalOptions struct {
+	overrideArch    string // Architecture to use for choosing images, instead of the runtime one
+	overrideOS      string // OS to use for choosing images, instead of the runtime one
+	overrideVariant string // Architecture variant to use for choosing images, instead of the runtime one
+	all             bool   // Sync all images if SOURCE-IMAGE is a list
+}
+
+func (opts *globalOptions) RegisterFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&opts.overrideArch, "override-arch", "", "use `ARCH` instead of the architecture of the machine for choosing images")
+	fs.StringVar(&opts.overrideOS, "override-os", "", "use `OS` instead of the running OS for choosing images")
+	fs.StringVar(&opts.overrideVariant, "override-variant", "", "use `VARIANT` instead of the running architecture variant for choosing images")
+	fs.BoolVarP(&opts.all, "all", "a", false, "Sync all images if SOURCE-IMAGE is a list")
+}
+func (opts *globalOptions) newSystemContext() *types.SystemContext {
+	ctx := &types.SystemContext{
+		ArchitectureChoice:          opts.overrideArch,
+		OSChoice:                    opts.overrideOS,
+		VariantChoice:               opts.overrideVariant,
+		DockerInsecureSkipTLSVerify: types.OptionalBoolTrue,
+	}
+	return ctx
+}
+func NewCopyRegistryCommand() *cobra.Command {
+	opts := globalOptions{}
+	cmd := &cobra.Command{
+		Use:   "copy SOURCE-IMAGE DST_REGISTRY",
+		Short: "copy one image from one registry to another",
+		Args:  cobra.ExactArgs(2),
+		Example: fmt.Sprintf(`%[1]s registry copy docker.io/labring/kubernetes:v1.25.0 sealos.hub:5000
+%[1]s registry copy -a docker.io/labring/kubernetes:v1.25.0 sealos.hub:5000`, rootCmd.CommandPath()),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCopy(cmd, args[0], args[1], opts)
+		},
+	}
+	fs := cmd.Flags()
+	fs.SetInterspersed(false)
+	opts.RegisterFlags(fs)
+	return cmd
+}
+
+func runCopy(cmd *cobra.Command, source, dst string, opts globalOptions) error {
+	ctx := cmd.Context()
+	out := cmd.OutOrStdout()
+	imageListSelection := imagecopy.CopySystemImage
+	if opts.all {
+		imageListSelection = imagecopy.CopyAllImages
+	}
+
+	auths, err := crane.GetAuthInfo(nil)
+	if err != nil {
+		return err
+	}
+
+	sys := opts.newSystemContext()
+	dep := sync.ParseRegistryAddress(dst)
+
+	eg, _ := errgroup.WithContext(ctx)
+	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	eg.Go(func() error {
+		return httputils.WaitUntilEndpointAlive(probeCtx, dep)
+	})
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+
+	srcRef, err := sync.ImageNameToReference(sys, source, auths)
+	if err != nil {
+		return err
+	}
+	if err := sync.ToImage(ctx, sys, srcRef, dep, imageListSelection); err != nil {
+		return err
+	}
+	fmt.Fprintln(out, "Copy image completed")
+	return nil
+}

--- a/pkg/registry/commands/init.go
+++ b/pkg/registry/commands/init.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2023 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import "github.com/spf13/cobra"
+
+var rootCmd *cobra.Command
+
+func SetRootCommand(root *cobra.Command) {
+	rootCmd = root
+}

--- a/pkg/registry/commands/sync.go
+++ b/pkg/registry/commands/sync.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package commands
 
 import (
@@ -21,7 +22,6 @@ import (
 	"time"
 
 	imagecopy "github.com/containers/image/v5/copy"
-	"github.com/containers/image/v5/types"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
@@ -30,23 +30,31 @@ import (
 )
 
 func NewSyncRegistryCommand() *cobra.Command {
-	var skipError bool
+	opts := globalOptions{}
 	cmd := &cobra.Command{
-		Use:     "sync source dst",
-		Aliases: []string{"copy"},
-		Short:   "sync all images from one registry to another",
-		Args:    cobra.ExactArgs(2),
+		Use:   "sync SOURCE_REGISTRY DST_REGISTRY",
+		Short: "sync all images from one registry to another",
+		Args:  cobra.ExactArgs(2),
+		Example: fmt.Sprintf(`%[1]s registry sync 127.0.0.1:9090 sealos.hub:5000
+%[1]s registry sync -a 127.0.0.1:9090 sealos.hub:5000`, rootCmd.CommandPath()),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runSync(cmd, args[0], args[1], skipError)
+			return runSync(cmd, args[0], args[1], opts)
 		},
 	}
-	cmd.Flags().BoolVar(&skipError, "skip-error", false, "skip error when syncing images")
+	fs := cmd.Flags()
+	fs.SetInterspersed(false)
+	opts.RegisterFlags(fs)
 	return cmd
 }
 
-func runSync(cmd *cobra.Command, source, dst string, skipError bool) error {
+func runSync(cmd *cobra.Command, source, dst string, opts globalOptions) error {
 	ctx := cmd.Context()
 	out := cmd.OutOrStdout()
+
+	imageListSelection := imagecopy.CopySystemImage
+	if opts.all {
+		imageListSelection = imagecopy.CopyAllImages
+	}
 
 	sep := sync.ParseRegistryAddress(source)
 	dep := sync.ParseRegistryAddress(dst)
@@ -65,17 +73,17 @@ func runSync(cmd *cobra.Command, source, dst string, skipError bool) error {
 		return err
 	}
 
-	sysCtx := &types.SystemContext{
-		DockerInsecureSkipTLSVerify: types.OptionalBoolTrue,
+	sys := opts.newSystemContext()
+
+	syncOpts := &sync.Options{
+		SystemContext: sys,
+		Source:        sep,
+		Target:        dst,
+		ReportWriter:  out,
+		Selection:     imageListSelection,
+		OmitError:     true,
 	}
-	opts := &sync.Options{
-		Sys:       sysCtx,
-		Source:    sep,
-		Target:    dst,
-		Writer:    out,
-		Selection: imagecopy.CopyAllImages,
-	}
-	if err := sync.ToRegistry(ctx, opts); err != nil {
+	if err := sync.ToRegistry(ctx, syncOpts); err != nil {
 		return err
 	}
 	fmt.Fprintln(out, "Sync completed")

--- a/pkg/registry/commands/sync.go
+++ b/pkg/registry/commands/sync.go
@@ -73,8 +73,7 @@ func runSync(cmd *cobra.Command, source, dst string, skipError bool) error {
 		Source:    sep,
 		Target:    dst,
 		Writer:    out,
-		Selection: imagecopy.CopySystemImage,
-		SkipError: skipError,
+		Selection: imagecopy.CopyAllImages,
 	}
 	if err := sync.ToRegistry(ctx, opts); err != nil {
 		return err

--- a/pkg/registry/sync/sync.go
+++ b/pkg/registry/sync/sync.go
@@ -88,18 +88,19 @@ func ToRegistry(ctx context.Context, opts *Options) error {
 			if err != nil {
 				return err
 			}
+			ref := refs[j]
 			logger.Debug("syncing %s", destRef.DockerReference().String())
 			err = retry.RetryIfNecessary(ctx, func() error {
-				_, err = copy.Image(ctx, policyContext, destRef, refs[j], &copy.Options{
+				_, copyErr := copy.Image(ctx, policyContext, destRef, ref, &copy.Options{
 					SourceCtx:          sys,
 					DestinationCtx:     sys,
 					ImageListSelection: selection,
 					ReportWriter:       reportWriter,
 				})
-				return err
+				return copyErr
 			}, getRetryOptions())
 			if err != nil {
-				return fmt.Errorf("failed to copy image %s: %v", refs[j].DockerReference().String(), err)
+				logger.Warn("failed to copy image %s: %v", refs[j].DockerReference().String(), err)
 			}
 		}
 	}
@@ -108,7 +109,7 @@ func ToRegistry(ctx context.Context, opts *Options) error {
 
 func getRetryOptions() *retry.RetryOptions {
 	return &retry.RetryOptions{
-		MaxRetry: 5,
+		MaxRetry: 3,
 	}
 }
 

--- a/pkg/registry/sync/sync.go
+++ b/pkg/registry/sync/sync.go
@@ -42,7 +42,21 @@ const (
 	defaultPort = "5000"
 )
 
-func ToRegistry(ctx context.Context, sys *types.SystemContext, src, dst string, reportWriter io.Writer, selection copy.ImageListSelection) error {
+type Options struct {
+	Sys       *types.SystemContext
+	Source    string
+	Target    string
+	Writer    io.Writer
+	Selection copy.ImageListSelection
+	SkipError bool
+}
+
+func ToRegistry(ctx context.Context, opts *Options) error {
+	src := opts.Source
+	dst := opts.Target
+	sys := opts.Sys
+	reportWriter := opts.Writer
+	selection := opts.Selection
 	policyContext, err := getPolicyContext()
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f99df11</samp>

### Summary
🆕📝♻️

<!--
1.  🆕 for adding a new subcommand `copy` to the `sealos registry` command.
2.  📝 for updating the documentation of the `sealos registry sync` and `sealos registry copy` commands in Chinese and English.
3.  ♻️ for refactoring the `Sync` function, the `sync` command, the `save` package, and the image sync functionality of the `sync` package.
-->
This pull request enhances the image registry synchronization and migration features of `sealos`. It refactors the `Sync` function and the `sync` and `save` packages to improve code quality and flexibility. It adds a new `copy` package and a `sealos registry copy` command to allow users to copy a single image between registries. It also updates the documentation of the `registry` commands in both Chinese and English.

> _If you want to copy an image with ease_
> _Use the `sealos registry copy` command, please_
> _It has options and docs_
> _And some refactored blocks_
> _To make image sync a breeze_

### Walkthrough
*  Add a new subcommand `copy` to the `sealos registry` command, which allows users to copy a single image from one registry to another ([link](https://github.com/labring/sealos/pull/3238/files?diff=unified&w=0#diff-ef80d106f76d3787c5a2bd1b56f56fa907895e49f6f847913184612256e1b023L31-R34), [link](https://github.com/labring/sealos/pull/3238/files?diff=unified&w=0#diff-298caa76ea9a44e2ffd1a75f6b5c998fcc0a0440e85d0c6df75c6537866869edR1-R114))
  * Define a `globalOptions` struct to hold the common flags for overriding the architecture, OS, variant, and all images selection ([link](https://github.com/labring/sealos/pull/3238/files?diff=unified&w=0#diff-298caa76ea9a44e2ffd1a75f6b5c998fcc0a0440e85d0c6df75c6537866869edR1-R114))
  * Define a `runCopy` function that uses the `sync` package to copy a single image from one registry to another, with authentication and retry logic ([link](https://github.com/labring/sealos/pull/3238/files?diff=unified&w=0#diff-298caa76ea9a44e2ffd1a75f6b5c998fcc0a0440e85d0c6df75c6537866869edR1-R114))
* Update the documentation of the `sealos registry sync` and `sealos registry copy` commands in Chinese and English, to reflect the new options and examples ([link](https://github.com/labring/sealos/pull/3238/files?diff=unified&w=0#diff-cfe3111100d80840759e239722cd7b0f898bd4ff0b0fee779e7829bf3ab0effbL137-R233), [link](https://github.com/labring/sealos/pull/3238/files?diff=unified&w=0#diff-c8056602e75b3635f33e8b434b9573d685c52da1340740f485b0a92d6238704eL137-R233))
* Modify the `Sync` function in the `sync.go` file, to use a new `Options` struct instead of multiple parameters, and to support both system and all images selection for syncing ([link](https://github.com/labring/sealos/pull/3238/files?diff=unified&w=0#diff-9d77d600601adda24842f567809994d01cf84d860574c5ed89288c53c3a5f7f5L117-R136))
  * Add a retry mechanism for each image, in case of network errors or other failures ([link](https://github.com/labring/sealos/pull/3238/files?diff=unified&w=0#diff-9d77d600601adda24842f567809994d01cf84d860574c5ed89288c53c3a5f7f5L117-R136))
* Modify the `NewSyncRegistryCommand` function in the `sync.go` file in the `commands` package, to use the `globalOptions` struct and register its flags to the command ([link](https://github.com/labring/sealos/pull/3238/files?diff=unified&w=0#diff-b9a560c7fd05d9f6ef1fe3e6031065b936a85c19b7c969dc8d1930ad7fc18d99L33-R58))
  * Update the usage and example strings of the command, to reflect the new options and syntax ([link](https://github.com/labring/sealos/pull/3238/files?diff=unified&w=0#diff-b9a560c7fd05d9f6ef1fe3e6031065b936a85c19b7c969dc8d1930ad7fc18d99L33-R58))
* Modify the `runSync` function in the `sync.go` file in the `commands` package, to use the `Options` struct and pass the `globalOptions` values to it ([link](https://github.com/labring/sealos/pull/3238/files?diff=unified&w=0#diff-b9a560c7fd05d9f6ef1fe3e6031065b936a85c19b7c969dc8d1930ad7fc18d99L66-R85))
  * Update the `imageListSelection` variable to use the `copy` package constants instead of the `sync` package constants, which are deprecated ([link](https://github.com/labring/sealos/pull/3238/files?diff=unified&w=0#diff-b9a560c7fd05d9f6ef1fe3e6031065b936a85c19b7c969dc8d1930ad7fc18d99L66-R85))
* Add a new function `ImageNameToReference` to the `sync.go` file in the `sync` package, which parses an image name string and returns a `types.ImageReference` object, with authentication and validation logic ([link](https://github.com/labring/sealos/pull/3238/files?diff=unified&w=0#diff-fca7ad9e3b88ff9fd9f29ed3abf2603753bea9e8355cbc7ef73bc1b5ad8de018L97-R140))
  * Use this function in the `copy` and `save` packages, to avoid duplicating the code and to handle different image name formats ([link](https://github.com/labring/sealos/pull/3238/files?diff=unified&w=0#diff-298caa76ea9a44e2ffd1a75f6b5c998fcc0a0440e85d0c6df75c6537866869edR1-R114), [link](https://github.com/labring/sealos/pull/3238/files?diff=unified&w=0#diff-74bab51d328e650ef8ce5589cba1b4a612757ec488b5d82c3a78a9d69fb7dce3L78-R79))
* Modify the `ToRegistry` function in the `sync.go` file in the `sync` package, to use the `Options` struct and unpack its values inside the function ([link](https://github.com/labring/sealos/pull/3238/files?diff=unified&w=0#diff-fca7ad9e3b88ff9fd9f29ed3abf2603753bea9e8355cbc7ef73bc1b5ad8de018L45-R62))
  * Assign the `refs[j]` value to a local variable `ref`, and use it in the `copy.Image` function ([link](https://github.com/labring/sealos/pull/3238/files?diff=unified&w=0#diff-fca7ad9e3b88ff9fd9f29ed3abf2603753bea9e8355cbc7ef73bc1b5ad8de018L77-R97))
  * Log a warning message instead of returning an error, if the `copy.Image` function fails ([link](https://github.com/labring/sealos/pull/3238/files?diff=unified&w=0#diff-fca7ad9e3b88ff9fd9f29ed3abf2603753bea9e8355cbc7ef73bc1b5ad8de018L85-R106))
  * Add a debug log message to indicate the source and destination of the image copy ([link](https://github.com/labring/sealos/pull/3238/files?diff=unified&w=0#diff-fca7ad9e3b88ff9fd9f29ed3abf2603753bea9e8355cbc7ef73bc1b5ad8de018R152))
* Modify the `SaveImages` function in the `registry_save.go` file in the `save` package, to use the `ImageNameToReference` function instead of parsing the image name manually ([link](https://github.com/labring/sealos/pull/3238/files?diff=unified&w=0#diff-74bab51d328e650ef8ce5589cba1b4a612757ec488b5d82c3a78a9d69fb7dce3L78-R79))
* Remove unused imports of the `os`, `alltransports`, and `name` packages from the `sync.go`, `registry_save.go`, and `copy.go` files, which are minor code cleanups ([link](https://github.com/labring/sealos/pull/3238/files?diff=unified&w=0#diff-9d77d600601adda24842f567809994d01cf84d860574c5ed89288c53c3a5f7f5L23), [link](https://github.com/labring/sealos/pull/3238/files?diff=unified&w=0#diff-b9a560c7fd05d9f6ef1fe3e6031065b936a85c19b7c969dc8d1930ad7fc18d99L24), [link](https://github.com/labring/sealos/pull/3238/files?diff=unified&w=0#diff-74bab51d328e650ef8ce5589cba1b4a612757ec488b5d82c3a78a9d69fb7dce3L25-R25))
* Add an empty line to the `sync.go` file in the `commands` package, which is a minor code formatting improvement ([link](https://github.com/labring/sealos/pull/3238/files?diff=unified&w=0#diff-b9a560c7fd05d9f6ef1fe3e6031065b936a85c19b7c969dc8d1930ad7fc18d99R16))

