### PR TITLE
perf: desktop openapp method adds the pathname parameter

### DIFF
--- a/frontend/desktop/src/components/desktop_content/index.tsx
+++ b/frontend/desktop/src/components/desktop_content/index.tsx
@@ -37,16 +37,18 @@ export default function DesktopContent(props: any) {
     ({
       appKey,
       query = {},
-      messageData = {}
+      messageData = {},
+      pathname = '/'
     }: {
       appKey: string;
       query?: Record<string, string>;
       messageData?: Record<string, any>;
+      pathname: string;
     }) => {
       const app = apps.find((item) => item.key === appKey);
       const runningApp = runningInfo.find((item) => item.key === appKey);
       if (!app) return;
-      openApp(app, { query });
+      openApp(app, { query, pathname });
       if (runningApp) {
         setToHighestLayerById(runningApp.pid);
       }

--- a/frontend/desktop/src/stores/app.ts
+++ b/frontend/desktop/src/stores/app.ts
@@ -119,7 +119,7 @@ const useAppStore = create<TOSState>()(
           });
         },
 
-        openApp: async (app: TApp, _query) => {
+        openApp: async (app: TApp, { query, raw, pathname = '/' } = {}) => {
           const zIndex = get().maxZIndex + 1;
           // debugger
           // 未支持多实例
@@ -143,9 +143,8 @@ const useAppStore = create<TOSState>()(
           _app.size = 'maximize';
           _app.isShow = true;
           // add query to url
-          if (_app.data?.url && _query) {
-            const { query, raw } = _query;
-            if (query) _app.data.url = formatUrl(_app.data.url, query);
+          if (_app.data?.url) {
+            if (query) _app.data.url = formatUrl(_app.data.url + pathname, query);
             else if (raw) {
               _app.data.url += `?${raw}`;
             }

--- a/frontend/desktop/src/types/app.ts
+++ b/frontend/desktop/src/types/app.ts
@@ -66,17 +66,21 @@ export type TOSState = {
   // init desktop
   init(): Promise<TOSState>;
   // open app
-  openApp(app: TApp, _query?: {
-    query?: Record<string, string>,
-    raw?: string
-  }): Promise<void>;
-// close app
-closeAppById: (pid: number) => void;
-// get current runningApp
-currentApp: () => AppInfo | undefined;
-switchAppById: (pid: number) => void;
-findAppInfoById: (pid: number) => AppInfo | undefined;
-setToHighestLayerById: (pid: number) => void;
-updateOpenedAppInfo: (app: TApp) => void;
-deleteLeastUsedAppByIndex: () => void;
+  openApp(
+    app: TApp,
+    _query?: {
+      query?: Record<string, string>;
+      raw?: string;
+      pathname?: string;
+    }
+  ): Promise<void>;
+  // close app
+  closeAppById: (pid: number) => void;
+  // get current runningApp
+  currentApp: () => AppInfo | undefined;
+  switchAppById: (pid: number) => void;
+  findAppInfoById: (pid: number) => AppInfo | undefined;
+  setToHighestLayerById: (pid: number) => void;
+  updateOpenedAppInfo: (app: TApp) => void;
+  deleteLeastUsedAppByIndex: () => void;
 };


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bd697a8</samp>

### Summary
🆕🛠️🗺️

<!--
1.  🆕 - This emoji represents the addition of a new feature or parameter, such as the `pathname` parameter to the `openApp` function call and type definition.
2.  🛠️ - This emoji represents the improvement or update of an existing function or logic, such as the `formatUrl` function that now handles the `pathname` parameter.
3.  🗺️ - This emoji represents the concept of routing or navigation, such as the ability to open apps with different routes based on the `pathname` parameter.
-->
The pull request adds support for opening apps with different routes based on a `pathname` parameter. The `openApp` function and its type definition are modified to accept the `pathname`, and the `formatUrl` function is updated to use it. The `desktop_content` component passes the `pathname` from the message data to the `openApp` function.

> _`openApp` can route_
> _with `pathname` parameter_
> _autumn leaves change paths_

### Walkthrough
*  Add `pathname` parameter to `openApp` function to support custom routes for apps ([link](https://github.com/labring/sealos/pull/3530/files?diff=unified&w=0#diff-6eec7bb4fac557f6da1a4c82880637cbb656e3b08ab0b2adcc12d6d9777aa028L40-R51), [link](https://github.com/labring/sealos/pull/3530/files?diff=unified&w=0#diff-b9b068e1b4338972538b99929a0a0137c3205c5b59d3eb7a01650926cea9684fL122-R122), [link](https://github.com/labring/sealos/pull/3530/files?diff=unified&w=0#diff-b9b068e1b4338972538b99929a0a0137c3205c5b59d3eb7a01650926cea9684fL148-R148), [link](https://github.com/labring/sealos/pull/3530/files?diff=unified&w=0#diff-69241c0f231df3241bd11a7615530d5d4118a08113e5f4def43798af6eb0cff6L69-R85))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
