### PR TITLE
build(main): dev to latest

### DIFF
--- a/.github/workflows/ci-patch-image.yml
+++ b/.github/workflows/ci-patch-image.yml
@@ -172,7 +172,7 @@ jobs:
       - name: Prepare
         id: prepare
         run: |
-          TAG=dev
+          TAG=latest
           echo tag_name=${GIT_COMMIT_SHORT_SHA} >> $GITHUB_OUTPUT
       - name: Renew issue and Sync Images
         uses: labring/gh-rebot@v0.0.6

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -11,8 +11,8 @@ on:
         type: boolean
         default: false
       push_image_tag:
-        description: 'Push all-in-one image tag, default is dev'
-        default: 'dev'
+        description: 'Push all-in-one image tag, default is latest'
+        default: 'latest'
         required: false
         type: string
       build_from:

--- a/.github/workflows/controllers.yml
+++ b/.github/workflows/controllers.yml
@@ -12,7 +12,7 @@ on:
         default: false
       push_image_tag:
         description: "Push image tag"
-        default: "dev"
+        default: "latest"
         required: false
         type: string
   push:
@@ -155,7 +155,6 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/sealos-${{ matrix.module.name }}-controller
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=raw,value=dev,enable=true
             type=raw,value=${{ steps.prepare.outputs.tag_name }},enable=true
 
       - name: build (and publish) ${{ matrix.module.name }} main image
@@ -229,7 +228,7 @@ jobs:
       - name: Mutate image tag in deploy files
         working-directory: controllers/${{ matrix.module.path }}/deploy
         run: |
