### PR TITLE
feature: recharge gift by configmap

### DIFF
--- a/controllers/account/config/rbac/role.yaml
+++ b/controllers/account/config/rbac/role.yaml
@@ -6,6 +6,18 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - account.sealos.io
   resources:
   - accountbalances

--- a/controllers/account/controllers/account_controller.go
+++ b/controllers/account/controllers/account_controller.go
@@ -21,8 +21,10 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -66,6 +68,8 @@ const (
 	DEFAULTACCOUNTNAMESPACE     = "sealos-system"
 	AccountAnnotationNewAccount = "account.sealos.io/new-account"
 	NEWACCOUNTAMOUNTENV         = "NEW_ACCOUNT_AMOUNT"
+	RECHARGEGIFT                = "recharge-gift"
+	SEALOS                      = "sealos"
 )
 
 // AccountReconciler reconciles a Account object
@@ -85,6 +89,7 @@ type AccountReconciler struct {
 //+kubebuilder:rbac:groups=account.sealos.io,resources=accountbalances/status,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 
 func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	//It should not stop the normal process for the failure to delete the payment
@@ -151,9 +156,18 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 		}()
 		now := time.Now().UTC()
-		payAmount := *orderResp.Amount.Total * 10000
 		//1¥ = 100WechatPayAmount; 1 WechatPayAmount = 10000 SealosAmount
-		err = crypto.RechargeBalance(account.Status.EncryptBalance, giveGift(payAmount))
+		payAmount := *orderResp.Amount.Total * 10000
+		// get recharge-gift configmap
+		configMap := &corev1.ConfigMap{}
+		if err := r.Client.Get(ctx, types.NamespacedName{Name: RECHARGEGIFT, Namespace: SEALOS}, configMap); err != nil {
+			r.Logger.Error(err, "get recharge-gift ConfigMap failed")
+		}
+		gift, err := giveGift(payAmount, configMap)
+		if err != nil {
+			r.Logger.Error(err, "get gift error")
+		}
+		err = crypto.RechargeBalance(account.Status.EncryptBalance, gift)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("recharge encrypt balance failed: %v", err)
 		}
@@ -493,36 +507,30 @@ func (p *NamespaceFilterPredicate) Generic(e event.GenericEvent) bool {
 	return e.Object.GetNamespace() == p.Namespace
 }
 
-const (
-	BaseUnit         = 1_000_000
-	Threshold1       = 299 * BaseUnit
-	Threshold2       = 599 * BaseUnit
-	Threshold3       = 1999 * BaseUnit
-	Threshold4       = 4999 * BaseUnit
-	Threshold5       = 19999 * BaseUnit
-	Ratio0     int64 = 0
-	Ratio1     int64 = 10
-	Ratio2     int64 = 15
-	Ratio3     int64 = 20
-	Ratio4     int64 = 25
-	Ratio5     int64 = 30
-)
+const BaseUnit = 1_000_000
 
