### PR TITLE
add anno and label for user, ns and so on.

### DIFF
--- a/controllers/account/api/v1/debt_webhook.go
+++ b/controllers/account/api/v1/debt_webhook.go
@@ -150,7 +150,7 @@ func checkOption(ctx context.Context, logger logr.Logger, c client.Client, nsNam
 		return admission.Allowed("namespace not found")
 	}
 	// Check if it is a user namespace
-	user, ok := ns.Annotations[userv1.UserAnnotationOwnerKey]
+	user, ok := ns.Annotations[userv1.UserAnnotationCreatorKey]
 	logger.V(1).Info("check user namespace", "ns.name", ns.Name, "ns", ns)
 	if !ok {
 		return admission.ValidationResponse(true, fmt.Sprintf("this namespace is not user namespace %s,or have not create", ns.Name))

--- a/controllers/account/controllers/billing_controller.go
+++ b/controllers/account/controllers/billing_controller.go
@@ -98,7 +98,7 @@ func (r *BillingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, nil
 	}
 
-	own := ns.Annotations[v1.UserAnnotationOwnerKey]
+	own := ns.Annotations[v1.UserAnnotationCreatorKey]
 	if own == "" {
 		r.Logger.V(1).Info("billing namespace not found owner annotation", "namespace", ns.Name)
 		return ctrl.Result{}, nil
@@ -119,7 +119,7 @@ func (r *BillingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	//	return ctrl.Result{}, err
 	//}
 	//for _, namespace := range nsList.Items {
-	//	if namespace.Annotations[v1.UserAnnotationOwnerKey] != own {
+	//	if namespace.Annotations[v1.UserAnnotationCreatorKey] != own {
 	//		continue
 	//	}
 	//	if err = r.syncResourceQuota(ctx, namespace.Name); err != nil {
@@ -270,7 +270,7 @@ func (r *BillingReconciler) SetupWithManager(mgr ctrl.Manager, rateOpts controll
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Namespace{}, builder.WithPredicates(predicate.Funcs{
 			CreateFunc: func(createEvent event.CreateEvent) bool {
-				_, ok := createEvent.Object.GetAnnotations()[v1.UserAnnotationOwnerKey]
+				_, ok := createEvent.Object.GetAnnotations()[v1.UserAnnotationCreatorKey]
 				return ok
 			},
 			UpdateFunc: func(updateEvent event.UpdateEvent) bool {

--- a/controllers/resources/controllers/monitor_controller.go
+++ b/controllers/resources/controllers/monitor_controller.go
@@ -272,7 +272,7 @@ func (r *MonitorReconciler) podResourceUsage(ctx context.Context, dbClient datab
 		if client.IgnoreNotFound(err) != nil {
 			return err
 		}
-		if _, ok := namespace.GetAnnotations()[v1.UserAnnotationOwnerKey]; ok {
+		if _, ok := namespace.GetAnnotations()[v1.UserAnnotationCreatorKey]; ok {
 			//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 			//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
 			//if err = r.syncResourceQuota(ctx, namespace.Name); err != nil {

--- a/controllers/user/api/v1/groupversion_info.go
+++ b/controllers/user/api/v1/groupversion_info.go
@@ -39,7 +39,11 @@ var (
 )
 
 const (
-	UserAnnotationOwnerKey   = "user.sealos.io/creator"
+	// UserAnnotationCreatorKey refers to the user who created the resource
+	UserAnnotationCreatorKey = "user.sealos.io/creator"
+	// UserAnnotationOwnerKey refers to the user who owns the resource
+	UserAnnotationOwnerKey   = "user.sealos.io/owner"
+	UserLabelOwnerKey        = "user.sealos.io/owner"
 	UserAnnotationDisplayKey = "user.sealos.io/display-name"
 )
 

--- a/controllers/user/api/v1/user_webhook.go
+++ b/controllers/user/api/v1/user_webhook.go
@@ -48,6 +48,9 @@ func (r *User) Default() {
 	if r.Annotations[UserAnnotationDisplayKey] == "" {
 		r.Annotations[UserAnnotationDisplayKey] = r.Name
 	}
+	if r.Annotations[UserAnnotationOwnerKey] == "" {
+		r.Annotations[UserAnnotationOwnerKey] = r.Name
+	}
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.

--- a/controllers/user/controllers/user_controller.go
+++ b/controllers/user/controllers/user_controller.go
@@ -58,7 +58,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+var userAnnotationCreatorKey = userv1.UserAnnotationCreatorKey
 var userAnnotationOwnerKey = userv1.UserAnnotationOwnerKey
+var userLabelOwnerKey = userv1.UserLabelOwnerKey
 
 // UserReconciler reconciles a User object
 type UserReconciler struct {
@@ -233,8 +235,13 @@ func (r *UserReconciler) syncNamespace(ctx context.Context, user *userv1.User) c
 			r.Logger.V(1).Info("define namespace User namespace is created", "isCreated", isCreated, "namespace", ns.Name)
 		}
 		if change, err = controllerutil.CreateOrUpdate(ctx, r.Client, ns, func() error {
-			ns.Annotations = map[string]string{userAnnotationOwnerKey: user.Name}
+			ns.Annotations = map[string]string{
+				userAnnotationCreatorKey: user.Name,
+				userAnnotationOwnerKey:   user.Annotations[userAnnotationOwnerKey],
+			}
 			ns.Labels = config.SetPodSecurity(ns.Labels)
+			// add label for namespace to filter
+			ns.Labels[userLabelOwnerKey] = user.Annotations[userAnnotationOwnerKey]
 			ns.SetOwnerReferences([]metav1.OwnerReference{})
 			return controllerutil.SetControllerReference(user, ns, r.Scheme)
 		}); err != nil {
@@ -274,7 +281,10 @@ func (r *UserReconciler) syncRole(ctx context.Context, user *userv1.User) contex
 		role.Namespace = config.GetUsersNamespace(user.Name)
 		role.Labels = map[string]string{}
 		if change, err = controllerutil.CreateOrUpdate(ctx, r.Client, role, func() error {
-			role.Annotations = map[string]string{userAnnotationOwnerKey: user.Name}
+			role.Annotations = map[string]string{
+				userAnnotationCreatorKey: user.Name,
+				userAnnotationOwnerKey:   user.Annotations[userAnnotationOwnerKey],
+			}
 			role.Rules = config.GetUserRole()
 			return controllerutil.SetControllerReference(user, role, r.Scheme)
 		}); err != nil {
@@ -313,7 +323,10 @@ func (r *UserReconciler) syncRoleBinding(ctx context.Context, user *userv1.User)
 		roleBinding.Namespace = config.GetUsersNamespace(user.Name)
 		roleBinding.Labels = map[string]string{}
 		if change, err = controllerutil.CreateOrUpdate(ctx, r.Client, roleBinding, func() error {
-			roleBinding.Annotations = map[string]string{userAnnotationOwnerKey: user.Name}
+			roleBinding.Annotations = map[string]string{
+				userAnnotationCreatorKey: user.Name,
+				userAnnotationOwnerKey:   user.Annotations[userAnnotationOwnerKey],
+			}
 			roleBinding.RoleRef = v12.RoleRef{
 				APIGroup: v12.GroupName,
 				Kind:     "Role",
@@ -379,7 +392,10 @@ func (r *UserReconciler) syncServiceAccount(ctx context.Context, user *userv1.Us
 		}
 		secretName := kubeconfig.SecretName(user.Name)
 		if change, err = controllerutil.CreateOrUpdate(ctx, r.Client, sa, func() error {
-			sa.Annotations = map[string]string{userAnnotationOwnerKey: user.Name}
+			sa.Annotations = map[string]string{
+				userAnnotationCreatorKey: user.Name,
+				userAnnotationOwnerKey:   user.Annotations[userAnnotationOwnerKey],
+			}
 			if len(sa.Secrets) == 0 {
 				sa.Secrets = []v1.ObjectReference{
 					{

--- a/controllers/user/controllers/user_controller.go
+++ b/controllers/user/controllers/user_controller.go
@@ -136,7 +136,7 @@ func (r *UserReconciler) SetupWithManager(mgr ctrl.Manager, opts utilcontroller.
 	owner := &handler.EnqueueRequestForOwner{OwnerType: &userv1.User{}, IsController: true}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&userv1.User{}, builder.WithPredicates(
-			predicate.Or(predicate.GenerationChangedPredicate{}))).
+			predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{}))).
 		Watches(&source.Kind{Type: &v1.ServiceAccount{}}, owner).
 		Watches(&source.Kind{Type: &v12.Role{}}, owner).
 		Watches(&source.Kind{Type: &v12.RoleBinding{}}, owner).


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3c4fdd3</samp>

### Summary
🔄🆕🛠️

<!--
1.  🔄 This emoji represents the change of using the `UserAnnotationCreatorKey` instead of the `UserAnnotationOwnerKey` in various functions and controllers. It implies that the logic or behavior of the code has been switched or updated to use a different key or value.
2.  🆕 This emoji represents the addition of new constants, annotations, and labels for the user owner feature. It implies that the code has introduced new elements or features that did not exist before.
3.  🛠️ This emoji represents the modification of the `Default` function to add and set the owner annotation for the user resource. It implies that the code has fixed or improved something that was missing or incomplete.
-->
This pull request implements a feature that allows users to transfer the ownership of their resources to other users. It introduces new annotations and labels for user and user-owned resources, and modifies several controllers and webhooks to use the new keys. It affects the files `billing_controller.go`, `user_controller.go`, `debt_webhook.go`, `monitor_controller.go`, `groupversion_info.go`, and `user_webhook.go`.

> _To transfer the ownership of resources_
> _We changed some annotations and sources_
> _We used `UserAnnotationCreatorKey`_
> _To track who made them originally_
> _And `UserAnnotationOwnerKey` for the new bosses_

### Walkthrough
*  Add new annotations and labels for user ownership transfer feature ([link](https://github.com/labring/sealos/pull/3544/files?diff=unified&w=0#diff-f986129dc985af66250920c5d55606c540d5b092f8030aa2c7033d8ba78251d7L42-R46), [link](https://github.com/labring/sealos/pull/3544/files?diff=unified&w=0#diff-cf79bcc58810cb7ec1a2b885456e061e38aabee8ee62e30f0240b79dabb3a1d9R51-R53), [link](https://github.com/labring/sealos/pull/3544/files?diff=unified&w=0#diff-480b5cf131d8b8899dcc4a3abf6abca7f6188e3e223963e4ce381628e2c40559L61-R63))
*  Modify billing, debt, and monitor controllers to use creator annotation instead of owner annotation to reconcile user namespaces and resources ([link](https://github.com/labring/sealos/pull/3544/files?diff=unified&w=0#diff-e240069d1b78e1e32ee1fc0d1387fbe54aea40bbaa70873d6d6ec80ee5062717L153-R153), [link](https://github.com/labring/sealos/pull/3544/files?diff=unified&w=0#diff-2cae722bbe8482079dc4646e6a3f15ef57b710f8144877a5c387cc58da4c85eeL101-R101), [link](https://github.com/labring/sealos/pull/3544/files?diff=unified&w=0#diff-2cae722bbe8482079dc4646e6a3f15ef57b710f8144877a5c387cc58da4c85eeL122-R122), [link](https://github.com/labring/sealos/pull/3544/files?diff=unified&w=0#diff-2cae722bbe8482079dc4646e6a3f15ef57b710f8144877a5c387cc58da4c85eeL273-R273), [link](https://github.com/labring/sealos/pull/3544/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL275-R275))
*  Modify user controller to add creator and owner annotations and owner label to user namespace, role, role binding, and service account ([link](https://github.com/labring/sealos/pull/3544/files?diff=unified&w=0#diff-480b5cf131d8b8899dcc4a3abf6abca7f6188e3e223963e4ce381628e2c40559L236-R244), [link](https://github.com/labring/sealos/pull/3544/files?diff=unified&w=0#diff-480b5cf131d8b8899dcc4a3abf6abca7f6188e3e223963e4ce381628e2c40559L277-R287), [link](https://github.com/labring/sealos/pull/3544/files?diff=unified&w=0#diff-480b5cf131d8b8899dcc4a3abf6abca7f6188e3e223963e4ce381628e2c40559L316-R329), [link](https://github.com/labring/sealos/pull/3544/files?diff=unified&w=0#diff-480b5cf131d8b8899dcc4a3abf6abca7f6188e3e223963e4ce381628e2c40559L382-R398))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
