### PR TITLE
build(main): add ci for latest

### DIFF
--- a/.github/workflows/ci-patch-image.yml
+++ b/.github/workflows/ci-patch-image.yml
@@ -169,11 +169,14 @@ jobs:
           bash docker/patch/manifest-cluster-images.sh
         env:
           OWNER: ${{ github.repository_owner }}
-      - name: Prepare
-        id: prepare
+      - name: Manifest Cluster Images for latest
         run: |
-          TAG=latest
-          echo tag_name=${GIT_COMMIT_SHORT_SHA} >> $GITHUB_OUTPUT
+          sudo sealos tag ghcr.io/${{ github.repository_owner }}/sealos-patch:"$GIT_COMMIT_SHORT_SHA"-amd64  ghcr.io/${{ github.repository_owner }}/sealos-patch:latest-amd64
+          sudo sealos tag ghcr.io/${{ github.repository_owner }}/sealos-patch:"$GIT_COMMIT_SHORT_SHA"-arm64  ghcr.io/${{ github.repository_owner }}/sealos-patch:latest-arm64
+          sudo sealos images
+          bash docker/patch/manifest-cluster-images.sh ghcr.io/${{ github.repository_owner }}/sealos-patch:latest
+        env:
+          OWNER: ${{ github.repository_owner }}
       - name: Renew issue and Sync Images
         uses: labring/gh-rebot@v0.0.6
         if: ${{ github.repository_owner == env.DEFAULT_OWNER }}
@@ -187,4 +190,4 @@ jobs:
           SEALOS_ISSUE_LABEL: "dayly-report"
           SEALOS_ISSUE_TYPE: "day"
           SEALOS_ISSUE_REPO: "labring-actions/cluster-image"
-          SEALOS_COMMENT_BODY: "/imagesync ghcr.io/${{ github.repository_owner }}/sealos-patch:${{ steps.prepare.outputs.tag_name }}"
+          SEALOS_COMMENT_BODY: "/imagesync ghcr.io/${{ github.repository_owner }}/sealos-patch:latest"

--- a/.github/workflows/services.yml
+++ b/.github/workflows/services.yml
@@ -221,16 +221,16 @@ jobs:
           CLUSTER_IMAGE_NAME=${{ steps.prepare.outputs.cluster_repo }}:${{ steps.prepare.outputs.tag_name }}
           sudo sealos build -t ${CLUSTER_IMAGE_NAME}-amd64 --platform linux/amd64 -f Kubefile
           sudo sealos build -t ${CLUSTER_IMAGE_NAME}-arm64 --platform linux/arm64 -f Kubefile
-
-      - name: Manifest Cluster Images
-        # if push to master, then patch images to ghcr.io
-        run: |
-          CLUSTER_IMAGE_NAME=${{ steps.prepare.outputs.cluster_repo }}:${{ steps.prepare.outputs.tag_name }}
           sudo sealos images
           bash docker/patch/manifest-cluster-images.sh $CLUSTER_IMAGE_NAME
-        env:
-          OWNER: ${{ github.repository_owner }}
-
+      - name: Build ${{ matrix.module }}-service cluster image for latest
+        working-directory: service/${{ matrix.module }}/deploy
+        run: |
+          CLUSTER_IMAGE_NAME_LATEST=${{ steps.prepare.outputs.cluster_repo }}:latest
+          sudo sealos build -t ${CLUSTER_IMAGE_NAME_LATEST}-amd64 --platform linux/amd64 -f Kubefile
+          sudo sealos build -t ${CLUSTER_IMAGE_NAME_LATEST}-arm64 --platform linux/arm64 -f Kubefile
+          sudo sealos images
+          bash docker/patch/manifest-cluster-images.sh $CLUSTER_IMAGE_NAME_LATEST
       - name: Renew issue and Sync Images
         uses: labring/gh-rebot@v0.0.6
         if: ${{ github.repository_owner == env.DEFAULT_OWNER }}
@@ -245,3 +245,17 @@ jobs:
           SEALOS_ISSUE_TYPE: "day"
           SEALOS_ISSUE_REPO: "labring-actions/cluster-image"
           SEALOS_COMMENT_BODY: "/imagesync ghcr.io/${{ github.repository_owner }}/sealos-cloud-${{ matrix.module }}-service:${{ steps.prepare.outputs.tag_name }}"
+      - name: Renew issue and Sync Images for latest
+        uses: labring/gh-rebot@v0.0.6
+        if: ${{ github.repository_owner == env.DEFAULT_OWNER }}
+        with:
+          version: v0.0.8-rc1
+        env:
+          GH_TOKEN: "${{ secrets.GH_PAT }}"
+          SEALOS_TYPE: "issue_renew"
+          SEALOS_ISSUE_TITLE: "[DaylyReport] Auto build for sealos"
+          SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"
+          SEALOS_ISSUE_LABEL: "dayly-report"
+          SEALOS_ISSUE_TYPE: "day"
+          SEALOS_ISSUE_REPO: "labring-actions/cluster-image"
+          SEALOS_COMMENT_BODY: "/imagesync ghcr.io/${{ github.repository_owner }}/sealos-cloud-${{ matrix.module }}-service:latest"


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6c4cf38</samp>

### Summary
🏷️🚀🤖

<!--
1.  🏷️ for tagging and manifesting the latest sealos-patch image
2.  🚀 for deploying the service cluster images
3.  🤖 for using the gh-rebot action
-->
This pull request adds multi-arch support for the sealos-patch and service cluster images, and uses `gh-rebot` to automate some tasks. It modifies the `.github/workflows/ci-patch-image.yml` and `.github/workflows/services.yml` files.

> _To support multi-arch in our images_
> _We tag and manifest with some changes_
> _We use `gh-rebot`_
> _To renew and sync what_
> _We build and deploy for our services_

### Walkthrough
*  Add steps to tag and create multi-arch manifests for sealos-patch and service cluster images with the latest suffix ([link](https://github.com/labring/sealos/pull/3514/files?diff=unified&w=0#diff-32e7e1062e41bfef162eb5aa471d42365df677ace95527c7ce0cdf492a4a40faL172-R179), [link](https://github.com/labring/sealos/pull/3514/files?diff=unified&w=0#diff-48839d65f7bfedd91312ee406fd94da103ede7d3c7e791eb2c1657f46afdea00L224-R233))
*  Modify comment body for gh-rebot action to use the latest tag for sealos-patch image ([link](https://github.com/labring/sealos/pull/3514/files?diff=unified&w=0#diff-32e7e1062e41bfef162eb5aa471d42365df677ace95527c7ce0cdf492a4a40faL190-R193))
*  Add step to use gh-rebot action to sync the latest service cluster images to the cluster-image repository ([link](https://github.com/labring/sealos/pull/3514/files?diff=unified&w=0#diff-48839d65f7bfedd91312ee406fd94da103ede7d3c7e791eb2c1657f46afdea00R248-R261))
*  Remove unnecessary env section for service cluster image build step ([link](https://github.com/labring/sealos/pull/3514/files?diff=unified&w=0#diff-48839d65f7bfedd91312ee406fd94da103ede7d3c7e791eb2c1657f46afdea00L224-R233))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
