### PR TITLE
feature(build):  add pr branch

### DIFF
--- a/.github/workflows/bot-cherry-pick.yml
+++ b/.github/workflows/bot-cherry-pick.yml
@@ -14,6 +14,17 @@ jobs:
           TARGET_BRANCH=$(jq -r ".comment.body" "$GITHUB_EVENT_PATH" | awk '{ print $2 }'  | tr -d '[:space:]')
           echo "🤖 says: ‼️ TARGET_BRANCH is $TARGET_BRANCH"
           echo "target=$TARGET_BRANCH" >> $GITHUB_OUTPUT
+          if [ -z "$PR_NUMBER" ]; then
+          	PR_NUMBER=$(jq -r ".pull_request.number" "$GITHUB_EVENT_PATH")
+          	if [[ "$PR_NUMBER" == "null" ]]; then
+          		PR_NUMBER=$(jq -r ".issue.number" "$GITHUB_EVENT_PATH")
+          	fi
+          	if [[ "$PR_NUMBER" == "null" ]]; then
+          		echo "Failed to determine PR Number."
+          		exit 1
+          	fi
+          fi
+          echo "prNumber=$PR_NUMBER" >> $GITHUB_OUTPUT
       - name: Checkout the latest code
         uses: actions/checkout@v2
         with:
@@ -37,11 +48,12 @@ jobs:
             Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
           commit-message: |
             🤖 cherry-pick to ${{ steps.set-target.outputs.target }} using robot.
-          branch: cherry-pick-${{ steps.set-target.outputs.target }}
+          branch: cherry-pick-${{ steps.set-target.outputs.target }}-${{ steps.set-target.outputs.prNumber }}
           base: ${{ steps.set-target.outputs.target }}
           signoff: true
           delete-branch: true
           token: ${{ secrets.GH_PAT }}
           reviewers: cuisongliu
+          milestone: cherry-pick
           committer: sealos-ci-robot <sealos-ci-robot@sealos.io>
           author: sealos-ci-robot <sealos-ci-robot@sealos.io>


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f849c9f</samp>

### Summary
🍒🔀🔢

<!--
1.  🍒 - This emoji is often used to represent cherry-picking, since it literally depicts a cherry with a stem that can be picked. It also conveys the idea of selecting something desirable or valuable from a larger set.
2.  🔀 - This emoji is used to represent branching, merging, or switching between branches, since it shows two arrows crossing each other. It also conveys the idea of combining or integrating different sources or versions of code.
3.  🔢 - This emoji is used to represent numbers, digits, or counting, since it shows a keypad with numbers from 0 to 9. It also conveys the idea of identifying, referencing, or extracting numerical information from data or events.
-->
Improve cherry-pick workflow by using pull request number. Add support for different GitHub event types to extract pull request number.

> _Sing, O Muse, of the skillful coder who devised_
> _A clever way to cherry-pick the commits of heroes_
> _From branch to branch, using the number of the pull_
> _As a guide and a name for the new branch of glory._

### Walkthrough
* Add logic to determine and store the pull request number from the event payload ([link](https://github.com/labring/sealos/pull/3591/files?diff=unified&w=0#diff-287bd000c2f59ec9a4088599c433a248de1072ea7839b6199c3104cfb72db208R17-R27))
* Use the pull request number and the target branch name to create a unique branch name for the cherry-pick operation ([link](https://github.com/labring/sealos/pull/3591/files?diff=unified&w=0#diff-287bd000c2f59ec9a4088599c433a248de1072ea7839b6199c3104cfb72db208L40-R51))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
