### PR TITLE
feature: recharge extra gift amount

### DIFF
--- a/controllers/account/controllers/account_controller.go
+++ b/controllers/account/controllers/account_controller.go
@@ -126,7 +126,8 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 		}()
 		now := time.Now().UTC()
-		account.Status.Balance += payment.Spec.Amount
+		var gift = giveGift(payment.Spec.Amount)
+		account.Status.Balance += payment.Spec.Amount + gift
 		if err := r.Status().Update(ctx, account); err != nil {
 			return ctrl.Result{}, fmt.Errorf("update account failed: %v", err)
 		}
@@ -338,4 +339,23 @@ func (r *AccountReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&source.Kind{Type: &accountv1.Payment{}}, &handler.EnqueueRequestForObject{}).
 		Watches(&source.Kind{Type: &accountv1.AccountBalance{}}, &handler.EnqueueRequestForObject{}).
 		Complete(r)
+}
+
+func giveGift(amount int64) int64 {
+	var ratio int64
+	switch {
+	case amount < 299:
+		ratio = 0
+	case amount < 599:
+		ratio = 10
+	case amount < 1999:
+		ratio = 15
+	case amount < 4999:
+		ratio = 20
+	case amount < 19999:
+		ratio = 25
+	default:
+		ratio = 30
+	}
+	return amount * ratio / 100
 }

--- a/controllers/account/controllers/account_controller.go
+++ b/controllers/account/controllers/account_controller.go
@@ -345,7 +345,7 @@ func giveGift(amount int64) int64 {
 	var ratio int64
 	switch {
 	case amount < 299:
-		ratio = 0
+		return 0
 	case amount < 599:
 		ratio = 10
 	case amount < 1999:

--- a/controllers/account/controllers/account_controller_test.go
+++ b/controllers/account/controllers/account_controller_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import "testing"
+
+func Test_giveGift(t *testing.T) {
+	type args struct {
+		amount int64
+	}
+	tests := []struct {
+		name string
+		args args
+		want int64
+	}{
+		// [1-298] -> 0%, [299-598] -> 10%, [599-1998] -> 15%, [1999-4998] -> 20%, [4999-19998] -> 25%, [19999+] -> 30%
+		{name: "0% less than 299", args: args{amount: 100}, want: 0},
+		{name: "10% between 299 and 599", args: args{amount: 299}, want: 29},
+		{name: "10% between 299 and 599", args: args{amount: 300}, want: 30},
+		{name: "15% between 599 and 1999", args: args{amount: 599}, want: 89},
+		{name: "15% between 599 and 1999", args: args{amount: 600}, want: 90},
+		{name: "20% between 1999 and 4999", args: args{amount: 1999}, want: 399},
+		{name: "20% between 1999 and 4999", args: args{amount: 2000}, want: 400},
+		{name: "25% between 4999 and 19999", args: args{amount: 4999}, want: 1249},
+		{name: "25% between 4999 and 19999", args: args{amount: 5000}, want: 1250},
+		{name: "30% more than 19999", args: args{amount: 19999}, want: 5999},
+		{name: "30% more than 19999", args: args{amount: 20000}, want: 6000},
+		{name: "30% more than 19999", args: args{amount: 99999}, want: 29999},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := giveGift(tt.args.amount); got != tt.want {
+				t.Errorf("giveGift() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When the user recharges, different amounts are given according to the recharge amount.

[1-298] -> 0%, [299-598] -> 10%, [599-1998] -> 15%
[1999-4998] -> 20%, [4999-19998] -> 25%, [19999+] -> 30%

<img width="239" alt="img_v2_7991aed0-5f84-4ffa-be88-3a61c250561g" src="https://github.com/labring/sealos/assets/72536832/343494cc-397e-4ad5-8004-32066b2b73f4">
