### PR TITLE
feature(build):  add add pr action

### DIFF
--- a/.github/workflows/bot-cherry-pick.yml
+++ b/.github/workflows/bot-cherry-pick.yml
@@ -11,9 +11,9 @@ jobs:
       - name: Write vars
         id: set-target
         run: |
-          commentbody="${{github.event.comment.body}}"
-          app=`echo "$commentbody"| awk '{print $2}'`
-          echo "target=$app" >> $GITHUB_OUTPUT
+          TARGET_BRANCH=$(jq -r ".comment.body" "$GITHUB_EVENT_PATH" | awk '{ print $2 }'  | tr -d '[:space:]')
+          echo "🤖 says: ‼️ TARGET_BRANCH is $TARGET_BRANCH"
+          echo "target=$TARGET_BRANCH" >> $GITHUB_OUTPUT
       - name: Checkout the latest code
         uses: actions/checkout@v2
         with:
@@ -37,7 +37,7 @@ jobs:
             Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
           commit-message: |
             🤖 cherry-pick to ${{ steps.set-target.outputs.target }} using robot.
-          branch: cherry-pick-${{steps.get-current-tag.outputs.tag }}
+          branch: cherry-pick-${{ steps.set-target.outputs.target }}
           base: ${{ steps.set-target.outputs.target }}
           signoff: true
           delete-branch: true


### PR DESCRIPTION
Signed-off-by: cuisongliu <cuisongliu@qq.com>

# Conflicts:
#	.github/workflows/bot-cherry-pick.yml

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0e40e06</samp>

### Summary
🍒🎯🌿

<!--
1.  🍒 - This emoji represents the cherry-picking process, and is a natural choice for this workflow.
2.  🎯 - This emoji represents the target branch, which is now specified by the comment body instead of the label.
3.  🌿 - This emoji represents the new branch, which is now named after the target branch and the original PR number.
-->
Improve `bot-cherry-pick` workflow to use comment body and branch naming.

> _Sing, O Muse, of the clever bot-cherry-pick_
> _That swiftly plucks the fruits of code from branch to branch_
> _And heeds the wise commands of the reviewers' speech_
> _To name its offspring well and avoid the merge conflict_

### Walkthrough
* Extract and trim target branch name from comment body in `set-target` step ([link](https://github.com/labring/sealos/pull/3568/files?diff=unified&w=0#diff-287bd000c2f59ec9a4088599c433a248de1072ea7839b6199c3104cfb72db208L14-R16))
* Use target branch name as suffix of new branch name in `cherry-pick` step ([link](https://github.com/labring/sealos/pull/3568/files?diff=unified&w=0#diff-287bd000c2f59ec9a4088599c433a248de1072ea7839b6199c3104cfb72db208L40-R40))
* Add log message to display target branch name in `set-target` step ([link](https://github.com/labring/sealos/pull/3568/files?diff=unified&w=0#diff-287bd000c2f59ec9a4088599c433a248de1072ea7839b6199c3104cfb72db208L14-R16))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
