### PR TITLE
refactor(main): add ednpoint rbac

### DIFF
--- a/controllers/db/adminer/config/rbac/role.yaml
+++ b/controllers/db/adminer/config/rbac/role.yaml
@@ -57,6 +57,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create

--- a/controllers/db/adminer/controllers/adminer_controller.go
+++ b/controllers/db/adminer/controllers/adminer_controller.go
@@ -91,6 +91,7 @@ type AdminerReconciler struct {
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,resources=endpoints,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f580cab</samp>

### Summary
🔌🌐🔐

<!--
1.  🔌 - This emoji can represent the endpoints resource, which is a way of connecting to services in the cluster.
2.  🌐 - This emoji can represent the web interface of the adminer pod, which allows users to manage different databases through a browser.
3.  🔐 - This emoji can represent the RBAC role and role binding, which are security mechanisms to control the access of the adminer service account.
-->
This pull request adds support for the `endpoints` resource to the adminer controller and service account. This enables the adminer web interface to connect to different databases in the cluster.

> _`adminer` pod needs_
> _`endpoints` to reach databases_
> _kubebuilder helps_

### Walkthrough
*  Add `endpoints` resource to RBAC role for adminer service account ([link](https://github.com/labring/sealos/pull/3303/files?diff=unified&w=0#diff-44f695e90dc472a831253de8db6879f2b9bd34886d1c24ed06a77ffdeea42bc0R60-R67))
*  Annotate adminer controller with RBAC for `endpoints` resource ([link](https://github.com/labring/sealos/pull/3303/files?diff=unified&w=0#diff-8ce8f6aaffe4bfb0b749fa5b461cc4a7914acc282ae0353db539fc210f358e0fR94))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
