### PR TITLE
feat: support override platform in diff command

### DIFF
--- a/pkg/buildah/diff.go
+++ b/pkg/buildah/diff.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/containers/common/libimage"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -117,6 +118,7 @@ func newDiffCommand() *cobra.Command {
 			rootCmd.CommandPath()),
 	}
 	opts.RegisterFlags(cmd.Flags())
+	cmd.Flags().AddFlagSet(getPlatformFlags())
 	cmd.SetUsageTemplate(UsageTemplate())
 	return cmd
 }
@@ -159,7 +161,7 @@ func runDiff(c *cobra.Command, args []string, opts *diffOption) error {
 
 	ctx := getContext()
 	if diffType == DiffImage {
-		if args, err = r.pullOrLoadImages(ctx, args...); err != nil {
+		if args, err = r.PullOrLoadImages(ctx, args, libimage.CopyOptions{}); err != nil {
 			return err
 		}
 	}

--- a/pkg/buildah/interface.go
+++ b/pkg/buildah/interface.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/containers/buildah"
 	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/common/libimage"
 	"github.com/containers/image/v5/transports"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
@@ -235,7 +236,7 @@ func (impl *realImpl) ListContainers() ([]JSONContainer, error) {
 
 func (impl *realImpl) Load(input string, transport string) (string, error) {
 	ref := FormatReferenceWithTransportName(transport, input)
-	names, err := impl.runtime.pullOrLoadImages(getContext(), ref)
+	names, err := impl.runtime.PullOrLoadImages(getContext(), []string{ref}, libimage.CopyOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/pkg/buildah/runtime.go
+++ b/pkg/buildah/runtime.go
@@ -89,7 +89,11 @@ func (r *Runtime) getLayerID(id string, diffType DiffType) (string, error) {
 	return "", fmt.Errorf("%s not found: %w", id, lastErr)
 }
 
-func (r *Runtime) pullOrLoadImages(ctx context.Context, args ...string) ([]string, error) {
+func (r *Runtime) PullOrLoadImages(ctx context.Context, args []string, options libimage.CopyOptions) ([]string, error) {
+	copyOpts := options
+	if copyOpts.Writer == nil {
+		copyOpts.Writer = os.Stderr
+	}
 	var result []string
 	for i := range args {
 		name := args[i]
@@ -103,9 +107,7 @@ func (r *Runtime) pullOrLoadImages(ctx context.Context, args ...string) ([]strin
 				ref = strings.TrimPrefix(ref, "//")
 			}
 			pullImages, err := r.Runtime.Pull(ctx, ref, config.PullPolicyMissing, &libimage.PullOptions{
-				CopyOptions: libimage.CopyOptions{
-					Writer: os.Stderr,
-				},
+				CopyOptions: copyOpts,
 			})
 			if err != nil {
 				return nil, err
@@ -123,9 +125,7 @@ func (r *Runtime) pullOrLoadImages(ctx context.Context, args ...string) ([]strin
 				ref = filepath.Join(cwd, ref)
 			}
 			images, err := r.Runtime.Load(ctx, ref, &libimage.LoadOptions{
-				CopyOptions: libimage.CopyOptions{
-					Writer: os.Stderr,
-				},
+				CopyOptions: copyOpts,
 			})
 			if err != nil {
 				return nil, err

--- a/pkg/buildah/util.go
+++ b/pkg/buildah/util.go
@@ -15,6 +15,8 @@
 package buildah
 
 import (
+	"github.com/containers/common/libimage"
+
 	"github.com/labring/sealos/pkg/utils/file"
 )
 
@@ -27,7 +29,7 @@ func PreloadIfTarFile(images []string, transport string) ([]string, error) {
 	for i := range images {
 		if file.IsTarFile(images[i]) {
 			ref := FormatReferenceWithTransportName(transport, images[i])
-			names, err := r.pullOrLoadImages(getContext(), ref)
+			names, err := r.PullOrLoadImages(getContext(), []string{ref}, libimage.CopyOptions{})
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ba571ed</samp>

Add platform support to `buildah` commands and functions. This allows users to compare, build and copy images across different OS, architecture and variant combinations.