### PR TITLE
build(main): add test docker image

### DIFF
--- a/.github/workflows/e2e_test_core.yml
+++ b/.github/workflows/e2e_test_core.yml
@@ -52,7 +52,16 @@ jobs:
             E2E_sealos_runtime_version_124_test,
             E2E_sealos_runtime_version_125_test,
             E2E_sealos_runtime_version_126_test,
-            E2E_sealos_runtime_version_127_test
+            E2E_sealos_runtime_version_127_test,
+            E2E_sealos_runtime_version_docker_119_test,
+            E2E_sealos_runtime_version_docker_120_test,
+            E2E_sealos_runtime_version_docker_121_test,
+            E2E_sealos_runtime_version_docker_122_test,
+            E2E_sealos_runtime_version_docker_123_test,
+            E2E_sealos_runtime_version_docker_124_test,
+            E2E_sealos_runtime_version_docker_125_test,
+            E2E_sealos_runtime_version_docker_126_test,
+            E2E_sealos_runtime_version_docker_127_test
           ]
     runs-on: ubuntu-latest
     steps:

--- a/test/e2e/runtime_version_docker_119_test.go
+++ b/test/e2e/runtime_version_docker_119_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/labring/sealos/test/e2e/suites/operators"
+	"github.com/labring/sealos/test/e2e/testhelper/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("E2E_sealos_runtime_version_docker_119_test", func() {
+	var (
+		fakeClient *operators.FakeClient
+		err        error
+	)
+	fakeClient = operators.NewFakeClient("")
+
+	Context("sealos run for many version", func() {
+		It("sealos apply single by docker v1.19.0", func() {
+			images := []string{"labring/kubernetes-docker:v1.19.0"}
+			defer func() {
+				err = fakeClient.Cluster.Reset()
+				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))
+			}()
+			err = fakeClient.Cluster.Run(images...)
+			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+		})
+	})
+
+})

--- a/test/e2e/runtime_version_docker_120_test.go
+++ b/test/e2e/runtime_version_docker_120_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/labring/sealos/test/e2e/suites/operators"
+	"github.com/labring/sealos/test/e2e/testhelper/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("E2E_sealos_runtime_version_docker_120_test", func() {
+	var (
+		fakeClient *operators.FakeClient
+		err        error
+	)
+	fakeClient = operators.NewFakeClient("")
+
+	Context("sealos run for many version", func() {
+		It("sealos apply single by docker v1.20.0", func() {
+			images := []string{"labring/kubernetes-docker:v1.20.0"}
+			defer func() {
+				err = fakeClient.Cluster.Reset()
+				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))
+			}()
+			err = fakeClient.Cluster.Run(images...)
+			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+		})
+	})
+
+})

--- a/test/e2e/runtime_version_docker_121_test.go
+++ b/test/e2e/runtime_version_docker_121_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/labring/sealos/test/e2e/suites/operators"
+	"github.com/labring/sealos/test/e2e/testhelper/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("E2E_sealos_runtime_version_docker_121_test", func() {
+	var (
+		fakeClient *operators.FakeClient
+		err        error
+	)
+	fakeClient = operators.NewFakeClient("")
+
+	Context("sealos run for many version", func() {
+		It("sealos apply single by docker v1.21.0", func() {
+			images := []string{"labring/kubernetes-docker:v1.21.0"}
+			defer func() {
+				err = fakeClient.Cluster.Reset()
+				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))
+			}()
+			err = fakeClient.Cluster.Run(images...)
+			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+		})
+	})
+
+})

--- a/test/e2e/runtime_version_docker_122_test.go
+++ b/test/e2e/runtime_version_docker_122_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/labring/sealos/test/e2e/suites/operators"
+	"github.com/labring/sealos/test/e2e/testhelper/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("E2E_sealos_runtime_version_docker_122_test", func() {
+	var (
+		fakeClient *operators.FakeClient
+		err        error
+	)
+	fakeClient = operators.NewFakeClient("")
+
+	Context("sealos run for many version", func() {
+		It("sealos apply single by docker v1.22.0", func() {
+			images := []string{"labring/kubernetes-docker:v1.22.0"}
+			defer func() {
+				err = fakeClient.Cluster.Reset()
+				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))
+			}()
+			err = fakeClient.Cluster.Run(images...)
+			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+		})
+	})
+
+})

--- a/test/e2e/runtime_version_docker_123_test.go
+++ b/test/e2e/runtime_version_docker_123_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/labring/sealos/test/e2e/suites/operators"
+	"github.com/labring/sealos/test/e2e/testhelper/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("E2E_sealos_runtime_version_docker_123_test", func() {
+	var (
+		fakeClient *operators.FakeClient
+		err        error
+	)
+	fakeClient = operators.NewFakeClient("")
+
+	Context("sealos run for many version", func() {
+		It("sealos apply single by docker v1.23.0", func() {
+			images := []string{"labring/kubernetes-docker:v1.23.0"}
+			defer func() {
+				err = fakeClient.Cluster.Reset()
+				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))
+			}()
+			err = fakeClient.Cluster.Run(images...)
+			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+		})
+	})
+
+})

--- a/test/e2e/runtime_version_docker_124_test.go
+++ b/test/e2e/runtime_version_docker_124_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/labring/sealos/test/e2e/suites/operators"
+	"github.com/labring/sealos/test/e2e/testhelper/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("E2E_sealos_runtime_version_docker_124_test", func() {
+	var (
+		fakeClient *operators.FakeClient
+		err        error
+	)
+	fakeClient = operators.NewFakeClient("")
+
+	Context("sealos run for many version", func() {
+		It("sealos apply single by docker v1.24.0", func() {
+			images := []string{"labring/kubernetes-docker:v1.24.0"}
+			defer func() {
+				err = fakeClient.Cluster.Reset()
+				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))
+			}()
+			err = fakeClient.Cluster.Run(images...)
+			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+		})
+	})
+
+})