-          OLD_DOCKER_IMAGE_NAME=${{ steps.prepare.outputs.old_docker_repo }}:dev
+          OLD_DOCKER_IMAGE_NAME=${{ steps.prepare.outputs.old_docker_repo }}:latest
           NEW_DOCKER_IMAGE_NAME=${{ steps.prepare.outputs.new_docker_repo }}:${{ steps.prepare.outputs.tag_name }}
           sudo sed -i "s;${OLD_DOCKER_IMAGE_NAME};${NEW_DOCKER_IMAGE_NAME};" manifests/*
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -12,7 +12,7 @@ on:
         default: false
       push_image_tag:
         description: "Push image tag"
-        default: "dev"
+        default: "latest"
         required: false
         type: string
   push:
@@ -87,7 +87,6 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/sealos-${{ env.MODULE_NAME }}-frontend
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=raw,value=dev,enable=true
             type=raw,value=${{ steps.prepare.outputs.tag_name }},enable=true
 
       - name: Set up QEMU
@@ -160,7 +159,7 @@ jobs:
         run: |
           tag_name=$(bash ./scripts/resolve-tag-image.sh "${{ inputs.push_image }}" "${{ steps.check_tag.outputs.isTag }}"  "${{ inputs.push_image_tag }}")
           echo old_docker_repo=ghcr.io/labring/sealos-${{ env.MODULE_NAME }}-frontend >> $GITHUB_OUTPUT
-          echo old_docker_image=ghcr.io/labring/sealos-${{ env.MODULE_NAME }}-frontend:dev >> $GITHUB_OUTPUT
+          echo old_docker_image=ghcr.io/labring/sealos-${{ env.MODULE_NAME }}-frontend:latest >> $GITHUB_OUTPUT
           echo new_docker_repo=ghcr.io/${{ github.repository_owner }}/sealos-${{ env.MODULE_NAME }}-frontend >> $GITHUB_OUTPUT
           echo new_docker_image=ghcr.io/${{ github.repository_owner }}/sealos-${{ env.MODULE_NAME }}-frontend:${tag_name} >> $GITHUB_OUTPUT
           echo cluster_repo=ghcr.io/${{ github.repository_owner }}/sealos-cloud-${{ env.MODULE_NAME }}-frontend >> $GITHUB_OUTPUT

--- a/.github/workflows/services.yml
+++ b/.github/workflows/services.yml
@@ -13,7 +13,7 @@ on:
         default: false
       push_image_tag:
         description: 'Push image tag'
-        default: 'dev'
+        default: 'latest'
         required: false
         type: string
   push:
@@ -144,7 +144,6 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/sealos-${{ matrix.module }}-service
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=raw,value=dev,enable=true
             type=raw,value=${{ steps.prepare.outputs.tag_name }},enable=true
 
       - name: build (and publish) ${{ matrix.module }} main image
@@ -212,7 +211,7 @@ jobs:
       - name: Mutate image tag in deploy files
         working-directory: service/${{ matrix.module }}/deploy
         run: |
-          OLD_DOCKER_IMAGE_NAME=${{ steps.prepare.outputs.old_docker_repo }}:dev
+          OLD_DOCKER_IMAGE_NAME=${{ steps.prepare.outputs.old_docker_repo }}:latest
           NEW_DOCKER_IMAGE_NAME=${{ steps.prepare.outputs.new_docker_repo }}:${{ steps.prepare.outputs.tag_name }}
           sed -i "s;${OLD_DOCKER_IMAGE_NAME};${NEW_DOCKER_IMAGE_NAME};" manifests/*
 

--- a/.github/workflows/webhooks.yml
+++ b/.github/workflows/webhooks.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Prepare
         id: prepare
         run: |
-          TAG=dev
+          TAG=latest
           echo tag_name=${TAG} >> $GITHUB_OUTPUT
 
       - # Add support for more platforms with QEMU (optional)

--- a/controllers/account/Makefile
+++ b/controllers/account/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/labring/sealos-account-controller:dev
+IMG ?= ghcr.io/labring/sealos-account-controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
 

--- a/controllers/account/config/default/manager_auth_proxy_patch.yaml
+++ b/controllers/account/config/default/manager_auth_proxy_patch.yaml
@@ -65,7 +65,7 @@ spec:
             value: "604800"
           - name: DebtDetectionCycleSeconds
             value: "300"
-        image: ghcr.io/labring/sealos-account-controller:dev
+        image: ghcr.io/labring/sealos-account-controller:latest
         imagePullPolicy: Always
         args:
         - "--health-probe-bind-address=:8081"

--- a/controllers/account/deploy/manifests/deploy.yaml
+++ b/controllers/account/deploy/manifests/deploy.yaml
@@ -1156,7 +1156,7 @@ spec:
         envFrom:
         - secretRef:
             name: payment-secret
-        image: ghcr.io/labring/sealos-account-controller:dev
+        image: ghcr.io/labring/sealos-account-controller:latest
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/controllers/app/Makefile
+++ b/controllers/app/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/labring/sealos-app-controller:dev
+IMG ?= ghcr.io/labring/sealos-app-controller:latest
 TARGETARCH ?= amd64
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.

--- a/controllers/app/deploy/manifests/deploy.yaml
+++ b/controllers/app/deploy/manifests/deploy.yaml
@@ -406,7 +406,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: ghcr.io/labring/sealos-app-controller:dev
+        image: ghcr.io/labring/sealos-app-controller:latest
         livenessProbe:
           httpGet:
             path: /healthz

--- a/controllers/cloud/deploy/manifests/deploy.yaml.tmpl
+++ b/controllers/cloud/deploy/manifests/deploy.yaml.tmpl
@@ -601,7 +601,7 @@ spec:
         env:
         - name: CAN_CONNECT_TO_EXTERNAL_NETWORK
           value: '{{ .canConnectToExternalNetwork }}'
-        image: ghcr.io/labring/sealos-cloud-controller:dev
+        image: ghcr.io/labring/sealos-cloud-controller:latest
         livenessProbe:
           httpGet:
             path: /healthz

--- a/controllers/cluster/Makefile
+++ b/controllers/cluster/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/labring/sealos-cluster-controller:dev
+IMG ?= ghcr.io/labring/sealos-cluster-controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.2
 

--- a/controllers/cluster/deploy/manifests/deploy.yaml
+++ b/controllers/cluster/deploy/manifests/deploy.yaml
@@ -443,7 +443,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: ghcr.io/labring/sealos-cluster-controller:dev
+        image: ghcr.io/labring/sealos-cluster-controller:latest
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/controllers/db/adminer/Makefile
+++ b/controllers/db/adminer/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/labring/sealos-db-adminer-controller:dev
+IMG ?= ghcr.io/labring/sealos-db-adminer-controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.1
 

--- a/controllers/db/adminer/deploy/README.md
+++ b/controllers/db/adminer/deploy/README.md
@@ -1,11 +1,11 @@
 ### How to build image
 
 ```shell
-sealos build -t docker.io/labring/sealos-db-adminer-controller:dev -f Dockerfile .
+sealos build -t docker.io/labring/sealos-db-adminer-controller:latest -f Dockerfile .
 ```
 
 ### How to run
 
 ```shell
-sealos run  docker.io/labring/sealos-db-adminer-controller:dev
+sealos run  docker.io/labring/sealos-db-adminer-controller:latest
 ```

--- a/controllers/db/adminer/deploy/manifests/deploy.yaml.tmpl
+++ b/controllers/db/adminer/deploy/manifests/deploy.yaml.tmpl
@@ -397,7 +397,7 @@ spec:
           value: {{ .wildcardCertSecretName }}
         - name: SECRET_NAMESPACE
           value: {{ .wildcardCertSecretNamespace }}
-        image: ghcr.io/labring/sealos-db-adminer-controller:dev
+        image: ghcr.io/labring/sealos-db-adminer-controller:latest
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/controllers/db/bytebase/deploy/README.md
+++ b/controllers/db/bytebase/deploy/README.md
@@ -1,11 +1,11 @@
 ### How to build image
 
 ```shell
-sealos build -t docker.io/labring/sealos-db-bytebase-controller:dev -f Dockerfile .
+sealos build -t docker.io/labring/sealos-db-bytebase-controller:latest -f Dockerfile .
 ```
 
 ### How to run
 
 ```shell
-sealos run  docker.io/labring/sealos-db-bytebase-controller:dev
+sealos run  docker.io/labring/sealos-db-bytebase-controller:latest
 ```

--- a/controllers/db/bytebase/deploy/manifests/deploy.yaml.tmpl
+++ b/controllers/db/bytebase/deploy/manifests/deploy.yaml.tmpl
@@ -512,7 +512,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: ghcr.io/labring/sealos-db-bytebase-controller:dev
+        image: ghcr.io/labring/sealos-db-bytebase-controller:latest
         livenessProbe:
           httpGet:
             path: /healthz

--- a/controllers/imagehub/Makefile
+++ b/controllers/imagehub/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/labring/sealos-imagehub-controller:dev
+IMG ?= ghcr.io/labring/sealos-imagehub-controller:latest
 TARGETARCH ?= amd64
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.

--- a/controllers/imagehub/deploy/manifests/deploy.yaml
+++ b/controllers/imagehub/deploy/manifests/deploy.yaml
@@ -867,7 +867,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: ghcr.io/labring/sealos-imagehub-controller:dev
+        image: ghcr.io/labring/sealos-imagehub-controller:latest
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/controllers/infra/Makefile
+++ b/controllers/infra/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/labring/sealos-infra-controller:dev
+IMG ?= ghcr.io/labring/sealos-infra-controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.1
 

--- a/controllers/infra/deploy/README.md
+++ b/controllers/infra/deploy/README.md
@@ -21,7 +21,7 @@ data:
 
 ### 部署方式
 ```
-sealos run docker.io/labring/sealos-account-controller:dev
+sealos run docker.io/labring/sealos-account-controller:latest
 
 ```
 

--- a/controllers/infra/deploy/manifests/deploy.yaml
+++ b/controllers/infra/deploy/manifests/deploy.yaml
@@ -603,7 +603,7 @@ spec:
         envFrom:
         - secretRef:
             name: infra-secret
-        image: ghcr.io/labring/sealos-infra-controller:dev
+        image: ghcr.io/labring/sealos-infra-controller:latest
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/controllers/metering/Makefile
+++ b/controllers/metering/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/labring/sealos-metering-controller:dev
+IMG ?= ghcr.io/labring/sealos-metering-controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
 

--- a/controllers/metering/deploy/manifests/deploy.yaml
+++ b/controllers/metering/deploy/manifests/deploy.yaml
@@ -567,7 +567,7 @@ spec:
         envFrom:
         - configMapRef:
             name: metering-manager-configmap
-        image: ghcr.io/labring/sealos-metering-controller:dev
+        image: ghcr.io/labring/sealos-metering-controller:latest
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/controllers/resources/Makefile
+++ b/controllers/resources/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/labring/sealos-resources-controller:dev
+IMG ?= ghcr.io/labring/sealos-resources-controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
 

--- a/controllers/resources/config/manager/manager.yaml
+++ b/controllers/resources/config/manager/manager.yaml
@@ -35,7 +35,7 @@ spec:
               secretKeyRef:
                 name: mongo-secret
                 key: MONGO_URI
-        image: ghcr.io/labring/sealos-resources-controller:dev
+        image: ghcr.io/labring/sealos-resources-controller:latest
         imagePullPolicy: Always
         name: manager
         securityContext:

--- a/controllers/resources/deploy/README.md
+++ b/controllers/resources/deploy/README.md
@@ -2,7 +2,7 @@
 
 ```shell
 # 需要传入完整的包含username passwd的mongo uri来创建secret：
-sealos run ghcr.io/labring/sealos-cloud-resources-controller:dev --env MONGO_URI="mongodb://username:passwd@ip:port/sealos-resources?authSource=admin"
+sealos run ghcr.io/labring/sealos-cloud-resources-controller:latest --env MONGO_URI="mongodb://username:passwd@ip:port/sealos-resources?authSource=admin"
 ```
 
 > 目前默认使用mongodb作为存储: sealos-resources 为数据库名

--- a/controllers/resources/deploy/manifests/deploy-manager.yaml
+++ b/controllers/resources/deploy/manifests/deploy-manager.yaml
@@ -55,7 +55,7 @@ spec:
                 secretKeyRef:
                   key: MONGO_URI
                   name: mongo-secret
-          image: ghcr.io/labring/sealos-resources-controller:dev
+          image: ghcr.io/labring/sealos-resources-controller:latest
           imagePullPolicy: Always
           livenessProbe:
             httpGet:

--- a/controllers/resources/metering/Makefile
+++ b/controllers/resources/metering/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/labring/sealos-resources-controller:dev
+IMG ?= ghcr.io/labring/sealos-resources-controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
 

--- a/controllers/resources/metering/deploy/manifests/deploy.yaml
+++ b/controllers/resources/metering/deploy/manifests/deploy.yaml
@@ -23,7 +23,7 @@ spec:
         control-plane: metering-manager
     spec:
       containers:
-        - image: ghcr.io/labring/sealos-resources-metering-controller:dev
+        - image: ghcr.io/labring/sealos-resources-metering-controller:latest
           name: resource-metering
           command:
             - "/manager"

--- a/controllers/terminal/Makefile
+++ b/controllers/terminal/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/labring/sealos-terminal-controller:dev
+IMG ?= ghcr.io/labring/sealos-terminal-controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.1
 

--- a/controllers/terminal/deploy/README.md
+++ b/controllers/terminal/deploy/README.md
@@ -1,11 +1,11 @@
 ### How to build image
 
 ```shell
-sealos build -t docker.io/labring/sealos-terminal-controller:dev -f Dockerfile .
+sealos build -t docker.io/labring/sealos-terminal-controller:latest -f Dockerfile .
 ```
 
 ### How to run
 
 ```shell
-sealos run  docker.io/labring/sealos-terminal-controller:dev
+sealos run  docker.io/labring/sealos-terminal-controller:latest
 ```

--- a/controllers/terminal/deploy/manifests/deploy.yaml.tmpl
+++ b/controllers/terminal/deploy/manifests/deploy.yaml.tmpl
@@ -447,7 +447,7 @@ spec:
           value: {{ .wildcardCertSecretName }}
         - name: SECRET_NAMESPACE
           value: {{ .wildcardCertSecretNamespace }}
-        image: ghcr.io/labring/sealos-terminal-controller:dev
+        image: ghcr.io/labring/sealos-terminal-controller:latest
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/controllers/user/Makefile
+++ b/controllers/user/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?=  ghcr.io/labring/sealos-user-controller:dev
+IMG ?=  ghcr.io/labring/sealos-user-controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.1
 

--- a/controllers/user/deploy/README.md
+++ b/controllers/user/deploy/README.md
@@ -1,11 +1,11 @@
 ### How to build image
 
 ```shell
-sealos build -t docker.io/labring/sealos-user-controller:dev -f Dockerfile .
+sealos build -t docker.io/labring/sealos-user-controller:latest -f Dockerfile .
 ```
 
 ### How to run
 
 ```shell
-sealos run docker.io/labring/sealos-user-controller:dev
+sealos run docker.io/labring/sealos-user-controller:latest
 ```

--- a/controllers/user/deploy/manifests/deploy.yaml.tmpl
+++ b/controllers/user/deploy/manifests/deploy.yaml.tmpl
@@ -341,7 +341,7 @@ spec:
           value: {{ .cloudDomain }}
         - name: SEALOS_CLOUD_PORT
           value: "{{ .cloudPort }}"
-        image: ghcr.io/labring/sealos-user-controller:dev
+        image: ghcr.io/labring/sealos-user-controller:latest
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/deploy/cloud-deprecated/README.md
+++ b/deploy/cloud-deprecated/README.md
@@ -17,7 +17,7 @@ metadata:
   name: secret
 spec:
   path: manifests/tls-secret.yaml
-  match: ghcr.io/labring/sealos-cloud:dev
+  match: ghcr.io/labring/sealos-cloud:latest
   strategy: merge
   data: |
     data:
@@ -27,5 +27,5 @@ spec:
 
 ### run sealos cloud cluster image
 ```shell
-sealos run ghcr.io/labring/sealos-cloud:dev --config-file tls-secret.yaml --env cloudDomain="cloud.example.com"
+sealos run ghcr.io/labring/sealos-cloud:latest --config-file tls-secret.yaml --env cloudDomain="cloud.example.com"
 ```

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -80,7 +80,7 @@ metadata:
   name: secret
 spec:
   path: manifests/tls-secret.yaml
-  match: docker.io/labring/sealos-cloud:dev
+  match: docker.io/labring/sealos-cloud:latest
   strategy: merge
   data: |
     data:
@@ -91,5 +91,5 @@ spec:
 ------
 ## run sealos cloud cluster image
 ```shell
-sealos run docker.io/labring/sealos-cloud:dev --env cloudDomain="cloud.example.com" --config-file tls-secret.yaml
+sealos run docker.io/labring/sealos-cloud:latest --env cloudDomain="cloud.example.com" --config-file tls-secret.yaml
 ```

--- a/frontend/desktop/deploy/README.md
+++ b/frontend/desktop/deploy/README.md
@@ -1,7 +1,7 @@
 ### How to build image
 
 ```shell
-sealos build -t docker.io/labring/sealos-cloud-desktop:dev -f Kubefile .
+sealos build -t docker.io/labring/sealos-cloud-desktop:latest -f Kubefile .
 ```
 
 ### Env
@@ -30,7 +30,7 @@ metadata:
   name: secret
 spec:
   path: manifests/secret.yaml
-  match: docker.io/labring/sealos-cloud-desktop:dev
+  match: docker.io/labring/sealos-cloud-desktop:latest
   strategy: merge
   data: |
     data:
@@ -48,6 +48,6 @@ sealos run \
     --env cloudDomain="cloud.sealos.io" \
     --env wildcardCertSecretName="wildcard-cert" \
     --env passwordEnabled="true" \
-    docker.io/labring/sealos-cloud-desktop:dev \
+    docker.io/labring/sealos-cloud-desktop:latest \
     --config-file desktop-config.yaml 
 ```

--- a/frontend/desktop/deploy/manifests/deploy.yaml.tmpl
+++ b/frontend/desktop/deploy/manifests/deploy.yaml.tmpl
@@ -155,7 +155,7 @@ spec:
             capabilities:
               drop:
                 - "ALL"
-          image: ghcr.io/labring/sealos-desktop-frontend:dev
+          image: ghcr.io/labring/sealos-desktop-frontend:latest
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: desktop-frontend-volume

--- a/frontend/providers/adminer/deploy/manifests/deploy.yaml
+++ b/frontend/providers/adminer/deploy/manifests/deploy.yaml
@@ -50,7 +50,7 @@ spec:
               drop:
                 - "ALL"
           # do not modify this image, it is used for CI/CD
-          image: ghcr.io/labring/sealos-adminer-frontend:dev
+          image: ghcr.io/labring/sealos-adminer-frontend:latest
           imagePullPolicy: Always
           volumeMounts:
             - name: adminer-frontend-volume

--- a/frontend/providers/applaunchpad/deploy/manifests/deploy.yaml.tmpl
+++ b/frontend/providers/applaunchpad/deploy/manifests/deploy.yaml.tmpl
@@ -57,7 +57,7 @@ spec:
               cpu: 10m
               memory: 128Mi
           # do not modify this image, it is used for CI/CD
-          image: ghcr.io/labring/sealos-applaunchpad-frontend:dev
+          image: ghcr.io/labring/sealos-applaunchpad-frontend:latest
           imagePullPolicy: Always
           volumeMounts:
             - name: applaunchpad-frontend-volume

--- a/frontend/providers/bytebase/deploy/manifests/deploy.yaml
+++ b/frontend/providers/bytebase/deploy/manifests/deploy.yaml
@@ -50,7 +50,7 @@ spec:
               drop:
                 - "ALL"
           # do not modify this image, it is used for CI/CD
-          image: ghcr.io/labring/sealos-bytebase-frontend:dev
+          image: ghcr.io/labring/sealos-bytebase-frontend:latest
           imagePullPolicy: Always
           volumeMounts:
             - name: bytebase-frontend-volume

--- a/frontend/providers/costcenter/deploy/manifests/deploy.yaml.tmpl
+++ b/frontend/providers/costcenter/deploy/manifests/deploy.yaml.tmpl
@@ -55,7 +55,7 @@ spec:
               drop:
                 - "ALL"
           # do not modify this image, it is used for CI/CD
-          image: ghcr.io/labring/sealos-costcenter-frontend:dev
+          image: ghcr.io/labring/sealos-costcenter-frontend:latest
           imagePullPolicy: Always
           volumeMounts:
             - name: costcenter-frontend-volume

--- a/frontend/providers/dbprovider/deploy/manifests/deploy.yaml.tmpl
+++ b/frontend/providers/dbprovider/deploy/manifests/deploy.yaml.tmpl
@@ -55,7 +55,7 @@ spec:
               cpu: 10m
               memory: 128Mi
           # do not modify this image, it is used for CI/CD
-          image: ghcr.io/labring/sealos-dbprovider-frontend:dev
+          image: ghcr.io/labring/sealos-dbprovider-frontend:latest
           imagePullPolicy: Always
           volumeMounts:
             - name: dbprovider-frontend-volume

--- a/frontend/providers/imagehub/deploy/manifests/deploy.yaml
+++ b/frontend/providers/imagehub/deploy/manifests/deploy.yaml
@@ -52,7 +52,7 @@ spec:
               drop:
                 - "ALL"
           # do not modify this image, it is used for CI/CD
-          image: ghcr.io/labring/sealos-imagehub-frontend:dev
+          image: ghcr.io/labring/sealos-imagehub-frontend:latest
           imagePullPolicy: Always
           volumeMounts:
             - name: imagehub-frontend-volume

--- a/frontend/providers/terminal/deploy/manifests/deploy.yaml.tmpl
+++ b/frontend/providers/terminal/deploy/manifests/deploy.yaml.tmpl
@@ -55,7 +55,7 @@ spec:
             - name: SITE
               value: {{ .cloudDomain }}
           # do not modify this image, it is used for CI/CD
-          image: ghcr.io/labring/sealos-terminal-frontend:dev
+          image: ghcr.io/labring/sealos-terminal-frontend:latest
           imagePullPolicy: Always
           volumeMounts:
             - name: terminal-frontend-volume

--- a/frontend/static-cdn/Makefile
+++ b/frontend/static-cdn/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-# IMG ?= ghcr.io/labring/sealos-desktop-static-cdn:dev
+# IMG ?= ghcr.io/labring/sealos-desktop-static-cdn:latest
 IMG ?= fanux/static-cdn:v0.0.1
 
 ##@ General

--- a/frontend/static-cdn/deploy/manifest.yaml
+++ b/frontend/static-cdn/deploy/manifest.yaml
@@ -55,7 +55,7 @@ spec:
             capabilities:
               drop:
                 - "ALL"
-          # image: ghcr.io/labring/sealos-desktop-static-cdn:dev
+          # image: ghcr.io/labring/sealos-desktop-static-cdn:latest
           image: fanux/static-cdn:v0.0.1
           ports:
             - containerPort: 8080

--- a/service/auth/Makefile
+++ b/service/auth/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?=  ghcr.io/labring/sealos-auth-service:dev
+IMG ?=  ghcr.io/labring/sealos-auth-service:latest
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/service/auth/deploy/README.md
+++ b/service/auth/deploy/README.md
@@ -1,7 +1,7 @@
 ### How to build image
 
 ```shell
-sealos build -t docker.io/labring/sealos-auth-service:dev -f Kubefile .
+sealos build -t docker.io/labring/sealos-auth-service:latest -f Kubefile .
 ```
 
 ### Env
@@ -23,5 +23,5 @@ sealos run
     --env callbackUrl="https://cloud.sealos.io/login/callback"
     --env ssoEndpoint="https://login.cloud.sealos.io"
     --env casdoorMysqlRootPassword="c2VhbG9zcHdk"
-    docker.io/labring/sealos-auth-service:dev
+    docker.io/labring/sealos-auth-service:latest
 ```

--- a/service/auth/deploy/manifests/deploy.yaml
+++ b/service/auth/deploy/manifests/deploy.yaml
@@ -274,7 +274,7 @@ spec:
         control-plane: service-manager
     spec:
       containers:
-        - image: ghcr.io/labring/sealos-auth-service:dev
+        - image: ghcr.io/labring/sealos-auth-service:latest
           imagePullPolicy: Always
           livenessProbe:
             initialDelaySeconds: 15

--- a/service/hub/Makefile
+++ b/service/hub/Makefile
@@ -1,4 +1,4 @@
-IMG ?= labring/sealos-hub-service:dev
+IMG ?= labring/sealos-hub-service:latest
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/service/hub/deploy/manifests/deploy.yaml
+++ b/service/hub/deploy/manifests/deploy.yaml
@@ -156,7 +156,7 @@ spec:
       serviceAccountName: hub-service-anonymous
       containers:
         - name: hub-service-server
-          image: lingdie/sealos-hub-service:dev
+          image: lingdie/sealos-hub-service:latest
           ports:
             - containerPort: 5001
           args:

--- a/service/payment/Makefile
+++ b/service/payment/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?=  ghcr.io/labring/sealos-payment-service:dev
+IMG ?=  ghcr.io/labring/sealos-payment-service:latest
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/webhooks/whitelist/Makefile
+++ b/webhooks/whitelist/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/labring/sealos-whitelist-webhook:dev
+IMG ?= ghcr.io/labring/sealos-whitelist-webhook:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.2
 

--- a/webhooks/whitelist/deploy/manifests/deploy.yaml
+++ b/webhooks/whitelist/deploy/manifests/deploy.yaml
@@ -303,7 +303,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: ghcr.io/labring/sealos-whitelist-webhook:dev
+        image: ghcr.io/labring/sealos-whitelist-webhook:latest
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1be6062</samp>

### Summary
🏷️🚀📝

<!--
1.  🏷️ - This emoji represents the change of the image tag from `dev` to `latest` in various files and workflows. It conveys the idea of labeling or tagging something with a different name or value.
2.  🚀 - This emoji represents the deployment of the images and manifests with the `latest` tag. It conveys the idea of launching or releasing something to a target environment or platform.
3.  📝 - This emoji represents the update of the documentation and the Makefiles to reflect the change of the image tag. It conveys the idea of writing or editing something to make it clear or accurate.
-->
This pull request changes the default image tag from `dev` to `latest` in various workflows, controllers, and manifests. The purpose of this change is to simplify the image building and deployment process, and to avoid confusion or inconsistency with the `dev` tag. This change affects the `.github/workflows` directory, the `controllers` directory, and some `README.md` and `Makefile` files.

> _We're breaking free from the `dev` tag_
> _We're using `latest` for our image flag_
> _We're simplifying our workflows and manifests_
> _We're building and deploying with the best_

### Walkthrough
*  Change the default value of the `push_image_tag` input parameter to `latest` in the `cloud`, `controllers`, `frontend`, and `services` workflows ([link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-7e4159d358d73ce740ffdf0b5737ccb6965692a7d3cea96bbb2a1ba054ea229eL14-R15), [link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-8e0e4903d4e4f8b8844d36370ca2d71c7c72d03ddb7a9cdcedc6328dfc5da8faL15-R15), [link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-ffe3a297ed15e9a79846161a3731a580511bf13c6b5cc5a9e03ddcbd8515fdeeL15-R15), [link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-48839d65f7bfedd91312ee406fd94da103ede7d3c7e791eb2c1657f46afdea00L16-R16))
*  Remove the `type=raw,value=dev,enable=true` line from the `sealos build` command in the `controllers`, `frontend`, and `services` workflows, as the image tag is determined by the `push_image_tag` input parameter ([link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-8e0e4903d4e4f8b8844d36370ca2d71c7c72d03ddb7a9cdcedc6328dfc5da8faL158), [link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-ffe3a297ed15e9a79846161a3731a580511bf13c6b5cc5a9e03ddcbd8515fdeeL90), [link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-48839d65f7bfedd91312ee406fd94da103ede7d3c7e791eb2c1657f46afdea00L147))
*  Modify the `TAG` variable in the `prepare` step of the `ci-patch-image` and `webhooks` workflows to use `latest` instead of `dev`, to align the image tag with the `push_image_tag` input parameter ([link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-32e7e1062e41bfef162eb5aa471d42365df677ace95527c7ce0cdf492a4a40faL175-R175), [link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-51dbe051fd6c1e7ad2d0ad8a0fca7276dfa01776803a136c0f03832857c1a871L102-R102))
*  Modify the `OLD_DOCKER_IMAGE_NAME` variable in the `patch-image` step of the `controllers` and `services` workflows to use `latest` instead of `dev`, to match the image tag in the original manifests ([link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-8e0e4903d4e4f8b8844d36370ca2d71c7c72d03ddb7a9cdcedc6328dfc5da8faL232-R231), [link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-48839d65f7bfedd91312ee406fd94da103ede7d3c7e791eb2c1657f46afdea00L215-R214))
*  Modify the `old_docker_image` variable in the `prepare` step of the `frontend` workflow to use `latest` instead of `dev`, to match the image tag in the original manifests ([link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-ffe3a297ed15e9a79846161a3731a580511bf13c6b5cc5a9e03ddcbd8515fdeeL163-R162))
*  Change the `IMG` variable in the `Makefile` of the `account`, `app`, `cluster`, `db/adminer`, `db/bytebase`, and `imagehub` controllers to use `latest` instead of `dev`, to match the image tag in the Dockerfile and the manifests ([link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-9d97a10c750632f1530d93c6f470a2b54d99ce8e57fb76e189fe5ddf3b62f6b1L3-R3), [link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-1388be4d8970b3654b6ce3d1ec1771e946e4d8f12c75d6bcaa7cb260afd63442L3-R3), [link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-23405e5fdd0b7f903c0ec63ac73b555bea2591ab5c7fdd18e83994b8232795b2L3-R3), [link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-f920f67fd9a60b6487eb8cf7d132a804a8a9ed6c25475cb5a6c89318968a0e49L3-R3), [link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-fd6150d3909c1f44b5db6569964ec187714eaa1b0855e551e5e2d5adf108dd55L3-R3))
*  Change the `image` field in the `manager_auth_proxy_patch.yaml` and `deploy.yaml` of the `account` controller to use `latest` instead of `dev`, to match the image tag in the `Makefile` ([link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-afec2944b73c1e73393bfd1cec2dd27add46df610da031de5679d216ffc2512dL68-R73), [link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-b4dca08a6cd3d21df60d689acb6983f7e411d29f9e5a8609c48aede3c341ef70L1159-R1159))
*  Change the `image` field in the `deploy.yaml` of the `app` and `cluster` controllers to use `latest` instead of `dev`, to match the image tag in the `Makefile` ([link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-3eb74f347094c907e9af0f712002ae2286d0d795755df9d59d52c440659fd554L409-R409), [link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-fe1c58b4623517b876751f9ee6e5c09651a0db2221cd0c7fb2d0f0ced729c45bL446-R446))
*  Change the `image` field in the `deploy.yaml.tmpl` of the `cloud`, `db/adminer`, and `db/bytebase` controllers to use `latest` instead of `dev`, to match the image tag in the `Makefile` ([link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-58ea08a4ae852fa9301868f2bdb44c0bf1d86462bf44202211ea418cc1f56474L604-R604), [link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-53f452673dbd125ef137a97c14f0a4ba052a3b31874767a000710eedafa998a3L400-R400), [link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-973659167d1b8e3c0a0b77ad05d708fb9a62836da1ff92e11db2e71ffb2d750fL515-R515))
*  Change the `sealos build` and `sealos run` commands in the `README.md` of the `db/adminer` and `db/bytebase` controllers to use `latest` instead of `dev`, to match the image tag in the `Makefile` ([link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-d29e3ad8a5318fcfeb03fdd07556b542d1606c8bef6f052f4863530f2f4e2ad2L4-R4), [link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-d29e3ad8a5318fcfeb03fdd07556b542d1606c8bef6f052f4863530f2f4e2ad2L10-R10), [link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-e6902322926b0526827b32ba6373b308959dc922e8278d000527dfec58c9f1b1L4-R4), [link](https://github.com/labring/sealos/pull/3482/files?diff=unified&w=0#diff-e6902322926b0526827b32ba6373b308959dc922e8278d000527dfec58c9f1b1L10-R10))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
