### PR TITLE
build(main): add ci for latest

### DIFF
--- a/.github/workflows/ci-patch-image.yml
+++ b/.github/workflows/ci-patch-image.yml
@@ -117,7 +117,7 @@ jobs:
         env:
           GH_TOKEN: "${{ secrets.GH_PAT }}"
           SEALOS_TYPE: "issue_renew"
-          SEALOS_ISSUE_TITLE: "[DaylyReport] Auto build for sealos"
+          SEALOS_ISSUE_TITLE: "【DaylyReport】 Auto build for sealos"
           SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"
           SEALOS_ISSUE_LABEL: "dayly-report"
           SEALOS_ISSUE_TYPE: "day"
@@ -182,7 +182,7 @@ jobs:
         env:
           GH_TOKEN: "${{ secrets.GH_PAT }}"
           SEALOS_TYPE: "issue_renew"
-          SEALOS_ISSUE_TITLE: "[DaylyReport] Auto build for sealos"
+          SEALOS_ISSUE_TITLE: "【DaylyReport】 Auto build for sealos"
           SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"
           SEALOS_ISSUE_LABEL: "dayly-report"
           SEALOS_ISSUE_TYPE: "day"

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -99,7 +99,7 @@ jobs:
         env:
           GH_TOKEN: "${{ secrets.GH_PAT }}"
           SEALOS_TYPE: "issue_renew"
-          SEALOS_ISSUE_TITLE: "[DaylyReport] Auto build for sealos"
+          SEALOS_ISSUE_TITLE: "【DaylyReport】 Auto build for sealos"
           SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"
           SEALOS_ISSUE_LABEL: "dayly-report"
           SEALOS_ISSUE_TYPE: "day"

--- a/.github/workflows/controllers.yml
+++ b/.github/workflows/controllers.yml
@@ -12,7 +12,7 @@ on:
         default: false
       push_image_tag:
         description: "Push image tag"
-        default: "dev"
+        default: "latest"
         required: false
         type: string
   push:
@@ -86,6 +86,7 @@ jobs:
           - { name: db-adminer, path: db/adminer }
           - { name: resources, path: resources }
           - { name: resources-metering, path: resources/metering }
+          - { name: cloud, path: cloud }
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -154,7 +155,6 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/sealos-${{ matrix.module.name }}-controller
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=raw,value=dev,enable=true
             type=raw,value=${{ steps.prepare.outputs.tag_name }},enable=true
 
       - name: build (and publish) ${{ matrix.module.name }} main image
@@ -190,6 +190,7 @@ jobs:
           - { name: db-adminer, path: db/adminer }
           - { name: resources, path: resources }
           - { name: resources-metering, path: resources/metering }
+          - { name: cloud, path: cloud }
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -209,10 +210,12 @@ jobs:
       - name: Prepare
         id: prepare
         run: |
-          bash ./scripts/resolve-tag-image.sh "${{ inputs.push_image }}" "${{ steps.check_tag.outputs.isTag }}"  "${{ inputs.push_image_tag }}"
+          tag_name=$(bash ./scripts/resolve-tag-image.sh "${{ inputs.push_image }}" "${{ steps.check_tag.outputs.isTag }}"  "${{ inputs.push_image_tag }}")
           echo old_docker_repo=ghcr.io/labring/sealos-${{ matrix.module.name }}-controller >> $GITHUB_OUTPUT
           echo new_docker_repo=ghcr.io/${{ github.repository_owner }}/sealos-${{ matrix.module.name }}-controller >> $GITHUB_OUTPUT
           echo cluster_repo=ghcr.io/${{ github.repository_owner }}/sealos-cloud-${{ matrix.module.name }}-controller >> $GITHUB_OUTPUT
+          echo cluster_image=ghcr.io/${{ github.repository_owner }}/sealos-cloud-${{ matrix.module.name }}-controller:${tag_name} >> $GITHUB_OUTPUT
+          echo latest_cluster_image=ghcr.io/${{ github.repository_owner }}/sealos-cloud-${{ matrix.module.name }}-controller:latest >> $GITHUB_OUTPUT
 
       - name: Download sealos
         uses: actions/download-artifact@v3
