### PR TITLE
fix: return fast

### DIFF
--- a/pkg/buildah/imagesaver.go
+++ b/pkg/buildah/imagesaver.go
@@ -55,6 +55,9 @@ func runSaveImages(contextDir string, platforms []v1.Platform, sys *types.System
 	if err != nil {
 		return err
 	}
+	if len(images) == 0 {
+		return nil
+	}
 	auths, err := crane.GetAuthInfo(sys)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8861036</samp>

Improve image saving feature of sealos. Add early return check to `runSaveImages` in `pkg/buildah/imagesaver.go` to avoid unnecessary or invalid calls to `buildah.NewImage`.