--- a/test/e2e/runtime_version_docker_125_test.go
+++ b/test/e2e/runtime_version_docker_125_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/labring/sealos/test/e2e/suites/operators"
+	"github.com/labring/sealos/test/e2e/testhelper/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("E2E_sealos_runtime_version_docker_125_test", func() {
+	var (
+		fakeClient *operators.FakeClient
+		err        error
+	)
+	fakeClient = operators.NewFakeClient("")
+
+	Context("sealos run for many version", func() {
+		It("sealos apply single by docker v1.25.0", func() {
+			images := []string{"labring/kubernetes-docker:v1.25.0"}
+			defer func() {
+				err = fakeClient.Cluster.Reset()
+				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))
+			}()
+			err = fakeClient.Cluster.Run(images...)
+			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+		})
+	})
+
+})

--- a/test/e2e/runtime_version_docker_126_test.go
+++ b/test/e2e/runtime_version_docker_126_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/labring/sealos/test/e2e/suites/operators"
+	"github.com/labring/sealos/test/e2e/testhelper/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("E2E_sealos_runtime_version_docker_126_test", func() {
+	var (
+		fakeClient *operators.FakeClient
+		err        error
+	)
+	fakeClient = operators.NewFakeClient("")
+
+	Context("sealos run for many version", func() {
+		It("sealos apply single by docker v1.26.0", func() {
+			images := []string{"labring/kubernetes-docker:v1.26.0"}
+			defer func() {
+				err = fakeClient.Cluster.Reset()
+				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))
+			}()
+			err = fakeClient.Cluster.Run(images...)
+			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+		})
+	})
+
+})

--- a/test/e2e/runtime_version_docker_127_test.go
+++ b/test/e2e/runtime_version_docker_127_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/labring/sealos/test/e2e/suites/operators"
+	"github.com/labring/sealos/test/e2e/testhelper/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("E2E_sealos_runtime_version_docker_127_test", func() {
+	var (
+		fakeClient *operators.FakeClient
+		err        error
+	)
+	fakeClient = operators.NewFakeClient("")
+
+	Context("sealos run for many version", func() {
+		It("sealos apply single by docker v1.27.0", func() {
+			images := []string{"labring/kubernetes-docker:v1.27.0"}
+			defer func() {
+				err = fakeClient.Cluster.Reset()
+				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))
+			}()
+			err = fakeClient.Cluster.Run(images...)
+			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+		})
+	})
+
+})


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f882fc8</samp>

### Summary
🐳🧪🚀

<!--
1.  🐳 - This emoji represents the docker container technology, which is used to run different versions of Kubernetes in the test scenarios.
2.  🧪 - This emoji represents the testing and experimentation aspect of the changes, which aim to improve the coverage and reliability of the end-to-end tests.
3.  🚀 - This emoji represents the speed and efficiency of the `sealos` tool, which can deploy Kubernetes clusters in minutes using docker images.
-->
This pull request adds new end-to-end test suites for different docker versions of Kubernetes using the `sealos` tool. It modifies the GitHub Actions workflow to run the tests for each version from v1.19.0 to v1.27.0. It also creates new files under the `test/e2e` directory to define the test scenarios and expectations for each version.

> _`sealos` tests more_
> _docker versions of k8s_
> _snowflakes on clusters_

### Walkthrough
*  Add new test suites for different docker versions of Kubernetes using the `sealos` tool ([link](https://github.com/labring/sealos/pull/3395/files?diff=unified&w=0#diff-85e99ec0f035b3350377258876aab02638af6de847310563256c90fe006a1257R1-R47), [link](https://github.com/labring/sealos/pull/3395/files?diff=unified&w=0#diff-14ceebc9c6bd281a5918f29ce3a195d2f7fdabcb73d87546cb52dcaeaec624a8R1-R47), [link](https://github.com/labring/sealos/pull/3395/files?diff=unified&w=0#diff-d703c31165b0c6f75d964c2f48fa9685661c62e8aa25caf20faf0eda25a1110dR1-R47), [link](https://github.com/labring/sealos/pull/3395/files?diff=unified&w=0#diff-c18999d719b9c26f615a0732318e206d88df35a51219f69ca450a555673e7a7aR1-R47), [link](https://github.com/labring/sealos/pull/3395/files?diff=unified&w=0#diff-46a1f10603c03f7760898bf64f3e9d0f372efe55f08ee8cd9999cbf5d6c792d9R1-R47), [link](https://github.com/labring/sealos/pull/3395/files?diff=unified&w=0#diff-8015a8708908935c62f781eb7e7018437dc3f49b464dd34e56b271b565e00075R1-R47), [link](https://github.com/labring/sealos/pull/3395/files?diff=unified&w=0#diff-093419af7858063319d0dd512a9da72855c6774f89bee4bc5b89d94abba01653R1-R47), [link](https://github.com/labring/sealos/pull/3395/files?diff=unified&w=0#diff-425b53a14d38b33d97e632f701bd98845c298155d3b4f20e4a2c49506446d2cbR1-R47), [link](https://github.com/labring/sealos/pull/3395/files?diff=unified&w=0#diff-870ce1e51394e0475a7523ec9e9895416a33e73f41749c174a840d313c4347e9R1-R47))
* Extend the GitHub Actions workflow to run end-to-end tests for each docker version of Kubernetes ([link](https://github.com/labring/sealos/pull/3395/files?diff=unified&w=0#diff-ba1d49071a00190331cbec05b1b76f5821a8ffac3ce1998d77de7e5d287bbd38L55-R64))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
