### PR TITLE
optimize transfer controller, add encryption to account and adapt

### DIFF
--- a/controllers/account/api/v1/account_types.go
+++ b/controllers/account/api/v1/account_types.go
@@ -63,13 +63,13 @@ type AccountSpec struct{}
 // AccountStatus defines the observed state of Account
 type AccountStatus struct {
 	// EncryptBalance is to encrypt balance
-	EncryptBalance string `json:"encryptBalance,omitempty"`
+	EncryptBalance *string `json:"encryptBalance,omitempty"`
 	// Recharge amount
 	Balance int64 `json:"balance,omitempty"`
 	//Deduction amount
 	DeductionBalance int64 `json:"deductionBalance,omitempty"`
 	// EncryptDeductionBalance is to encrypt DeductionBalance
-	EncryptDeductionBalance string `json:"encryptDeductionBalance,omitempty"`
+	EncryptDeductionBalance *string `json:"encryptDeductionBalance,omitempty"`
 	// delete in the future
 	ChargeList []Charge `json:"chargeList,omitempty"`
 }

--- a/controllers/account/api/v1/transfer_types.go
+++ b/controllers/account/api/v1/transfer_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -34,7 +36,8 @@ const (
 
 // TransferSpec defines the desired state of Transfer
 type TransferSpec struct {
-	To string `json:"to"`
+	From string `json:"from"`
+	To   string `json:"to"`
 	// +kubebuilder:validation:Minimum=1000000
 	Amount int64 `json:"amount"`
 }
@@ -68,4 +71,18 @@ type TransferList struct {
 
 func init() {
 	SchemeBuilder.Register(&Transfer{}, &TransferList{})
+}
+
+func (t *Transfer) ToJSON() string {
+	return `{
+	"spec": {
+		"from": "` + t.Spec.From + `",
+		"to": "` + t.Spec.To + `",
+		"amount": ` + fmt.Sprint(t.Spec.Amount) + `
+	},
+	"status": {
+		"reason": "` + t.Status.Reason + `",
+		"progress": "` + string(rune(t.Status.Progress)) + `"
+	}
+}`
 }

--- a/controllers/account/config/crd/bases/account.sealos.io_accounts.yaml
+++ b/controllers/account/config/crd/bases/account.sealos.io_accounts.yaml
@@ -70,6 +70,12 @@ spec:
                 description: Deduction amount
                 format: int64
                 type: integer
+              encryptBalance:
+                description: EncryptBalance is to encrypt balance
+                type: string
+              encryptDeductionBalance:
+                description: EncryptDeductionBalance is to encrypt DeductionBalance
+                type: string
             type: object
         type: object
     served: true

--- a/controllers/account/config/crd/bases/account.sealos.io_transfers.yaml
+++ b/controllers/account/config/crd/bases/account.sealos.io_transfers.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: transfers.account.sealos.io
+spec:
+  group: account.sealos.io
+  names:
+    kind: Transfer
+    listKind: TransferList
+    plural: transfers
+    singular: transfer
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Transfer is the Schema for the transfers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TransferSpec defines the desired state of Transfer
+            properties:
+              amount:
+                format: int64
+                minimum: 1000000
+                type: integer
+              from:
+                type: string
+              to:
+                type: string
+            required:
+            - amount
+            - to
+            type: object
+          status:
+            description: TransferStatus defines the observed state of Transfer
+            properties:
+              progress:
+                type: integer
+              reason:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/controllers/account/config/rbac/transfer_editor_role.yaml
+++ b/controllers/account/config/rbac/transfer_editor_role.yaml
@@ -1,0 +1,24 @@
+# permissions for end users to edit transfers.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: transfer-editor-role
+rules:
+- apiGroups:
+  - account.sealos.io
+  resources:
+  - transfers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - account.sealos.io
+  resources:
+  - transfers/status
+  verbs:
+  - get

--- a/controllers/account/config/rbac/transfer_viewer_role.yaml
+++ b/controllers/account/config/rbac/transfer_viewer_role.yaml
@@ -1,0 +1,20 @@
+# permissions for end users to view transfers.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: transfer-viewer-role
+rules:
+- apiGroups:
+  - account.sealos.io
+  resources:
+  - transfers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - account.sealos.io
+  resources:
+  - transfers/status
+  verbs:
+  - get

--- a/controllers/account/config/samples/account_v1_transfer.yaml
+++ b/controllers/account/config/samples/account_v1_transfer.yaml
@@ -1,0 +1,6 @@
+apiVersion: account.sealos.io/v1
+kind: Transfer
+metadata:
+  name: transfer-sample
+spec:
+  # TODO(user): Add fields here

--- a/controllers/account/controllers/account_controller.go
+++ b/controllers/account/controllers/account_controller.go
@@ -23,6 +23,11 @@ import (
 	"strconv"
 	"time"
 
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+
 	"github.com/labring/sealos/controllers/pkg/crypto"
 
 	retry2 "k8s.io/client-go/util/retry"
@@ -58,7 +63,6 @@ import (
 
 const (
 	ACCOUNTNAMESPACEENV         = "ACCOUNT_NAMESPACE"
-	PrivateDeployEnv            = "PRIVATE_DEPLOY"
 	DEFAULTACCOUNTNAMESPACE     = "sealos-system"
 	AccountAnnotationNewAccount = "account.sealos.io/new-account"
 	NEWACCOUNTAMOUNTENV         = "NEW_ACCOUNT_AMOUNT"
@@ -66,7 +70,6 @@ const (
 
 // AccountReconciler reconciles a Account object
 type AccountReconciler struct {
-	PrivateDeploy bool
 	client.Client
 	Scheme                 *runtime.Scheme
 	Logger                 logr.Logger
@@ -99,8 +102,10 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	accountBalance := accountv1.AccountBalance{}
 	if err := r.Get(ctx, req.NamespacedName, &accountBalance); err == nil {
-		if err := r.updateDeductionBalance(ctx, &accountBalance); err != nil {
-			r.Logger.Error(err, err.Error())
+		err = retry2.RetryOnConflict(retry2.DefaultBackoff, func() error {
+			return r.updateDeductionBalance(ctx, &accountBalance)
+		})
+		if err != nil {
 			return ctrl.Result{}, err
 		}
 	} else if client.IgnoreNotFound(err) != nil {
@@ -126,21 +131,6 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, fmt.Errorf("get account failed: %v", err)
 	}
 
-	if r.PrivateDeploy {
-		encryptBalance := account.Status.EncryptBalance
-		encryptDeductionBalance := account.Status.EncryptDeductionBalance
-		balance, err := crypto.DecryptInt64(encryptBalance)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("decrypt balance failed: %v", err)
-		}
-		account.Status.Balance = balance
-		deductionBalance, err := crypto.DecryptInt64(encryptDeductionBalance)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("decrypt deduction balance failed: %v", err)
-		}
-		account.Status.DeductionBalance = deductionBalance
-	}
-
 	orderResp, err := pay.QueryOrder(payment.Status.TradeNO)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("query order failed: %v", err)
@@ -163,17 +153,11 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		now := time.Now().UTC()
 		payAmount := *orderResp.Amount.Total * 10000
 		//1¥ = 100WechatPayAmount; 1 WechatPayAmount = 10000 SealosAmount
-		var gift = giveGift(payAmount)
-		if r.PrivateDeploy {
-			encryptBalance := account.Status.EncryptBalance
-			encryptBalance, err = crypto.RechargeBalance(encryptBalance, payAmount+gift)
-			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("recharge encrypt balance failed: %v", err)
-			}
-			account.Status.EncryptBalance = encryptBalance
+		account.Status.EncryptBalance, err = crypto.RechargeBalance(account.Status.EncryptBalance, giveGift(payAmount))
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("recharge encrypt balance failed: %v", err)
 		}
-		account.Status.Balance += payAmount + gift
-		if err := r.Status().Update(ctx, account); err != nil {
+		if err := r.updateAccountStatus(ctx, account); err != nil {
 			return ctrl.Result{}, fmt.Errorf("update account failed: %v", err)
 		}
 		payment.Status.Status = pay.StatusSuccess
@@ -255,17 +239,16 @@ func (r *AccountReconciler) syncAccount(ctx context.Context, name, accountNamesp
 	}); err != nil {
 		return nil, err
 	}
-	if r.PrivateDeploy {
-		encryptBalance := account.Status.EncryptBalance
-		encryptBalance, err = crypto.RechargeBalance(encryptBalance, int64(amount))
-		if err != nil {
-			return nil, fmt.Errorf("recharge balance failed: %v", err)
-		}
-		account.Status.EncryptBalance = encryptBalance
+	err = r.initBalance(&account)
+	if err != nil {
+		return nil, fmt.Errorf("sync init balance failed: %v", err)
 	}
-	account.Status.Balance += int64(amount)
-	if err := r.Status().Update(ctx, &account); err != nil {
-		return nil, err
+	account.Status.EncryptBalance, err = crypto.RechargeBalance(account.Status.EncryptBalance, int64(amount))
+	if err != nil {
+		return nil, fmt.Errorf("recharge balance failed: %v", err)
+	}
+	if err := r.updateAccountStatus(ctx, &account); err != nil {
+		return nil, fmt.Errorf("update account failed: %v", err)
 	}
 	r.Logger.Info("account created,will charge new account some money", "account", account, "stringAmount", stringAmount)
 
@@ -376,33 +359,34 @@ func (r *AccountReconciler) updateDeductionBalance(ctx context.Context, accountB
 		r.Logger.Error(err, err.Error())
 		return err
 	}
-
-	if accountBalance.Spec.Type == accountv1.TransferIn {
-		account.Status.Balance += accountBalance.Spec.Amount
-	} else {
-		account.Status.DeductionBalance += accountBalance.Spec.Amount
+	err = r.initBalance(account)
+	if err != nil {
+		return fmt.Errorf("sync balance failed: %v", err)
 	}
-	if r.PrivateDeploy {
-		if accountBalance.Spec.Type == accountv1.TransferIn {
-			encryptBalance := account.Status.EncryptBalance
-			encryptBalance, err = crypto.RechargeBalance(encryptBalance, accountBalance.Spec.Amount)
-			if err != nil {
-				r.Logger.Error(err, err.Error())
-				return err
-			}
-			account.Status.EncryptBalance = encryptBalance
-		} else {
-			encryptDeductionBalance := account.Status.EncryptDeductionBalance
-			encryptDeductionBalance, err = crypto.RechargeBalance(encryptDeductionBalance, accountBalance.Spec.Amount)
-			if err != nil {
-				r.Logger.Error(err, err.Error())
-				return err
-			}
-			account.Status.EncryptDeductionBalance = encryptDeductionBalance
+	switch accountBalance.Spec.Type {
+	case accountv1.TransferIn:
+		account.Status.EncryptBalance, err = crypto.RechargeBalance(account.Status.EncryptBalance, accountBalance.Spec.Amount)
+		if err != nil {
+			r.Logger.Error(err, err.Error())
+			return err
 		}
+	case accountv1.TransferOut:
+		account.Status.EncryptBalance, err = crypto.DeductBalance(account.Status.EncryptBalance, accountBalance.Spec.Amount)
+		if err != nil {
+			r.Logger.Error(err, err.Error())
+			return err
+		}
+	case accountv1.Consumption:
+		account.Status.EncryptDeductionBalance, err = crypto.RechargeBalance(account.Status.EncryptDeductionBalance, accountBalance.Spec.Amount)
+		if err != nil {
+			r.Logger.Error(err, err.Error())
+			return err
+		}
+	default:
+		return fmt.Errorf("unknown accountbalance type: %v", accountBalance.Spec.Type)
 	}
 
-	if err := r.Status().Update(ctx, account); err != nil {
+	if err := r.updateAccountStatus(ctx, account); err != nil {
 		r.Logger.Error(err, err.Error())
 		return err
 	}
@@ -431,6 +415,34 @@ func (r *AccountReconciler) updateDeductionBalance(ctx context.Context, accountB
 	return nil
 }
 
+func (r *AccountReconciler) updateAccountStatus(ctx context.Context, account *accountv1.Account) (err error) {
+	account.Status.Balance, err = crypto.DecryptInt64(*account.Status.EncryptBalance)
+	if err != nil {
+		return fmt.Errorf("update decrypt balance failed: %v", err)
+	}
+	account.Status.DeductionBalance, err = crypto.DecryptInt64(*account.Status.EncryptDeductionBalance)
+	if err != nil {
+		return fmt.Errorf("update decrypt deduction balance failed: %v", err)
+	}
+	return r.Status().Update(ctx, account)
+}
+
+func (r *AccountReconciler) initBalance(account *accountv1.Account) (err error) {
+	if account.Status.EncryptBalance == nil {
+		account.Status.EncryptBalance, err = crypto.EncryptInt64(account.Status.Balance)
+		if err != nil {
+			return fmt.Errorf("sync encrypt balance failed: %v", err)
+		}
+	}
+	if account.Status.EncryptDeductionBalance == nil {
+		account.Status.EncryptDeductionBalance, err = crypto.EncryptInt64(account.Status.DeductionBalance)
+		if err != nil {
+			return fmt.Errorf("sync encrypt deduction balance failed: %v", err)
+		}
+	}
+	return nil
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *AccountReconciler) SetupWithManager(mgr ctrl.Manager, rateOpts controller.Options) error {
 	const controllerName = "account_controller"
@@ -447,10 +459,31 @@ func (r *AccountReconciler) SetupWithManager(mgr ctrl.Manager, rateOpts controll
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&accountv1.Account{}).
 		Watches(&source.Kind{Type: &accountv1.Payment{}}, &handler.EnqueueRequestForObject{}).
-		Watches(&source.Kind{Type: &accountv1.AccountBalance{}}, &handler.EnqueueRequestForObject{}).
+		Watches(&source.Kind{Type: &accountv1.AccountBalance{}}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(&NamespaceFilterPredicate{Namespace: r.AccountSystemNamespace})).
 		Watches(&source.Kind{Type: &userV1.User{}}, &handler.EnqueueRequestForObject{}).
 		WithOptions(rateOpts).
 		Complete(r)
+}
+
+type NamespaceFilterPredicate struct {
+	Namespace string
+	predicate.Funcs
+}
+
+func (p *NamespaceFilterPredicate) Create(e event.CreateEvent) bool {
+	return e.Object.GetNamespace() == p.Namespace
+}
+
+func (p *NamespaceFilterPredicate) Delete(e event.DeleteEvent) bool {
+	return e.Object.GetNamespace() == p.Namespace
+}
+
+func (p *NamespaceFilterPredicate) Update(e event.UpdateEvent) bool {
+	return e.ObjectOld.GetNamespace() == p.Namespace
+}
+
+func (p *NamespaceFilterPredicate) Generic(e event.GenericEvent) bool {
+	return e.Object.GetNamespace() == p.Namespace
 }
 
 const (
@@ -483,5 +516,5 @@ func giveGift(amount int64) int64 {
 	default:
 		ratio = Ratio5
 	}
-	return amount * ratio / 100
+	return (amount * ratio / 100) + amount
 }

--- a/controllers/account/deploy/manifests/deploy.yaml
+++ b/controllers/account/deploy/manifests/deploy.yaml
@@ -160,6 +160,12 @@ spec:
                 description: Deduction amount
                 format: int64
                 type: integer
+              encryptBalance:
+                description: EncryptBalance is to encrypt balance
+                type: string
+              encryptDeductionBalance:
+                description: EncryptDeductionBalance is to encrypt DeductionBalance
+                type: string
             type: object
         type: object
     served: true
@@ -551,6 +557,8 @@ spec:
                 format: int64
                 minimum: 1000000
                 type: integer
+              from:
+                type: string
               to:
                 type: string
             required:

--- a/controllers/pkg/crypto/crypto.go
+++ b/controllers/pkg/crypto/crypto.go
@@ -69,22 +69,32 @@ func DecryptInt64(in string) (int64, error) {
 	return strconv.ParseInt(string(out), 10, 64)
 }
 
-func RechargeBalance(balance *string, amount int64) (*string, error) {
-	balanceInt, err := DecryptInt64(*balance)
+func RechargeBalance(rawBalance *string, amount int64) error {
+	balanceInt, err := DecryptInt64(*rawBalance)
 	if err != nil {
-		return nil, fmt.Errorf("failed to recharge balance: %w", err)
+		return fmt.Errorf("failed to recharge balance: %w", err)
 	}
 	balanceInt += amount
-	return EncryptInt64(balanceInt)
+	encryptBalance, err := EncryptInt64(balanceInt)
+	if err != nil {
+		return fmt.Errorf("failed to recharge balance: %w", err)
+	}
+	*rawBalance = *encryptBalance
+	return nil
 }
 
-func DeductBalance(balance *string, amount int64) (*string, error) {
+func DeductBalance(balance *string, amount int64) error {
 	balanceInt, err := DecryptInt64(*balance)
 	if err != nil {
-		return nil, fmt.Errorf("failed to deduct balance: %w", err)
+		return fmt.Errorf("failed to deduct balance: %w", err)
 	}
 	balanceInt -= amount
-	return EncryptInt64(balanceInt)
+	encryptBalance, err := EncryptInt64(balanceInt)
+	if err != nil {
+		return fmt.Errorf("failed to deduct balance: %w", err)
+	}
+	*balance = *encryptBalance
+	return nil
 }
 
 // Decrypt decrypts the given ciphertext using AES-GCM.

--- a/controllers/pkg/crypto/crypto.go
+++ b/controllers/pkg/crypto/crypto.go
@@ -56,8 +56,9 @@ func Encrypt(plaintext []byte) (string, error) {
 	return base64.StdEncoding.EncodeToString(append(nonce, ciphertext...)), nil
 }
 
-func EncryptInt64(in int64) (string, error) {
-	return Encrypt([]byte(strconv.FormatInt(in, 10)))
+func EncryptInt64(in int64) (*string, error) {
+	out, err := Encrypt([]byte(strconv.FormatInt(in, 10)))
+	return &out, err
 }
 
 func DecryptInt64(in string) (int64, error) {
@@ -68,12 +69,21 @@ func DecryptInt64(in string) (int64, error) {
 	return strconv.ParseInt(string(out), 10, 64)
 }
 
-func RechargeBalance(balance string, amount int64) (string, error) {
-	balanceInt, err := DecryptInt64(balance)
+func RechargeBalance(balance *string, amount int64) (*string, error) {
+	balanceInt, err := DecryptInt64(*balance)
 	if err != nil {
-		return "", fmt.Errorf("failed to recharge balance: %w", err)
+		return nil, fmt.Errorf("failed to recharge balance: %w", err)
 	}
 	balanceInt += amount
+	return EncryptInt64(balanceInt)
+}
+
+func DeductBalance(balance *string, amount int64) (*string, error) {
+	balanceInt, err := DecryptInt64(*balance)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deduct balance: %w", err)
+	}
+	balanceInt -= amount
 	return EncryptInt64(balanceInt)
 }
 

--- a/controllers/pkg/crypto/crypto_test.go
+++ b/controllers/pkg/crypto/crypto_test.go
@@ -1,0 +1,61 @@
+package crypto
+
+import (
+	"testing"
+)
+
+func TestRechargeBalance(t *testing.T) {
+	rawInt := int64(100_000_000)
+	addInt := int64(200_000_000)
+	expectedInt := int64(300_000_000)
+
+	account := createEncryptedAccount(t, rawInt)
+
+	rechargeAccount(t, account, addInt)
+
+	validateAccount(t, account, expectedInt, "recharge balance failed")
+}
+
+func TestDeductBalance(t *testing.T) {
+	rawInt := int64(300_000_000)
+	deductInt := int64(200_000_000)
+	expectedInt := int64(100_000_000)
+
+	account := createEncryptedAccount(t, rawInt)
+
+	deductAccount(t, account, deductInt)
+
+	validateAccount(t, account, expectedInt, "deduct balance failed")
+}
+
+func createEncryptedAccount(t *testing.T, rawInt int64) *string {
+	account, err := EncryptInt64(rawInt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return account
+}
+
+func rechargeAccount(t *testing.T, account *string, amount int64) {
+	err := RechargeBalance(account, amount)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func deductAccount(t *testing.T, account *string, amount int64) {
+	err := DeductBalance(account, amount)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func validateAccount(t *testing.T, account *string, expectedInt int64, errMsg string) {
+	decryptedInt, err := DecryptInt64(*account)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decryptedInt != expectedInt {
+		t.Fatalf("%s: expected %d, got %d", errMsg, expectedInt, decryptedInt)
+	}
+}


### PR DESCRIPTION


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5c2a6e5</samp>

### Summary
:moneybag::lock::wrench:

<!--
1.  :moneybag: - This emoji represents the money transfer feature and the encryption of account balances, which are the main features of this pull request.
2. :lock: - This emoji represents the security and validation aspects of the pull request, such as the cluster roles, the namespace filter, and the duplicate transfer check.
3. :wrench: - This emoji represents the bug fixes and code improvements of the pull request, such as the pointer types, the JSON conversion, and the simplified logic.
-->
This pull request adds a new feature to the account controller that allows users to create and manage money transfers between accounts. It modifies the `AccountStatus` struct and the `account.sealos.io_accounts` CRD to support encrypted balances, and adds a new `Transfer` struct and the `account.sealos.io_transfers` CRD to represent transfers. It also updates the controller logic, the `crypto.go` file, and the `deploy.yaml` file to handle the encryption and validation of balances and transfers. Additionally, it adds new cluster roles and a sample file for the transfer feature.

> _Sing, O Muse, of the cunning code review_
> _That brought to light the deeds of the account API_
> _How the skilled developers, with Zeus' favor, wrought_
> _New schemas, roles, and logic for the transfers of gold_

### Walkthrough
*  Change the type of `EncryptBalance` and `EncryptDeductionBalance` fields in `AccountStatus` struct from `string` to `*string` to allow nil values and avoid empty strings ([link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-9a954adb0f037b9c43d5dda396006bdafadd0619290fc89ff497bba21fa2f348L66-R66), [link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-9a954adb0f037b9c43d5dda396006bdafadd0619290fc89ff497bba21fa2f348L72-R72), [link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-aa3531d8ce3be0fca9d48ab98e03bc487a0d1839e27f25731466efab4cfd6be6R73-R78), [link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-b4dca08a6cd3d21df60d689acb6983f7e411d29f9e5a8609c48aede3c341ef70R163-R168))
* Add the `Transfer` custom resource and its controller to represent and handle money transfers between accounts ([link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-893a58a3837d7767e4a3cfb72acc6016f458c485454ff59b576fd48012bc60b4R20-R21), [link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-893a58a3837d7767e4a3cfb72acc6016f458c485454ff59b576fd48012bc60b4L37-R40), [link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-893a58a3837d7767e4a3cfb72acc6016f458c485454ff59b576fd48012bc60b4R75-R88), [link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-c64d31a10a5ffde15f80a4e46572fb7e8fef0ccc53ccc9d2b255ca4cd908bf9dR1-R68), [link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-137c0f053e888c2137678bb1b1b3e57f4164696ab87a9966d2047db2c3184540L70-R73), [link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-137c0f053e888c2137678bb1b1b3e57f4164696ab87a9966d2047db2c3184540R86-R88), [link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-137c0f053e888c2137678bb1b1b3e57f4164696ab87a9966d2047db2c3184540R130), [link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-137c0f053e888c2137678bb1b1b3e57f4164696ab87a9966d2047db2c3184540R157), [link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-137c0f053e888c2137678bb1b1b3e57f4164696ab87a9966d2047db2c3184540R176-R178), [link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-b4dca08a6cd3d21df60d689acb6983f7e411d29f9e5a8609c48aede3c341ef70R560-R561))
* Add the `transfer-editor-role` and `transfer-viewer-role` cluster roles to grant permissions for end users to edit and view transfers ([link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-f7e399c4ddd427d8b20f4180f8d3e37896750841eed1d9637d580f57f7dde7f5R1-R24), [link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-4e5795b91a07863f7de606949cdfc5534fec7cbf2af931dd0b21ac3809e42afcR1-R20))
* Add the `account_v1_transfer.yaml` sample file to provide an example of how to create a `Transfer` custom resource ([link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-aadd5f2f72c33dbc2363ae5801f16e85b0a52a8de49e9563a60702ab381ba3aaR1-R6))
* Simplify the logic of updating the balance and deduction balance fields in the `AccountReconciler` by always using the encrypted fields and calling the `updateAccountStatus` and `initBalance` methods ([link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L61), [link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L69), [link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L129-L143), [link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L166-R160), [link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L258-R252), [link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L379-R389), [link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4R418-R445))
* Wrap the `updateDeductionBalance` method with the `RetryOnConflict` function to retry the update in case of a conflict error ([link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L102-R108))
* Add the `NamespaceFilterPredicate` and the `WithPredicates` function to filter the events from the `AccountBalance` custom resources based on the namespace of the `AccountReconciler` ([link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4R26-R30), [link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L450-R462), [link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4R468-R488))
* Modify the `giveGift` function to return the sum of the amount and the gift instead of just the gift ([link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L486-R519))
* Modify the `EncryptInt64` function to return a pointer to a string instead of a string to match the changes in the `AccountStatus` struct ([link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-4b235d07ce6cae9a536affded1ae23dd8f1bbcf9412eeb24908bace314c6a64dL59-R61))
* Modify the `RechargeBalance` function to accept and return a pointer to a string instead of a string to match the changes in the `EncryptInt64` function and the `AccountStatus` struct ([link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-4b235d07ce6cae9a536affded1ae23dd8f1bbcf9412eeb24908bace314c6a64dL71-R75))
* Add the `DeductBalance` function to perform the opposite operation of the `RechargeBalance` function, i.e. deduct an amount from an encrypted balance and return the new encrypted balance ([link](https://github.com/labring/sealos/pull/3463/files?diff=unified&w=0#diff-4b235d07ce6cae9a536affded1ae23dd8f1bbcf9412eeb24908bace314c6a64dR81-R89))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
