### PR TITLE
fix: upgrade cluster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.2.0 // indirect
+	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/Microsoft/hcsshim v0.10.0-rc.8 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJ
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.2.0 h1:3MEsd0SM6jqZojhjLWWeBY+Kcjy9i6MQAeY7YgDP83g=
 github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
+github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
+github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj9n6YA=
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=

--- a/pkg/apply/processor/install.go
+++ b/pkg/apply/processor/install.go
@@ -180,10 +180,9 @@ func (c *InstallProcessor) UpgradeIfNeed(cluster *v2.Cluster) error {
 		if version == "" {
 			continue
 		}
-		logger.Debug("try Upgrade Cluster to %s", version)
 		err := c.Runtime.UpgradeCluster(version)
 		if err != nil {
-			logger.Info("upgrade cluster failed")
+			logger.Error("upgrade cluster failed")
 			return err
 		}
 		//upgrade success; replace the old cluster mount

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -18,11 +18,12 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/Masterminds/semver/v3"
+
 	"github.com/labring/sealos/pkg/client-go/kubernetes"
 	"github.com/labring/sealos/pkg/ssh"
 	v2 "github.com/labring/sealos/pkg/types/v1beta1"
 	"github.com/labring/sealos/pkg/utils/logger"
-	"github.com/labring/sealos/pkg/utils/versionutil"
 	"github.com/labring/sealos/pkg/utils/yaml"
 )
 
@@ -168,19 +169,27 @@ func (k *KubeadmRuntime) Validate() error {
 }
 
 func (k *KubeadmRuntime) UpgradeCluster(version string) error {
-	curversion := k.getKubeVersionFromImage()
-	if curversion == version {
-		logger.Info("The cluster version has not changed")
-		return nil
-	} else if versionutil.Compare(version, curversion) {
-		if err := versionutil.UpgradeVersionLimit(curversion, version); err != nil {
-			return err
-		}
-		logger.Info("cluster vesion: %s will be upgraded into %s.", curversion, version)
-		return k.upgradeCluster(version)
-	} else if versionutil.Compare(curversion, version) {
-		logger.Info("new cluster version %s behind the current version %s", version, curversion)
+	currVersion := k.getKubeVersionFromImage()
+
+	v0, err := semver.NewVersion(currVersion)
+	if err != nil {
+		return err
+	}
+	v1, err := semver.NewVersion(version)
+	if err != nil {
+		return err
+	}
+	if v0.Equal(v1) {
+		logger.Info("skip upgrade because of same version")
 		return nil
 	}
-	return fmt.Errorf("verion format error")
+
+	if v0.GreaterThan(v1) {
+		return fmt.Errorf("cannot apply an older version %s than %s", version, currVersion)
+	}
+	if v0.Minor()+1 < v1.Minor() {
+		return fmt.Errorf("cannot be upgraded across more than one major releases, %s -> %s", currVersion, version)
+	}
+
+	return k.upgradeCluster(version)
 }

--- a/pkg/types/v1beta1/cluster.go
+++ b/pkg/types/v1beta1/cluster.go
@@ -79,10 +79,7 @@ type MountImage struct {
 }
 
 func (img *MountImage) KubeVersion() string {
-	if img.Type != RootfsImage {
-		return ""
-	}
-	if img.Labels == nil {
+	if img.Type != RootfsImage || img.Labels == nil {
 		return ""
 	}
 	return img.Labels[ImageKubeVersionKey]

--- a/pkg/utils/versionutil/version.go
+++ b/pkg/utils/versionutil/version.go
@@ -17,7 +17,6 @@ limitations under the License.
 package versionutil
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -50,30 +49,4 @@ func Compare(v1, v2 string) bool {
 	}
 
 	return true
-}
-
-// assure version format right and new >=
-// The upgrade of minor version number cannot be skipped
-func UpgradeVersionLimit(older, newer string) error {
-	newer = strings.Replace(newer, "v", "", -1)
-	older = strings.Replace(older, "v", "", -1)
-	newer = strings.Split(newer, "-")[0]
-	older = strings.Split(older, "-")[0]
-	newList := strings.Split(newer, ".")
-	oldList := strings.Split(older, ".")
-
-	minorNewV, err := strconv.Atoi(newList[1])
-	if err != nil {
-		return err
-	}
-	minorOldV, err := strconv.Atoi(oldList[1])
-	if err != nil {
-		return err
-	}
-	if newList[0] > oldList[0] {
-		return fmt.Errorf("upgrade of senior version cannot be executed")
-	} else if minorNewV > minorOldV+1 {
-		return fmt.Errorf("upgrade of minor version number cannot be skipped")
-	}
-	return nil
 }


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ff49fbf</samp>

This pull request refactors and simplifies the Kubernetes version upgrade logic in the `pkg/runtime` and `pkg/types/v1beta1` packages, using the `semver` and `kubeadm` libraries. It also updates the dependency version of `semver` in the `go.mod` file, and fixes some log level issues in the `pkg/apply/processor` package. The goal of these changes is to improve the performance, reliability, and readability of the code.