### PR TITLE
add base64 for public key

### DIFF
--- a/controllers/cloud/deploy/manifests/configmaps.yaml
+++ b/controllers/cloud/deploy/manifests/configmaps.yaml
@@ -19,3 +19,14 @@ kind: ConfigMap
 metadata:
   name: cloud-license-history
   namespace: cloud-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloud-secret
+  namespace: cloud-system
+  labels:
+    registered: "false"
+data:
+  "uid": "e30="
+  "key": "e30="

--- a/controllers/pkg/crypto/crypto.go
+++ b/controllers/pkg/crypto/crypto.go
@@ -129,7 +129,11 @@ func Decrypt(ciphertextBase64 string) ([]byte, error) {
 }
 
 func IsLicenseValid(license v1.License) (map[string]interface{}, bool) {
-	publicKey, err := parseRSAPublicKeyFromPEM(license.Spec.Key)
+	decodeKey, err := base64.StdEncoding.DecodeString(license.Spec.Key)
+	if err != nil {
+		return nil, false
+	}
+	publicKey, err := parseRSAPublicKeyFromPEM(string(decodeKey))
 	if err != nil {
 		return nil, false
 	}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 414f396</samp>

### Summary
:lock::cloud::wrench:

<!--
1.  :lock: This emoji represents the Secret resource and the encryption key, which are related to security and encryption.
2.  :cloud: This emoji represents the cloud-system namespace and the cloud license, which are related to cloud computing and licensing.
3.  :wrench: This emoji represents the modification of the IsLicenseValid function, which is related to fixing or improving the code functionality.
-->
This pull request adds a new Secret resource to store the cloud license key and modifies the license validation logic to decode the key from base64. The changes affect the `controllers/cloud/deploy/manifests/configmaps.yaml` and `controllers/pkg/crypto/crypto.go` files.

> _`cloud-secret` holds_
> _uid and key for license_
> _autumn of trust ends_

### Walkthrough
*  Add a new Secret resource `cloud-secret` to store the license key and identifier ([link](https://github.com/labring/sealos/pull/3470/files?diff=unified&w=0#diff-95bcdab3362762f4053f76e5a5ec94a339e92c0104ea8de0ccf4532793d8248bL21-R32))
*  Decode the license key from base64 before verifying the license token in `IsLicenseValid` function ([link](https://github.com/labring/sealos/pull/3470/files?diff=unified&w=0#diff-4b235d07ce6cae9a536affded1ae23dd8f1bbcf9412eeb24908bace314c6a64dL132-R139))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