@@ -227,7 +230,7 @@ jobs:
       - name: Mutate image tag in deploy files
         working-directory: controllers/${{ matrix.module.path }}/deploy
         run: |
-          OLD_DOCKER_IMAGE_NAME=${{ steps.prepare.outputs.old_docker_repo }}:dev
+          OLD_DOCKER_IMAGE_NAME=${{ steps.prepare.outputs.old_docker_repo }}:latest
           NEW_DOCKER_IMAGE_NAME=${{ steps.prepare.outputs.new_docker_repo }}:${{ steps.prepare.outputs.tag_name }}
           sudo sed -i "s;${OLD_DOCKER_IMAGE_NAME};${NEW_DOCKER_IMAGE_NAME};" manifests/*
 
@@ -239,22 +242,23 @@ jobs:
       - name: Build ${{ matrix.module.name }}-controller cluster image
         working-directory: controllers/${{ matrix.module.path }}/deploy
         run: |
-          CLUSTER_IMAGE_NAME=${{ steps.prepare.outputs.cluster_repo }}:${{ steps.prepare.outputs.tag_name }}
-          sudo sealos build -t ${CLUSTER_IMAGE_NAME}-amd64 --platform linux/amd64 -f Kubefile
+          sudo sealos build -t ${{ steps.prepare.outputs.cluster_image }}-amd64 --platform linux/amd64 -f Kubefile
+          sudo sealos build -t ${{ steps.prepare.outputs.latest_cluster_image }}-amd64 --platform linux/amd64 -f Kubefile
           # delete old registry cache
           sudo rm -rf registry
-          sudo sealos build -t ${CLUSTER_IMAGE_NAME}-arm64 --platform linux/arm64 -f Kubefile
+          sudo sealos build -t ${{ steps.prepare.outputs.cluster_image }}-arm64 --platform linux/arm64 -f Kubefile
+          sudo sealos build -t ${{ steps.prepare.outputs.latest_cluster_image }}-arm64 --platform linux/arm64 -f Kubefile
 
       - name: Manifest Cluster Images
         # if push to master, then patch images to ghcr.io
         run: |
-          CLUSTER_IMAGE_NAME=${{ steps.prepare.outputs.cluster_repo }}:${{ steps.prepare.outputs.tag_name }}
           sudo sealos images
-          bash docker/patch/manifest-cluster-images.sh $CLUSTER_IMAGE_NAME
+          bash docker/patch/manifest-cluster-images.sh ${{ steps.prepare.outputs.cluster_image }}
+          bash docker/patch/manifest-cluster-images.sh ${{ steps.prepare.outputs.latest_cluster_image }}
         env:
           OWNER: ${{ github.repository_owner }}
 
-      - name: Renew issue and Sync Images
+      - name: Renew issue and Sync Images for ${{ steps.prepare.outputs.cluster_image }}
         uses: labring/gh-rebot@v0.0.6
         if: ${{ github.repository_owner == env.DEFAULT_OWNER }}
         with:
@@ -262,9 +266,24 @@ jobs:
         env:
           GH_TOKEN: "${{ secrets.GH_PAT }}"
           SEALOS_TYPE: "issue_renew"
-          SEALOS_ISSUE_TITLE: "[DaylyReport] Auto build for sealos"
+          SEALOS_ISSUE_TITLE: "【DaylyReport】 Auto build for sealos"
           SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"
           SEALOS_ISSUE_LABEL: "dayly-report"
           SEALOS_ISSUE_TYPE: "day"
           SEALOS_ISSUE_REPO: "labring-actions/cluster-image"
-          SEALOS_COMMENT_BODY: "/imagesync ghcr.io/${{ github.repository_owner }}/sealos-cloud-${{ matrix.module.name }}-controller:${{ steps.prepare.outputs.tag_name }}"
+          SEALOS_COMMENT_BODY: "/imagesync ${{ steps.prepare.outputs.cluster_image }}"
+
+      - name: Renew issue and Sync Images for ${{ steps.prepare.outputs.latest_cluster_image }}
+        uses: labring/gh-rebot@v0.0.6
+        if: ${{ github.repository_owner == env.DEFAULT_OWNER }}
+        with:
+          version: v0.0.8-rc1
+        env:
+          GH_TOKEN: "${{ secrets.GH_PAT }}"
+          SEALOS_TYPE: "issue_renew"
+          SEALOS_ISSUE_TITLE: "【DaylyReport】 Auto build for sealos"
+          SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"
+          SEALOS_ISSUE_LABEL: "dayly-report"
+          SEALOS_ISSUE_TYPE: "day"
+          SEALOS_ISSUE_REPO: "labring-actions/cluster-image"
+          SEALOS_COMMENT_BODY: "/imagesync ${{ steps.prepare.outputs.latest_cluster_image }}"

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -12,7 +12,7 @@ on:
         default: false
       push_image_tag:
         description: "Push image tag"
-        default: "dev"
+        default: "latest"
         required: false
         type: string
   push:
@@ -87,7 +87,6 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/sealos-${{ env.MODULE_NAME }}-frontend
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=raw,value=dev,enable=true
             type=raw,value=${{ steps.prepare.outputs.tag_name }},enable=true
 
       - name: Set up QEMU
@@ -160,11 +159,12 @@ jobs:
         run: |
           tag_name=$(bash ./scripts/resolve-tag-image.sh "${{ inputs.push_image }}" "${{ steps.check_tag.outputs.isTag }}"  "${{ inputs.push_image_tag }}")
           echo old_docker_repo=ghcr.io/labring/sealos-${{ env.MODULE_NAME }}-frontend >> $GITHUB_OUTPUT
-          echo old_docker_image=ghcr.io/labring/sealos-${{ env.MODULE_NAME }}-frontend:dev >> $GITHUB_OUTPUT
+          echo old_docker_image=ghcr.io/labring/sealos-${{ env.MODULE_NAME }}-frontend:latest >> $GITHUB_OUTPUT
           echo new_docker_repo=ghcr.io/${{ github.repository_owner }}/sealos-${{ env.MODULE_NAME }}-frontend >> $GITHUB_OUTPUT
           echo new_docker_image=ghcr.io/${{ github.repository_owner }}/sealos-${{ env.MODULE_NAME }}-frontend:${tag_name} >> $GITHUB_OUTPUT
           echo cluster_repo=ghcr.io/${{ github.repository_owner }}/sealos-cloud-${{ env.MODULE_NAME }}-frontend >> $GITHUB_OUTPUT
           echo cluster_image=ghcr.io/${{ github.repository_owner }}/sealos-cloud-${{ env.MODULE_NAME }}-frontend:${tag_name} >> $GITHUB_OUTPUT
+          echo latest_cluster_image=ghcr.io/${{ github.repository_owner }}/sealos-cloud-${{ env.MODULE_NAME }}-frontend:latest >> $GITHUB_OUTPUT
 
       - name: Download sealos
         uses: actions/download-artifact@v3
@@ -186,19 +186,21 @@ jobs:
         run: |
           sudo sed -i "s;${{ steps.prepare.outputs.old_docker_image }};${{ steps.prepare.outputs.new_docker_image }};" manifests/*
           sudo sealos build -t ${{ steps.prepare.outputs.cluster_image }}-amd64 --platform linux/amd64 -f Kubefile
+          sudo sealos build -t ${{ steps.prepare.outputs.latest_cluster_image }}-amd64 --platform linux/amd64 -f Kubefile
           # delete old registry cache
           sudo rm -rf registry
           sudo sealos build -t ${{ steps.prepare.outputs.cluster_image }}-arm64 --platform linux/arm64 -f Kubefile
+          sudo sealos build -t ${{ steps.prepare.outputs.latest_cluster_image }}-arm64 --platform linux/arm64 -f Kubefile
 
       - name: Manifest Cluster Images
         run: |
-          CLUSTER_IMAGE_NAME=${{ steps.prepare.outputs.cluster_image }}
           sudo sealos images
-          bash docker/patch/manifest-cluster-images.sh $CLUSTER_IMAGE_NAME
+          bash docker/patch/manifest-cluster-images.sh ${{ steps.prepare.outputs.cluster_image }}
+          bash docker/patch/manifest-cluster-images.sh ${{ steps.prepare.outputs.latest_cluster_image }}
         env:
           OWNER: ${{ github.repository_owner }}
 
-      - name: Renew issue and Sync Images
+      - name: Renew issue and Sync Images for ${{ steps.prepare.outputs.cluster_image }}
         uses: labring/gh-rebot@v0.0.6
         if: ${{ github.repository_owner == env.DEFAULT_OWNER }}
         with:
@@ -206,9 +208,24 @@ jobs:
         env:
           GH_TOKEN: "${{ secrets.GH_PAT }}"
           SEALOS_TYPE: "issue_renew"
-          SEALOS_ISSUE_TITLE: "[DaylyReport] Auto build for sealos"
+          SEALOS_ISSUE_TITLE: "【DaylyReport】 Auto build for sealos"
           SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"
           SEALOS_ISSUE_LABEL: "dayly-report"
           SEALOS_ISSUE_TYPE: "day"
           SEALOS_ISSUE_REPO: "labring-actions/cluster-image"
-          SEALOS_COMMENT_BODY: "/imagesync ghcr.io/${{ github.repository_owner }}/sealos-cloud-${{ env.MODULE_NAME }}-frontend:${{ steps.prepare.outputs.tag_name }}"
+          SEALOS_COMMENT_BODY: "/imagesync ${{ steps.prepare.outputs.cluster_image }}"
+
+      - name: Renew issue and Sync Images for ${{ steps.prepare.outputs.latest_cluster_image }}
+        uses: labring/gh-rebot@v0.0.6
+        if: ${{ github.repository_owner == env.DEFAULT_OWNER }}
+        with:
+          version: v0.0.8-rc1
+        env:
+          GH_TOKEN: "${{ secrets.GH_PAT }}"
+          SEALOS_TYPE: "issue_renew"
+          SEALOS_ISSUE_TITLE: "【DaylyReport】 Auto build for sealos"
+          SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"
+          SEALOS_ISSUE_LABEL: "dayly-report"
+          SEALOS_ISSUE_TYPE: "day"
+          SEALOS_ISSUE_REPO: "labring-actions/cluster-image"
+          SEALOS_COMMENT_BODY: "/imagesync ${{ steps.prepare.outputs.latest_cluster_image }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         env:
           GH_TOKEN: "${{ secrets.GH_PAT }}"
           SEALOS_TYPE: "issue_renew"
-          SEALOS_ISSUE_TITLE: "[DaylyReport] Auto build for sealos"
+          SEALOS_ISSUE_TITLE: "【DaylyReport】 Auto build for sealos"
           SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"
           SEALOS_ISSUE_LABEL: "dayly-report"
           SEALOS_ISSUE_TYPE: "day"
@@ -83,7 +83,7 @@ jobs:
         env:
           GH_TOKEN: "${{ secrets.GH_PAT }}"
           SEALOS_TYPE: "issue_renew"
-          SEALOS_ISSUE_TITLE: "[DaylyReport] Auto build for sealos"
+          SEALOS_ISSUE_TITLE: "【DaylyReport】 Auto build for sealos"
           SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"
           SEALOS_ISSUE_LABEL: "dayly-report"
           SEALOS_ISSUE_TYPE: "day"

--- a/.github/workflows/services.yml
+++ b/.github/workflows/services.yml
@@ -232,6 +232,17 @@ jobs:
         env:
           OWNER: ${{ github.repository_owner }}
 
+      - name: Build ${{ matrix.module }}-service latest cluster image
+        working-directory: service/${{ matrix.module }}/deploy
+        run: |
+          CLUSTER_IMAGE_NAME_LATEST=${{ steps.prepare.outputs.cluster_repo }}:latest
+          sudo sealos build -t ${CLUSTER_IMAGE_NAME_LATEST}-amd64 --platform linux/amd64 -f Kubefile
+          sudo sealos build -t ${CLUSTER_IMAGE_NAME_LATEST}-arm64 --platform linux/arm64 -f Kubefile
+          sudo sealos images
+          bash docker/patch/manifest-cluster-images.sh $CLUSTER_IMAGE_NAME_LATEST
+        env:
+          OWNER: ${{ github.repository_owner }}
+
       - name: Renew issue and Sync Images
         uses: labring/gh-rebot@v0.0.6
         if: ${{ github.repository_owner == env.DEFAULT_OWNER }}
@@ -240,9 +251,24 @@ jobs:
         env:
           GH_TOKEN: "${{ secrets.GH_PAT }}"
           SEALOS_TYPE: "issue_renew"
-          SEALOS_ISSUE_TITLE: "[DaylyReport] Auto build for sealos"
+          SEALOS_ISSUE_TITLE: "【DaylyReport】 Auto build for sealos"
           SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"
           SEALOS_ISSUE_LABEL: "dayly-report"
           SEALOS_ISSUE_TYPE: "day"
           SEALOS_ISSUE_REPO: "labring-actions/cluster-image"
           SEALOS_COMMENT_BODY: "/imagesync ghcr.io/${{ github.repository_owner }}/sealos-cloud-${{ matrix.module }}-service:${{ steps.prepare.outputs.tag_name }}"
+
+      - name: Renew issue and Sync Images for latest
+        uses: labring/gh-rebot@v0.0.6
+        if: ${{ github.repository_owner == env.DEFAULT_OWNER }}
+        with:
+          version: v0.0.8-rc1
+        env:
+          GH_TOKEN: "${{ secrets.GH_PAT }}"
+          SEALOS_TYPE: "issue_renew"
+          SEALOS_ISSUE_TITLE: "【DaylyReport】 Auto build for sealos"
+          SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"
+          SEALOS_ISSUE_LABEL: "dayly-report"
+          SEALOS_ISSUE_TYPE: "day"
+          SEALOS_ISSUE_REPO: "labring-actions/cluster-image"
+          SEALOS_COMMENT_BODY: "/imagesync ghcr.io/${{ github.repository_owner }}/sealos-cloud-${{ matrix.module }}-service:latest"


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d008fcf</samp>

### Summary
:truck::speech_balloon::hammer_and_wrench:

<!--
1.  :truck: for changing the file name of the workflow
2.  :speech_balloon: for using Chinese brackets for issue titles
3.  :hammer_and_wrench: for updating the logic and actions for building and pushing the cluster images
-->
This pull request updates several GitHub workflows for building, pushing, and renewing the cluster images for sealos. It also fixes the issue title format for the gh-rebot action and renames the `cloud.yml` workflow to `ci-patch-image.yml`.

> _We'll build and push the cluster images, `latest` and `tag`_
> _We'll sync them with the issues, and the `gh-rebot` flag_
> _We'll heave away and haul away with `buildx` and `output`_
> _We'll patch the sealos images and make the cloud module stout_

### Walkthrough
*  Rename the workflow file from `cloud.yml` to `ci-patch-image.yml` to reflect its purpose ([link](https://github.com/labring/sealos/pull/3512/files?diff=unified&w=0#diff-7e4159d358d73ce740ffdf0b5737ccb6965692a7d3cea96bbb2a1ba054ea229eL102-R102))
*  Add the cloud module to the matrix of modules that are built and pushed by the controllers workflow, to include the cloud controller in the cluster images ([link](https://github.com/labring/sealos/pull/3512/files?diff=unified&w=0#diff-8e0e4903d4e4f8b8844d36370ca2d71c7c72d03ddb7a9cdcedc6328dfc5da8faR89), [link](https://github.com/labring/sealos/pull/3512/files?diff=unified&w=0#diff-8e0e4903d4e4f8b8844d36370ca2d71c7c72d03ddb7a9cdcedc6328dfc5da8faR193))
*  Remove the raw value of `dev` from the matrix of tags that are checked by the controllers and frontend workflows, to avoid building images with the `dev` tag, which is not used anymore ([link](https://github.com/labring/sealos/pull/3512/files?diff=unified&w=0#diff-8e0e4903d4e4f8b8844d36370ca2d71c7c72d03ddb7a9cdcedc6328dfc5da8faL157), [link](https://github.com/labring/sealos/pull/3512/files?diff=unified&w=0#diff-ffe3a297ed15e9a79846161a3731a580511bf13c6b5cc5a9e03ddcbd8515fdeeL90))
*  Modify the output variables of the prepare steps in the controllers and frontend workflows, to include the cluster image name with the tag name and the latest cluster image name with the `latest` tag ([link](https://github.com/labring/sealos/pull/3512/files?diff=unified&w=0#diff-8e0e4903d4e4f8b8844d36370ca2d71c7c72d03ddb7a9cdcedc6328dfc5da8faL212-R218), [link](https://github.com/labring/sealos/pull/3512/files?diff=unified&w=0#diff-ffe3a297ed15e9a79846161a3731a580511bf13c6b5cc5a9e03ddcbd8515fdeeL163-R167))
*  Modify the sed command that replaces the old docker image name with the new docker image name in the manifests, to use the `latest` tag instead of the `dev` tag for the old docker image name, in the controllers and frontend workflows ([link](https://github.com/labring/sealos/pull/3512/files?diff=unified&w=0#diff-8e0e4903d4e4f8b8844d36370ca2d71c7c72d03ddb7a9cdcedc6328dfc5da8faL230-R233), [link](https://github.com/labring/sealos/pull/3512/files?diff=unified&w=0#diff-ffe3a297ed15e9a79846161a3731a580511bf13c6b5cc5a9e03ddcbd8515fdeeL189-R203))
*  Modify the cluster image building and manifesting steps in the controllers, frontend, and services workflows, to build and manifest both the cluster image with the tag name and the cluster image with the `latest` tag, for each platform and module ([link](https://github.com/labring/sealos/pull/3512/files?diff=unified&w=0#diff-8e0e4903d4e4f8b8844d36370ca2d71c7c72d03ddb7a9cdcedc6328dfc5da8faL242-R261), [link](https://github.com/labring/sealos/pull/3512/files?diff=unified&w=0#diff-ffe3a297ed15e9a79846161a3731a580511bf13c6b5cc5a9e03ddcbd8515fdeeL189-R203), [link](https://github.com/labring/sealos/pull/3512/files?diff=unified&w=0#diff-48839d65f7bfedd91312ee406fd94da103ede7d3c7e791eb2c1657f46afdea00R235-R245))
*  Modify the renew issue and sync images steps in the controllers, frontend, services, and release workflows, to use the Chinese brackets for the issue title, for consistency with other issues in the repository ([link](https://github.com/labring/sealos/pull/3512/files?diff=unified&w=0#diff-32e7e1062e41bfef162eb5aa471d42365df677ace95527c7ce0cdf492a4a40faL120-R120), [link](https://github.com/labring/sealos/pull/3512/files?diff=unified&w=0#diff-32e7e1062e41bfef162eb5aa471d42365df677ace95527c7ce0cdf492a4a40faL185-R185), [link](https://github.com/labring/sealos/pull/3512/files?diff=unified&w=0#diff-8e0e4903d4e4f8b8844d36370ca2d71c7c72d03ddb7a9cdcedc6328dfc5da8faL265-R289), [link](https://github.com/labring/sealos/pull/3512/files?diff=unified&w=0#diff-ffe3a297ed15e9a79846161a3731a580511bf13c6b5cc5a9e03ddcbd8515fdeeL209-R231), [link](https://github.com/labring/sealos/pull/3512/files?diff=unified&w=0#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L71-R71), [link](https://github.com/labring/sealos/pull/3512/files?diff=unified&w=0#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L86-R86), [link](https://github.com/labring/sealos/pull/3512/files?diff=unified&w=0#diff-48839d65f7bfedd91312ee406fd94da103ede7d3c7e791eb2c1657f46afdea00L243-R254), [link](https://github.com/labring/sealos/pull/3512/files?diff=unified&w=0#diff-48839d65f7bfedd91312ee406fd94da103ede7d3c7e791eb2c1657f46afdea00R260-R274))
*  Add new steps to the renew issue and sync images steps in the controllers, frontend, and services workflows, to renew the issue and sync the images for the cluster image with the `latest` tag, using the same action but with a different comment body and version ([link](https://github.com/labring/sealos/pull/3512/files?diff=unified&w=0#diff-8e0e4903d4e4f8b8844d36370ca2d71c7c72d03ddb7a9cdcedc6328dfc5da8faL265-R289), [link](https://github.com/labring/sealos/pull/3512/files?diff=unified&w=0#diff-ffe3a297ed15e9a79846161a3731a580511bf13c6b5cc5a9e03ddcbd8515fdeeL209-R231), [link](https://github.com/labring/sealos/pull/3512/files?diff=unified&w=0#diff-48839d65f7bfedd91312ee406fd94da103ede7d3c7e791eb2c1657f46afdea00R260-R274))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
