### PR TITLE
Adjusted the resource configuration for community edition

### DIFF
--- a/controllers/account/deploy/manifests/deploy.yaml
+++ b/controllers/account/deploy/manifests/deploy.yaml
@@ -1203,7 +1203,7 @@ spec:
         resources:
           limits:
             cpu: 1000m
-            memory: 256Mi
+            memory: 1024Mi
           requests:
             cpu: 100m
             memory: 64Mi
@@ -1229,7 +1229,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 512Mi
           requests:
             cpu: 5m
             memory: 64Mi

--- a/controllers/account/deploy/manifests/deploy.yaml
+++ b/controllers/account/deploy/manifests/deploy.yaml
@@ -1132,7 +1132,7 @@ metadata:
   name: account-controller-manager
   namespace: account-system
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       control-plane: controller-manager
@@ -1203,10 +1203,10 @@ spec:
         resources:
           limits:
             cpu: 1000m
-            memory: 1000Mi
+            memory: 256Mi
           requests:
             cpu: 100m
-            memory: 640Mi
+            memory: 64Mi
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true
@@ -1229,7 +1229,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 512Mi
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 64Mi

--- a/controllers/licenseissuer/deploy/Kubefile
+++ b/controllers/licenseissuer/deploy/Kubefile
@@ -13,4 +13,4 @@ ENV RegisterURL "https://license.sealos.io/register"
 ENV CloudSyncURL "https://license.sealos.io/datasync"
 ENV LicenseMonitorURL "https://license.sealos.io/license"
 
-CMD ["kubectl apply -f manifests/customconfig.yaml -f manifests/deploy.yaml"]
+CMD ["kubectl apply -f manifests/deploy.yaml -f manifests/customconfig.yaml"]

--- a/controllers/user/deploy/manifests/deploy.yaml.tmpl
+++ b/controllers/user/deploy/manifests/deploy.yaml.tmpl
@@ -313,7 +313,7 @@ metadata:
   name: user-controller-manager
   namespace: user-system
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       control-plane: controller-manager


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7f5f5d0</samp>

### Summary
🔄🔽🚀

<!--
1.  🔄 This emoji represents the change in the order of applying the manifests for the license issuer controller, as it implies switching or reversing something.
2.  🔽 This emoji represents the reduction in the number of replicas for the user controller deployment, as it implies decreasing or lowering something.
3.  🚀 This emoji represents the improvement in the performance and efficiency of the account controller deployment, as it implies speeding up or boosting something.
-->
Reduced the number of replicas and resource requirements for the account and user controller deployments, and fixed the order of applying the manifests for the license issuer controller. These changes aim to improve the performance and efficiency of the sealos controllers.

> _To patch the `customconfig` well_
> _The order of manifests had to change as well_
> _The `user` controller got one pod_
> _The `account` controller less load_
> _And the account service now runs more swell_

### Walkthrough
*  Reduce the number of replicas for the account and user controller deployments to 1, to save resources and simplify the deployment ([link](https://github.com/labring/sealos/pull/3607/files?diff=unified&w=0#diff-b4dca08a6cd3d21df60d689acb6983f7e411d29f9e5a8609c48aede3c341ef70L1135-R1135), [link](https://github.com/labring/sealos/pull/3607/files?diff=unified&w=0#diff-40a26874ba94d4ab16c7fbecb9c3f9fb3e5879b708f32cef9033a8eade9a43e3L316-R316)).


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
