### PR TITLE
fix(main): fix merge support $()

### DIFF
--- a/pkg/buildimage/merge_test.go
+++ b/pkg/buildimage/merge_test.go
@@ -120,3 +120,50 @@ COPY --from=cccc  . .`,
 		})
 	}
 }
+
+func Test_replaceDao(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "default",
+			args: args{
+				s: "sealos.io",
+			},
+			want: "sealos.io",
+		},
+		{
+			name: "default",
+			args: args{
+				s: "sea$(ss)los.io",
+			},
+			want: "sea$(ss)los.io",
+		},
+		{
+			name: "default",
+			args: args{
+				s: "sea$sslos.io",
+			},
+			want: "sea\\$sslos.io",
+		},
+		{
+			name: "default",
+			args: args{
+				s: "sea$(s)sl$os.io",
+			},
+			want: "sea$(s)sl\\$os.io",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := escapeDollarSign(tt.args.s, true); got != tt.want {
+				t.Errorf("escapeDollarSign() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/guest/guest.go
+++ b/pkg/guest/guest.go
@@ -64,9 +64,11 @@ func (d *Default) Apply(cluster *v2.Cluster, mounts []v2.MountImage) error {
 		}()
 	}
 	sshInterface := ssh.NewSSHClient(&cluster.Spec.SSH, true)
-	logger.Debug("start to exec guest commands")
-	if err := sshInterface.CmdAsync(cluster.GetMaster0IPAndPort(), guestCMD...); err != nil {
-		return err
+	for _, cmd := range guestCMD {
+		logger.Debug("exec guest command: %s", cmd)
+		if err := sshInterface.CmdAsync(cluster.GetMaster0IPAndPort(), envInterface.WrapperShell(cluster.GetMaster0IP(), cmd)); err != nil {
+			return err
+		}
 	}
 	logger.Debug("finish to exec guest commands: %v", guestCMD)
 	return nil


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fd0a9b7</samp>

### Summary
🧪🐚💲

<!--
1.  🧪 for adding a unit test
2.  🐚 for modifying the SSH command execution
3.  💲 for escaping `$` characters in Dockerfile strings
-->
This pull request enhances the `buildimage` and `guest` packages of sealos. It adds a function to escape `$` characters in Dockerfile strings and a unit test for it. It also improves the logging and error handling of the commands executed on the master node of the cluster.

> _Sing, O Muse, of the code that the heroes wrought_
> _To build and test the image of the cluster's lord_
> _With `replaceDao` function and table-driven test_
> _They checked the strings for errors and made them best_

### Walkthrough
*  Escape `$` characters in Dockerfile template to avoid variable expansion ([link](https://github.com/labring/sealos/pull/3427/files?diff=unified&w=0#diff-147909dd4ac96c8dbda522215351cc4f88e1584291545344dadaa1113fe0a92aR31-R46),[link](https://github.com/labring/sealos/pull/3427/files?diff=unified&w=0#diff-147909dd4ac96c8dbda522215351cc4f88e1584291545344dadaa1113fe0a92aL55-R77))
  - Add unit test for `replaceDao` function in `pkg/buildimage/merge_test.go` ([link](https://github.com/labring/sealos/pull/3427/files?diff=unified&w=0#diff-e5a173977e8ab15f6abe364a01a66874bcfd9cbacff8dc2913137ea7dd7c5c96R123-R169))
* Log and wrap commands executed on master node in `Apply` function of `pkg/guest/guest.go` ([link](https://github.com/labring/sealos/pull/3427/files?diff=unified&w=0#diff-2fff8ad69185df503a777c91856e8cf472e5a5d16905d4a3a2e544873e889c46L67-R71))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
