### PR TITLE
feat: support override platform flags for inspect command

### DIFF
--- a/pkg/buildah/common.go
+++ b/pkg/buildah/common.go
@@ -19,14 +19,17 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/containers/buildah"
+	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/common/pkg/umask"
 	is "github.com/containers/image/v5/storage"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/unshare"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/labring/sealos/pkg/system"
 	wrapunshare "github.com/labring/sealos/pkg/unshare"
@@ -56,6 +59,15 @@ func setDefaultFlagsWithSetters(c *cobra.Command, setters ...func(*cobra.Command
 		}
 	}
 	return nil
+}
+
+func getPlatformFlags() *pflag.FlagSet {
+	fs := &pflag.FlagSet{}
+	fs.String("arch", runtime.GOARCH, "set the ARCH of the image to the provided value instead of the architecture of the host")
+	fs.String("os", runtime.GOOS, "set the OS to the provided value instead of the current operating system of the host")
+	fs.StringSlice("platform", []string{parse.DefaultPlatform()}, "set the OS/ARCH/VARIANT of the image to the provided value instead of the current operating system and architecture of the host (for example `linux/arm`)")
+	fs.String("variant", "", "override the `variant` of the specified image")
+	return fs
 }
 
 func flagsAssociatedWithPlatform() []string {

--- a/pkg/buildah/inspect.go
+++ b/pkg/buildah/inspect.go
@@ -63,8 +63,8 @@ func newDefaultInspectResults() *inspectResults {
 
 func (opts *inspectResults) RegisterFlags(fs *pflag.FlagSet) {
 	fs.SetInterspersed(false)
-	fs.StringVarP(&opts.format, "format", "f", "", "use `format` as a Go template to format the output")
-	fs.StringVarP(&opts.inspectType, "type", "t", inspectTypeContainer, "look at the item of the specified `type` (container or image) and name")
+	fs.StringVarP(&opts.format, "format", "f", opts.format, "use `format` as a Go template to format the output")
+	fs.StringVarP(&opts.inspectType, "type", "t", opts.inspectType, "look at the item of the specified `type` (container or image) and name")
 }
 
 func newInspectCommand() *cobra.Command {
@@ -89,7 +89,12 @@ func newInspectCommand() *cobra.Command {
   %[1]s inspect --format '{{.OCIv1.Config.Env}}' alpine`, rootCmd.CommandPath()),
 	}
 	inspectCommand.SetUsageTemplate(UsageTemplate())
-	opts.RegisterFlags(inspectCommand.Flags())
+
+	fs := inspectCommand.Flags()
+	opts.RegisterFlags(fs)
+	// only useful for docker/container-storage transport
+	fs.AddFlagSet(getPlatformFlags())
+
 	return inspectCommand
 }
 


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ab04399</samp>

This pull request adds the platform flags feature to the `buildah` package, which enables cross-platform image inspection. It also improves the `inspect` command by adding more options for output formatting and object selection.
