### PR TITLE
fix: name regx

### DIFF
--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
@@ -288,8 +288,8 @@ const Form = ({
                     {...register('appName', {
                       required: '应用名称不能为空',
                       pattern: {
-                        value: /^[a-z]+([-.][a-z0-9]+)*$/g,
-                        message: '应用名只能包含小写字母、数字和 -'
+                        value: /^[a-z][a-z0-9]+([-.][a-z0-9]+)*$/g,
+                        message: '应用名只能包含小写字母、数字和 -,并且字母开头。'
                       }
                     })}
                   />

--- a/frontend/providers/dbprovider/src/pages/db/edit/components/Form.tsx
+++ b/frontend/providers/dbprovider/src/pages/db/edit/components/Form.tsx
@@ -242,8 +242,8 @@ const Form = ({
                     {...register('dbName', {
                       required: '应用名称不能为空',
                       pattern: {
-                        value: /^[a-z]+([-.][a-z0-9]+)*$/g,
-                        message: '应用名只能包含小写字母、数字和 -'
+                        value: /^[a-z][a-z0-9]+([-.][a-z0-9]+)*$/g,
+                        message: '应用名只能包含小写字母、数字和 -,并且字母开头。'
                       }
                     })}
                   />


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e053b67</samp>

### Summary
📝🔤🔄

<!--
1.  📝 - This emoji can be used to indicate that some text or code was edited or updated, such as the pattern validation and the error message.
2.  🔤 - This emoji can be used to signify that something related to letters or alphabets was changed, such as the rule that the app name must start with a letter.
3.  🔄 - This emoji can be used to denote that something was repeated or applied to another component, such as the same change being made to the dbprovider form component.
-->
The pull request modifies the pattern validation and error message for the app name field in two form components: `Form.tsx` for `applaunchpad` and `dbprovider`. The purpose is to ensure that app names start with a letter and are consistent across providers.

> _App names must start with_
> _a letter, not just have them_
> _`dbprovider` too_

### Walkthrough
*  Modify the pattern validation and error message for the app name field in both `applaunchpad` and `dbprovider` forms to enforce that the app name must start with a letter ([link](https://github.com/labring/sealos/pull/3254/files?diff=unified&w=0#diff-aa041a9224e2f824f92075b3c8dbf486176dc3465642fe70bf39ab83fde12c57L291-R292), [link](https://github.com/labring/sealos/pull/3254/files?diff=unified&w=0#diff-29203f04abf2be150e119bd6fa257b8f6bef5eebdf768a1ac4a91083077bee8cL245-R246))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
