### PR TITLE
fix: avoid fetching local repos repeatly

### DIFF
--- a/pkg/registry/commands/sync.go
+++ b/pkg/registry/commands/sync.go
@@ -73,15 +73,15 @@ func runSync(cmd *cobra.Command, source, dst string, opts globalOptions) error {
 		return err
 	}
 
-	sys := opts.newSystemContext()
-
 	syncOpts := &sync.Options{
-		SystemContext: sys,
+		SystemContext: opts.newSystemContext(),
 		Source:        sep,
 		Target:        dst,
 		ReportWriter:  out,
-		Selection:     imageListSelection,
-		OmitError:     true,
+		SelectionOptions: []imagecopy.ImageListSelection{
+			imageListSelection,
+		},
+		OmitError: true,
 	}
 	if err := sync.ToRegistry(ctx, syncOpts); err != nil {
 		return err


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f731c94</samp>

This pull request improves the registry sync function to handle multiple image list selections for the same source and target. It also simplifies and refactors the sync options struct and removes some unused code from `pkg/registry/sync/sync.go`, `pkg/filesystem/registry/sync.go`, and `pkg/registry/commands/sync.go`.