### PR TITLE
feat. update cloud cluster image build process

### DIFF
--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -11,8 +11,13 @@ on:
         type: boolean
         default: false
       push_image_tag:
-        description: 'Push image tag'
+        description: 'Push all-in-one image tag, default is dev'
         default: 'dev'
+        required: false
+        type: string
+      build_from:
+        description: 'Build all-in-one image from components image tag, default is nightly'
+        default: 'nightly'
         required: false
         type: string
   push:
@@ -85,6 +90,7 @@ jobs:
       - name: Build sealos cloud cluster image
         working-directory: deploy/cloud
         run: |
+          sed -i "s#nightly#${{ inputs.build_from }}#g" init.sh
           sudo bash init.sh
           sudo sealos build  -t ${{ steps.prepare.outputs.repo }}:${{ steps.prepare.outputs.tag_name }} -f Kubefile
           sudo sealos push ${{ steps.prepare.outputs.repo }}:${{ steps.prepare.outputs.tag_name }}

--- a/deploy/cloud/init.sh
+++ b/deploy/cloud/init.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 mkdir -p tars
-sealos pull ghcr.io/labring/sealos-cloud-user-controller:dev
-sealos pull ghcr.io/labring/sealos-cloud-terminal-controller:dev
-sealos pull ghcr.io/labring/sealos-cloud-app-controller:dev
-sealos pull ghcr.io/labring/sealos-cloud-desktop-frontend:dev
-sealos pull ghcr.io/labring/sealos-cloud-terminal-frontend:dev
-sealos pull ghcr.io/labring/sealos-cloud-applaunchpad-frontend:dev
+sealos pull ghcr.io/labring/sealos-cloud-user-controller:nightly
+sealos pull ghcr.io/labring/sealos-cloud-terminal-controller:nightly
+sealos pull ghcr.io/labring/sealos-cloud-app-controller:nightly
+sealos pull ghcr.io/labring/sealos-cloud-desktop-frontend:nightly
+sealos pull ghcr.io/labring/sealos-cloud-terminal-frontend:nightly
+sealos pull ghcr.io/labring/sealos-cloud-applaunchpad-frontend:nightly
 
 
 
-sealos save -o tars/user.tar ghcr.io/labring/sealos-cloud-user-controller:dev
-sealos save -o tars/terminal.tar ghcr.io/labring/sealos-cloud-terminal-controller:dev
-sealos save -o tars/app.tar ghcr.io/labring/sealos-cloud-app-controller:dev
-sealos save -o tars/frontend-desktop.tar  ghcr.io/labring/sealos-cloud-desktop-frontend:dev
-sealos save -o tars/frontend-terminal.tar  ghcr.io/labring/sealos-cloud-terminal-frontend:dev
-sealos save -o tars/frontend-applaunchpad.tar ghcr.io/labring/sealos-cloud-applaunchpad-frontend:dev
+sealos save -o tars/user.tar ghcr.io/labring/sealos-cloud-user-controller:nightly
+sealos save -o tars/terminal.tar ghcr.io/labring/sealos-cloud-terminal-controller:nightly
+sealos save -o tars/app.tar ghcr.io/labring/sealos-cloud-app-controller:nightly
+sealos save -o tars/frontend-desktop.tar  ghcr.io/labring/sealos-cloud-desktop-frontend:nightly
+sealos save -o tars/frontend-terminal.tar  ghcr.io/labring/sealos-cloud-terminal-frontend:nightly
+sealos save -o tars/frontend-applaunchpad.tar ghcr.io/labring/sealos-cloud-applaunchpad-frontend:nightly
 

--- a/deploy/cloud/scripts/init.sh
+++ b/deploy/cloud/scripts/init.sh
@@ -25,15 +25,12 @@ function mock_tls {
 function sealos_run_controller {
   # run user controller
   sealos run tars/user.tar
-  # \ 1 > /dev/null
 
   # run terminal controller
   sealos run tars/terminal.tar --env cloudDomain=$cloudDomain --env userNamespace="user-system" --env wildcardCertSecretName="wildcard-cert" --env wildcardCertSecretNamespace="sealos-system"
-  # \ 1 > /dev/null
 
   # run app controller
   sealos run tars/app.tar
-  # \ 1 > /dev/null
 }
 
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b7ad8ca</samp>

### Summary
🌙🔊🏷️

<!--
1.  🌙 - This emoji represents the `nightly` tag, which is used for the components images. It also implies that the images are updated regularly and have the latest features and fixes.
2.  🔊 - This emoji represents the removal of the output redirection, which allows the logs of the components to be displayed. It also implies that the logs are loud, clear, and informative.
3.  🏷️ - This emoji represents the option to build the all-in-one image from a specific tag of the components images. It also implies that the tag is a label or a marker that identifies the version of the images.
-->
This pull request adds an option to build the all-in-one image from a specific tag of the components images, and changes the default tag to `nightly`. It also enables the output of the `sealos run` commands in the `init.sh` script.

> _We build from the ashes of the night_
> _We run the sealos and unleash the light_
> _We don't fear the logs, we face the truth_
> _We choose our own tag, we are the proof_

### Walkthrough
*  Add `build_from` parameter to workflow to specify tag of components images ([link](https://github.com/labring/sealos/pull/3426/files?diff=unified&w=0#diff-7e4159d358d73ce740ffdf0b5737ccb6965692a7d3cea96bbb2a1ba054ea229eL14-R22))
*  Update `init.sh` script to use `nightly` tag for components images by default ([link](https://github.com/labring/sealos/pull/3426/files?diff=unified&w=0#diff-7c20f8ecac334e472df2875627ce9de0e4297d7c839ef4ed0da3e80cb4e16595L3-R17))
*  Replace `nightly` tag with `build_from` value in `init.sh` script before building all-in-one image ([link](https://github.com/labring/sealos/pull/3426/files?diff=unified&w=0#diff-7e4159d358d73ce740ffdf0b5737ccb6965692a7d3cea96bbb2a1ba054ea229eR93))
*  Remove output redirection of `sealos run` commands in `scripts/init.sh` to show logs of components ([link](https://github.com/labring/sealos/pull/3426/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844L28-R33))


