### PR TITLE
crypto prices && add default prices

### DIFF
--- a/controllers/account/controllers/account_controller.go
+++ b/controllers/account/controllers/account_controller.go
@@ -460,7 +460,7 @@ func (r *AccountReconciler) SetupWithManager(mgr ctrl.Manager, rateOpts controll
 	if r.AccountSystemNamespace == "" {
 		r.AccountSystemNamespace = DEFAULTACCOUNTNAMESPACE
 	}
-	if r.MongoDBURI = os.Getenv(database.MongoURL); r.MongoDBURI == "" {
+	if r.MongoDBURI = os.Getenv(database.MongoURI); r.MongoDBURI == "" {
 		return fmt.Errorf("mongo url is empty")
 	}
 	return ctrl.NewControllerManagedBy(mgr).

--- a/controllers/account/controllers/billingrecordquery_controller.go
+++ b/controllers/account/controllers/billingrecordquery_controller.go
@@ -122,8 +122,8 @@ func CheckOpts(billingRecordQuery *accountv1.BillingRecordQuery) error {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *BillingRecordQueryReconciler) SetupWithManager(mgr ctrl.Manager, rateOpts controller.Options) error {
-	if r.MongoDBURI = os.Getenv(database.MongoURL); r.MongoDBURI == "" {
-		return fmt.Errorf("env %s is empty", database.MongoURL)
+	if r.MongoDBURI = os.Getenv(database.MongoURI); r.MongoDBURI == "" {
+		return fmt.Errorf("env %s is empty", database.MongoURI)
 	}
 	r.Logger = log.Log.WithName("billingrecordquery-controller")
 	return ctrl.NewControllerManagedBy(mgr).

--- a/controllers/pkg/crypto/crypto.go
+++ b/controllers/pkg/crypto/crypto.go
@@ -37,6 +37,11 @@ var encryptionKey = []byte("0123456789ABCDEF0123456789ABCDEF")
 
 // Encrypt encrypts the given plaintext using AES-GCM.
 func Encrypt(plaintext []byte) (string, error) {
+	return EncryptWithKey(plaintext, encryptionKey)
+}
+
+// EncryptWithKey encrypts the given plaintext using AES-GCM.
+func EncryptWithKey(plaintext []byte, encryptionKey []byte) (string, error) {
 	block, err := aes.NewCipher(encryptionKey)
 	if err != nil {
 		return "", err
@@ -61,8 +66,23 @@ func EncryptInt64(in int64) (*string, error) {
 	return &out, err
 }
 
+// EncryptWithKey encrypts the given plaintext using AES-GCM.
+func EncryptInt64WithKey(in int64, encryptionKey []byte) (*string, error) {
+	out, err := EncryptWithKey([]byte(strconv.FormatInt(in, 10)), encryptionKey)
+	return &out, err
+}
+
 func DecryptInt64(in string) (int64, error) {
 	out, err := Decrypt(in)
+	if err != nil {
+		return 0, fmt.Errorf("failed to decrpt balance: %w", err)
+	}
+	return strconv.ParseInt(string(out), 10, 64)
+}
+
+// DecryptInt64WithKey decrypts the given ciphertext using AES-GCM.
+func DecryptInt64WithKey(in string, encryptionKey []byte) (int64, error) {
+	out, err := DecryptWithKey(in, encryptionKey)
 	if err != nil {
 		return 0, fmt.Errorf("failed to decrpt balance: %w", err)
 	}
@@ -99,6 +119,11 @@ func DeductBalance(balance *string, amount int64) error {
 
 // Decrypt decrypts the given ciphertext using AES-GCM.
 func Decrypt(ciphertextBase64 string) ([]byte, error) {
+	return DecryptWithKey(ciphertextBase64, encryptionKey)
+}
+
+// DecryptWithKey decrypts the given ciphertext using AES-GCM.
+func DecryptWithKey(ciphertextBase64 string, encryptionKey []byte) ([]byte, error) {
 	ciphertext, err := base64.StdEncoding.DecodeString(ciphertextBase64)
 	if err != nil {
 		return nil, err

--- a/controllers/pkg/database/mongodb_test.go
+++ b/controllers/pkg/database/mongodb_test.go
@@ -30,7 +30,7 @@ func TestMongoDB_GetMeteringOwnerTimeResult(t *testing.T) {
 	}()
 
 	// 2023-04-30T17:00:00.000+00:00
-	queryTime := time.Date(2023, 4, 30, 17, 0, 0, 0, time.UTC)
+	queryTime := time.Date(2023, 7, 14, 04, 0, 0, 0, time.UTC)
 
 	//[]string{"ns-vd1k1dk3", "ns-cv46sqlr", "ns-wu8nptea", "ns-a2sh413v", "ns-l8ad16ee"}
 	got, err := m.GetMeteringOwnerTimeResult(queryTime, []string{"ns-vd1k1dk3"}, []string{"cpu", "memory", "storage"}, "ns-vd1k1dk3")
@@ -38,6 +38,12 @@ func TestMongoDB_GetMeteringOwnerTimeResult(t *testing.T) {
 		t.Errorf("failed to get metering owner time result: error = %v", err)
 	}
 	t.Logf("got: %v", got)
+
+	got, err = m.GetMeteringOwnerTimeResult(queryTime, []string{"ns-7wdqa36k"}, nil, "ns-7wdqa36k")
+	if err != nil {
+		t.Errorf("failed to get metering owner time result: error = %v", err)
+	}
+	t.Logf("all properties got: %v", got)
 }
 
 func TestMongoDB_QueryBillingRecords(t *testing.T) {
@@ -349,4 +355,23 @@ func TestMongoDB_GetBillingLastUpdateTime(t *testing.T) {
 		t.Fatalf(" billing last update time not exist")
 	}
 	t.Logf("lastUpdateTime: %v", lastUpdateTime)
+}
+
+func TestMongoDB_GetAllPricesMap(t *testing.T) {
+	dbCTX := context.Background()
+
+	m, err := NewMongoDB(dbCTX, os.Getenv("MONGODB_URI"))
+	if err != nil {
+		t.Errorf("failed to connect mongo: error = %v", err)
+	}
+	defer func() {
+		if err = m.Disconnect(dbCTX); err != nil {
+			t.Errorf("failed to disconnect mongo: error = %v", err)
+		}
+	}()
+	pricesMap, err := m.GetAllPricesMap()
+	if err != nil {
+		t.Fatalf("failed to get all prices map: %v", err)
+	}
+	t.Logf("pricesMap: %v", pricesMap)
 }

--- a/controllers/resources/controllers/monitor_controller.go
+++ b/controllers/resources/controllers/monitor_controller.go
@@ -48,7 +48,7 @@ type MonitorReconciler struct {
 	logr.Logger
 	Interval          time.Duration
 	Scheme            *runtime.Scheme
-	mongoURL          string
+	mongoURI          string
 	stopCh            chan struct{}
 	wg                sync.WaitGroup
 	periodicReconcile time.Duration
@@ -81,9 +81,9 @@ func NewMonitorReconciler(mgr ctrl.Manager) (*MonitorReconciler, error) {
 		Logger:            ctrl.Log.WithName("controllers").WithName("Monitor"),
 		stopCh:            make(chan struct{}),
 		periodicReconcile: 1 * time.Minute,
-		mongoURL:          os.Getenv(database.MongoURL),
+		mongoURI:          os.Getenv(database.MongoURI),
 	}
-	if r.mongoURL == "" {
+	if r.mongoURI == "" {
 		return nil, fmt.Errorf("mongo uri is empty")
 	}
 	r.initNamespaceFuncs()
@@ -187,7 +187,7 @@ func (r *MonitorReconciler) processNamespaceList(ctx context.Context, namespaceL
 	wg := sync.WaitGroup{}
 	wg.Add(len(namespaceList.Items))
 	dbCtx := context.Background()
-	dbClient, err := database.NewMongoDB(dbCtx, r.mongoURL)
+	dbClient, err := database.NewMongoDB(dbCtx, r.mongoURI)
 	if err != nil {
 		r.Logger.Error(err, "connect mongo client failed")
 		return err
@@ -241,7 +241,7 @@ func (r *MonitorReconciler) processNamespace(ctx context.Context, dbClient datab
 
 func (r *MonitorReconciler) preApply() error {
 	ctx := context.Background()
-	dbClient, err := database.NewMongoDB(ctx, r.mongoURL)
+	dbClient, err := database.NewMongoDB(ctx, r.mongoURI)
 	if err != nil {
 		return fmt.Errorf("failed to connect mongo: %v", err)
 	}

--- a/controllers/resources/metering/main.go
+++ b/controllers/resources/metering/main.go
@@ -8,6 +8,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/labring/sealos/controllers/pkg/common"
+
 	"github.com/labring/sealos/controllers/pkg/database"
 
 	"github.com/labring/sealos/pkg/utils/flags"
@@ -20,7 +22,7 @@ import (
 
 type Config struct {
 	// mongodb connect url
-	MongoConnectURL string
+	MongoConnectURI string
 	MongoUsername   string
 	MongoPassword   string
 
@@ -77,11 +79,11 @@ func ResourcesMetering() {
 
 func PreApply() error {
 	switch {
-	case config.MongoConnectURL == "":
+	case config.MongoConnectURI == "":
 		return fmt.Errorf("mongo connect url is empty")
 	}
 	dbCtx := context.Background()
-	dbClient, err := database.NewMongoDB(dbCtx, config.MongoConnectURL)
+	dbClient, err := database.NewMongoDB(dbCtx, config.MongoConnectURI)
 	if err != nil {
 		return fmt.Errorf("connect mongo client failed: %v", err)
 	}
@@ -104,7 +106,7 @@ func PreApply() error {
 func executeTask() error {
 	//opts := options.Client().ApplyURI("mongodb://192.168.64.17:27017")
 	dbCtx := context.Background()
-	dbClient, err := database.NewMongoDB(dbCtx, config.MongoConnectURL)
+	dbClient, err := database.NewMongoDB(dbCtx, config.MongoConnectURI)
 	if err != nil {
 		return fmt.Errorf("connect mongo client failed: %v", err)
 	}
@@ -116,7 +118,11 @@ func executeTask() error {
 	}()
 	prices, err := dbClient.GetAllPricesMap()
 	if err != nil {
-		return fmt.Errorf("failed to get all prices map: %v", err)
+		logger.Error("failed to get all prices map: %v", err)
+	}
+	//prices is empty, use default price
+	if len(prices) == 0 || err != nil {
+		prices = getDefaultPrices()
 	}
 	now := time.Now().UTC()
 	startTime := time.Date(now.Year(), now.Month(), now.Day(), now.Hour()-1, 0, 0, 0, time.UTC)
@@ -129,6 +135,23 @@ func executeTask() error {
 		return fmt.Errorf("failed to create monitor time series: %v", err)
 	}
 	return nil
+}
+
+func getDefaultPrices() map[string]common.Price {
+	return map[string]common.Price{
+		"cpu": {
+			Property: "cpu",
+			Price:    67,
+		},
+		"memory": {
+			Property: "memory",
+			Price:    33,
+		},
+		"storage": {
+			Property: "storage",
+			Price:    2,
+		},
+	}
 }
 
 func CreateMonitorTimeSeries(dbClient database.Interface, collTime time.Time) error {
@@ -189,7 +212,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&showPath, "show-path", false, "enable show code path")
 	rootCmd.AddCommand(newStartCmd())
 	config = &Config{
-		MongoConnectURL: os.Getenv(database.MongoURL),
+		MongoConnectURI: os.Getenv(database.MongoURI),
 		MongoUsername:   os.Getenv(database.MongoUsername),
 		MongoPassword:   os.Getenv(database.MongoPassword),
 	}


### PR DESCRIPTION
default metering all queryProperties;

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d76660b</samp>

### Summary
🔒🔄🧪

<!--
1.  🔒 - This emoji represents the encryption and decryption of prices and balances using AES-GCM, which enhances the security and privacy of the data stored in the database.
2.  🔄 - This emoji represents the renaming and unification of the MongoDB connection string format from `MongoURL` to `MongoURI`, which improves consistency and flexibility across the codebase.
3.  🧪 - This emoji represents the improvement of the test coverage and accuracy of the `database` package, which increases the reliability and quality of the code.
-->
The pull request implements encryption and decryption of prices and balances in the MongoDB database using the `crypto` package, and updates the codebase to use the `MongoURI` constant and field instead of the `MongoURL` constant and field for the database connection string. It also improves the test coverage and accuracy of the `database` package and the metering program.

> _We are the masters of the MongoURI_
> _We encrypt the prices and the balances_
> _We query the database with flexibility_
> _We face the doom of metering challenges_

### Walkthrough
*  Rename `MongoURL` to `MongoURI` in the `database` package and all the types and functions that use it to unify the naming of the environment variable for the MongoDB connection string ([link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L463-R463), [link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-2cae722bbe8482079dc4646e6a3f15ef57b710f8144877a5c387cc58da4c85eeL56-R56), [link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-2cae722bbe8482079dc4646e6a3f15ef57b710f8144877a5c387cc58da4c85eeL80-R80), [link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-2cae722bbe8482079dc4646e6a3f15ef57b710f8144877a5c387cc58da4c85eeL204-R204), [link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-2cae722bbe8482079dc4646e6a3f15ef57b710f8144877a5c387cc58da4c85eeL259-R260), [link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-86d8d3e3c5437a16535b518a2119bb44ab128dff71b975031641b945d850eb11L125-R126), [link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46L30-R38), [link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL51-R51), [link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL84-R86), [link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL190-R190), [link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL244-R244), [link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-7b41d7c379e687468c6d660ee2d0ec2e2f74263b043b0ab23b7b99015a05f45cL23-R25), [link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-7b41d7c379e687468c6d660ee2d0ec2e2f74263b043b0ab23b7b99015a05f45cL80-R86), [link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-7b41d7c379e687468c6d660ee2d0ec2e2f74263b043b0ab23b7b99015a05f45cL107-R109), [link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-7b41d7c379e687468c6d660ee2d0ec2e2f74263b043b0ab23b7b99015a05f45cL192-R215))
* Add encryption and decryption functions for prices and balances using AES-GCM in the `crypto` package ([link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-4b235d07ce6cae9a536affded1ae23dd8f1bbcf9412eeb24908bace314c6a64dR40-R44), [link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-4b235d07ce6cae9a536affded1ae23dd8f1bbcf9412eeb24908bace314c6a64dR69-R74), [link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-4b235d07ce6cae9a536affded1ae23dd8f1bbcf9412eeb24908bace314c6a64dR83-R91), [link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-4b235d07ce6cae9a536affded1ae23dd8f1bbcf9412eeb24908bace314c6a64dR122-R126))
* Update the `GetMeteringOwnerTimeResult` function in the `database` package to accept a nil value for the `queryProperties` argument and query all properties instead of a fixed list of properties ([link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-2cae722bbe8482079dc4646e6a3f15ef57b710f8144877a5c387cc58da4c85eeL164-R164), [link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46L104-R116))
* Update the `GetAllPricesMap` function in the `database` package to decrypt the prices using the `crypto` package and a `cryptoKey` variable ([link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46L179-R190), [link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46L185-R204))
* Update the `metering` program to handle the error from the `GetAllPricesMap` function and use default prices if the prices map is empty or the error is not nil ([link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-7b41d7c379e687468c6d660ee2d0ec2e2f74263b043b0ab23b7b99015a05f45cL119-R126), [link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-7b41d7c379e687468c6d660ee2d0ec2e2f74263b043b0ab23b7b99015a05f45cR140-R156))
* Add a test case for querying a single namespace with all properties in the `TestMongoDB_GetMeteringOwnerTimeResult` function in the `database` package ([link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-a126f522b0bf02974f6f06cb25dcf2bd66f62276b372d5fbfc93959f7e15c136R41-R46))
* Add a test function for the `GetAllPricesMap` function in the `database` package using a mock MongoDB client and a test database ([link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-a126f522b0bf02974f6f06cb25dcf2bd66f62276b372d5fbfc93959f7e15c136R359-R377))
* Use a different query time for testing in the `TestMongoDB_GetMeteringOwnerTimeResult` function in the `database` package to use a query time that has more data in the database for testing purposes ([link](https://github.com/labring/sealos/pull/3575/files?diff=unified&w=0#diff-a126f522b0bf02974f6f06cb25dcf2bd66f62276b372d5fbfc93959f7e15c136L33-R33))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
