### PR TITLE
fix nil point error

### DIFF
--- a/controllers/account/controllers/account_controller.go
+++ b/controllers/account/controllers/account_controller.go
@@ -222,8 +222,10 @@ func (r *AccountReconciler) syncAccount(ctx context.Context, name, accountNamesp
 			Namespace: accountNamespace,
 		},
 	}
-	account.Annotations = make(map[string]string)
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, &account, func() error {
+		if account.Annotations == nil {
+			account.Annotations = make(map[string]string)
+		}
 		return nil
 	}); err != nil {
 		return nil, err
@@ -249,7 +251,7 @@ func (r *AccountReconciler) syncAccount(ctx context.Context, name, accountNamesp
 	}
 
 	if account.Annotations[AccountAnnotationNewAccount] == "false" {
-		r.Logger.V(1).Info("account is not a new user ", "account", account)
+		//r.Logger.V(1).Info("account is not a new user ", "account", account)
 		return &account, nil
 	}
 
@@ -259,6 +261,9 @@ func (r *AccountReconciler) syncAccount(ctx context.Context, name, accountNamesp
 		return nil, fmt.Errorf("convert %s to int failed: %v", stringAmount, err)
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, &account, func() error {
+		if account.Annotations == nil {
+			account.Annotations = make(map[string]string)
+		}
 		account.Annotations[AccountAnnotationNewAccount] = "false"
 		return nil
 	}); err != nil {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3ff0efc</samp>

### Summary
🐛🔇🎨

<!--
1.  🐛 for fixing a bug with account annotations
2.  🔇 for reducing log verbosity
3.  🎨 for improving code consistency in the account controller
-->
Fix account annotation bug, reduce log noise, and refactor account controller code. This pull request enhances the functionality and readability of the `account_controller.go` file.

> _Oh we're the crew of the `account_controller`_
> _We fix the bugs and we make it bolder_
> _We heave away on the count of three_
> _And we annotate with consistency_

### Walkthrough
* Fix a bug that causes a nil pointer dereference error when the account CRD does not have the annotations field by initializing the account.Annotations map inside the CreateOrUpdate function ([link](https://github.com/labring/sealos/pull/3606/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L225-R228), [link](https://github.com/labring/sealos/pull/3606/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4R264-R266))
* Remove a log statement that prints the account information when it is not a new user to reduce the log verbosity and avoid exposing sensitive data ([link](https://github.com/labring/sealos/pull/3606/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L252-R254))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
