### PR TITLE
feat: expose mongo uri.

### DIFF
--- a/deploy/cloud/Kubefile
+++ b/deploy/cloud/Kubefile
@@ -5,5 +5,6 @@ COPY scripts scripts
 COPY manifests manifests
 
 ENV cloudDomain="127.0.0.1.nip.io"
+ENV mongodbUri=""
 
-CMD ["bash scripts/init.sh"]
+CMD ["mongodb_uri=$(mongodbUri) bash scripts/init.sh"]

--- a/deploy/cloud/Kubefile
+++ b/deploy/cloud/Kubefile
@@ -7,4 +7,4 @@ COPY manifests manifests
 ENV cloudDomain="127.0.0.1.nip.io"
 ENV mongodbUri=""
 
-CMD ["mongodb_uri=$(mongodbUri) bash scripts/init.sh"]
+CMD ["mongodbUri=$(mongodbUri) bash scripts/init.sh"]

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -118,3 +118,5 @@ sealos run docker.io/labring/sealos-cloud:latest\
     --env cloudDomain="127.0.0.1.nip.io"\
     --config-file tls-secret.yaml
 ```
+
+If you already have a mongodb, you can use it by setting `--env mongodbUri=<your mongodb uri>`.

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -119,4 +119,10 @@ sealos run docker.io/labring/sealos-cloud:latest\
     --config-file tls-secret.yaml
 ```
 
-If you already have a mongodb, you can use it by setting `--env mongodbUri=<your mongodb uri>`.
+If you already have a mongodb, you can use it by setting `--env mongodbUri=<your mongodb uri>`:
+
+```shell
+sealos run docker.io/labring/sealos-cloud:latest\
+    --env cloudDomain="127.0.0.1.nip.io"\
+    --env mongodbUri=<your mongodb uri>
+```

--- a/deploy/cloud/scripts/init.sh
+++ b/deploy/cloud/scripts/init.sh
@@ -4,7 +4,7 @@ set -ex
 cloudDomain="127.0.0.1.nip.io"
 tlsCrtPlaceholder="<tls-crt-placeholder>"
 tlsKeyPlaceholder="<tls-key-placeholder>"
