### PR TITLE
Update frontend deploy update strategy.

### DIFF
--- a/frontend/desktop/deploy/manifests/deploy.yaml.tmpl
+++ b/frontend/desktop/deploy/manifests/deploy.yaml.tmpl
@@ -48,7 +48,10 @@ spec:
     matchLabels:
       app: desktop-frontend
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
   template:
     metadata:
       labels:

--- a/frontend/providers/adminer/deploy/manifests/deploy.yaml
+++ b/frontend/providers/adminer/deploy/manifests/deploy.yaml
@@ -24,7 +24,10 @@ spec:
     matchLabels:
       app: adminer-frontend
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
   template:
     metadata:
       labels:

--- a/frontend/providers/applaunchpad/deploy/manifests/deploy.yaml.tmpl
+++ b/frontend/providers/applaunchpad/deploy/manifests/deploy.yaml.tmpl
@@ -25,7 +25,10 @@ spec:
     matchLabels:
       app: applaunchpad-frontend
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
   template:
     metadata:
       labels:

--- a/frontend/providers/bytebase/deploy/manifests/deploy.yaml
+++ b/frontend/providers/bytebase/deploy/manifests/deploy.yaml
@@ -24,7 +24,10 @@ spec:
     matchLabels:
       app: bytebase-frontend
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
   template:
     metadata:
       labels:

--- a/frontend/providers/costcenter/deploy/manifests/deploy.yaml
+++ b/frontend/providers/costcenter/deploy/manifests/deploy.yaml
@@ -24,7 +24,10 @@ spec:
     matchLabels:
       app: costcenter-frontend
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
   template:
     metadata:
       labels:

--- a/frontend/providers/dbprovider/deploy/manifests/deploy.yaml.tmpl
+++ b/frontend/providers/dbprovider/deploy/manifests/deploy.yaml.tmpl
@@ -25,7 +25,10 @@ spec:
     matchLabels:
       app: dbprovider-frontend
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
   template:
     metadata:
       labels:

--- a/frontend/providers/imagehub/deploy/manifests/deploy.yaml
+++ b/frontend/providers/imagehub/deploy/manifests/deploy.yaml
@@ -25,7 +25,10 @@ spec:
     matchLabels:
       app: imagehub-frontend
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
   template:
     metadata:
       labels:

--- a/frontend/providers/terminal/deploy/manifests/deploy.yaml
+++ b/frontend/providers/terminal/deploy/manifests/deploy.yaml
@@ -24,7 +24,10 @@ spec:
     matchLabels:
       app: terminal-frontend
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
   template:
     metadata:
       labels:

--- a/frontend/static-cdn/deploy/manifest.yaml
+++ b/frontend/static-cdn/deploy/manifest.yaml
@@ -38,7 +38,10 @@ spec:
     matchLabels:
       app: desktop-local-cdn
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
   template:
     metadata:
       labels:


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 52cffb7</samp>

### Summary
🔄🚀🖥️

<!--
1.  🔄 This emoji represents the rolling update strategy, which implies a continuous and gradual replacement of the old pods with the new ones, without interrupting the service availability.
2.  🚀 This emoji represents the deployment process, which involves launching the new version of the application and updating the configuration and resources accordingly.
3.  🖥️ This emoji represents the desktop-frontend application and its providers and dependencies, which are all web-based tools that run on the browser and provide various functionalities for the users.
-->
This pull request updates the deployment strategy of the desktop-frontend application and its providers and dependencies from Recreate to RollingUpdate, to enable zero-downtime deployments and reduce the risk of service disruption. It modifies the `deploy.yaml` or `deploy.yaml.tmpl` files of eight applications under the `frontend` directory, and specifies the parameters for the rolling update.

> _`RollingUpdate` now_
> _for all frontends and cdn_
> _smooth deployments in spring_

### Walkthrough
*  Change the deployment strategy of eight web-based applications from Recreate to RollingUpdate ([link](https://github.com/labring/sealos/pull/3390/files?diff=unified&w=0#diff-106b3bc7df5746bebbe21fc9aa46f605af9a0c65ce49b2021816340f6a4d99dfL51-R54), [link](https://github.com/labring/sealos/pull/3390/files?diff=unified&w=0#diff-7a847d6a4c169bd252229205e07446be8cd46489ac41cb14729b39e834ecdb30L27-R30), [link](https://github.com/labring/sealos/pull/3390/files?diff=unified&w=0#diff-4a0a2039e5ccec7cfbebd9819eb00bcb2dc38097079136dd81342f30f4b5b879L28-R31), [link](https://github.com/labring/sealos/pull/3390/files?diff=unified&w=0#diff-bfc5f3229af347feb6066ba08bd73202cb7cf8c5eeb4a58fd5f3523b4a6e93afL27-R30), [link](https://github.com/labring/sealos/pull/3390/files?diff=unified&w=0#diff-08d442378d1d5b9102a2d0eedfa18f9b02082912207c092c37baada608850aeaL27-R30), [link](https://github.com/labring/sealos/pull/3390/files?diff=unified&w=0#diff-b4883f3cd2aea01e7969518b8e640103e5624c60307a1e41ea38976443dcfb7cL28-R31), [link](https://github.com/labring/sealos/pull/3390/files?diff=unified&w=0#diff-23413b5745bb25b4e98d112b36b13841a591ddf7c9a7f4bb9545af4ffdd7e701L28-R31), [link](https://github.com/labring/sealos/pull/3390/files?diff=unified&w=0#diff-420f3bb4059fbd6390dc459e2c781d9223936a29d8fff944c2adc735fe85c738L27-R30), [link](https://github.com/labring/sealos/pull/3390/files?diff=unified&w=0#diff-dff6bbd7de79cdeb35ac7391340bf29c6566f87b186707b1003cc21dadcb49dfL41-R44))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
