### PR TITLE
feat: add ide-extension for i18next handling

### DIFF
--- a/inlang.config.js
+++ b/inlang.config.js
@@ -1,0 +1,24 @@
+/**
+ * @type { import("@inlang/core/config").DefineConfig }
+ */
+export async function defineConfig(env) {
+	const { default: jsonPlugin } = await env.$import(
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-i18next@3/dist/index.js",
+	)
+
+	const { default: standardLintRules } = await env.$import(
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-standard-lint-rules@3/dist/index.js",
+	)
+
+	return {
+		referenceLanguage: "en",
+		plugins: [
+			jsonPlugin({
+				pathPattern: {
+					common: "frontend/desktop/public/locales/{language}/common.json",
+				},
+			}),
+			standardLintRules(),
+		],
+	}
+}


### PR DESCRIPTION
> Let me know if I need to change something to merge this PR

I added the inlang [IDE extension](https://inlang.com/documentation/apps/ide-extension) to sealos. Helps with handling translation keys and translation linting.

## What did I add?
- `inlang.config.js` to configure where language translations are
- Would recommend adding it to the `.vscode` folder so other contributors can use it.

## How to use it?

### Extract Messages (translations)
Extract Messages (translations) via the Inlang: Extract Message code action.

![Extract Messages](https://cdn.jsdelivr.net/gh/inlang/inlang/assets/ide-extension/extract.gif)

### Inline annotations
You can see translations directly in your code. No back-and-forth looking into the translation files themselves. (code example from sealos)

<img width="836" alt="image" src="https://github.com/labring/sealos/assets/58360188/835b42ed-aa0c-4d62-bdff-b75f6ae1a0b3">

Ootb [editor](https://inlang.com/documentation/apps/web-editor) & [CLI](https://inlang.com/documentation/apps/inlang-cli) if needed.