### PR TITLE
fix: set default storage config path for root users

### DIFF
--- a/pkg/buildah/setup.go
+++ b/pkg/buildah/setup.go
@@ -56,6 +56,7 @@ func init() {
 		DefaultConfigFile, err = types.DefaultConfigFile(true)
 		bailOnError(err, "")
 	}
+	logger.Debug("using file %s as container storage config", DefaultConfigFile)
 
 	// config path
 	if unshare.IsRootless() {

--- a/pkg/system/env.go
+++ b/pkg/system/env.go
@@ -92,6 +92,11 @@ var configOptions = []ConfigOption{
 		Description:  "enable registry sync experimental feature, using containers/image module to save and sync images",
 		DefaultValue: "false",
 	},
+	{
+		Key:         ContainerStorageConfEnvKey,
+		Description: "path of container storage config file, setting this env will override the default location",
+		OSEnv:       ContainerStorageConfEnvKey,
+	},
 }
 
 const (
@@ -100,6 +105,7 @@ const (
 	DataRootConfigKey                 = "DATA_ROOT"
 	BuildahFormatConfigKey            = "BUILDAH_FORMAT"
 	BuildahLogLevelConfigKey          = "BUILDAH_LOG_LEVEL"
+	ContainerStorageConfEnvKey        = "CONTAINERS_STORAGE_CONF"
 	ScpChecksumConfigKey              = "SCP_CHECKSUM"
 	RegistrySyncExperimentalConfigKey = "REGISTRY_SYNC_EXPERIMENTAL"
 )


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e358dc7</samp>

Improve `buildah` package configuration and error handling. Use appropriate config files for different modes.