### PR TITLE
refactor(main): delete node for check

### DIFF
--- a/pkg/apply/processor/interface.go
+++ b/pkg/apply/processor/interface.go
@@ -174,6 +174,9 @@ func MountClusterImages(bdah buildah.Interface, cluster *v2.Cluster, skipApp boo
 	for _, img := range cluster.Spec.Image {
 		info, err := inspectImage(bdah, img)
 		if err != nil {
+			if skipApp {
+				continue
+			}
 			return err
 		}
 		var imageType string

--- a/pkg/apply/processor/scale.go
+++ b/pkg/apply/processor/scale.go
@@ -167,6 +167,9 @@ func (c *ScaleProcessor) preProcess(cluster *v2.Cluster) error {
 		return err
 	}
 	if c.IsScaleUp {
+		if cluster.GetRootfsImage().KubeVersion() == "" {
+			return fmt.Errorf("rootfs image not found kube version")
+		}
 		clusterPath := constants.Clusterfile(cluster.Name)
 		obj := []interface{}{cluster}
 		if configs := c.ClusterFile.GetConfigs(); len(configs) > 0 {

--- a/pkg/runtime/runtime_getter.go
+++ b/pkg/runtime/runtime_getter.go
@@ -42,8 +42,8 @@ func (k *KubeadmRuntime) getKubeVersion() string {
 
 // old implementation doesn't consider multiple rootfs images; here get the first rootfs image
 func (k *KubeadmRuntime) getKubeVersionFromImage() string {
-	img := k.Cluster.GetRootfsImage("")
-	if img.Labels == nil {
+	img := k.Cluster.GetRootfsImage()
+	if img == nil || img.Labels == nil {
 		return ""
 	}
 	return img.Labels[v1beta1.ImageKubeVersionKey]

--- a/pkg/types/v1beta1/cluster_args.go
+++ b/pkg/types/v1beta1/cluster_args.go
@@ -121,7 +121,7 @@ func (c *Cluster) GetAllIPS() []string {
 	return hosts
 }
 
-func (c *Cluster) GetRootfsImage(defaultMount string) *MountImage {
+func (c *Cluster) GetRootfsImage() *MountImage {
 	var image *MountImage
 	if c.Status.Mounts != nil {
 		for _, img := range c.Status.Mounts {
@@ -129,16 +129,6 @@ func (c *Cluster) GetRootfsImage(defaultMount string) *MountImage {
 				image = &img
 				break
 			}
-		}
-	}
-	if image == nil {
-		image = &MountImage{
-			Name:       fmt.Sprintf("%s-%d", c.Name, 0),
-			Type:       RootfsImage,
-			MountPoint: defaultMount,
-		}
-		if len(c.Spec.Image) > 0 {
-			image.ImageName = c.Spec.Image[0]
 		}
 	}
 	return image


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e6f3a96</samp>

### Summary
:wastebasket::truck::hammer_and_wrench:

<!--
1.  :wastebasket: - This emoji represents the removal of the `PreProcess` function from the delete processor pipeline, as it implies that the function was no longer needed and was discarded.
2.  :truck: - This emoji represents the movement of the logic from the `PreProcess` function to the `DeleteNodes` and `ScaleNodes` functions, as it implies that the logic was transferred from one place to another.
3.  :hammer_and_wrench: - This emoji represents the refactoring of the delete and scale processor pipelines, as it implies that the code was improved and simplified.
-->
This pull request removes the `PreProcess` functions from the delete and scale processor pipelines, as they are redundant after refactoring the `DeleteNodes` and `ScaleNodes` functions in `pkg/apply/delete.go` and `pkg/apply/scale.go`. This simplifies the processor pipelines and avoids unnecessary checks and actions.

> _`PreProcess` gone_
> _Logic moved to other funcs_
> _Pipeline simplified_

### Walkthrough
*  Remove `PreProcess` functions from delete and scale processor pipelines ([link](https://github.com/labring/sealos/pull/3405/files?diff=unified&w=0#diff-9824a9d8dc140a8c2c8b7e5e99677b466e2b5bea37bf7ae494892d127f3e409aL60), [link](https://github.com/labring/sealos/pull/3405/files?diff=unified&w=0#diff-d48ba8412842b9224105abdc78efc6af4031a5e68498f66ace1f9de18d3ec438L83))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
