### PR TITLE
fix e2e apply test with infra && fix wrong ssh.fetch interface method implementation

### DIFF
--- a/.github/workflows/e2e_test_apply.yml
+++ b/.github/workflows/e2e_test_apply.yml
@@ -3,12 +3,12 @@ name: E2E Apply Test
 on:
   workflow_dispatch:
   pull_request_target:
-    types: [ opened, synchronize, reopened, labeled ]
+    types: [ labeled ]
 
 jobs:
   call_ci_workflow:
     uses: ./.github/workflows/import-patch-image.yml
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'need-e2e-apply-test') }}
+    if: ${{ github.event.action == 'labeled' && github.event.label.name == 'need-e2e-apply-test' }}
     with:
       arch: amd64,arm64
       e2e: true
@@ -19,6 +19,7 @@ jobs:
     permissions:
       issues: write
     strategy:
+      fail-fast: false
       matrix:
         arch: [ arm64, amd64 ]
     outputs:
@@ -43,26 +44,28 @@ jobs:
       - name: Install ginkgo && Run e2e apply test
         id: apply_test
         shell: bash
+        env:
+          SEALOS_E2E_TEST_IMAGE_NAME: hub.sealos.cn/labring/kubernetes:v1.25.6
+          SEALOS_E2E_TEST_PATCH_IMAGE_TAR: /tmp/sealos/images/patch-${{ matrix.arch }}.tar.gz
+          SEALOS_E2E_TEST_PATCH_IMAGE_NAME: ghcr.io/labring/sealos-patch:${{ env.GIT_COMMIT_SHORT_SHA }}-${{ matrix.arch }}
+          SEALOS_E2E_TEST_SEALOS_BIN_PATH: /tmp/sealos/bin/sealos
+          ALIYUN_ACCESS_KEY_ID: ${{ secrets.E2E_ALIYUN_ACCESS_KEY_ID }}
+          ALIYUN_ACCESS_KEY_SECRET: ${{ secrets.E2E_ALIYUN_ACCESS_KEY_SECRET }}
+          ALIYUN_RESOURCE_GROUP_ID: ${{ secrets.E2E_ALIYUN_RESOURCE_GROUP_ID }}
+          ALIYUN_REGION_ID: ${{ secrets.E2E_ALIYUN_REGION_ID }}
         run: |
           set -ex
-          sudo chmod a+x /tmp/e2e.test
+          sudo su
+          chmod a+x /tmp/e2e.test
           gzip /tmp/sealos/images/patch-${{ matrix.arch }}.tar
-          sudo export SEALOS_E2E_TEST_IMAGE_NAME="hub.sealos.cn/labring/kubernetes:v1.25.6" \
-            SEALOS_E2E_TEST_PATCH_IMAGE_TAR="/tmp/sealos/images/patch-${{ matrix.arch }}.tar.gz" \
-            SEALOS_E2E_TEST_PATCH_IMAGE_NAME="ghcr.io/labring/sealos-patch:${{ env.GIT_COMMIT_SHORT_SHA }}-${{ matrix.arch }}" \
-            SEALOS_E2E_TEST_SEALOS_BIN_PATH="/tmp/sealos/bin/sealos" \
-            ALIYUN_ACCESS_KEY_ID="${{ secrets.E2E_ALIYUN_ACCESS_KEY_ID }}" \
-            ALIYUN_ACCESS_KEY_SECRET="${{ secrets.E2E_ALIYUN_ACCESS_KEY_SECRET }}" \
-            ALIYUN_RESOURCE_GROUP_ID="${{ secrets.E2E_ALIYUN_RESOURCE_GROUP_ID }}" \
-            ALIYUN_REGION_ID="${{ secrets.E2E_ALIYUN_REGION_ID }}" 
-          sudo /tmp/e2e.test --ginkgo.v --ginkgo.focus="E2E_sealos_apply_infra_test"
+          /tmp/e2e.test --ginkgo.v --ginkgo.focus="E2E_sealos_apply_infra_test"
           echo 'test_result=success' >> "$GITHUB_OUTPUT"
   issue_commit:
     needs: [ e2e_apply_test ]
     runs-on: ubuntu-latest
     permissions:
       issues: write
-    if: ${{ always() && contains(github.event.pull_request.labels.*.name, 'need-e2e-apply-test') }} #success() || failure()
+    if: ${{ always() && github.event.label.name == 'need-e2e-apply-test' }} #success() || failure()
     steps:
       - name: Add comment to PR with test status
         uses: peter-evans/create-or-update-comment@v1

