### PR TITLE
add cost-center env.

### DIFF
--- a/frontend/providers/costcenter/deploy/Kubefile
+++ b/frontend/providers/costcenter/deploy/Kubefile
@@ -7,5 +7,7 @@ COPY manifests manifests
 
 ENV certSecretName="wildcard-cert"
 ENV cloudDomain="cloud.example.com"
+ENV transferEnabled="true"
+ENV rechargeEnabled="true"
 
 CMD ["kubectl apply -f manifests"]

--- a/frontend/providers/costcenter/deploy/manifests/appcr.yaml.tmpl
+++ b/frontend/providers/costcenter/deploy/manifests/appcr.yaml.tmpl
@@ -7,7 +7,7 @@ spec:
   data:
     desc: sealos CLoud costcenter
     url: "https://costcenter.{{ .cloudDomain }}"
-  icon: "https://costcenter.{{ .cloudDomain }}/images/cost_center.svg"
+  icon: "/images/cost_center.svg"
   menuData:
     helpDocs: https://www.sealos.io/docs/cloud/apps/costcenter/
     helpDropDown: false

--- a/frontend/providers/costcenter/deploy/manifests/deploy.yaml.tmpl
+++ b/frontend/providers/costcenter/deploy/manifests/deploy.yaml.tmpl
@@ -35,6 +35,11 @@ spec:
     spec:
       containers:
         - name: costcenter-frontend
+          env:
+            - name: TRANSFER_ENABLED
+              value: '{{ .transferEnabled }}'
+            - name: RECHARGE_ENABLED
+              value: '{{ .rechargeEnabled }}'
           resources:
             limits:
               cpu: 100m


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at eaa827c</samp>

### Summary
🌐🖼️🚀

<!--
1.  🌐 - This emoji represents the environment variables that control the app features, as they affect the app's functionality and user interface across the network. The globe emoji also suggests the idea of transferring and recharging credits among different cost centers.
2. 🖼️ - This emoji represents the icon path change, as it affects the app's appearance and branding. The framed picture emoji also suggests the idea of displaying an image from a local source, instead of a remote one.
3. 🚀 - This emoji represents the deployment resource change, as it affects the app's performance and scalability. The rocket emoji also suggests the idea of launching and running the app on the Kubernetes cluster.
-->
This pull request adds two new features to the costcenter app: transfer and recharge credits. It also changes the icon path to a relative one. It updates the `Kubefile`, `appcr.yaml.tmpl`, and `deploy.yaml.tmpl` files to reflect these changes.

> _`costcenter` app_
> _adds two env variables_
> _features toggle now_

### Walkthrough
*  Add and interpolate environment variables to control transfer and recharge features in costcenter app ([link](https://github.com/labring/sealos/pull/3468/files?diff=unified&w=0#diff-972fa290b24ab7df51ec4baf1aca3dbd614d867fa7140e1ce394dd174463b25aR10-R11), [link](https://github.com/labring/sealos/pull/3468/files?diff=unified&w=0#diff-54d90a80dafd78723ca1df53369c521026e9418ebbbdfcac4f62e51458b5f746R38-R42))
* Change icon path from absolute url to relative path in appcr template ([link](https://github.com/labring/sealos/pull/3468/files?diff=unified&w=0#diff-e4f0dd85bc6f34921be4de70c904e70b5c4ae4bafc918e56492b0c8e5e4a9dc1L10-R10))

