### PR TITLE
fix(cert sign): not get the correct first svc ip from cidr

### DIFF
--- a/pkg/cert/kube_certs.go
+++ b/pkg/cert/kube_certs.go
@@ -186,10 +186,11 @@ func NewSealosCertMetaData(certPATH, certEtcdPATH string, apiServerIPAndDomains 
 	data.DNSDomain = DNSDomain
 	data.APIServer.IPs = make(map[string]net.IP)
 	data.APIServer.DNSNames = make(map[string]string)
-	svcFirstIP, _, err := net.ParseCIDR(SvcCIDR)
+	_, svcNet, err := net.ParseCIDR(SvcCIDR)
 	if err != nil {
 		return nil, err
 	}
+	svcFirstIP := svcNet.IP
 	svcFirstIP[len(svcFirstIP)-1]++ //取svc第一个ip
 	data.APIServer.IPs[svcFirstIP.String()] = svcFirstIP
 


### PR DESCRIPTION
### SealosVersion
```bash
$ sealos version --short
4.2.0-f696a621
```
### How to reproduce the bug?
1. generate clusterfile
```bash
sealos gen labring/kubernetes:v1.25.0 \
     --masters 10.246.132.125,10.246.132.132,10.246.132.145 \
     --nodes 10.246.132.142 \
     --user root --passwd password > my.Clusterfile
```
2. modify clusterfile, change ServiceSubnet
```bash
$ vim my.Clusterfile.new
$ diff my.Clusterfile.new my.Clusterfile
137c137
<   ServiceSubnet: 172.6.0.0/13
---
>   ServiceSubnet: 10.96.0.0/22
```
3. sealos apply
```bash
$ sealos apply -f my.Clusterfile.new
```
4. get  "certificate apiserver is invalid"  error 
<img width="913" alt="image" src="https://github.com/labring/sealos/assets/73829796/b8543b23-8dd2-414d-a23b-1ac03e68b591">
<br />
<br />
the correct(172.6.0.0/13) first ip is 172.0.0.1
<img width="526" alt="image" src="https://github.com/labring/sealos/assets/73829796/39f18dca-269e-4e17-88d9-9ade30102f1e">

