### PR TITLE
add user env

### DIFF
--- a/controllers/user/deploy/Kubefile
+++ b/controllers/user/deploy/Kubefile
@@ -5,4 +5,7 @@ USER 65532:65532
 COPY registry registry
 COPY manifests manifests
 
+ENV cloudDomain="cloud.example.io"
+ENV cloudPort="6443"
+
 CMD ["kubectl apply -f manifests/deploy.yaml","kubectl delete -f manifests/rbac.yaml --ignore-not-found=true","kubectl delete crd usergroups.user.sealos.io --ignore-not-found=true","kubectl delete crd usergroupbindings.user.sealos.io --ignore-not-found=true"]

--- a/controllers/user/deploy/manifests/deploy.yaml.tmpl
+++ b/controllers/user/deploy/manifests/deploy.yaml.tmpl
@@ -338,9 +338,9 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         - name: SEALOS_CLOUD_HOST
-          value: cloud.sealos.io
+          value: {{ .cloudDomain }}
         - name: SEALOS_CLOUD_PORT
-          value: "443"
+          value: "{{ .cloudPort }}"
         image: ghcr.io/labring/sealos-user-controller:dev
         imagePullPolicy: Always
         livenessProbe:

--- a/deploy/cloud/scripts/init.sh
+++ b/deploy/cloud/scripts/init.sh
@@ -25,7 +25,9 @@ function mock_tls {
 
 function sealos_run_controller {
   # run user controller
-  sealos run tars/user.tar
+  sealos run tars/user.tar \
+  --env cloudDomain=$cloudDomain \
+  --env cloudPort="6443"
 
   # run terminal controller
   sealos run tars/terminal.tar \

--- a/frontend/providers/costcenter/deploy/Kubefile
+++ b/frontend/providers/costcenter/deploy/Kubefile
@@ -7,5 +7,7 @@ COPY manifests manifests
 
 ENV certSecretName="wildcard-cert"
 ENV cloudDomain="cloud.example.com"
+ENV transferEnabled="true"
+ENV rechargeEnabled="true"
 
 CMD ["kubectl apply -f manifests"]

--- a/frontend/providers/costcenter/deploy/manifests/appcr.yaml.tmpl
+++ b/frontend/providers/costcenter/deploy/manifests/appcr.yaml.tmpl
@@ -7,7 +7,7 @@ spec:
   data:
     desc: sealos CLoud costcenter
     url: "https://costcenter.{{ .cloudDomain }}"
-  icon: "https://costcenter.{{ .cloudDomain }}/images/cost_center.svg"
+  icon: "/images/cost_center.svg"
   menuData:
     helpDocs: https://www.sealos.io/docs/cloud/apps/costcenter/
     helpDropDown: false

--- a/frontend/providers/costcenter/deploy/manifests/deploy.yaml.tmpl
+++ b/frontend/providers/costcenter/deploy/manifests/deploy.yaml.tmpl
@@ -35,6 +35,11 @@ spec:
     spec:
       containers:
         - name: costcenter-frontend
+          env:
+            - name: TRANSFER_ENABLED
+              value: '{{ .transferEnabled }}'
+            - name: RECHARGE_ENABLED
+              value: '{{ .rechargeEnabled }}'
           resources:
             limits:
               cpu: 100m


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 084c691</samp>

### Summary
🌐🛂💰

<!--
1.  🌐 - This emoji represents the cloud domain and port settings, which are related to the network and connectivity of the sealos cloud API server and the user controller.
2.  🛂 - This emoji represents the user authentication and authorization features, which are handled by the user controller and depend on the sealos cloud API server.
3.  💰 - This emoji represents the costcenter provider and its web app, which provide the functionality of managing the costs and budgets of sealos cloud resources.
-->
This pull request adds or modifies environment variables in the Kubefiles and manifests of the user controller and the costcenter provider, to make them more configurable and consistent with the sealos cloud API server settings. It also fixes the icon URL of the costcenter appcr.

> _`Kubefile` changes_
> _Configuring sealos cloud_
> _Autumn of features_

### Walkthrough
*  Add and interpolate environment variables for sealos cloud domain and port in user controller Kubefile and deployment manifest ([link](https://github.com/labring/sealos/pull/3469/files?diff=unified&w=0#diff-4cddd3dc4b71f847f1af01238ead78ac93ec59d01c0732a39b1b2455295754ebR8-R10), [link](https://github.com/labring/sealos/pull/3469/files?diff=unified&w=0#diff-40a26874ba94d4ab16c7fbecb9c3f9fb3e5879b708f32cef9033a8eade9a43e3L341-R343))
*  Pass environment variables from user controller Kubefile to sealos run command in init script ([link](https://github.com/labring/sealos/pull/3469/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844L28-R30))
*  Add and interpolate environment variables for transfer and recharge features in costcenter provider Kubefile and deployment manifest ([link](https://github.com/labring/sealos/pull/3469/files?diff=unified&w=0#diff-972fa290b24ab7df51ec4baf1aca3dbd614d867fa7140e1ce394dd174463b25aR10-R11), [link](https://github.com/labring/sealos/pull/3469/files?diff=unified&w=0#diff-54d90a80dafd78723ca1df53369c521026e9418ebbbdfcac4f62e51458b5f746R38-R42))
*  Replace hard-coded icon URL with relative path in costcenter provider appcr manifest ([link](https://github.com/labring/sealos/pull/3469/files?diff=unified&w=0#diff-e4f0dd85bc6f34921be4de70c904e70b5c4ae4bafc918e56492b0c8e5e4a9dc1L10-R10))


