### PR TITLE
add a support for community edition simply 

### DIFF
--- a/controllers/licenseissuer/deploy/Kubefile
+++ b/controllers/licenseissuer/deploy/Kubefile
@@ -13,4 +13,4 @@ ENV RegisterURL "https://license.sealos.io/register"
 ENV CloudSyncURL "https://license.sealos.io/datasync"
 ENV LicenseMonitorURL "https://license.sealos.io/license"
 
-CMD ["(chmod +x /manifests/setup.sh) && (bash /manifests/setup.sh)"]
+CMD ["(chmod +x manifests/setup.sh) && (bash manifests/setup.sh)"]

--- a/controllers/licenseissuer/deploy/Kubefile
+++ b/controllers/licenseissuer/deploy/Kubefile
@@ -7,8 +7,6 @@ COPY manifests manifests
 
 ENV canConnectToExternalNetwork "true"
 ENV enableMonitor "true"
-ENV MongoURI ""
-ENV PasswordSalt ""
 ENV CollectorURL "https://license.sealos.io/collector"
 ENV NotificationURL "https://license.sealos.io/notify"
 ENV RegisterURL "https://license.sealos.io/register"

--- a/controllers/licenseissuer/deploy/Kubefile
+++ b/controllers/licenseissuer/deploy/Kubefile
@@ -7,10 +7,12 @@ COPY manifests manifests
 
 ENV canConnectToExternalNetwork "true"
 ENV enableMonitor "true"
+ENV MongoURI ""
+ENV PasswordSalt ""
 ENV CollectorURL "https://license.sealos.io/collector"
 ENV NotificationURL "https://license.sealos.io/notify"
 ENV RegisterURL "https://license.sealos.io/register"
 ENV CloudSyncURL "https://license.sealos.io/datasync"
 ENV LicenseMonitorURL "https://license.sealos.io/license"
 
-CMD ["(chmod +x manifests/setup.sh) && (bash manifests/setup.sh)"]
+CMD ["chmod +x manifests/setup.sh && bash manifests/setup.sh"]

--- a/controllers/licenseissuer/deploy/Kubefile
+++ b/controllers/licenseissuer/deploy/Kubefile
@@ -13,4 +13,4 @@ ENV RegisterURL "https://license.sealos.io/register"
 ENV CloudSyncURL "https://license.sealos.io/datasync"
 ENV LicenseMonitorURL "https://license.sealos.io/license"
 
-CMD ["kubectl apply -f manifests/deploy.yaml -f manifests/customconfig.yaml"]
+CMD ["(chmod +x /manifests/setup.sh) && (bash /manifests/setup.sh)"]

--- a/controllers/licenseissuer/deploy/manifests/customconfig.yaml.tmpl
+++ b/controllers/licenseissuer/deploy/manifests/customconfig.yaml.tmpl
@@ -37,22 +37,3 @@ metadata:
 spec:
   description: This YAML file is responsible for launching the entire cloud module.
   name: Cloud-Launcher
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: mongo-init-job
-  namespace: sealos-system
-spec:
-  template:
-    spec:
-      containers:
-      - name: sealos-admin-preset
-        image: registry.cn-hangzhou.aliyuncs.com/fckc/job:v0.0.3
-        env:
-        - name: MONGO_URI
-          value: {{ .MongoURI }}
-        - name: PASSWORD_SALT
-          value: {{ .PasswordSalt }}
-      restartPolicy: Never
-  backoffLimit: 1

--- a/controllers/licenseissuer/deploy/manifests/customconfig.yaml.tmpl
+++ b/controllers/licenseissuer/deploy/manifests/customconfig.yaml.tmpl
@@ -37,3 +37,22 @@ metadata:
 spec:
   description: This YAML file is responsible for launching the entire cloud module.
   name: Cloud-Launcher
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mongo-init-job
+  namespace: sealos-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: sealos-admin-preset
+        image: registry.cn-hangzhou.aliyuncs.com/fckc/job:v0.0.3
+        env:
+        - name: MONGO_URI
+          value: {{ .MongoURI }}
+        - name: PASSWORD_SALT
+          value: {{ .PasswordSalt }}
+      restartPolicy: Never
+  backoffLimit: 1

