### PR TITLE
optimize docs: install latest sealos version

### DIFF
--- a/docs/4.0/docs/lifecycle-management/quick-start/installation.md
+++ b/docs/4.0/docs/lifecycle-management/quick-start/installation.md
@@ -7,11 +7,26 @@ import TabItem from '@theme/TabItem';
 
 # Installing Sealos
 
+You can get the list of versions by running:
+
+```bash
+curl --silent "https://api.github.com/repos/labring/sealos/releases" | jq -r '.[].tag_name'
+```
+
+Note: While choosing the version, it's recommended to use a stable version. The versions like `v4.3.0-rcx`, `v4.3.0-alpha1` are pre-releases, use them with caution.
+
+Set the 'VERSION' environment variable to the latest VERSION number, or replace 'version' with the Sealos version you want to install:
+
+```shell
+VERSION=`curl -s https://api.github.com/repos/labring/sealos/releases/latest | grep -oE '"tag_name": "[^"]+"' | head -n1 | cut -d'"' -f4`
+```
+
 ## Binary Auto Download
 
 ```bash
-$ curl -sfL  https://raw.githubusercontent.com/labring/sealos/v4.2.0/scripts/install.sh \
-    | sh -s v4.2.0 labring/sealos
+curl -sfL https://raw.githubusercontent.com/labring/sealos/${VERSION}/scripts/install.sh |
+  sh - ${VERSION} labring/sealos
+
 ```
 
 ## Binary Manual Download
@@ -20,16 +35,16 @@ $ curl -sfL  https://raw.githubusercontent.com/labring/sealos/v4.2.0/scripts/ins
   <TabItem value="amd64" label="amd64" default>
 
 ```bash
