### PR TITLE
feat: adapt changeable port.

### DIFF
--- a/controllers/terminal/controllers/terminal_controller.go
+++ b/controllers/terminal/controllers/terminal_controller.go
@@ -52,7 +52,8 @@ const (
 
 const (
 	DefaultDomain          = "cloud.sealos.io"
-	DefaultSecretName      = "wildcard-cloud-sealos-io-cert"
+	DefaultPort            = ""
+	DefaultSecretName      = "wildcard-cert"
 	DefaultSecretNamespace = "sealos-system"
 )
 
@@ -71,6 +72,7 @@ type TerminalReconciler struct {
 	recorder        record.EventRecorder
 	Config          *rest.Config
 	terminalDomain  string
+	terminalPort    string
 	secretName      string
 	secretNamespace string
 }
@@ -210,7 +212,7 @@ func (r *TerminalReconciler) syncApisixIngress(ctx context.Context, terminal *te
 		return err
 	}
 
-	domain := Protocol + host
+	domain := Protocol + host + r.terminalPort
 	if terminal.Status.Domain != domain {
 		terminal.Status.Domain = domain
 		return r.Status().Update(ctx, terminal)
@@ -237,7 +239,7 @@ func (r *TerminalReconciler) syncNginxIngress(ctx context.Context, terminal *ter
 		return err
 	}
 
-	domain := Protocol + host
+	domain := Protocol + host + r.terminalPort
 	if terminal.Status.Domain != domain {
 		terminal.Status.Domain = domain
 		return r.Status().Update(ctx, terminal)
@@ -447,6 +449,14 @@ func getDomain() string {
 	return domain
 }
 
+func getPort() string {
+	port := os.Getenv("PORT")
+	if port == "" {
+		return DefaultPort
+	}
+	return port
+}
+
 func getSecretName() string {
 	secretName := os.Getenv("SECRET_NAME")
 	if secretName == "" {
@@ -467,6 +477,7 @@ func getSecretNamespace() string {
 func (r *TerminalReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.recorder = mgr.GetEventRecorderFor("sealos-terminal-controller")
 	r.terminalDomain = getDomain()
+	r.terminalPort = getPort()
 	r.secretName = getSecretName()
 	r.secretNamespace = getSecretNamespace()
 	r.Config = mgr.GetConfig()

--- a/controllers/terminal/deploy/Kubefile
+++ b/controllers/terminal/deploy/Kubefile
@@ -7,6 +7,7 @@ COPY manifests manifests
 
 ENV userNamespace="user-system"
 ENV cloudDomain="127.0.0.1.nip.io"
+ENV port=""
 ENV wildcardCertSecretName="wildcard-cert"
 ENV wildcardCertSecretNamespace="sealos-system"
 

--- a/controllers/terminal/deploy/manifests/deploy.yaml.tmpl
+++ b/controllers/terminal/deploy/manifests/deploy.yaml.tmpl
@@ -443,6 +443,8 @@ spec:
           value: {{ .userNamespace }}
         - name: DOMAIN
           value: {{ .cloudDomain }}
+        - name: PORT
+          value: {{ .port }}
         - name: SECRET_NAME
           value: {{ .wildcardCertSecretName }}
         - name: SECRET_NAMESPACE


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1dc13a2</samp>

### Summary
🌐🛠️🚀

<!--
1.  🌐 - This emoji represents the environment variable and the port value, which are related to networking and domain configuration.
2.  🛠️ - This emoji represents the Kubefile and the deployment manifest, which are related to building and deploying the terminal controller.
3.  🚀 - This emoji represents the terminal controller itself, which is the main feature of the pull request and the application.
-->
The pull request adds support for customizing the port value for the terminal domain in the terminal controller. It introduces a new environment variable `PORT` and a new parameter `port` that can be used to configure the port in the `Kubefile` and the `deploy.yaml.tmpl` files.

> _To make the terminal controller more flexible_
> _The port value can now be selectable_
> _By setting `PORT` in the `Kubefile`_
> _Or the `deploy.yaml.tmpl` file_
> _The ingress sync will use the `port` variable_

### Walkthrough
*  Simplify the secret name and avoid hardcoding the domain name for the terminal certificate by changing the constant `DefaultSecretName` from `wildcard-cloud-sealos-io-cert` to `wildcard-cert` ([link](https://github.com/labring/sealos/pull/3626/files?diff=unified&w=0#diff-39f755c585164a06c548b8d890a2dc0b2da829d0d95b8709020dd2d343dece82L55-R56))
* Add the constant `DefaultPort` to store the default port value for the terminal domain ([link](https://github.com/labring/sealos/pull/3626/files?diff=unified&w=0#diff-39f755c585164a06c548b8d890a2dc0b2da829d0d95b8709020dd2d343dece82L55-R56))
* Add the field `terminalPort` to the `TerminalReconciler` struct to store the port value for the terminal domain ([link](https://github.com/labring/sealos/pull/3626/files?diff=unified&w=0#diff-39f755c585164a06c548b8d890a2dc0b2da829d0d95b8709020dd2d343dece82R75))
* Update the domain value for the terminal status to include the port value from the `terminalPort` field in the `syncApisixIngress` and `syncNginxIngress` functions, which synchronize the terminal ingress with the apisix and nginx ingress controllers respectively ([link](https://github.com/labring/sealos/pull/3626/files?diff=unified&w=0#diff-39f755c585164a06c548b8d890a2dc0b2da829d0d95b8709020dd2d343dece82L213-R215), [link](https://github.com/labring/sealos/pull/3626/files?diff=unified&w=0#diff-39f755c585164a06c548b8d890a2dc0b2da829d0d95b8709020dd2d343dece82L240-R242))
* Add the `getPort` function to the `controllers` package, which reads the port value from the environment variable `PORT` or returns the `DefaultPort` value if the variable is empty ([link](https://github.com/labring/sealos/pull/3626/files?diff=unified&w=0#diff-39f755c585164a06c548b8d890a2dc0b2da829d0d95b8709020dd2d343dece82R452-R459))
* Initialize the `terminalPort` field of the `TerminalReconciler` struct with the value returned by the `getPort` function in the `SetupWithManager` function, which sets up the controller manager for the terminal controller ([link](https://github.com/labring/sealos/pull/3626/files?diff=unified&w=0#diff-39f755c585164a06c548b8d890a2dc0b2da829d0d95b8709020dd2d343dece82R480))
* Add the environment variable `PORT` to the `Kubefile` file, which is used to build the docker image for the terminal controller, and set it to an empty string by default ([link](https://github.com/labring/sealos/pull/3626/files?diff=unified&w=0#diff-39fee567e1de0e2c1257e3c0147614b591930cf5dc5931e75ea25ce8d0779c5dR10))
* Add the environment variable `PORT` to the `deploy.yaml.tmpl` file, which is used to generate the deployment manifest for the terminal controller, and set it to the value of the `port` parameter, which can be customized by the user ([link](https://github.com/labring/sealos/pull/3626/files?diff=unified&w=0#diff-5f7ea67facfb5818c0b4c04cbe297b80cf1ab1ce9d79e2d7e1dc077963d026b9R446-R447))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