--- a/controllers/licenseissuer/deploy/manifests/deploy.yaml
+++ b/controllers/licenseissuer/deploy/manifests/deploy.yaml
@@ -629,7 +629,7 @@ spec:
             memory: 1024Mi
           requests:
             cpu: 10m
-            memory: 128Mi
+            memory: 64Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/controllers/licenseissuer/deploy/manifests/setup.sh
+++ b/controllers/licenseissuer/deploy/manifests/setup.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+kubectl apply -f manifests/deploy.yaml
+
+while kubectl get crd | grep -q "launchers.infostream.sealos.io"; do
+    echo "Waiting for launchers.infostream.sealos.io CRD to be created..."
+    sleep 1
+done
+
+kubectl apply -f manifests/customconfig.yaml

--- a/controllers/licenseissuer/deploy/manifests/setup.sh
+++ b/controllers/licenseissuer/deploy/manifests/setup.sh
@@ -16,9 +16,9 @@ fi
 
 kubectl apply -f manifests/deploy.yaml
 
-while kubectl get crd | grep -q "launchers.infostream.sealos.io"; do
+while ! kubectl get crd | grep -q "launchers.infostream.sealos.io"; do
     echo "Waiting for launchers.infostream.sealos.io CRD to be created..."
-    sleep 1
+    sleep 3
 done
 
 kubectl apply -f manifests/customconfig.yaml

--- a/controllers/licenseissuer/deploy/manifests/setup.sh
+++ b/controllers/licenseissuer/deploy/manifests/setup.sh
@@ -1,4 +1,19 @@
 #! /bin/bash
+
+# check and create namespace of sealos-system
+if ! kubectl get namespace sealos-system &> /dev/null; then
+    # if not exist, create namespace and check until it is created
+    echo "Namespace sealos-system does not exist. Creating..."
+    kubectl create namespace sealos-system
+    echo "Waiting for the creation of namespace sealos-system..."
+    while ! kubectl get namespace sealos-system &> /dev/null; do
+        sleep 1
+    done
+    echo "Namespace sealos-system created."
+else
+    echo "Namespace sealos-system already exists. Skipping creation."
+fi
+
 kubectl apply -f manifests/deploy.yaml
 
 while kubectl get crd | grep -q "launchers.infostream.sealos.io"; do

