### PR TITLE
fix ingress.

### DIFF
--- a/controllers/terminal/controllers/ingress.go
+++ b/controllers/terminal/controllers/ingress.go
@@ -33,7 +33,7 @@ const (
 )
 
 func (r *TerminalReconciler) createNginxIngress(terminal *terminalv1.Terminal, host string) *networkingv1.Ingress {
-	cors := fmt.Sprintf("https://%s,https://*.%s", r.terminalDomain, r.terminalDomain)
+	cors := fmt.Sprintf("https://%s,https://*.%s", r.terminalDomain+":"+r.terminalPort, r.terminalDomain+":"+r.terminalPort)
 
 	objectMeta := metav1.ObjectMeta{
 		Name:      terminal.Name,

--- a/controllers/terminal/controllers/terminal_controller.go
+++ b/controllers/terminal/controllers/terminal_controller.go
@@ -212,7 +212,7 @@ func (r *TerminalReconciler) syncApisixIngress(ctx context.Context, terminal *te
 		return err
 	}
 
-	domain := Protocol + host + r.terminalPort
+	domain := Protocol + host + ":" + r.terminalPort
 	if terminal.Status.Domain != domain {
 		terminal.Status.Domain = domain
 		return r.Status().Update(ctx, terminal)
@@ -239,7 +239,7 @@ func (r *TerminalReconciler) syncNginxIngress(ctx context.Context, terminal *ter
 		return err
 	}
 
-	domain := Protocol + host + r.terminalPort
+	domain := Protocol + host + ":" + r.terminalPort
 	if terminal.Status.Domain != domain {
 		terminal.Status.Domain = domain
 		return r.Status().Update(ctx, terminal)


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 18a9c42</samp>

### Summary
🌐🔧🚪

<!--
1.  🌐 - This emoji represents the web, networking, and cross-origin issues that are involved in this change. It also suggests the global scope of the terminal service, which can be accessed from anywhere on the internet.
2.  🔧 - This emoji represents the fix or adjustment that is made to the domain variable, by adding the missing colon. It also suggests the configuration or tooling aspect of the change, which involves editing the helm chart values.
3.  🚪 - This emoji represents the ingress or entry point that is affected by this change, which is the nginx ingress controller. It also suggests the security or access control aspect of the change, which involves setting the cors header.
-->
This pull request fixes the domain and cors variables for the terminal resource, which are used to access and secure the terminal web interface. It adds a colon and the terminal port to the domain in `terminal_controller.go`, and to the cors in `ingress.go`.

> _To allow cross-origin requests_
> _We must update the `cors` object_
> _And add the `terminal port`_
> _To the origins we support_
> _Or else the browser will reject_

### Walkthrough
*  Add terminal port to cors variable to allow cross-origin requests from terminal web interface ([link](https://github.com/labring/sealos/pull/3629/files?diff=unified&w=0#diff-65673d58ecf0453347e31602461ad302917dc6e7dced011b8168fb73624020baL36-R36))
*  Append terminal port to domain variable to form valid URLs for terminal status and ingress ([link](https://github.com/labring/sealos/pull/3629/files?diff=unified&w=0#diff-39f755c585164a06c548b8d890a2dc0b2da829d0d95b8709020dd2d343dece82L215-R215), [link](https://github.com/labring/sealos/pull/3629/files?diff=unified&w=0#diff-39f755c585164a06c548b8d890a2dc0b2da829d0d95b8709020dd2d343dece82L242-R242))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
