### PR TITLE
fix: router back invalid; perf: database ux

### DIFF
--- a/frontend/providers/applaunchpad/src/pages/_app.tsx
+++ b/frontend/providers/applaunchpad/src/pages/_app.tsx
@@ -12,6 +12,7 @@ import throttle from 'lodash/throttle';
 import { useGlobalStore } from '@/store/global';
 import { useLoading } from '@/hooks/useLoading';
 import { getServiceEnv, SEALOS_DOMAIN } from '@/store/static';
+import { useRouter } from 'next/router';
 
 import 'nprogress/nprogress.css';
 import '@/styles/reset.scss';
@@ -33,7 +34,8 @@ const queryClient = new QueryClient({
 });
 
 export default function App({ Component, pageProps }: AppProps) {
-  const { setScreenWidth, loading } = useGlobalStore();
+  const router = useRouter();
+  const { setScreenWidth, loading, setLastRoute } = useGlobalStore();
   const { Loading } = useLoading();
   const { openConfirm, ConfirmChild } = useConfirm({
     title: '跳转提示',
@@ -78,6 +80,13 @@ export default function App({ Component, pageProps }: AppProps) {
       window.removeEventListener('resize', resize);
     };
   }, [setScreenWidth]);
+
+  // record route
+  useEffect(() => {
+    return () => {
+      setLastRoute(router.asPath);
+    };
+  }, [router.asPath, setLastRoute]);
 
   return (
     <>

--- a/frontend/providers/applaunchpad/src/pages/_app.tsx
+++ b/frontend/providers/applaunchpad/src/pages/_app.tsx
@@ -86,7 +86,7 @@ export default function App({ Component, pageProps }: AppProps) {
     return () => {
       setLastRoute(router.asPath);
     };
-  }, [router.asPath, setLastRoute]);
+  }, [router.pathname, setLastRoute]);
 
   return (
     <>

--- a/frontend/providers/applaunchpad/src/pages/app/detail/components/Header.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/detail/components/Header.tsx
@@ -102,7 +102,7 @@ const Header = ({
 
   return (
     <Flex h={'86px'} alignItems={'center'}>
-      <Button variant={'unstyled'} onClick={router.back} lineHeight={1}>
+      <Button variant={'unstyled'} onClick={() => router.replace('/apps')} lineHeight={1}>
         <MyIcon name="arrowLeft" />
       </Button>
       <Box ml={5} mr={3} fontSize={'3xl'} fontWeight={'bold'}>

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
@@ -284,11 +284,12 @@ const Form = ({
                     disabled={isEdit}
                     title={isEdit ? '不允许修改应用名称' : ''}
                     autoFocus={true}
+                    placeholder={'字母开头，仅能包含小写字母、数字和 -'}
                     {...register('appName', {
                       required: '应用名称不能为空',
                       pattern: {
-                        value: /^[a-z0-9]+([-.][a-z0-9]+)*$/g,
-                        message: '应用名只能包含小写字母、数字、-和.'
+                        value: /^[a-z]+([-.][a-z0-9]+)*$/g,
+                        message: '应用名只能包含小写字母、数字和 -'
                       }
                     })}
                   />

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/Header.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/Header.tsx
@@ -6,6 +6,7 @@ import JSZip from 'jszip';
 import type { YamlItemType } from '@/types/index';
 import { downLoadBold } from '@/utils/tools';
 import dayjs from 'dayjs';
+import { useGlobalStore } from '@/store/global';
 
 const Header = ({
   appName,
@@ -21,6 +22,7 @@ const Header = ({
   applyBtnText: string;
 }) => {
   const router = useRouter();
+  const { lastRoute } = useGlobalStore();
 
   const handleExportYaml = useCallback(async () => {
     const zip = new JSZip();
@@ -37,7 +39,7 @@ const Header = ({
 
   return (
     <Flex w={'100%'} px={10} h={'86px'} alignItems={'center'}>
-      <Flex alignItems={'center'} cursor={'pointer'} onClick={() => router.back()}>
+      <Flex alignItems={'center'} cursor={'pointer'} onClick={() => router.replace(lastRoute)}>
         <MyIcon name="arrowLeft" />
         <Box ml={6} fontWeight={'bold'} color={'black'} fontSize={'3xl'}>
           {title}

--- a/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
@@ -128,11 +128,10 @@ const EditApp = ({ appName }: { appName?: string }) => {
       const data = yamlList.map((item) => item.value);
       if (appName) {
         await putApp(data, appName);
-        router.back();
       } else {
         await postDeployApp(data);
-        router.push(`/apps`);
       }
+      router.replace(`/app/detail?name=${formHook.getValues('appName')}`);
       toast({
         title: applySuccess,
         status: 'success'
@@ -142,7 +141,7 @@ const EditApp = ({ appName }: { appName?: string }) => {
       setErrorMessage(JSON.stringify(error));
     }
     setIsLoading(false);
-  }, [applySuccess, appName, router, setIsLoading, toast, yamlList]);
+  }, [setIsLoading, yamlList, appName, router, formHook, toast, applySuccess]);
   const submitError = useCallback(() => {
     // deep search message
     const deepSearch = (obj: any): string => {

--- a/frontend/providers/applaunchpad/src/store/global.ts
+++ b/frontend/providers/applaunchpad/src/store/global.ts
@@ -7,6 +7,8 @@ type State = {
   setScreenWidth: (e: number) => void;
   loading: boolean;
   setLoading: (val: boolean) => void;
+  lastRoute: string;
+  setLastRoute: (val: string) => void;
 };
 
 export const useGlobalStore = create<State>()(
@@ -22,6 +24,12 @@ export const useGlobalStore = create<State>()(
       setLoading(val: boolean) {
         set((state) => {
           state.loading = val;
+        });
+      },
+      lastRoute: '/',
+      setLastRoute(val) {
+        set((state) => {
+          state.lastRoute = val;
         });
       }
     }))

--- a/frontend/providers/dbprovider/src/api/db.ts
+++ b/frontend/providers/dbprovider/src/api/db.ts
@@ -16,7 +16,7 @@ export const getDBSecret = (data: { dbName: string; dbType: DBType }) =>
   GET<SecretResponse>(`/api/getSecretByName`, data);
 export const delDBByName = (name: string) => DELETE('/api/delDBByName', { name });
 
-export const applyYamlList = (yamlList: string[], type: 'create' | 'replace'|'update') =>
+export const applyYamlList = (yamlList: string[], type: 'create' | 'replace' | 'update') =>
   POST('/api/applyYamlList', { yamlList, type });
 
 export const getPodsByDBName = (name: string) =>
@@ -37,7 +37,7 @@ export const restartPodByName = (podName: string) => GET(`/api/pod/restartPod?po
 /* db operation */
 export const restartDB = (data: { dbName: string; dbType: DBType }) => {
   const yaml = json2Restart(data);
-  return applyYamlList([yaml],'update');
+  return applyYamlList([yaml], 'update');
 };
 
 export const pauseDBByName = (data: { dbName: string; dbType: DBType }) => {
@@ -45,7 +45,7 @@ export const pauseDBByName = (data: { dbName: string; dbType: DBType }) => {
     ...data,
     type: 'Stop'
   });
-  return applyYamlList([yaml],'update');
+  return applyYamlList([yaml], 'update');
 };
 
 export const startDBByName = (data: { dbName: string; dbType: DBType }) => {
@@ -53,5 +53,5 @@ export const startDBByName = (data: { dbName: string; dbType: DBType }) => {
     ...data,
     type: 'Start'
   });
-  return applyYamlList([yaml],'update');
+  return applyYamlList([yaml], 'update');
 };

--- a/frontend/providers/dbprovider/src/constants/db.ts
+++ b/frontend/providers/dbprovider/src/constants/db.ts
@@ -1,5 +1,5 @@
 import { DBEditType, DBDetailType, PodDetailType, BackupStatusMapType } from '@/types/db';
-import { CpuSlideMarkList,MemorySlideMarkList } from './editApp';
+import { CpuSlideMarkList, MemorySlideMarkList } from './editApp';
 
 export const crLabelKey = 'sealos-db-provider-cr';
 

--- a/frontend/providers/dbprovider/src/constants/editApp.ts
+++ b/frontend/providers/dbprovider/src/constants/editApp.ts
@@ -40,6 +40,6 @@ export const MemorySlideMarkList = [
   { label: '5G', value: 5120 },
   { label: '6G', value: 6144 },
   { label: '7G', value: 7168 },
-  { label: '8G', value: 8192 },
+  { label: '8G', value: 8192 }
   // { label: '16G', value: 16384 }
 ];

--- a/frontend/providers/dbprovider/src/pages/_app.tsx
+++ b/frontend/providers/dbprovider/src/pages/_app.tsx
@@ -85,7 +85,7 @@ export default function App({ Component, pageProps, domain }: AppProps & { domai
     return () => {
       setLastRoute(router.asPath);
     };
-  }, [router.asPath, setLastRoute]);
+  }, [router.pathname, setLastRoute]);
 
   return (
     <>

--- a/frontend/providers/dbprovider/src/pages/_app.tsx
+++ b/frontend/providers/dbprovider/src/pages/_app.tsx
@@ -11,6 +11,7 @@ import { useConfirm } from '@/hooks/useConfirm';
 import throttle from 'lodash/throttle';
 import { useGlobalStore } from '@/store/global';
 import { useLoading } from '@/hooks/useLoading';
+import { useRouter } from 'next/router';
 
 import 'nprogress/nprogress.css';
 import 'react-day-picker/dist/style.css';
@@ -33,7 +34,8 @@ const queryClient = new QueryClient({
 });
 
 export default function App({ Component, pageProps, domain }: AppProps & { domain: string }) {
-  const { setScreenWidth, loading } = useGlobalStore();
+  const router = useRouter();
+  const { setScreenWidth, loading, setLastRoute } = useGlobalStore();
   const { Loading } = useLoading();
   const { openConfirm, ConfirmChild } = useConfirm({
     title: '跳转提示',
@@ -77,6 +79,13 @@ export default function App({ Component, pageProps, domain }: AppProps & { domai
       window.removeEventListener('resize', resize);
     };
   }, [setScreenWidth]);
+
+  // record route
+  useEffect(() => {
+    return () => {
+      setLastRoute(router.asPath);
+    };
+  }, [router.asPath, setLastRoute]);
 
   return (
     <>

--- a/frontend/providers/dbprovider/src/pages/db/detail/components/AppBaseInfo.tsx
+++ b/frontend/providers/dbprovider/src/pages/db/detail/components/AppBaseInfo.tsx
@@ -5,7 +5,7 @@ import { useCopyData, printMemory } from '@/utils/tools';
 import MyIcon from '@/components/Icon';
 import { getDBSecret } from '@/api/db';
 import { useQuery } from '@tanstack/react-query';
-import { DBTypeEnum, defaultDBDetail } from '@/constants/db';
+import { DBStatusEnum, DBTypeEnum, defaultDBDetail } from '@/constants/db';
 import { sealosApp } from 'sealos-desktop-sdk/app';
 
 const AppBaseInfo = ({ db = defaultDBDetail }: { db: DBDetailType }) => {
@@ -120,12 +120,17 @@ const AppBaseInfo = ({ db = defaultDBDetail }: { db: DBDetailType }) => {
         </Box>
       ))}
       {/* secret */}
-      {secret && (
+      {secret && db.status.value === DBStatusEnum.Running && (
         <>
           <Flex mt={6} alignItems={'center'} color={'myGray.500'}>
             <MyIcon w={'16px'} name={'analyze'}></MyIcon>
             <Box ml={2}>连接信息</Box>
-            <Button ml={3} size={'xs'} onClick={onclickConnectDB}>
+            <Button
+              ml={3}
+              size={'xs'}
+              disabled={db.status.value !== DBStatusEnum.Running}
+              onClick={onclickConnectDB}
+            >
               一键连接
             </Button>
           </Flex>

--- a/frontend/providers/dbprovider/src/pages/db/detail/components/Header.tsx
+++ b/frontend/providers/dbprovider/src/pages/db/detail/components/Header.tsx
@@ -99,7 +99,7 @@ const Header = ({
 
   return (
     <Flex h={'86px'} alignItems={'center'}>
-      <Button variant={'unstyled'} onClick={router.back} lineHeight={1}>
+      <Button variant={'unstyled'} onClick={() => router.replace('/dbs')} lineHeight={1}>
         <MyIcon name="arrowLeft" />
       </Button>
       <Box mx={5} fontSize={'3xl'} fontWeight={'bold'}>

--- a/frontend/providers/dbprovider/src/pages/db/detail/components/Pods.tsx
+++ b/frontend/providers/dbprovider/src/pages/db/detail/components/Pods.tsx
@@ -96,60 +96,44 @@ const Pods = ({ dbName, dbType }: { dbName: string; dbType: string }) => {
           >
             详情
           </Button>
-          <MyMenu
-            width={100}
-            Button={
-              <MenuButton
-                w={'32px'}
-                h={'32px'}
-                borderRadius={'sm'}
-                _hover={{
-                  bg: 'myWhite.400',
-                  color: 'hover.iconBlue'
-                }}
-              >
-                <MyIcon name={'more'} px={3} />
-              </MenuButton>
-            }
-            menuList={[
-              // {
-              //   child: (
-              //     <>
-              //       <MyIcon name={'terminal'} w={'14px'} />
-              //       <Box ml={2}>终端</Box>
-              //     </>
-              //   ),
-              //   onClick: () => {
-              //     const defaultCommand = `kubectl exec -it ${item.podName} -c ${dbName} -- sh -c "clear; (bash || ash || sh)"`;
-              //     sealosApp.runEvents('openDesktopApp', {
-              //       appKey: 'system-terminal',
-              //       query: {
-              //         defaultCommand
-              //       },
-              //       messageData: { type: 'new terminal', command: defaultCommand }
-              //     });
-              //   }
-              // },
-              {
-                child: (
-                  <>
-                    <MyIcon name={'log'} w={'14px'} />
-                    <Box ml={2}>日志</Box>
-                  </>
-                ),
-                onClick: () => setLogsPodIndex(i)
-              },
-              {
-                child: (
-                  <>
-                    <MyIcon name={'restart'} />
-                    <Box ml={2}>重启</Box>
-                  </>
-                ),
-                onClick: openConfirmRestart(() => handleRestartPod(item.podName))
+          {item.status.value === PodStatusEnum.Running && (
+            <MyMenu
+              width={100}
+              Button={
+                <MenuButton
+                  w={'32px'}
+                  h={'32px'}
+                  borderRadius={'sm'}
+                  _hover={{
+                    bg: 'myWhite.400',
+                    color: 'hover.iconBlue'
+                  }}
+                >
+                  <MyIcon name={'more'} px={3} />
+                </MenuButton>
               }
-            ]}
-          />
+              menuList={[
+                {
+                  child: (
+                    <>
+                      <MyIcon name={'log'} w={'14px'} />
+                      <Box ml={2}>日志</Box>
+                    </>
+                  ),
+                  onClick: () => setLogsPodIndex(i)
+                },
+                {
+                  child: (
+                    <>
+                      <MyIcon name={'restart'} />
+                      <Box ml={2}>重启</Box>
+                    </>
+                  ),
+                  onClick: openConfirmRestart(() => handleRestartPod(item.podName))
+                }
+              ]}
+            />
+          )}
         </Flex>
       )
     }

--- a/frontend/providers/dbprovider/src/pages/db/edit/components/Form.tsx
+++ b/frontend/providers/dbprovider/src/pages/db/edit/components/Form.tsx
@@ -238,11 +238,12 @@ const Form = ({
                     disabled={isEdit}
                     title={isEdit ? '不允许修改应用名称' : ''}
                     autoFocus={true}
+                    placeholder={'字母开头，仅能包含小写字母、数字和 -'}
                     {...register('dbName', {
                       required: '应用名称不能为空',
                       pattern: {
-                        value: /^[a-z0-9]+([-.][a-z0-9]+)*$/g,
-                        message: '应用名只能包含小写字母、数字、-和.'
+                        value: /^[a-z]+([-.][a-z0-9]+)*$/g,
+                        message: '应用名只能包含小写字母、数字和 -'
                       }
                     })}
                   />
@@ -256,7 +257,7 @@ const Form = ({
                   setVal={(e) => {
                     setValue('cpu', CpuSlideMarkList[e].value);
                   }}
-                  max={CpuSlideMarkList.length-1}
+                  max={CpuSlideMarkList.length - 1}
                   min={0}
                   step={1}
                 />
@@ -272,7 +273,7 @@ const Form = ({
                   setVal={(e) => {
                     setValue('memory', MemorySlideMarkList[e].value);
                   }}
-                  max={MemorySlideMarkList.length-1}
+                  max={MemorySlideMarkList.length - 1}
                   min={0}
                   step={1}
                 />
@@ -301,7 +302,7 @@ const Form = ({
                   }}
                 />
               </Flex>
-              <FormControl isInvalid={!!errors.dbName} w={'500px'}>
+              <FormControl isInvalid={!!errors.storage} w={'500px'}>
                 <Flex alignItems={'center'}>
                   <Label>存储容量</Label>
                   <Tooltip label={`容量范围: ${minStorage}~200 Gi`}>

--- a/frontend/providers/dbprovider/src/pages/db/edit/components/Header.tsx
+++ b/frontend/providers/dbprovider/src/pages/db/edit/components/Header.tsx
@@ -6,6 +6,7 @@ import JSZip from 'jszip';
 import type { YamlItemType } from '@/types/index';
 import { downLoadBold } from '@/utils/tools';
 import dayjs from 'dayjs';
+import { useGlobalStore } from '@/store/global';
 
 const Header = ({
   dbName,
@@ -21,6 +22,7 @@ const Header = ({
   applyBtnText: string;
 }) => {
   const router = useRouter();
+  const { lastRoute } = useGlobalStore();
 
   const handleExportYaml = useCallback(async () => {
     const zip = new JSZip();
@@ -37,7 +39,7 @@ const Header = ({
 
   return (
     <Flex w={'100%'} px={10} h={'86px'} alignItems={'center'}>
-      <Flex alignItems={'center'} cursor={'pointer'} onClick={() => router.back()}>
+      <Flex alignItems={'center'} cursor={'pointer'} onClick={() => router.replace(lastRoute)}>
         <MyIcon name="arrowLeft" />
         <Box ml={6} fontWeight={'bold'} color={'black'} fontSize={'3xl'}>
           {title}

--- a/frontend/providers/dbprovider/src/pages/db/edit/index.tsx
+++ b/frontend/providers/dbprovider/src/pages/db/edit/index.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useMemo } from 'react';
 import { useRouter } from 'next/router';
 import { Flex, Box } from '@chakra-ui/react';
 import type { YamlItemType } from '@/types';
-import { json2CreateCluster, json2Account,limitRangeYaml } from '@/utils/json2Yaml';
+import { json2CreateCluster, json2Account, limitRangeYaml } from '@/utils/json2Yaml';
 import { useForm } from 'react-hook-form';
 import { editModeMap } from '@/constants/editApp';
 import { defaultDBEditValue } from '@/constants/db';
@@ -85,8 +85,8 @@ const EditApp = ({ dbName, tabType }: { dbName?: string; tabType?: 'form' | 'yam
   const submitSuccess = useCallback(async () => {
     setIsLoading(true);
     try {
-      !isEdit && await applyYamlList([limitRangeYaml],'create')
-    } catch (err) { }
+      !isEdit && (await applyYamlList([limitRangeYaml], 'create'));
+    } catch (err) {}
     try {
       const data = yamlList.map((item) => item.value);
 
@@ -96,13 +96,13 @@ const EditApp = ({ dbName, tabType }: { dbName?: string; tabType?: 'form' | 'yam
         title: applySuccess,
         status: 'success'
       });
-      router.back();
+      router.replace(`/db/detail?name=${formHook.getValues('dbName')}`);
     } catch (error) {
       console.error(error);
       setErrorMessage(JSON.stringify(error));
     }
     setIsLoading(false);
-  }, [applySuccess, isEdit, router, setIsLoading, toast, yamlList]);
+  }, [applySuccess, formHook, isEdit, router, setIsLoading, toast, yamlList]);
   const submitError = useCallback(() => {
     // deep search message
     const deepSearch = (obj: any): string => {

--- a/frontend/providers/dbprovider/src/store/global.ts
+++ b/frontend/providers/dbprovider/src/store/global.ts
@@ -7,6 +7,8 @@ type State = {
   setScreenWidth: (e: number) => void;
   loading: boolean;
   setLoading: (val: boolean) => void;
+  lastRoute: string;
+  setLastRoute: (val: string) => void;
 };
 
 export const useGlobalStore = create<State>()(
@@ -22,6 +24,12 @@ export const useGlobalStore = create<State>()(
       setLoading(val: boolean) {
         set((state) => {
           state.loading = val;
+        });
+      },
+      lastRoute: '/',
+      setLastRoute(val) {
+        set((state) => {
+          state.lastRoute = val;
         });
       }
     }))

--- a/frontend/providers/dbprovider/src/utils/json2Yaml.ts
+++ b/frontend/providers/dbprovider/src/utils/json2Yaml.ts
@@ -542,4 +542,4 @@ spec:
         cpu: 50m
         memory: 64Mi
       type: Container
-`
+`;

--- a/frontend/providers/dbprovider/src/utils/json2Yaml.ts
+++ b/frontend/providers/dbprovider/src/utils/json2Yaml.ts
@@ -60,7 +60,7 @@ export const json2CreateCluster = (data: DBEditType) => {
                         storage: `${data.storage}Gi`
                       }
                     },
-                    storageClassName: 'openebs-lvmpv-backup'
+                    storageClassName: 'openebs-backup'
                   }
                 }
               ]
@@ -102,7 +102,8 @@ export const json2CreateCluster = (data: DBEditType) => {
                       requests: {
                         storage: `${data.storage}Gi`
                       }
-                    }
+                    },
+                    storageClassName: 'openebs-backup'
                   }
                 }
               ]
@@ -147,7 +148,8 @@ export const json2CreateCluster = (data: DBEditType) => {
                       requests: {
                         storage: `${data.storage}Gi`
                       }
-                    }
+                    },
+                    storageClassName: 'openebs-backup'
                   }
                 }
               ]
@@ -497,7 +499,7 @@ export const json2BackupPvc = ({
           storage: `${storage}Gi`
         }
       },
-      storageClassName: 'openebs-lvmpv-backup',
+      storageClassName: 'openebs-backup',
       volumeMode: 'Filesystem'
     }
   };


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fd20eb7</samp>

### Summary
🛠️🚀🧹

<!--
1.  🛠️ - This emoji represents the changes that fix or improve the navigation, user interface, and code quality of the app and database components. It conveys the idea of repairing or enhancing something.
2.  🚀 - This emoji represents the changes that add new features or functionality to the app and database components, such as remembering the last visited route or using a different storage class. It conveys the idea of launching or boosting something.
3.  🧹 - This emoji represents the changes that remove unused or commented out code, or fix minor formatting issues. It conveys the idea of cleaning or tidying up something.
-->
This pull request adds features and improvements to the app and database pages of the frontend providers. It enhances the navigation experience by remembering the last visited route and using `router.replace` to avoid unwanted history entries. It also improves the user interface and code quality by adding placeholders, validations, conditions, and formatting fixes. It updates the `storageClassName` values of the PVCs to support backup and restore features.

> _This pull request has many changes_
> _To improve the app and database pages_
> _It uses `router.replace`_
> _And the global store's `lastRoute`_
> _To avoid unwanted backstages_

### Walkthrough
*  Record the last visited route in the global store when the app or database component unmounts and use it to navigate back to the previous page when editing or creating an app or a database ([link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-ebd69d41e82f5d5fbc4c8884ac0789e5e3e743e88c10031cebbf19d53120ea02R15),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-ebd69d41e82f5d5fbc4c8884ac0789e5e3e743e88c10031cebbf19d53120ea02L36-R38),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-ebd69d41e82f5d5fbc4c8884ac0789e5e3e743e88c10031cebbf19d53120ea02R84-R90),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-bf3b509719610c1c67d4864285ce644d306f51ded7d87b80d23417b01d73182fR10-R11),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-bf3b509719610c1c67d4864285ce644d306f51ded7d87b80d23417b01d73182fR28-R33),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-ed93ee59d9c7208ec4b3941117521bf9fed9bf925c6cd5af0b238085afd613c3R14),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-ed93ee59d9c7208ec4b3941117521bf9fed9bf925c6cd5af0b238085afd613c3L36-R38),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-ed93ee59d9c7208ec4b3941117521bf9fed9bf925c6cd5af0b238085afd613c3R83-R89),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-794ad40d4b5888d9d4760013ed7440528c727a43f7a693bc253d4d60794344dcR10-R11),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-794ad40d4b5888d9d4760013ed7440528c727a43f7a693bc253d4d60794344dcR28-R33),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-2f3845d19612259d3e58faffb9977cee54c5f65b51eed7276fe55ba93854055cR9),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-2f3845d19612259d3e58faffb9977cee54c5f65b51eed7276fe55ba93854055cR25),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-2f3845d19612259d3e58faffb9977cee54c5f65b51eed7276fe55ba93854055cL40-R42),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-acdfde6af3361f4c336af98abbba7b00d1cb64ebcb6572b9dc5bd085cfc8e87dR9),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-acdfde6af3361f4c336af98abbba7b00d1cb64ebcb6572b9dc5bd085cfc8e87dR25),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-acdfde6af3361f4c336af98abbba7b00d1cb64ebcb6572b9dc5bd085cfc8e87dL40-R42))
* Use `router.replace` instead of `router.back` to go to the app or database detail page after applying the changes and show the updated details ([link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-134f94c26d993fe5ecf63494e11b4cd294dfbc24ae94a78aff78e154af844df4L105-R105),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-892cbbe4d621ecd2c14c9beff22da9d6a7bd32d75da2ff82081fb42cc18a67efL131-R134),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-892cbbe4d621ecd2c14c9beff22da9d6a7bd32d75da2ff82081fb42cc18a67efL145-R144),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-8370c7b39c1a3818220f8f5421d9f05174ad45eb8ee847bb579ec8161a2b8221L102-R102),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-b43affe7fc2ddae7748f5878fb00d5a86545a0cb47d825172eea4c56f489135bL99-R99),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-b43affe7fc2ddae7748f5878fb00d5a86545a0cb47d825172eea4c56f489135bL105-R105))
* Add a `placeholder` attribute to the app or database name input field and modify the `message` attribute of the `pattern` validator to show the required format of the name ([link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-aa041a9224e2f824f92075b3c8dbf486176dc3465642fe70bf39ab83fde12c57L287-R292),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-29203f04abf2be150e119bd6fa257b8f6bef5eebdf768a1ac4a91083077bee8cL241-R246))
* Render the secret and the connect button only when the database status is running in the `AppBaseInfo.tsx` component ([link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-f7988281611b0fe0a39c1b2426b3c37b5864e30f40b4f5584e1e31a6700538e6L8-R8),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-f7988281611b0fe0a39c1b2426b3c37b5864e30f40b4f5584e1e31a6700538e6L123-R133))
* Render the menu button with the log and restart options only when the pod status is running in the `Pods.tsx` component ([link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-9416e9fc99fb3f715ec2380fc681cf84d3cfddb6b899d85221590782154516baL99-R136))
* Modify the `storageClassName` value of the backup PVC and add the `storageClassName` property to the data PVC in the `json2Yaml.ts` module to use the `openebs-backup` storage class that supports backup and restore features ([link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-dbfdf7f57dc6e2caf2884409586ab2da585f46024959973487d84a2631539392L63-R63),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-dbfdf7f57dc6e2caf2884409586ab2da585f46024959973487d84a2631539392L105-R106),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-dbfdf7f57dc6e2caf2884409586ab2da585f46024959973487d84a2631539392L150-R152),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-dbfdf7f57dc6e2caf2884409586ab2da585f46024959973487d84a2631539392L500-R502))
* Add spaces after commas in `import` statements and function calls, add parentheses and semicolons where needed, and remove commented out code to improve the code style and readability ([link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-fb2e06ea4d7cbe39a989e49264c5873a590426926ff1b15f81fb303c0d3d2151L19-R19),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-fb2e06ea4d7cbe39a989e49264c5873a590426926ff1b15f81fb303c0d3d2151L40-R40),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-fb2e06ea4d7cbe39a989e49264c5873a590426926ff1b15f81fb303c0d3d2151L48-R48),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-fb2e06ea4d7cbe39a989e49264c5873a590426926ff1b15f81fb303c0d3d2151L56-R56),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-3fd153f7fed2b7a9d785aabcfac28851a32b034abbf3bd14cd486392448361c3L2-R2),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-ed63924a8344bc3d163b90eabc2a68ec4ebbf6f3cf6f939d5fe8623df31d3977L43-R43),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-29203f04abf2be150e119bd6fa257b8f6bef5eebdf768a1ac4a91083077bee8cL259-R260),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-29203f04abf2be150e119bd6fa257b8f6bef5eebdf768a1ac4a91083077bee8cL275-R276),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-29203f04abf2be150e119bd6fa257b8f6bef5eebdf768a1ac4a91083077bee8cL304-R305),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-b43affe7fc2ddae7748f5878fb00d5a86545a0cb47d825172eea4c56f489135bL5-R5),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-b43affe7fc2ddae7748f5878fb00d5a86545a0cb47d825172eea4c56f489135bL88-R89),[link](https://github.com/labring/sealos/pull/3241/files?diff=unified&w=0#diff-dbfdf7f57dc6e2caf2884409586ab2da585f46024959973487d84a2631539392L545-R547))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