--- a/deploy/cloud/scripts/init.sh
+++ b/deploy/cloud/scripts/init.sh
@@ -55,8 +55,6 @@ function sealos_run_controller {
   sealos run tars/licenseissuer.tar \
   --env canConnectToExternalNetwork="true" \
   --env enableMonitor="true" \
-  --env MongoURI="$mongodbUri" \
-  --env PasswordSalt="$saltKey"
 }
 
 function sealos_authorize {

--- a/deploy/cloud/scripts/init.sh
+++ b/deploy/cloud/scripts/init.sh
@@ -54,7 +54,7 @@ function sealos_run_controller {
   # run licenseissuer controller
   sealos run tars/licenseissuer.tar \
   --env canConnectToExternalNetwork="true" \
-  --env enableMonitor="true" \
+  --env enableMonitor="true" 
 }
 
 function sealos_authorize {

--- a/deploy/cloud/scripts/init.sh
+++ b/deploy/cloud/scripts/init.sh
@@ -5,6 +5,7 @@ cloudDomain="127.0.0.1.nip.io"
 tlsCrtPlaceholder="<tls-crt-placeholder>"
 tlsKeyPlaceholder="<tls-key-placeholder>"
 mongodbUri=""
+saltKey=""
 
 function read_env {
   source $1
@@ -53,7 +54,9 @@ function sealos_run_controller {
   # run licenseissuer controller
   sealos run tars/licenseissuer.tar \
   --env canConnectToExternalNetwork="true" \
-  --env enableMonitor="true" 
+  --env enableMonitor="true" \
+  --env MongoURI="$mongodbUri" \
+  --env PasswordSalt="$saltKey"
 }
 
 function sealos_authorize {
@@ -77,6 +80,10 @@ function sealos_authorize {
     # issue license for admin-user
     echo "license issue for admin-user"
     kubectl apply -f manifests/free-license.yaml
+}
+
+function gen_saltKey() {
+    saltKey=$(tr -dc 'a-z0-9' </dev/urandom | head -c64 | base64 -w 0)
 }
 
 function gen_mongodbUri() {
@@ -134,8 +141,10 @@ function mutate_desktop_config() {
   # mutate etc/sealos/desktop-config.yaml by using mongodb uri and two random base64 string
   sed -i -e "s;<your-mongodb-uri-base64>;$(echo -n "$mongodbUri" | base64 -w 0);" etc/sealos/desktop-config.yaml
   sed -i -e "s;<your-jwt-secret-base64>;$(tr -cd 'a-z0-9' </dev/urandom | head -c64 | base64 -w 0);" etc/sealos/desktop-config.yaml
-  sed -i -e "s;<your-password-salt-base64>;$(tr -cd 'a-z0-9' </dev/urandom | head -c64 | base64 -w 0);" etc/sealos/desktop-config.yaml
+  sed -i -e "s;<your-password-salt-base64>;$saltKey;" etc/sealos/desktop-config.yaml
 }
+
+
 
 function install {
   # read env
@@ -152,6 +161,9 @@ function install {
 
   # gen mongodb uri
   gen_mongodbUri
+
+  # gen saltKey
+  gen_saltKey
 
   # sealos run controllers
   sealos_run_controller


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1dc6ab5</samp>

### Summary
🐌📜🔑

<!--
1.  🐌 - This emoji represents the reduced memory request for the license issuer container, which makes the service more efficient and less resource-intensive.
2.  📜 - This emoji represents the shell script that implements the license issuer logic, which is the core functionality of the service and handles the license generation and verification.
3.  🔑 - This emoji represents the password salt variable and environment variables that improve the security and configuration of the license issuer and desktop services.
-->
This pull request improves the deployment and security of the license issuer and desktop services. It adds environment variables and a password salt for the MongoDB connection, adjusts the memory request and deployment order for the license issuer, and adds a `setup.sh` script for the license issuer image command.

> _`Kubefile` changes_
> _Enhance deployment, security_
> _Autumn of license_

### Walkthrough
*  Add environment variables `MongoURI` and `PasswordSalt` to `Kubefile` for license issuer image ([link](https://github.com/labring/sealos/pull/3622/files?diff=unified&w=0#diff-927f5e074d21e616995c71f76c4db50ad95bef6a1753ba51a4016facee2f7a39R10-R11))
*  Change license issuer image command to run `setup.sh` script instead of applying manifests directly ([link](https://github.com/labring/sealos/pull/3622/files?diff=unified&w=0#diff-927f5e074d21e616995c71f76c4db50ad95bef6a1753ba51a4016facee2f7a39L16-R18))
*  Create `setup.sh` script that checks and creates `sealos-system` namespace, applies `deploy.yaml` manifest, waits for custom resource definition, and applies `customconfig.yaml` manifest ([link](https://github.com/labring/sealos/pull/3622/files?diff=unified&w=0#diff-fd2ddaf136728bf2bf24b3716a75fd32a1f88322fa85fd77bca78ced8ac998b1L1-R23))
*  Reduce memory request for license issuer container from 128Mi to 64Mi in `deploy.yaml` manifest ([link](https://github.com/labring/sealos/pull/3622/files?diff=unified&w=0#diff-e6475dd00f737c5c8674f3c21e0b749a4e746654e80843382fef9c1c738cdca3L632-R632))
*  Add variable `saltKey` to `init.sh` script for sealos desktop service ([link](https://github.com/labring/sealos/pull/3622/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844R8))
*  Fix syntax error in `init.sh` script by adding backslash at the end of `sealos run` command for license issuer image ([link](https://github.com/labring/sealos/pull/3622/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844L56-R57))
*  Add function `gen_saltKey` to `init.sh` script that generates and encodes a random string for password salt ([link](https://github.com/labring/sealos/pull/3622/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844R83-R86))
*  Use `saltKey` variable instead of generating a new random string for password salt in desktop config file ([link](https://github.com/labring/sealos/pull/3622/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844L137-R146), [link](https://github.com/labring/sealos/pull/3622/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844R163-R165))
*  Call `gen_saltKey` function in `init.sh` script before installing desktop service ([link](https://github.com/labring/sealos/pull/3622/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844R163-R165))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
