### PR TITLE
feat: adapt for gpu cost

### DIFF
--- a/controllers/account/deploy/Kubefile
+++ b/controllers/account/deploy/Kubefile
@@ -8,4 +8,4 @@ COPY manifests manifests
 ENV DEFAULT_NAMESPACE account-system
 ENV MONGO_URI "mongodb://mongo:27017/resources"
 
-CMD ["( kubectl create -f manifests/mongo-secret.yaml -n $DEFAULT_NAMESPACE || true ) && kubectl apply -f manifests/deploy.yaml -n $DEFAULT_NAMESPACE"]
+CMD ["( kubectl create ns $DEFAULT_NAMESPACE || true ) && ( kubectl create -f manifests/mongo-secret.yaml -n $DEFAULT_NAMESPACE || true ) && kubectl apply -f manifests/deploy.yaml -n $DEFAULT_NAMESPACE"]

--- a/controllers/account/deploy/manifests/deploy.yaml
+++ b/controllers/account/deploy/manifests/deploy.yaml
@@ -1168,6 +1168,7 @@ spec:
         envFrom:
         - secretRef:
             name: payment-secret
+            optional: true
         image: ghcr.io/labring/sealos-account-controller:latest
         imagePullPolicy: Always
         livenessProbe:

--- a/controllers/pkg/common/gpu/nvidia.go
+++ b/controllers/pkg/common/gpu/nvidia.go
@@ -1,0 +1,120 @@
+package gpu
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// nvidia labels for gpu
+const (
+	NvidiaGpuKey                          = "nvidia.com/gpu"
+	NvidiaCudaDriverMajorKey              = "nvidia.com/cuda.driver.major"
+	NvidiaCudaDriverMinorKey              = "nvidia.com/cuda.driver.minor"
+	NvidiaCudaDriverRevKey                = "nvidia.com/cuda.driver.rev"
+	NvidiaCudaRuntimeMajorKey             = "nvidia.com/cuda.runtime.major"
+	NvidiaCudaRuntimeMinorKey             = "nvidia.com/cuda.runtime.minor"
+	NvidiaGfdTimestampKey                 = "nvidia.com/gfd.timestamp"
+	NvidiaGpuComputeMajorKey              = "nvidia.com/gpu.compute.major"
+	NvidiaGpuComputeMinorKey              = "nvidia.com/gpu.compute.minor"
+	NvidiaGpuCountKey                     = "nvidia.com/gpu.count"
+	NvidiaGpuDeployContainerToolkitKey    = "nvidia.com/gpu.deploy.container-toolkit"
+	NvidiaGpuDeployDcgmKey                = "nvidia.com/gpu.deploy.dcgm"
+	NvidiaGpuDeployDcgmExporterKey        = "nvidia.com/gpu.deploy.dcgm-exporter"
+	NvidiaGpuDeployDevicePluginKey        = "nvidia.com/gpu.deploy.device-plugin"
+	NvidiaGpuDeployDriverKey              = "nvidia.com/gpu.deploy.driver"
+	NvidiaGpuDeployGpuFeatureDiscoveryKey = "nvidia.com/gpu.deploy.gpu-feature-discovery"
+	NvidiaGpuDeployNodeStatusExporterKey  = "nvidia.com/gpu.deploy.node-status-exporter"
+	NvidiaGpuDeployOperatorValidatorKey   = "nvidia.com/gpu.deploy.operator-validator"
+	NvidiaGpuFamilyKey                    = "nvidia.com/gpu.family"
+	NvidiaGpuMachineKey                   = "nvidia.com/gpu.machine"
+	NvidiaGpuMemoryKey                    = "nvidia.com/gpu.memory"
+	NvidiaGpuPresentKey                   = "nvidia.com/gpu.present"
+	NvidiaGpuProductKey                   = "nvidia.com/gpu.product"
+	NvidiaGpuReplicasKey                  = "nvidia.com/gpu.replicas"
+	NvidiaMigCapableKey                   = "nvidia.com/mig.capable"
+	NvidiaMigStrategyKey                  = "nvidia.com/mig.strategy"
+)
+
+type NvidiaGPU struct {
+	GpuInfo    Information
+	CudaInfo   CudaInformation
+	GpuDeploy  Deployment
+	GpuDetails DetailInformation
+	MigInfo    MigInformation
+}
+
+type Information struct {
+	Gpu         string
+	GpuCount    string
+	GpuPresent  string
+	GpuProduct  string
+	GpuReplicas string
+}
+
+type CudaInformation struct {
+	CudaDriverMajor  string
+	CudaDriverMinor  string
+	CudaDriverRev    string
+	CudaRuntimeMajor string
+	CudaRuntimeMinor string
+}
+
+type Deployment struct {
+	GpuDeployContainerToolkit    string
+	GpuDeployDcgm                string
+	GpuDeployDcgmExporter        string
+	GpuDeployDevicePlugin        string
+	GpuDeployDriver              string
+	GpuDeployGpuFeatureDiscovery string
+	GpuDeployNodeStatusExporter  string
+	GpuDeployOperatorValidator   string
+}
+
+type DetailInformation struct {
+	GpuComputeMajor string
+	GpuComputeMinor string
+	GpuFamily       string
+	GpuMachine      string
+	GpuMemory       string
+	GfdTimestamp    string
+}
+
+type MigInformation struct {
+	MigCapable  string
+	MigStrategy string
+}
+
+//nvidia.com/gpu
+
+func GetNodeGpuModel(c client.Client) (map[string]NvidiaGPU, error) {
+	nodeList := &corev1.NodeList{}
+	err := c.List(context.Background(), nodeList)
+	if err != nil {
+		return nil, err
+	}
+
+	gpuModels := make(map[string]NvidiaGPU)
+	for _, node := range nodeList.Items {
+		gpu := NvidiaGPU{
+			GpuInfo: Information{
+				Gpu:         node.Labels[NvidiaGpuKey],
+				GpuCount:    node.Labels[NvidiaGpuCountKey],
+				GpuPresent:  node.Labels[NvidiaGpuPresentKey],
+				GpuProduct:  node.Labels[NvidiaGpuProductKey],
+				GpuReplicas: node.Labels[NvidiaGpuReplicasKey],
+			},
+			CudaInfo: CudaInformation{
+				CudaDriverMajor:  node.Labels[NvidiaCudaDriverMajorKey],
+				CudaDriverMinor:  node.Labels[NvidiaCudaDriverMinorKey],
+				CudaDriverRev:    node.Labels[NvidiaCudaDriverRevKey],
+				CudaRuntimeMajor: node.Labels[NvidiaCudaRuntimeMajorKey],
+				CudaRuntimeMinor: node.Labels[NvidiaCudaRuntimeMinorKey],
+			},
+			// fill in the rest similarly...
+		}
+		gpuModels[node.Name] = gpu
+	}
+	return gpuModels, nil
+}

