### PR TITLE
opt: add hints for the order of commands in documentations

### DIFF
--- a/docs/4.0/docs/lifecycle-management/operations/build-image/build_run_application_private_registry.md
+++ b/docs/4.0/docs/lifecycle-management/operations/build-image/build_run_application_private_registry.md
@@ -151,6 +151,7 @@ sealos run labring/ingress-nginx:4.1.0
 sealos run docker.io/luanshaotong/osm:v0.1.1
 ```
 
+Notice: labring/helm should be set before labring/calico.
 If every step of the application installation goes smoothly, that's it. Otherwise, you may need to debug and clean up the cluster for reinstallation.
 
 ## Other Issues

--- a/docs/4.0/docs/lifecycle-management/operations/run-cluster/gen-apply-cluster.md
+++ b/docs/4.0/docs/lifecycle-management/operations/run-cluster/gen-apply-cluster.md
@@ -12,6 +12,8 @@ $ sealos gen labring/kubernetes:v1.25.0 labring/helm:v3.8.2 labring/calico:v3.24
    --nodes 192.168.0.5,192.168.0.6,192.168.0.7 --passwd 'xxx' > Clusterfile
 ```
 
+Notice: labring/helm should be set before labring/calico.
+
 The generated Clusterfile is as follows:
 
 <details>

--- a/docs/4.0/docs/lifecycle-management/quick-start/quick-start.md
+++ b/docs/4.0/docs/lifecycle-management/quick-start/quick-start.md
@@ -38,6 +38,8 @@ $ sealos run labring/kubernetes:v1.25.0 labring/helm:v3.8.2 labring/calico:v3.24
      --nodes 192.168.64.21,192.168.64.19 -p [your-ssh-passwd]
 ```
 
+Notice: labring/helm should be set before labring/calico.
+
 Parameter explanation:
 
 | Parameter | Example Value   | Description                              |

--- a/docs/4.0/docs/lifecycle-management/reference/sealos/commands/gen.md
+++ b/docs/4.0/docs/lifecycle-management/reference/sealos/commands/gen.md
@@ -14,6 +14,8 @@ Here are the basic usage of `sealos gen` command and some common examples:
    sealos gen labring/kubernetes:v1.25.0 labring/helm:v3.8.2 labring/calico:v3.24.1
    ```
 
+Notice: labring/helm should be set before labring/calico.
+
 2. Generate a cluster that includes multiple images and specifies the master and worker nodes:
 
    ```bash
@@ -21,6 +23,8 @@ Here are the basic usage of `sealos gen` command and some common examples:
        --masters 192.168.0.2,192.168.0.3,192.168.0.4 \
        --nodes 192.168.0.5,192.168.0.6,192.168.0.7 --passwd 'xxx'
    ```
+
+Notice: labring/helm should be set before labring/calico.
 
 3. Specify SSH port, for servers using the same SSH port:
 

--- a/docs/4.0/i18n/zh-Hans/lifecycle-management/operations/build-image/build_run_application_private_registry.md
+++ b/docs/4.0/i18n/zh-Hans/lifecycle-management/operations/build-image/build_run_application_private_registry.md
@@ -149,6 +149,7 @@ sealos run labring/ingress-nginx:4.1.0
 sealos run docker.io/luanshaotong/osm:v0.1.1
 ```
 
+注意：labring/helm 应当在 labring/calico 之前。
 如果每一步的应用安装顺利，即可，否则可能需要调试并清理集群重新安装。
 
 ## 其他问题

--- a/docs/4.0/i18n/zh-Hans/lifecycle-management/operations/run-cluster/gen-apply-cluster.md
+++ b/docs/4.0/i18n/zh-Hans/lifecycle-management/operations/run-cluster/gen-apply-cluster.md
@@ -12,6 +12,8 @@ $ sealos gen labring/kubernetes:v1.25.0 labring/helm:v3.8.2 labring/calico:v3.24
    --nodes 192.168.0.5,192.168.0.6,192.168.0.7 --passwd 'xxx' > Clusterfile
 ```
 
+注意：labring/helm 应当在 labring/calico 之前。
+
 生成的 Clusterfile 如下：
 
 <details>

--- a/docs/4.0/i18n/zh-Hans/lifecycle-management/quick-start/quick-start.md
+++ b/docs/4.0/i18n/zh-Hans/lifecycle-management/quick-start/quick-start.md
@@ -39,6 +39,8 @@ $ sealos run labring/kubernetes:v1.25.0 labring/helm:v3.8.2 labring/calico:v3.24
      --nodes 192.168.64.21,192.168.64.19 -p [your-ssh-passwd]
 ```
 
+注意：labring/helm 应当在 labring/calico 之前。
+
 参数说明：
 
 | 参数名 | 参数值示例 | 参数说明 |

--- a/docs/4.0/i18n/zh-Hans/lifecycle-management/reference/sealos/commands/gen.md
+++ b/docs/4.0/i18n/zh-Hans/lifecycle-management/reference/sealos/commands/gen.md
@@ -14,6 +14,8 @@ Sealos 的 `gen` 命令是用于生成 Kubernetes 集群的配置文件（Cluste
    sealos gen labring/kubernetes:v1.25.0 labring/helm:v3.8.2 labring/calico:v3.24.1
    ```
 
+注意：labring/helm 应当在 labring/calico 之前。
+
 2. 生成一个包含多个镜像、指定了主节点和工作节点的集群：
 
    ```bash
@@ -21,6 +23,8 @@ Sealos 的 `gen` 命令是用于生成 Kubernetes 集群的配置文件（Cluste
        --masters 192.168.0.2,192.168.0.3,192.168.0.4 \
        --nodes 192.168.0.5,192.168.0.6,192.168.0.7 --passwd 'xxx'
    ```
+
+注意：labring/helm 应当在 labring/calico 之前。
 
 3. 指定 SSH 端口，对于所有服务器使用相同的 SSH 端口：
 


### PR DESCRIPTION
this is not a feature or bugfix, it's just an optimization suggestion for doc.

when we run `sealos run` or `sealos gen` command, the order of the image list is important.
if we set the helm behind the calico, nothing will run after the components of k8s installed.
