### PR TITLE
fix termianl port

### DIFF
--- a/controllers/terminal/controllers/ingress.go
+++ b/controllers/terminal/controllers/ingress.go
@@ -33,7 +33,7 @@ const (
 )
 
 func (r *TerminalReconciler) createNginxIngress(terminal *terminalv1.Terminal, host string) *networkingv1.Ingress {
-	cors := fmt.Sprintf("https://%s,https://*.%s", r.terminalDomain+":"+r.terminalPort, r.terminalDomain+":"+r.terminalPort)
+	cors := fmt.Sprintf("https://%s,https://*.%s", r.terminalDomain+r.getPort(), r.terminalDomain+r.getPort())
 
 	objectMeta := metav1.ObjectMeta{
 		Name:      terminal.Name,

--- a/controllers/terminal/controllers/ingress.go
+++ b/controllers/terminal/controllers/ingress.go
@@ -33,7 +33,7 @@ const (
 )
 
 func (r *TerminalReconciler) createNginxIngress(terminal *terminalv1.Terminal, host string) *networkingv1.Ingress {
-	cors := fmt.Sprintf("https://%s,https://*.%s", r.terminalDomain, r.terminalDomain)
+	cors := fmt.Sprintf("https://%s,https://*.%s", r.terminalDomain+":"+r.terminalPort, r.terminalDomain+":"+r.terminalPort)
 
 	objectMeta := metav1.ObjectMeta{
 		Name:      terminal.Name,

--- a/controllers/terminal/controllers/terminal_controller.go
+++ b/controllers/terminal/controllers/terminal_controller.go
@@ -212,7 +212,7 @@ func (r *TerminalReconciler) syncApisixIngress(ctx context.Context, terminal *te
 		return err
 	}
 
-	domain := Protocol + host + r.terminalPort
+	domain := Protocol + host + ":" + r.terminalPort
 	if terminal.Status.Domain != domain {
 		terminal.Status.Domain = domain
 		return r.Status().Update(ctx, terminal)
@@ -239,7 +239,7 @@ func (r *TerminalReconciler) syncNginxIngress(ctx context.Context, terminal *ter
 		return err
 	}
 
-	domain := Protocol + host + r.terminalPort
+	domain := Protocol + host + ":" + r.terminalPort
 	if terminal.Status.Domain != domain {
 		terminal.Status.Domain = domain
 		return r.Status().Update(ctx, terminal)

--- a/controllers/terminal/controllers/terminal_controller.go
+++ b/controllers/terminal/controllers/terminal_controller.go
@@ -212,7 +212,7 @@ func (r *TerminalReconciler) syncApisixIngress(ctx context.Context, terminal *te
 		return err
 	}
 
-	domain := Protocol + host + ":" + r.terminalPort
+	domain := Protocol + host + r.getPort()
 	if terminal.Status.Domain != domain {
 		terminal.Status.Domain = domain
 		return r.Status().Update(ctx, terminal)
@@ -239,7 +239,7 @@ func (r *TerminalReconciler) syncNginxIngress(ctx context.Context, terminal *ter
 		return err
 	}
 
-	domain := Protocol + host + ":" + r.terminalPort
+	domain := Protocol + host + r.getPort()
 	if terminal.Status.Domain != domain {
 		terminal.Status.Domain = domain
 		return r.Status().Update(ctx, terminal)
@@ -471,6 +471,13 @@ func getSecretNamespace() string {
 		return DefaultSecretNamespace
 	}
 	return secretNamespace
+}
+
+func (r *TerminalReconciler) getPort() string {
+	if r.terminalPort == "" {
+		return ""
+	}
+	return ":" + r.terminalPort
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at acbacef</samp>

### Summary
🛠️➕♻️

<!--
1.  🛠️ - This emoji represents a tool or a fix, and can be used to indicate that the `createNginxIngress` function was modified to fix a bug or improve its functionality.
2.  ➕ - This emoji represents adding something new, and can be used to indicate that a new `getPort` method was added to handle the port number logic for ingress functions.
3.  ♻️ - This emoji represents recycling or refactoring, and can be used to indicate that the `syncApisixIngress` and `syncNginxIngress` functions were refactored to use the new `getPort` method and avoid extra colons in the domain name.
-->
Refactored the port number logic for ingress functions in the terminal controller. Added a `getPort` method to `controllers/terminal/controllers/terminal_controller.go` and used it in `createNginxIngress` and `syncApisixIngress` to avoid extra colons in the domain name.

> _To create an ingress for nginx_
> _We used to append a suffix_
> _But now we use `getPort`_
> _To avoid extra colons_
> _And make the domain name more prefix_

### Walkthrough
*  Add a `getPort` method to the `TerminalReconciler` struct that returns a colon followed by the `terminalPort` value or an empty string if the value is empty ([link](https://github.com/labring/sealos/pull/3630/files?diff=unified&w=0#diff-39f755c585164a06c548b8d890a2dc0b2da829d0d95b8709020dd2d343dece82R476-R482))
*  Use the `getPort` method to simplify the logic of appending the port number to the domain name in the `createNginxIngress`, `syncApisixIngress`, and `syncNginxIngress` functions ([link](https://github.com/labring/sealos/pull/3630/files?diff=unified&w=0#diff-65673d58ecf0453347e31602461ad302917dc6e7dced011b8168fb73624020baL36-R36), [link](https://github.com/labring/sealos/pull/3630/files?diff=unified&w=0#diff-39f755c585164a06c548b8d890a2dc0b2da829d0d95b8709020dd2d343dece82L215-R215), [link](https://github.com/labring/sealos/pull/3630/files?diff=unified&w=0#diff-39f755c585164a06c548b8d890a2dc0b2da829d0d95b8709020dd2d343dece82L242-R242))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