-mongodb_uri=""
+mongodbUri=""
 
 function read_env {
   source $1
@@ -38,9 +38,9 @@ function sealos_run_controller {
   sealos run tars/app.tar
 }
 
-function gen_mongodb_uri() {
-  # if mongodb_uri is empty then apply kubeblocks mongodb cr and gen mongodb uri
-  if [ -z "$mongodb_uri" ]; then
+function gen_mongodbUri() {
+  # if mongodbUri is empty then create mongodb and gen mongodb uri
+  if [ -z "$mongodbUri" ]; then
     echo "no mongodb uri found, apply kubeblocks mongodb cr"
     kubectl apply -f manifests/mongodb.yaml
     # if there is no sealos-mongodb-conn-credential secret then wait for mongodb ready
@@ -49,7 +49,7 @@ function gen_mongodb_uri() {
       sleep 5
     done
     chmod +x scripts/gen-mongodb-uri.sh
-    mongodb_uri=$(scripts/gen-mongodb-uri.sh)
+    mongodbUri=$(scripts/gen-mongodb-uri.sh)
   fi
 }
 
@@ -84,7 +84,7 @@ function sealos_run_frontend {
 
 function mutate_desktop_config() {
   # mutate etc/sealos/desktop-config.yaml by using mongodb uri and two random base64 string
-  sed -i -e "s;<your-mongodb-uri-base64>;$(echo -n "$mongodb_uri" | base64 -w 0);" etc/sealos/desktop-config.yaml
+  sed -i -e "s;<your-mongodb-uri-base64>;$(echo -n "$mongodbUri" | base64 -w 0);" etc/sealos/desktop-config.yaml
   sed -i -e "s;<your-jwt-secret-base64>;$(tr -cd 'a-z0-9' </dev/urandom | head -c64 | base64 -w 0);" etc/sealos/desktop-config.yaml
   sed -i -e "s;<your-password-salt-base64>;$(tr -cd 'a-z0-9' </dev/urandom | head -c64 | base64 -w 0);" etc/sealos/desktop-config.yaml
 }
@@ -100,7 +100,7 @@ function install {
   create_tls_secret $cloudDomain
 
   # gen mongodb uri
-  gen_mongodb_uri
+  gen_mongodbUri
 
   # sealos run controllers
   sealos_run_controller

--- a/deploy/cloud/scripts/init.sh
+++ b/deploy/cloud/scripts/init.sh
@@ -41,6 +41,7 @@ function sealos_run_controller {
 function gen_mongodb_uri() {
   # if mongodb_uri is empty then apply kubeblocks mongodb cr and gen mongodb uri
   if [ -z "$mongodb_uri" ]; then
+    echo "no mongodb uri found, apply kubeblocks mongodb cr"
     kubectl apply -f manifests/mongodb.yaml
     # if there is no sealos-mongodb-conn-credential secret then wait for mongodb ready
     while [ -z "$(kubectl get secret -n sealos sealos-mongodb-conn-credential)" ]; do

--- a/deploy/cloud/scripts/init.sh
+++ b/deploy/cloud/scripts/init.sh
@@ -41,7 +41,7 @@ function sealos_run_controller {
 function gen_mongodbUri() {
   # if mongodbUri is empty then create mongodb and gen mongodb uri
   if [ -z "$mongodbUri" ]; then
-    echo "no mongodb uri found, apply kubeblocks mongodb cr"
+    echo "no mongodb uri found, create mongodb and gen mongodb uri"
     kubectl apply -f manifests/mongodb.yaml
     # if there is no sealos-mongodb-conn-credential secret then wait for mongodb ready
     while [ -z "$(kubectl get secret -n sealos sealos-mongodb-conn-credential)" ]; do


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9489259</samp>

### Summary
🌐📝🗣️

<!--
1.  🌐 - This emoji represents the addition of a new environment variable that allows users to connect to an external network resource, such as a mongodb database. The globe emoji conveys the idea of network connectivity and external services.
2. 📝 - This emoji represents the update of the README.md file, which provides documentation and instructions for the users of the sealos-cloud image. The memo emoji conveys the idea of writing and editing text.
3. 🗣️ - This emoji represents the addition of a conditional message to the `init.sh` script, which communicates with the user about the status and options of the mongodb deployment. The speaking head emoji conveys the idea of dialogue and feedback.
-->
This pull request adds support for using an external mongodb database for sealos-cloud deployments. It introduces a new environment variable `mongodbUri` in the `Kubefile` and the `init.sh` script, and updates the `README.md` file to explain how to use it.

> _`mongodbUri` set_
> _External or internal_
> _Spring choice for cloud_

### Walkthrough
*  Add support for using an external mongodb by setting the `mongodbUri` environment variable ([link](https://github.com/labring/sealos/pull/3586/files?diff=unified&w=0#diff-e4247ffa6d74e55ecb0294d7d215212f8cdca29bc743c86c769a0f257cb0e597L8-R10), [link](https://github.com/labring/sealos/pull/3586/files?diff=unified&w=0#diff-e5a74fab87ec2353240365589f23b63386a45bbcdbf1512850a1fb07eee48742L121-R127), [link](https://github.com/labring/sealos/pull/3586/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844R44))
  * Modify the `Kubefile` to accept the `mongodbUri` value and pass it to the `init.sh` script ([link](https://github.com/labring/sealos/pull/3586/files?diff=unified&w=0#diff-e4247ffa6d74e55ecb0294d7d215212f8cdca29bc743c86c769a0f257cb0e597L8-R10))
  * Update the `README.md` file to explain the new option and provide an example command ([link](https://github.com/labring/sealos/pull/3586/files?diff=unified&w=0#diff-e5a74fab87ec2353240365589f23b63386a45bbcdbf1512850a1fb07eee48742L121-R127))
  * Add a conditional message to the `init.sh` script to indicate whether the kubeblocks mongodb custom resource will be applied or not ([link](https://github.com/labring/sealos/pull/3586/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844R44))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
