### PR TITLE
fix cherry pick action failed #3561

### DIFF
--- a/.github/workflows/e2e_test_apply.yml
+++ b/.github/workflows/e2e_test_apply.yml
@@ -3,12 +3,12 @@ name: E2E Apply Test
 on:
   workflow_dispatch:
   pull_request_target:
-    types: [ opened, synchronize, reopened, labeled ]
+    types: [ labeled ]
 
 jobs:
   call_ci_workflow:
     uses: ./.github/workflows/import-patch-image.yml
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'need-e2e-apply-test') }}
+    if: ${{ github.event.action == 'labeled' && github.event.label.name == 'need-e2e-apply-test' }}
     with:
       arch: amd64,arm64
       e2e: true
@@ -19,6 +19,7 @@ jobs:
     permissions:
       issues: write
     strategy:
+      fail-fast: false
       matrix:
         arch: [ arm64, amd64 ]
     outputs:
@@ -43,26 +44,28 @@ jobs:
       - name: Install ginkgo && Run e2e apply test
         id: apply_test
         shell: bash
+        env:
+          SEALOS_E2E_TEST_IMAGE_NAME: hub.sealos.cn/labring/kubernetes:v1.25.6
+          SEALOS_E2E_TEST_PATCH_IMAGE_TAR: /tmp/sealos/images/patch-${{ matrix.arch }}.tar.gz
+          SEALOS_E2E_TEST_PATCH_IMAGE_NAME: ghcr.io/labring/sealos-patch:${{ env.GIT_COMMIT_SHORT_SHA }}-${{ matrix.arch }}
+          SEALOS_E2E_TEST_SEALOS_BIN_PATH: /tmp/sealos/bin/sealos
+          ALIYUN_ACCESS_KEY_ID: ${{ secrets.E2E_ALIYUN_ACCESS_KEY_ID }}
+          ALIYUN_ACCESS_KEY_SECRET: ${{ secrets.E2E_ALIYUN_ACCESS_KEY_SECRET }}
+          ALIYUN_RESOURCE_GROUP_ID: ${{ secrets.E2E_ALIYUN_RESOURCE_GROUP_ID }}
+          ALIYUN_REGION_ID: ${{ secrets.E2E_ALIYUN_REGION_ID }}
         run: |
           set -ex
-          sudo chmod a+x /tmp/e2e.test
+          sudo su
+          chmod a+x /tmp/e2e.test
           gzip /tmp/sealos/images/patch-${{ matrix.arch }}.tar
-          sudo export SEALOS_E2E_TEST_IMAGE_NAME="hub.sealos.cn/labring/kubernetes:v1.25.6" \
-            SEALOS_E2E_TEST_PATCH_IMAGE_TAR="/tmp/sealos/images/patch-${{ matrix.arch }}.tar.gz" \
-            SEALOS_E2E_TEST_PATCH_IMAGE_NAME="ghcr.io/labring/sealos-patch:${{ env.GIT_COMMIT_SHORT_SHA }}-${{ matrix.arch }}" \
-            SEALOS_E2E_TEST_SEALOS_BIN_PATH="/tmp/sealos/bin/sealos" \
-            ALIYUN_ACCESS_KEY_ID="${{ secrets.E2E_ALIYUN_ACCESS_KEY_ID }}" \
-            ALIYUN_ACCESS_KEY_SECRET="${{ secrets.E2E_ALIYUN_ACCESS_KEY_SECRET }}" \
-            ALIYUN_RESOURCE_GROUP_ID="${{ secrets.E2E_ALIYUN_RESOURCE_GROUP_ID }}" \
-            ALIYUN_REGION_ID="${{ secrets.E2E_ALIYUN_REGION_ID }}" 
-          sudo /tmp/e2e.test --ginkgo.v --ginkgo.focus="E2E_sealos_apply_infra_test"
+          /tmp/e2e.test --ginkgo.v --ginkgo.focus="E2E_sealos_apply_infra_test"
           echo 'test_result=success' >> "$GITHUB_OUTPUT"
   issue_commit:
     needs: [ e2e_apply_test ]
     runs-on: ubuntu-latest
     permissions:
       issues: write
-    if: ${{ always() && contains(github.event.pull_request.labels.*.name, 'need-e2e-apply-test') }} #success() || failure()
+    if: ${{ always() && github.event.label.name == 'need-e2e-apply-test' }} #success() || failure()
     steps:
       - name: Add comment to PR with test status
         uses: peter-evans/create-or-update-comment@v1

