### PR TITLE
refactor(main): add qa for storage

### DIFF
--- a/cmd/sealos/cmd/root.go
+++ b/cmd/sealos/cmd/root.go
@@ -107,6 +107,7 @@ func setRequireBuildahAnnotation(cmd *cobra.Command) {
 }
 
 func onBootOnDie() {
+	logger.CfgConsoleAndFileLogger(debug, constants.LogPath(), "sealos", false)
 	val, err := system.Get(system.DataRootConfigKey)
 	errExit(err)
 	constants.DefaultClusterRootFsDir = val
@@ -119,7 +120,6 @@ func onBootOnDie() {
 		constants.Workdir(),
 	}
 	errExit(file.MkDirs(rootDirs...))
-	logger.CfgConsoleAndFileLogger(debug, constants.LogPath(), "sealos", false)
 }
 
 func errExit(err error) {

--- a/docs/4.0/docs/lifecycle-management/QA.md
+++ b/docs/4.0/docs/lifecycle-management/QA.md
@@ -127,7 +127,32 @@ export SEALOS_DATA_ROOT=/data/sealos
 sealos run labring/kubernetes:v1.24.0
 ```
 
-### Q3：ssh传输文件时，如何禁止检查文件的md5？
+### Q3: 如何修改 Sealos 镜像数据和状态的存储路径?
+
+> 在使用 Sealos 集群时，可能需要改变默认的镜像数据存储路径和状态数据的存储路径。默认情况下，这些数据被存储在 `/etc/containers/storage.conf` 文件定义的位置。
+
+1. **查看当前存储配置**
+   首先，我们可以使用下面的命令来查看当前的镜像存储配置：
+    ```
+    sealos images --debug
+    ```
+   这个命令会打印出包含当前存储配置的文件，例如：
+    ```
+    2023-06-07T16:27:02 debug using file /etc/containers/storage.conf as container storage config
+    REPOSITORY   TAG   IMAGE ID   CREATED   SIZE
+    ```
+2. **修改镜像数据存储路径**
+   如果你希望更改镜像数据的存储路径，你可以编辑 `/etc/containers/storage.conf` 文件。在这个文件中，找到并修改 `graphroot` 字段设置为新的路径。例如：
+    ```
+    vim /etc/containers/storage.conf
+    ```
+   在编辑器中，将 `graphroot` 字段的值修改为你希望的新路径。
+3. **修改状态数据存储路径**
+   参考 Buildah 的设计，Sealos 同样提供了状态数据存储路径的设置。在同样的配置文件 `/etc/containers/storage.conf` 中，找到并修改 `runroot` 字段为新的路径。
+
+通过以上步骤，你可以将 Sealos 集群的镜像数据和状态数据保存到新的地址。每次运行 Sealos 命令时，它都将使用你在 `graphroot` 和 `runroot` 中设置的新路径来分别存储镜像数据和状态数据。
+
+### Q4：ssh传输文件时，如何禁止检查文件的md5？
 
 在网络环境良好时，禁用md5检查可以极大提升传输速度。若不想在ssh传输文件时检查文件的md5，可将SEALOS_SCP_CHECKSUM环境变量设置为false以禁用此功能。建议将此环境变量设为全局，以便在多场景下使用。
 

--- a/docs/4.0/i18n/zh-Hans/lifecycle-management/QA.md
+++ b/docs/4.0/i18n/zh-Hans/lifecycle-management/QA.md
@@ -127,7 +127,32 @@ export SEALOS_DATA_ROOT=/data/sealos
 sealos run labring/kubernetes:v1.24.0
 ```
 
-### Q3：ssh传输文件时，如何禁止检查文件的md5？
+### Q3: 如何修改 Sealos 镜像数据和状态的存储路径?
+
+> 在使用 Sealos 集群时，可能需要改变默认的镜像数据存储路径和状态数据的存储路径。默认情况下，这些数据被存储在 `/etc/containers/storage.conf` 文件定义的位置。
+
+1. **查看当前存储配置**
+   首先，我们可以使用下面的命令来查看当前的镜像存储配置：
+    ```
+    sealos images --debug
+    ```
+   这个命令会打印出包含当前存储配置的文件，例如：
+    ```
+    2023-06-07T16:27:02 debug using file /etc/containers/storage.conf as container storage config
+    REPOSITORY   TAG   IMAGE ID   CREATED   SIZE
+    ```
+2. **修改镜像数据存储路径**
+   如果你希望更改镜像数据的存储路径，你可以编辑 `/etc/containers/storage.conf` 文件。在这个文件中，找到并修改 `graphroot` 字段设置为新的路径。例如：
+    ```
+    vim /etc/containers/storage.conf
+    ```
+   在编辑器中，将 `graphroot` 字段的值修改为你希望的新路径。
+3. **修改状态数据存储路径**
+   参考 Buildah 的设计，Sealos 同样提供了状态数据存储路径的设置。在同样的配置文件 `/etc/containers/storage.conf` 中，找到并修改 `runroot` 字段为新的路径。
+
+通过以上步骤，你可以将 Sealos 集群的镜像数据和状态数据保存到新的地址。每次运行 Sealos 命令时，它都将使用你在 `graphroot` 和 `runroot` 中设置的新路径来分别存储镜像数据和状态数据。
+
+### Q4：ssh传输文件时，如何禁止检查文件的md5？
 
 在网络环境良好时，禁用md5检查可以极大提升传输速度。若不想在ssh传输文件时检查文件的md5，可将SEALOS_SCP_CHECKSUM环境变量设置为false以禁用此功能。建议将此环境变量设为全局，以便在多场景下使用。
 

--- a/pkg/buildah/setup.go
+++ b/pkg/buildah/setup.go
@@ -21,6 +21,8 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/labring/sealos/pkg/system"
+
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/storage/pkg/homedir"
@@ -33,7 +35,6 @@ import (
 
 var (
 	// use the defaultOverrideConfigFile var as default
-	storageConfEnv                     = "CONTAINERS_STORAGE_CONF"
 	defaultOverrideConfigFile          = "/etc/containers/storage.conf"
 	DefaultConfigFile                  string
 	DefaultSignaturePolicyPath         = config.DefaultSignaturePolicyPath
@@ -47,7 +48,7 @@ func init() {
 	_ = os.Setenv("TMPDIR", parse.GetTempDir())
 
 	// storage config path
-	if path, ok := os.LookupEnv(storageConfEnv); ok {
+	if path, ok := os.LookupEnv(system.ContainerStorageConfEnvKey); ok {
 		DefaultConfigFile = path
 	} else if !unshare.IsRootless() {
 		DefaultConfigFile = defaultOverrideConfigFile
@@ -56,8 +57,6 @@ func init() {
 		DefaultConfigFile, err = types.DefaultConfigFile(true)
 		bailOnError(err, "")
 	}
-	logger.Debug("using file %s as container storage config", DefaultConfigFile)
-
 	// config path
 	if unshare.IsRootless() {
 		configHome, err := homedir.GetConfigHome()
@@ -137,6 +136,7 @@ func setupRegistriesFile() error {
 }
 
 func setupStorageConfigFile() error {
+	logger.Debug("using file %s as container storage config", DefaultConfigFile)
 	var content string
 	if unshare.IsRootless() {
 		runRoot := fmt.Sprintf("/run/user/%d", unshare.GetRootlessUID())


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4e2e537</samp>

### Summary
🔄🌐🛠️

<!--
1.  🔄 for the first change, since it replaces an existing question and answer with a new one.
2. 🌐 for the second change, since it is a translation of the first change to another language.
3. 🛠️ for the third and fourth changes, since they are related to adding and updating the buildah functionality and configuration.
-->
This pull request adds buildah-related commands and features to sealos, allowing users to manage images and containers with buildah. It also updates the documentation and the storage configuration for the new feature. It modifies the files `cmd/sealos/cmd/root.go`, `pkg/buildah/setup.go`, and `docs/4.0/docs/lifecycle-management/QA.md` and their Chinese translations.

> _Oh, we are the sealos crew, and we have a job to do_
> _We'll use buildah for our images, and store them where we choose_
> _So heave away, me hearties, heave away with all your might_
> _We'll update the docs and code, and sail into the night_

### Walkthrough
*  Configure logger for buildah commands and features ([link](https://github.com/labring/sealos/pull/3307/files?diff=unified&w=0#diff-004120f0fc828f4af6e0eb88621cf5aecd80ab9e039cde8a4a6210d13b8aa56eR110))
*  Initialize buildah storage and environment when sealos starts ([link](https://github.com/labring/sealos/pull/3307/files?diff=unified&w=0#diff-004120f0fc828f4af6e0eb88621cf5aecd80ab9e039cde8a4a6210d13b8aa56eL122-R123), [link](https://github.com/labring/sealos/pull/3307/files?diff=unified&w=0#diff-c88308209fa36d6bcf017e5ae0fc885d6b37027c88e9079545c3950974961fceL46-R51))
*  Use `system` package constants and functions for buildah storage configuration and environment variables ([link](https://github.com/labring/sealos/pull/3307/files?diff=unified&w=0#diff-c88308209fa36d6bcf017e5ae0fc885d6b37027c88e9079545c3950974961fceR24-R25), [link](https://github.com/labring/sealos/pull/3307/files?diff=unified&w=0#diff-c88308209fa36d6bcf017e5ae0fc885d6b37027c88e9079545c3950974961fceL36), [link](https://github.com/labring/sealos/pull/3307/files?diff=unified&w=0#diff-c88308209fa36d6bcf017e5ae0fc885d6b37027c88e9079545c3950974961fceL46-R51))
*  Update documentation to reflect buildah feature and storage customization ([link](https://github.com/labring/sealos/pull/3307/files?diff=unified&w=0#diff-cac3e7881dc81ec8a9881c761253ec6d556c90a23de8e63c39ecc27cda65479eL130-R156), [link](https://github.com/labring/sealos/pull/3307/files?diff=unified&w=0#diff-96e0b8f0535c6be19a5627d93ec84b9b7e8a9426fda878814cfbf6386ec68b49L130-R156))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