--- a/controllers/pkg/common/resources.go
+++ b/controllers/pkg/common/resources.go
@@ -6,6 +6,8 @@ import (
 	"math"
 	"time"
 
+	"github.com/labring/sealos/controllers/pkg/common/gpu"
+
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 
@@ -112,6 +114,12 @@ const (
 	PropertyInfraDisk   = "infra-disk"
 )
 
+const ResourceGPU corev1.ResourceName = gpu.NvidiaGpuKey
+
+func NewGpuResource(product string) corev1.ResourceName {
+	return corev1.ResourceName("gpu-" + product)
+}
+
 var (
 	bin1Mi  = resource.NewQuantity(1<<20, resource.BinarySI)
 	cpuUnit = resource.MustParse("1m")
@@ -119,6 +127,7 @@ var (
 
 var PricesUnit = map[corev1.ResourceName]*resource.Quantity{
 	corev1.ResourceCPU:     &cpuUnit, // 1 m CPU (1000 μ)
+	ResourceGPU:            &cpuUnit, // 1 m CPU (1000 μ)
 	corev1.ResourceMemory:  bin1Mi,   // 1 MiB
 	corev1.ResourceStorage: bin1Mi,   // 1 MiB
 }

--- a/controllers/pkg/database/mongodb.go
+++ b/controllers/pkg/database/mongodb.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"strings"
 	"time"
 
 	"github.com/labring/sealos/controllers/pkg/crypto"
@@ -197,7 +196,7 @@ func (m *MongoDB) GetAllPricesMap() (map[string]common.Price, error) {
 		if err != nil {
 			return nil, fmt.Errorf("decrypt price error: %v", err)
 		}
-		pricesMap[strings.ToLower(prices[i].Property)] = common.Price{
+		pricesMap[prices[i].Property] = common.Price{
 			Price:    price,
 			Detail:   prices[i].Detail,
 			Property: prices[i].Property,

--- a/controllers/resources/config/rbac/role.yaml
+++ b/controllers/resources/config/rbac/role.yaml
@@ -16,6 +16,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get

--- a/controllers/resources/config/rbac/role.yaml
+++ b/controllers/resources/config/rbac/role.yaml
@@ -24,6 +24,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get

--- a/controllers/resources/controllers/monitor_controller.go
+++ b/controllers/resources/controllers/monitor_controller.go
@@ -25,6 +25,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/labring/sealos/controllers/pkg/common/gpu"
+
 	"golang.org/x/sync/semaphore"
 
 	"github.com/labring/sealos/pkg/utils/logger"
@@ -52,6 +54,7 @@ type MonitorReconciler struct {
 	stopCh            chan struct{}
 	wg                sync.WaitGroup
 	periodicReconcile time.Duration
+	NvidiaGpu         map[string]gpu.NvidiaGPU
 }
 
 type quantity struct {
@@ -87,8 +90,13 @@ func NewMonitorReconciler(mgr ctrl.Manager) (*MonitorReconciler, error) {
 		return nil, fmt.Errorf("mongo uri is empty")
 	}
 	r.initNamespaceFuncs()
-	if err := r.preApply(); err != nil {
+	err := r.preApply()
+	if err != nil {
 		return nil, err
+	}
+	r.NvidiaGpu, err = gpu.GetNodeGpuModel(mgr.GetClient())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get node gpu model: %v", err)
 	}
 	r.startPeriodicReconcile()
 	return r, nil
@@ -268,20 +276,17 @@ func (r *MonitorReconciler) podResourceUsage(ctx context.Context, dbClient datab
 		return err
 	}
 	rs := initResources()
+	hasStorageQuota := false
 	if err := r.Get(ctx, client.ObjectKey{Name: meteringv1.ResourceQuotaPrefix + namespace.Name, Namespace: namespace.Name}, &quota); err != nil {
 		if client.IgnoreNotFound(err) != nil {
 			return err
 		}
-		if _, ok := namespace.GetAnnotations()[v1.UserAnnotationCreatorKey]; ok {
-			//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
-			//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
-			//if err = r.syncResourceQuota(ctx, namespace.Name); err != nil {
-			//	r.Logger.Error(err, "sync resource quota failed", "namespace", namespace.Name)
-			//}
+		if _, ok := namespace.GetAnnotations()[v1.UserAnnotationOwnerKey]; ok {
 			r.Logger.Error(fmt.Errorf("resources quota is empty"), "", "namespace", namespace.Name)
 		}
 		rs[corev1.ResourceStorage].detail = "no resource quota"
 	} else {
+		hasStorageQuota = true
 		rs[corev1.ResourceStorage].Add(*quota.Status.Used.Name("requests.storage", resource.BinarySI))
 	}
 	for _, pod := range podList.Items {
@@ -300,50 +305,69 @@ func (r *MonitorReconciler) podResourceUsage(ctx context.Context, dbClient datab
 			} else {
 				rs[corev1.ResourceMemory].Add(container.Resources.Requests[corev1.ResourceMemory])
 			}
+			// gpu only use limit
+			if gpuRequest, ok := container.Resources.Limits[gpu.NvidiaGpuKey]; ok {
+				gpuModel, ok := r.NvidiaGpu[pod.Spec.NodeName]
+				if !ok {
+					var err error
+					r.NvidiaGpu, err = gpu.GetNodeGpuModel(r.Client)
+					if err != nil {
+						logger.Error(err, "get node gpu model failed")
+						continue
+					}
+					gpuModel, ok = r.NvidiaGpu[pod.Spec.NodeName]
+					if !ok {
+						logger.Error(fmt.Errorf("node %s not found gpu model", pod.Spec.NodeName), "")
+						continue
+					}
+				}
+				rs[common.NewGpuResource(gpuModel.GpuInfo.GpuProduct)].Add(gpuRequest)
+			}
 		}
 	}
-	cpuValue, memoryValue, storageValue := getResourceValue(corev1.ResourceCPU, rs), getResourceValue(corev1.ResourceMemory, rs), getResourceValue(corev1.ResourceStorage, rs)
+	if !hasStorageQuota {
+		pvcList := corev1.PersistentVolumeClaimList{}
+		if err := r.List(context.Background(), &pvcList, &client.ListOptions{Namespace: namespace.Name}); err != nil {
+			return err
+		}
+		for _, pvc := range pvcList.Items {
+			if pvc.Status.Phase != corev1.ClaimBound {
+				continue
+			}
+			rs[corev1.ResourceStorage].Add(pvc.Spec.Resources.Requests[corev1.ResourceStorage])
+		}
+	}
 	var monitors []*common.Monitor
-	if cpuValue > 0 {
-		monitors = append(monitors, &common.Monitor{
-			Category: namespace.Name,
-			Property: corev1.ResourceCPU.String(),
-			Value:    cpuValue,
-			Time:     timeStamp,
-			Detail:   rs[corev1.ResourceCPU].String(),
-		})
-	}
-	if memoryValue > 0 {
-		monitors = append(monitors, &common.Monitor{
-			Category: namespace.Name,
-			Property: corev1.ResourceMemory.String(),
-			Value:    memoryValue,
-			Time:     timeStamp,
-			Detail:   rs[corev1.ResourceMemory].String(),
-		})
-	}
-	if storageValue > 0 {
-		monitors = append(monitors, &common.Monitor{
-			Category: namespace.Name,
-			Property: corev1.ResourceStorage.String(),
-			Value:    storageValue,
-			Time:     timeStamp,
-			Detail:   rs[corev1.ResourceStorage].String(),
-		})
+	for resour, value := range rs {
+		v := getResourceValue(resour, rs)
+		if v > 0 {
+			monitors = append(monitors, &common.Monitor{
+				Category: namespace.Name,
+				Property: resour.String(),
+				Value:    v,
+				Time:     timeStamp,
+				Detail:   value.detail,
+			})
+		}
 	}
 	return dbClient.InsertMonitor(ctx, monitors...)
 }
 
 func getResourceValue(resourceName corev1.ResourceName, res map[corev1.ResourceName]*quantity) int64 {
 	quantity := res[resourceName]
+	priceUnit := common.PricesUnit[resourceName]
+	if strings.Contains(resourceName.String(), "gpu") {
+		priceUnit = common.PricesUnit[common.ResourceGPU]
+	}
 	if quantity != nil && quantity.MilliValue() != 0 {
-		return int64(math.Ceil(float64(quantity.MilliValue()) / float64(common.PricesUnit[resourceName].MilliValue())))
+		return int64(math.Ceil(float64(quantity.MilliValue()) / float64(priceUnit.MilliValue())))
 	}
 	return 0
 }
 
 func initResources() (rs map[corev1.ResourceName]*quantity) {
 	rs = make(map[corev1.ResourceName]*quantity)
+	rs[common.ResourceGPU] = &quantity{Quantity: resource.NewQuantity(0, resource.DecimalSI), detail: ""}
 	rs[corev1.ResourceCPU] = &quantity{Quantity: resource.NewQuantity(0, resource.DecimalSI), detail: ""}
 	rs[corev1.ResourceMemory] = &quantity{Quantity: resource.NewQuantity(0, resource.BinarySI), detail: ""}
 	rs[corev1.ResourceStorage] = &quantity{Quantity: resource.NewQuantity(0, resource.BinarySI), detail: ""}

--- a/controllers/resources/controllers/monitor_controller.go
+++ b/controllers/resources/controllers/monitor_controller.go
@@ -71,6 +71,7 @@ const (
 var namespaceMonitorFuncs = make(map[string]func(ctx context.Context, dbClient database.Interface, namespace *corev1.Namespace) error)
 
 //+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
+//+kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=resourcequotas,verbs=get;list;watch

--- a/controllers/resources/controllers/monitor_controller.go
+++ b/controllers/resources/controllers/monitor_controller.go
@@ -36,7 +36,6 @@ import (
 	meteringv1 "github.com/labring/sealos/controllers/metering/api/v1"
 	"github.com/labring/sealos/controllers/pkg/common"
 	"github.com/labring/sealos/controllers/pkg/database"
-	v1 "github.com/labring/sealos/controllers/user/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -283,9 +282,9 @@ func (r *MonitorReconciler) podResourceUsage(ctx context.Context, dbClient datab
 		if client.IgnoreNotFound(err) != nil {
 			return err
 		}
-		if _, ok := namespace.GetAnnotations()[v1.UserAnnotationOwnerKey]; ok {
-			r.Logger.Error(fmt.Errorf("resources quota is empty"), "", "namespace", namespace.Name)
-		}
+		//if _, ok := namespace.GetAnnotations()[v1.UserAnnotationOwnerKey]; ok {
+		//	r.Logger.Error(fmt.Errorf("resources quota is empty"), "", "namespace", namespace.Name)
+		//}
 		rs[corev1.ResourceStorage].detail = "no resource quota"
 	} else {
 		hasStorageQuota = true

--- a/controllers/resources/controllers/monitor_controller.go
+++ b/controllers/resources/controllers/monitor_controller.go
@@ -70,6 +70,7 @@ const (
 
 var namespaceMonitorFuncs = make(map[string]func(ctx context.Context, dbClient database.Interface, namespace *corev1.Namespace) error)
 
+//+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=resourcequotas,verbs=get;list;watch

--- a/controllers/resources/deploy/manifests/deploy.yaml
+++ b/controllers/resources/deploy/manifests/deploy.yaml
@@ -66,6 +66,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get

--- a/controllers/resources/deploy/manifests/deploy.yaml
+++ b/controllers/resources/deploy/manifests/deploy.yaml
@@ -74,6 +74,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d5f5b71</samp>

### Summary
🎮🛡️📊

<!--
1.  🎮 - This emoji represents Nvidia GPUs, which are often used for gaming and graphics applications. It also suggests the idea of performance and speed, which are important aspects of GPU resources.
2.  🛡️ - This emoji represents the RBAC rules and permissions that are added to the `monitor` role and the `monitor-controller` deployment. It suggests the idea of security and protection, which are important aspects of access control and authorization.
3.  📊 - This emoji represents the GPU resource monitoring and data collection that are added to the `MonitorReconciler`. It suggests the idea of analysis and reporting, which are important aspects of resource management and optimization.
-->
This pull request adds support for Nvidia GPU resources in the `sealos` controller. It defines GPU-related constants, types, and functions in the `gpu` package, and uses them to create, price, and monitor GPU resources in the `resources.go` and `monitor_controller.go` files. It also updates the RBAC and deployment configurations for the `monitor-controller` controller to allow it to access node information.

> _We're the `monitor-controller` crew, we watch the nodes and pods_
> _We gather GPU data and we store it in our logs_
> _We heave and haul on the `MonitorReconciler` line_
> _And we sing this shanty chorus on the count of three and nine_

### Walkthrough
*  Add support for collecting and storing Nvidia GPU resource usage data from pods and nodes ([link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-d18b6a87d8be8db668ff42c15bea6107757bda983123798750396eaf82f918ecR1-R120),[link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-4766b3b00bd1d2cd9279874228122ee5f286a902fd6edab4c47751b8a70cf053R9-R10),[link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-4766b3b00bd1d2cd9279874228122ee5f286a902fd6edab4c47751b8a70cf053R117-R122),[link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-4766b3b00bd1d2cd9279874228122ee5f286a902fd6edab4c47751b8a70cf053R130),[link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-e1f4a0c1bb335e13d8f5b046c195f2f6c6c4a9b6847cb3f9914477955fa96f8dR19-R26),[link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dR28-R29),[link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dR57),[link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dR73),[link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL90-R101),[link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL271-R290),[link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL303-R353),[link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL339-R364),[link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dR371),[link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-cf16844a79d4b3b06937d7c9438e29b792263e9a035c67295e61f819869a6300R69-R76))
  * Define constants, types, and functions related to Nvidia GPU labels and information in `nvidia.go` ([link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-d18b6a87d8be8db668ff42c15bea6107757bda983123798750396eaf82f918ecR1-R120))
  * Import the `gpu` package and add a new constant `ResourceGPU` and a new function `NewGpuResource` to `resources.go` ([link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-4766b3b00bd1d2cd9279874228122ee5f286a902fd6edab4c47751b8a70cf053R9-R10),[link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-4766b3b00bd1d2cd9279874228122ee5f286a902fd6edab4c47751b8a70cf053R117-R122))
  * Add the `ResourceGPU` constant to the `PricesUnit` map in `resources.go` to define the unit price for GPU resources ([link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-4766b3b00bd1d2cd9279874228122ee5f286a902fd6edab4c47751b8a70cf053R130))
  * Add a new rule to `role.yaml` and `deploy.yaml` to allow the `monitor` role and the `monitor-controller` controller to get, list, and watch nodes ([link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-e1f4a0c1bb335e13d8f5b046c195f2f6c6c4a9b6847cb3f9914477955fa96f8dR19-R26),[link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-cf16844a79d4b3b06937d7c9438e29b792263e9a035c67295e61f819869a6300R69-R76))
  * Import the `gpu` package and add a new field `NvidiaGpu` to the `MonitorReconciler` struct in `monitor_controller.go` ([link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dR28-R29),[link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dR57))
  * Add a `kubebuilder` annotation to `monitor_controller.go` to generate RBAC rules for accessing nodes ([link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dR73))
  * Modify the `NewMonitorReconciler` function in `monitor_controller.go` to call the `GetNodeGpuModel` function from the `gpu` package and assign the result to the `NvidiaGpu` field ([link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL90-R101))
  * Modify the `podResourceUsage` function in `monitor_controller.go` to handle the GPU resource usage from pods by checking the GPU limit, getting the GPU model, and adding the GPU request to the `rs` map ([link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL303-R353))
  * Modify the `getResourceValue` function in `monitor_controller.go` to convert the GPU resource usage to integer values based on the unit price ([link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL339-R364))
  * Modify the `initResources` function in `monitor_controller.go` to initialize the `rs` map with zero values for the `ResourceGPU` constant ([link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dR371))
* Add error handling and logging for the case when a user-owned namespace does not have a resource quota for storage ([link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL271-R290))
  * Add a new variable `hasStorageQuota` to indicate whether the namespace has a resource quota for storage in the `podResourceUsage` function in `monitor_controller.go` ([link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL271-R290))
  * Add a condition to check if the namespace has the `UserAnnotationOwnerKey` annotation and log an error if the resource quota is empty in the `podResourceUsage` function in `monitor_controller.go` ([link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL271-R290))
  * Add a block of code to list all the PVCs in the namespace and add their storage requests to the `rs` map if the namespace does not have a storage quota in the `podResourceUsage` function in `monitor_controller.go` ([link](https://github.com/labring/sealos/pull/3596/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL303-R353))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