--- a/pkg/ssh/scp.go
+++ b/pkg/ssh/scp.go
@@ -183,7 +183,7 @@ func (c *Client) Fetch(host, src, dst string) error {
 		return err
 	}
 	defer created.Close()
-	_, err = io.Copy(rfp, created)
+	_, err = io.Copy(created, rfp)
 	return err
 }
 

--- a/test/e2e/suites/apply/apply.go
+++ b/test/e2e/suites/apply/apply.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/labring/sealos/test/e2e/suites/operators"
+
 	"github.com/labring/sealos/test/e2e/testhelper/utils"
 
 	"github.com/labring/sealos/pkg/types/v1beta1"
@@ -107,6 +109,22 @@ func (a *Applier) initImage() {
 		}
 		err = a.RemoteSealosCmd.ImageLoad(a.Infra.PatchImageTar)
 		utils.CheckErr(err)
+		images, err := operators.NewFakeImage(a.RemoteSealosCmd).ListImages(false)
+		utils.CheckErr(err)
+		logger.Info("images:", images)
+		patchImageName := ""
+		for _, image := range images {
+			for i := range image.Names {
+				if strings.Contains(image.Names[i], "sealos-patch") {
+					patchImageName = image.Names[i]
+					break
+				}
+			}
+			if patchImageName != "" {
+				a.Infra.PatchImageName = patchImageName
+				break
+			}
+		}
 	} else {
 		err = a.RemoteSealosCmd.ImagePull(&cmd2.PullOptions{
 			ImageRefs: []string{a.Infra.PatchImageName},

--- a/test/e2e/suites/infra/check.go
+++ b/test/e2e/suites/infra/check.go
@@ -18,6 +18,7 @@ package infra
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/labring/sealos/test/e2e/testhelper/utils"
 
@@ -48,9 +49,9 @@ func NewFakeInfra() *FakeInfra {
 
 func (f *FakeInfra) PreSetEnv() {
 	f.ImageName = settings.GetEnvWithDefault(settings.TestImageName, settings.DefaultTestImageName)
-	f.ImageTar = settings.GetEnvWithDefault(settings.TestImageTar, settings.DefaultTestImageTar)
-	f.PatchImageName = settings.GetEnvWithDefault(settings.TestPatchImageName, settings.DefaultPatchImageName)
-	f.PatchImageTar = settings.GetEnvWithDefault(settings.TestPatchImageTar, settings.DefaultPatchImageTar)
+	f.ImageTar = os.Getenv(settings.TestImageTar)
+	f.PatchImageTar = os.Getenv(settings.TestPatchImageTar)
+	f.PatchImageName = os.Getenv(settings.TestPatchImageName)
 	f.InfraDriver = settings.GetEnvWithDefault(settings.TestInfra, settings.DefaultInfraDriver)
 	f.TestDir = settings.GetEnvWithDefault(settings.TestDir, settings.DefaultTestDir)
 	f.ClusterName = settings.GetEnvWithDefault(settings.TestClusterName, settings.DefaultTestClusterName)

--- a/test/e2e/suites/operators/image.go
+++ b/test/e2e/suites/operators/image.go
@@ -17,7 +17,7 @@ type fakeImageClient struct {
 	*cmd.SealosCmd
 }
 
-func newFakeImage(sealosCmd *cmd.SealosCmd) FakeImageInterface {
+func NewFakeImage(sealosCmd *cmd.SealosCmd) FakeImageInterface {
 	return &fakeImageClient{
 		SealosCmd: sealosCmd,
 	}

--- a/test/e2e/suites/operators/operators.go
+++ b/test/e2e/suites/operators/operators.go
@@ -36,7 +36,7 @@ func NewFakeClient(clusterName string) *FakeClient {
 	}
 	localCmd := cmd.NewSealosCmd(settings.E2EConfig.SealosBinPath, &cmd.LocalCmd{})
 	return &FakeClient{
-		Image:        newFakeImage(localCmd),
+		Image:        NewFakeImage(localCmd),
 		CRI:          newCRIClient(localCmd),
 		Cluster:      newClusterClient(localCmd, clusterName),
 		Cert:         newCertClient(localCmd, clusterName),


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2938376</samp>

### Summary
🐛🚀🧪

<!--
1.  🐛 - This emoji represents the bug fix for the `Fetch` function in the `scp.go` file, which was causing the e2e test to fail.
2.  🚀 - This emoji represents the improvement and simplification of the e2e test workflow and setup, which makes it easier to run and configure the test.
3.  🧪 - This emoji represents the update and enhancement of the e2e test suite for apply, which uses a fake image generator and dynamic patch image name, and reduces the dependency on environment variables.
-->
This pull request improves the e2e test workflow and suite for the `apply` command, fixes a bug in the `scp` package, and refactors some code in the `operators` package. It uses a label to trigger the workflow, a fake image generator to mock the image operations, and environment variables to configure the test settings. It also renames and exports a function for reusability.

> _The e2e test suite for apply_
> _Had a bug that made it go awry_
> _They fixed the `Fetch` function_
> _And simplified the junction_
> _And used a fake image to comply_

### Walkthrough
* Fix the `Fetch` function in `scp.go` to copy the file from the remote to the local, instead of the other way around ([link](https://github.com/labring/sealos/pull/3560/files?diff=unified&w=0#diff-b16c36d4f08b48cbf3c1ea3ba2e4cc74463e7581ea73b0827620e04841061051L186-R186))
* Simplify the trigger condition for the e2e test workflow to only run when a pull request is labeled with `need-e2e-apply-test` ([link](https://github.com/labring/sealos/pull/3560/files?diff=unified&w=0#diff-96496a1660b6f6172d5bc3e79e74fafa75dc7c81656e153c5e85ff90991524b1L6-R11), [link](https://github.com/labring/sealos/pull/3560/files?diff=unified&w=0#diff-96496a1660b6f6172d5bc3e79e74fafa75dc7c81656e153c5e85ff90991524b1L65-R68))
* Set the `fail-fast` option to false for the matrix strategy, to run all the jobs even if one of them fails ([link](https://github.com/labring/sealos/pull/3560/files?diff=unified&w=0#diff-96496a1660b6f6172d5bc3e79e74fafa75dc7c81656e153c5e85ff90991524b1R22))
* Move the environment variables for the e2e test from the `sudo export` command to the `env` section of the step, and add the `sudo su` command to switch to the root user ([link](https://github.com/labring/sealos/pull/3560/files?diff=unified&w=0#diff-96496a1660b6f6172d5bc3e79e74fafa75dc7c81656e153c5e85ff90991524b1L46-R61))
* Update the `initImage` function in `apply.go` to use the `NewFakeImage` function to list the images on the remote server, and to find the patch image name from the image names ([link](https://github.com/labring/sealos/pull/3560/files?diff=unified&w=0#diff-bf6169de9c92130266308ad4a2758f24a72d5e67a2c7712a3b856d6a0f254b9dR112-R127))
* Export and rename the `NewFakeImage` function in `image.go`, to make it accessible from other packages that need to use the fake image client ([link](https://github.com/labring/sealos/pull/3560/files?diff=unified&w=0#diff-ca97db7f080c56b85f2bc27ed20cb30955a9848a07a5c09de6f655f849f05f59L20-R20))
* Update the `NewFakeClient` function in `operators.go` to use the `NewFakeImage` function instead of the `newFakeImage` function ([link](https://github.com/labring/sealos/pull/3560/files?diff=unified&w=0#diff-ba5522e82dc7b6a56ba8e9508ff0ccd53294fa49e70d76b80cb3e88f56860b52L39-R39))
* Update the `PreSetEnv` function in `check.go` to use the `os.Getenv` function to get the environment variables for the image tar files and the patch image name, instead of the `settings.GetEnvWithDefault` function ([link](https://github.com/labring/sealos/pull/3560/files?diff=unified&w=0#diff-7fce8fd889335a59196c61f6ab2f3f753ea45a2e87369d1f1f9cde18a3149dc5L51-R54))
* Import the `os` package in `check.go`, to use the `os.Getenv` function ([link](https://github.com/labring/sealos/pull/3560/files?diff=unified&w=0#diff-7fce8fd889335a59196c61f6ab2f3f753ea45a2e87369d1f1f9cde18a3149dc5R21))
* Import the `operators` package in `apply.go`, to use the `NewFakeImage` function ([link](https://github.com/labring/sealos/pull/3560/files?diff=unified&w=0#diff-bf6169de9c92130266308ad4a2758f24a72d5e67a2c7712a3b856d6a0f254b9dR11-R12))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