-$ wget https://github.com/labring/sealos/releases/download/v4.2.0/sealos_4.2.0_linux_amd64.tar.gz \
-   && tar zxvf sealos_4.2.0_linux_amd64.tar.gz sealos && chmod +x sealos && mv sealos /usr/bin
+$ wget https://github.com/labring/sealos/releases/download/${VERSION}/sealos_${VERSION#v}_linux_amd64.tar.gz \
+   && tar zxvf sealos_${VERSION#v}_linux_amd64.tar.gz sealos && chmod +x sealos && mv sealos /usr/bin
 ```
 
   </TabItem>
   <TabItem value="arm64" label="arm64">
 
 ```bash
-$ wget https://github.com/labring/sealos/releases/download/v4.2.0/sealos_4.2.0_linux_arm64.tar.gz \
-   && tar zxvf sealos_4.2.0_linux_arm64.tar.gz sealos && chmod +x sealos && mv sealos /usr/bin
+$ wget https://github.com/labring/sealos/releases/download/${VERSION}/sealos_${VERSION#v}_linux_arm64.tar.gz \
+   && tar zxvf sealos_${VERSION#v}_linux_arm64.tar.gz sealos && chmod +x sealos && mv sealos /usr/bin
 ```
 
   </TabItem>

--- a/docs/4.0/i18n/zh-Hans/lifecycle-management/quick-start/installation.md
+++ b/docs/4.0/i18n/zh-Hans/lifecycle-management/quick-start/installation.md
@@ -7,11 +7,26 @@ import TabItem from '@theme/TabItem';
 
 # 安装sealos
 
+你可以通过运行命令来获取版本列表:
+
+```shell
+curl --silent "https://api.github.com/repos/labring/sealos/releases" | jq -r '.[].tag_name'
+```
+
+> 注意:在选择版本时，建议使用稳定版本例如`v4.3.0`。像`v4.3.0-rc1`、`v4.3.0-alpha1`这样的版本是预发布版，请谨慎使用。
+
+设置`VERSION`环境变量为latest版本号，或者将`VERSION`替换为您要安装的Sealos版本:
+
+```shell
+VERSION=`curl -s https://api.github.com/repos/labring/sealos/releases/latest | grep -oE '"tag_name": "[^"]+"' | head -n1 | cut -d'"' -f4`
+```
+
 ## 二进制自动下载
 
 ```bash
-$ curl -sfL  https://raw.githubusercontent.com/labring/sealos/v4.2.0/scripts/install.sh \
-    | sh -s v4.2.0 labring/sealos
+curl -sfL https://raw.githubusercontent.com/labring/sealos/${VERSION}/scripts/install.sh |
+  sh - ${VERSION} labring/sealos
+
 ```
 
 ## 二进制手动下载
@@ -20,16 +35,16 @@ $ curl -sfL  https://raw.githubusercontent.com/labring/sealos/v4.2.0/scripts/ins
   <TabItem value="amd64" label="amd64" default>
 
 ```bash
-$ wget https://github.com/labring/sealos/releases/download/v4.2.0/sealos_4.2.0_linux_amd64.tar.gz \
-   && tar zxvf sealos_4.2.0_linux_amd64.tar.gz sealos && chmod +x sealos && mv sealos /usr/bin
+$ wget https://github.com/labring/sealos/releases/download/${VERSION}/sealos_${VERSION#v}_linux_amd64.tar.gz \
+   && tar zxvf sealos_${VERSION#v}_linux_amd64.tar.gz sealos && chmod +x sealos && mv sealos /usr/bin
 ```
 
   </TabItem>
   <TabItem value="arm64" label="arm64">
 
 ```bash
-$ wget https://github.com/labring/sealos/releases/download/v4.2.0/sealos_4.2.0_linux_arm64.tar.gz \
-   && tar zxvf sealos_4.2.0_linux_arm64.tar.gz sealos && chmod +x sealos && mv sealos /usr/bin
+$ wget https://github.com/labring/sealos/releases/download/${VERSION}/sealos_${VERSION#v}_linux_arm64.tar.gz \
+   && tar zxvf sealos_${VERSION#v}_linux_arm64.tar.gz sealos && chmod +x sealos && mv sealos /usr/bin
 ```
 
   </TabItem>

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -100,6 +100,10 @@ verify_downloader() {
 
 get_release_version() {
     VERSION=$1
+    # If the incoming version number is latest, get the latest version number from github
+    if [ "$VERSION" = "latest" ]; then
+        VERSION=$(curl -s https://api.github.com/repos/${OWN_REPO}/releases/latest | grep tag_name | cut -d '"' -f 4)
+    fi
     info "Using ${VERSION} as release"
     OWN_REPO=$2
     if [ -z "$OWN_REPO" ]; then


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8934360</samp>

### Summary
:sparkles::memo::globe_with_meridians:

<!--
1.  :sparkles: This emoji represents the new feature of using `latest` as a version number for Sealos installation. It conveys the idea of something shiny, exciting, and useful.
2.  :memo: This emoji represents the documentation update for the installation instructions. It conveys the idea of writing, editing, and informing the users.
3.  :globe_with_meridians: This emoji represents the localization update for the Chinese documentation. It conveys the idea of global, multilingual, and inclusive communication.
-->
This pull request introduces a new way of installing Sealos using an environment variable `VERSION` that can be set to a specific version number or `latest`. It updates the documentation in English and Chinese to reflect this change and modifies the `install.sh` script to handle the `latest` keyword.

> _`install.sh` changes_
> _`VERSION` lets you choose or_
> _get the latest one_

### Walkthrough
*  Add instructions on how to get and set the desired version of Sealos for installation ([link](https://github.com/labring/sealos/pull/3638/files?diff=unified&w=0#diff-f44082587c1c607f27a95bc328916e886023a9fedf54c404bd651ed45a28e510L10-R29), [link](https://github.com/labring/sealos/pull/3638/files?diff=unified&w=0#diff-13b6a10b6eb1b7cce0f3e97ef37e7e3934fbb2e27bab831d406d468678c93d4fL10-R29))
*  Replace hard-coded version numbers with the `VERSION` environment variable in the wget commands for downloading the binary for Linux amd64 and arm64 ([link](https://github.com/labring/sealos/pull/3638/files?diff=unified&w=0#diff-f44082587c1c607f27a95bc328916e886023a9fedf54c404bd651ed45a28e510L23-R39), [link](https://github.com/labring/sealos/pull/3638/files?diff=unified&w=0#diff-f44082587c1c607f27a95bc328916e886023a9fedf54c404bd651ed45a28e510L31-R47), [link](https://github.com/labring/sealos/pull/3638/files?diff=unified&w=0#diff-13b6a10b6eb1b7cce0f3e97ef37e7e3934fbb2e27bab831d406d468678c93d4fL23-R39), [link](https://github.com/labring/sealos/pull/3638/files?diff=unified&w=0#diff-13b6a10b6eb1b7cce0f3e97ef37e7e3934fbb2e27bab831d406d468678c93d4fL31-R47))
*  Modify the `install.sh` script to handle the `latest` keyword as a shortcut for installing the latest version of Sealos by fetching the version number from the GitHub API ([link](https://github.com/labring/sealos/pull/3638/files?diff=unified&w=0#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09ccR103-R106))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