-func giveGift(amount int64) int64 {
-	var ratio int64
-	switch {
-	case amount < Threshold1:
-		ratio = Ratio0
-	case amount < Threshold2:
-		ratio = Ratio1
-	case amount < Threshold3:
-		ratio = Ratio2
-	case amount < Threshold4:
-		ratio = Ratio3
-	case amount < Threshold5:
-		ratio = Ratio4
-	default:
-		ratio = Ratio5
+func giveGift(amount int64, configMap *corev1.ConfigMap) (int64, error) {
+	if configMap.Data == nil {
+		return amount, fmt.Errorf("configMap's data is nil")
 	}
-	return (amount * ratio / 100) + amount
+	stepsStr := strings.Split(configMap.Data["steps"], ",")
+	ratiosStr := strings.Split(configMap.Data["ratios"], ",")
+
+	var ratio int64
+
+	for i, stepStr := range stepsStr {
+		step, err := strconv.ParseInt(stepStr, 10, 64)
+		if err != nil {
+			return amount, fmt.Errorf("steps format error :%s", err)
+		}
+		if amount >= step*BaseUnit {
+			ratio, err = strconv.ParseInt(ratiosStr[i], 10, 64)
+			if err != nil {
+				return amount, fmt.Errorf("ratios format error :%s", err)
+			}
+		} else {
+			break
+		}
+	}
+	return amount*ratio/100 + amount, nil
 }

--- a/controllers/account/controllers/account_controller_test.go
+++ b/controllers/account/controllers/account_controller_test.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package controllers
 
-import "testing"
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
 
 func Test_giveGift(t *testing.T) {
 	type args struct {
@@ -43,9 +47,15 @@ func Test_giveGift(t *testing.T) {
 		{name: "30% more than 19999", args: args{amount: 99999 * BaseUnit}, want: 29999_700_000 + 99999*BaseUnit},
 		{"0% less than 299", args{amount: 1 * BaseUnit}, 1 * BaseUnit},
 	}
+
+	configMap := &corev1.ConfigMap{}
+	configMap.Data = make(map[string]string)
+	configMap.Data["steps"] = "299,599,1999,4999,19999"
+	configMap.Data["ratios"] = "10,15,20,25,30"
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := giveGift(tt.args.amount); got != tt.want {
+			if got, _ := giveGift(tt.args.amount, configMap); got != tt.want {
 				t.Errorf("giveGift() = %v, want %v", got, tt.want)
 			}
 		})

--- a/controllers/account/deploy/manifests/deploy.yaml
+++ b/controllers/account/deploy/manifests/deploy.yaml
@@ -637,6 +637,18 @@ metadata:
   name: account-manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - account.sealos.io
   resources:
   - accountbalances


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b64332f</samp>

### Summary
🎁🛠️🧪

<!--
1.  🎁 - This emoji represents the gift feature that is added by this pull request, which allows users to receive rewards for recharging their balance.
2.  🛠️ - This emoji represents the RBAC rule that is added to the role.yaml and deploy.yaml files, which grants the account controller access to the configmaps resource. This is a tool or fix that is needed for the gift feature to work properly.
3.  🧪 - This emoji represents the unit test that is updated to mock the configmap object and check the error value. This is a test or experiment that verifies the functionality and quality of the gift feature.
-->
This pull request adds a feature to the account controller that allows it to give variable gifts to users who recharge their balance, based on a configmap named `recharge-gift`. It also updates the unit test and the RBAC rules for the account controller to support this feature.

> _Oh we are the coders of the `account` controller_
> _And we need to access the `configmaps` resource_
> _So we add the RBAC rule to the role and deploy_
> _Heave away, heave away, heave away with force_

### Walkthrough
*  Add RBAC rule for configmaps resource to grant account controller access to recharge-gift configmap ([link](https://github.com/labring/sealos/pull/3579/files?diff=unified&w=0#diff-692ae5af1fa1de7cc9a448545795d0e7d5bdf981f9ef3d09b8441f0c0c6f98f1R9-R20), [link](https://github.com/labring/sealos/pull/3579/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4R92), [link](https://github.com/labring/sealos/pull/3579/files?diff=unified&w=0#diff-b4dca08a6cd3d21df60d689acb6983f7e411d29f9e5a8609c48aede3c341ef70R640-R651))
*  Modify giveGift function to use dynamic thresholds and ratios from configmap data instead of hard-coded values, and add error return value ([link](https://github.com/labring/sealos/pull/3579/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L496-R535))
*  Modify Reconcile function to get recharge-gift configmap from client and pass it to giveGift function, and add error handling and logging for configmap operations ([link](https://github.com/labring/sealos/pull/3579/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L154-R171))
*  Modify Test_giveGift function to create mock configmap object and pass it to giveGift function, and modify expected return value to include error value ([link](https://github.com/labring/sealos/pull/3579/files?diff=unified&w=0#diff-c7876ab0713f84c92267be9ce356251e4516fec8f0d6f90b383f6393cb3e5befL46-R58))
*  Add imports for corev1, strings, and types packages to use configmap object, split configmap data, and construct namespaced name for configmap ([link](https://github.com/labring/sealos/pull/3579/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L24-R27), [link](https://github.com/labring/sealos/pull/3579/files?diff=unified&w=0#diff-c7876ab0713f84c92267be9ce356251e4516fec8f0d6f90b383f6393cb3e5befL19-R24))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
