### PR TITLE
Fix ass go-lint-ci version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,6 @@ jobs:
       - name: Run Linter
         uses: golangci/golangci-lint-action@v3
         with:
-          version: latest
+          version: v1.52.2
           working-directory: ${{ matrix.workdir }}
           args: "--out-${NO_FUTURE}format colored-line-number"

--- a/.github/workflows/controllers.yml
+++ b/.github/workflows/controllers.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Run Linter
         uses: golangci/golangci-lint-action@v3
         with:
-          version: latest
+          version: v1.52.2
           working-directory: ${{ matrix.workdir }}
           args: "--out-${NO_FUTURE}format colored-line-number"
 

--- a/.github/workflows/services.yml
+++ b/.github/workflows/services.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Run Linter
         uses: golangci/golangci-lint-action@v3
         with:
-          version: latest
+          version: v1.52.2
           working-directory: ${{ matrix.workdir }}
           args: "--out-${NO_FUTURE}format colored-line-number"
 

--- a/.github/workflows/webhooks.yml
+++ b/.github/workflows/webhooks.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Run Linter
         uses: golangci/golangci-lint-action@v3
         with:
-          version: latest
+          version: v1.52.2
           working-directory: ${{ matrix.workdir }}
           args: "--out-${NO_FUTURE}format colored-line-number"
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 66c0d08</samp>

### Summary
:wrench::recycle::sparkles:

<!--
1.  :wrench: - This emoji represents fixing or adjusting something, such as the version of the golangci-lint-action.
2.  :recycle: - This emoji represents recycling or reusing something, such as the same change applied to different workflows.
3.  :sparkles: - This emoji represents adding or improving something, such as the quality of the code by using the golangci-lint-action.
-->
Fixed the version of `golangci-lint-action` to v1.52.2 in all GitHub workflows that use it. This ensures consistent and reliable linting results across different directories.

> _`golangci-lint-action`_
> _Fixed to a stable version_
> _Winter of no bugs_

### Walkthrough
* Fix the version of golangci-lint-action to v1.52.2 in all workflows to avoid potential breaking changes or bugs ([link](https://github.com/labring/sealos/pull/3244/files?diff=unified&w=0#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL74-R74), [link](https://github.com/labring/sealos/pull/3244/files?diff=unified&w=0#diff-8e0e4903d4e4f8b8844d36370ca2d71c7c72d03ddb7a9cdcedc6328dfc5da8faL68-R68), [link](https://github.com/labring/sealos/pull/3244/files?diff=unified&w=0#diff-48839d65f7bfedd91312ee406fd94da103ede7d3c7e791eb2c1657f46afdea00L68-R68), [link](https://github.com/labring/sealos/pull/3244/files?diff=unified&w=0#diff-51dbe051fd6c1e7ad2d0ad8a0fca7276dfa01776803a136c0f03832857c1a871L62-R62))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