--- a/pkg/ssh/scp.go
+++ b/pkg/ssh/scp.go
@@ -183,7 +183,7 @@ func (c *Client) Fetch(host, src, dst string) error {
 		return err
 	}
 	defer created.Close()
-	_, err = io.Copy(rfp, created)
+	_, err = io.Copy(created, rfp)
 	return err
 }
 

--- a/test/e2e/suites/apply/apply.go
+++ b/test/e2e/suites/apply/apply.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/labring/sealos/test/e2e/suites/operators"
+
 	"github.com/labring/sealos/test/e2e/testhelper/utils"
 
 	"github.com/labring/sealos/pkg/types/v1beta1"
@@ -107,6 +109,22 @@ func (a *Applier) initImage() {
 		}
 		err = a.RemoteSealosCmd.ImageLoad(a.Infra.PatchImageTar)
 		utils.CheckErr(err)
+		images, err := operators.NewFakeImage(a.RemoteSealosCmd).ListImages(false)
+		utils.CheckErr(err)
+		logger.Info("images:", images)
+		patchImageName := ""
+		for _, image := range images {
+			for i := range image.Names {
+				if strings.Contains(image.Names[i], "sealos-patch") {
+					patchImageName = image.Names[i]
+					break
+				}
+			}
+			if patchImageName != "" {
+				a.Infra.PatchImageName = patchImageName
+				break
+			}
+		}
 	} else {
 		err = a.RemoteSealosCmd.ImagePull(&cmd2.PullOptions{
 			ImageRefs: []string{a.Infra.PatchImageName},

--- a/test/e2e/suites/infra/check.go
+++ b/test/e2e/suites/infra/check.go
@@ -18,6 +18,7 @@ package infra
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/labring/sealos/test/e2e/testhelper/utils"
 
@@ -48,9 +49,9 @@ func NewFakeInfra() *FakeInfra {
 
 func (f *FakeInfra) PreSetEnv() {
 	f.ImageName = settings.GetEnvWithDefault(settings.TestImageName, settings.DefaultTestImageName)
-	f.ImageTar = settings.GetEnvWithDefault(settings.TestImageTar, settings.DefaultTestImageTar)
-	f.PatchImageName = settings.GetEnvWithDefault(settings.TestPatchImageName, settings.DefaultPatchImageName)
-	f.PatchImageTar = settings.GetEnvWithDefault(settings.TestPatchImageTar, settings.DefaultPatchImageTar)
+	f.ImageTar = os.Getenv(settings.TestImageTar)
+	f.PatchImageTar = os.Getenv(settings.TestPatchImageTar)
+	f.PatchImageName = os.Getenv(settings.TestPatchImageName)
 	f.InfraDriver = settings.GetEnvWithDefault(settings.TestInfra, settings.DefaultInfraDriver)
 	f.TestDir = settings.GetEnvWithDefault(settings.TestDir, settings.DefaultTestDir)
 	f.ClusterName = settings.GetEnvWithDefault(settings.TestClusterName, settings.DefaultTestClusterName)

--- a/test/e2e/suites/operators/image.go
+++ b/test/e2e/suites/operators/image.go
@@ -17,7 +17,7 @@ type fakeImageClient struct {
 	*cmd.SealosCmd
 }
 
-func newFakeImage(sealosCmd *cmd.SealosCmd) FakeImageInterface {
+func NewFakeImage(sealosCmd *cmd.SealosCmd) FakeImageInterface {
 	return &fakeImageClient{
 		SealosCmd: sealosCmd,
 	}

--- a/test/e2e/suites/operators/operators.go
+++ b/test/e2e/suites/operators/operators.go
@@ -36,7 +36,7 @@ func NewFakeClient(clusterName string) *FakeClient {
 	}
 	localCmd := cmd.NewSealosCmd(settings.E2EConfig.SealosBinPath, &cmd.LocalCmd{})
 	return &FakeClient{
-		Image:        newFakeImage(localCmd),
+		Image:        NewFakeImage(localCmd),
 		CRI:          newCRIClient(localCmd),
 		Cluster:      newClusterClient(localCmd, clusterName),
 		Cert:         newCertClient(localCmd, clusterName),


### PR DESCRIPTION
#3561
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 59136b9</samp>

### Summary
🐛🚀♻️

<!--
1.  🐛 for the bug fix in the `Fetch` function.
2.  🚀 for the improvement in the e2e test apply job configuration and trigger.
3.  ♻️ for the refactoring and simplification of the test code.
-->
This pull request fixes some bugs and improves some features in the e2e test apply job and the related test suites. It simplifies the trigger and configuration of the job, uses environment variables for image names, fixes the `Fetch` function in `pkg/ssh/scp.go`, and exports the `NewFakeImage` function in `test/e2e/suites/operators/image.go`.

> _The e2e test apply job was broken_
> _By a bug in the `scp` token_
> _But the `Fetch` function was fixed_
> _And the `NewFakeImage` was mixed_
> _With the `os` package and envs unspoken_

### Walkthrough
*  Simplify the workflow trigger for the e2e test apply job to run only when the label `need-e2e-apply-test` is added to a pull request ([link](https://github.com/labring/sealos/pull/3562/files?diff=unified&w=0#diff-96496a1660b6f6172d5bc3e79e74fafa75dc7c81656e153c5e85ff90991524b1L6-R11))
*  Set the `fail-fast` option to false for the matrix strategy of the e2e test apply job to run for both amd64 and arm64 architectures even if one fails ([link](https://github.com/labring/sealos/pull/3562/files?diff=unified&w=0#diff-96496a1660b6f6172d5bc3e79e74fafa75dc7c81656e153c5e85ff90991524b1R22))
*  Move the environment variables for the e2e test apply job from the `sudo export` command to the `env` section of the step and add the `sudo su` command to switch to the root user before running the e2e test binary ([link](https://github.com/labring/sealos/pull/3562/files?diff=unified&w=0#diff-96496a1660b6f6172d5bc3e79e74fafa75dc7c81656e153c5e85ff90991524b1L46-R61))
*  Change the condition for the issue commit job to match the same trigger as the e2e test apply job ([link](https://github.com/labring/sealos/pull/3562/files?diff=unified&w=0#diff-96496a1660b6f6172d5bc3e79e74fafa75dc7c81656e153c5e85ff90991524b1L65-R68))
*  Fix the `Fetch` function in the `pkg/ssh/scp.go` file to copy the file from the remote to the local ([link](https://github.com/labring/sealos/pull/3562/files?diff=unified&w=0#diff-b16c36d4f08b48cbf3c1ea3ba2e4cc74463e7581ea73b0827620e04841061051L186-R186))
*  Import the `operators` package in the `test/e2e/suites/apply/apply.go` file to use some helper functions to interact with the sealos command and the cluster resources ([link](https://github.com/labring/sealos/pull/3562/files?diff=unified&w=0#diff-bf6169de9c92130266308ad4a2758f24a72d5e67a2c7712a3b856d6a0f254b9dR11-R12))
*  Update the `initImage` function in the `test/e2e/suites/apply/apply.go` file to list the images on the remote server using the `operators` package and find the patch image name that matches the `sealos-patch` prefix ([link](https://github.com/labring/sealos/pull/3562/files?diff=unified&w=0#diff-bf6169de9c92130266308ad4a2758f24a72d5e67a2c7712a3b856d6a0f254b9dR112-R127))
*  Import the `os` package in the `test/e2e/suites/infra/check.go` file to access the environment variables ([link](https://github.com/labring/sealos/pull/3562/files?diff=unified&w=0#diff-7fce8fd889335a59196c61f6ab2f3f753ea45a2e87369d1f1f9cde18a3149dc5R21))
*  Change the `PreSetEnv` function in the `test/e2e/suites/infra/check.go` file to use the `os.Getenv` function instead of the `settings.GetEnvWithDefault` function for the image tar and patch image tar and name variables ([link](https://github.com/labring/sealos/pull/3562/files?diff=unified&w=0#diff-7fce8fd889335a59196c61f6ab2f3f753ea45a2e87369d1f1f9cde18a3149dc5L51-R54))
*  Rename and export the `newFakeImage` function in the `test/e2e/suites/operators/image.go` file to `NewFakeImage` to allow the `apply` package to use it ([link](https://github.com/labring/sealos/pull/3562/files?diff=unified&w=0#diff-ca97db7f080c56b85f2bc27ed20cb30955a9848a07a5c09de6f655f849f05f59L20-R20))
*  Use the `NewFakeImage` function in the `NewFakeClient` function in the `test/e2e/suites/operators/operators.go` file to reflect the change in the function name and visibility ([link](https://github.com/labring/sealos/pull/3562/files?diff=unified&w=0#diff-ba5522e82dc7b6a56ba8e9508ff0ccd53294fa49e70d76b80cb3e88f56860b52L39-R39))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
