### PR TITLE
fix: install latest sealos docs.

### DIFF
--- a/docs/4.0/docs/lifecycle-management/lifecycle-management.md
+++ b/docs/4.0/docs/lifecycle-management/lifecycle-management.md
@@ -33,8 +33,8 @@ Sealos offers features like cluster scaling, backup and recovery, and cluster re
 Running a Kubernetes cluster with Sealos is straightforward. Just follow these steps:
 
 ```bash
-$ curl -sfL  https://raw.githubusercontent.com/labring/sealos/v4.2.0/scripts/install.sh \
-    | sh -s v4.2.0 labring/sealos
+$ curl -sfL  https://raw.githubusercontent.com/labring/sealos/v4.3.0/scripts/install.sh \
+    | sh -s v4.3.0 labring/sealos
 # Create a cluster
 $ sealos run labring/kubernetes:v1.25.0-4.2.0 labring/helm:v3.8.2 labring/calico:v3.24.1 \
      --masters 192.168.64.2,192.168.64.22,192.168.64.20 \

--- a/docs/4.0/docs/lifecycle-management/quick-start/installation.md
+++ b/docs/4.0/docs/lifecycle-management/quick-start/installation.md
@@ -25,7 +25,7 @@ VERSION=`curl -s https://api.github.com/repos/labring/sealos/releases/latest | g
 
 ```bash
 curl -sfL https://raw.githubusercontent.com/labring/sealos/${VERSION}/scripts/install.sh |
-  sh - ${VERSION} labring/sealos
+  sh -s ${VERSION} labring/sealos
 
 ```
 

--- a/docs/4.0/i18n/zh-Hans/lifecycle-management/lifecycle-management.md
+++ b/docs/4.0/i18n/zh-Hans/lifecycle-management/lifecycle-management.md
@@ -33,8 +33,8 @@ Sealos 具有自由伸缩集群、备份恢复、释放集群等功能，即使�
 使用 Sealos 运行一个 Kubernetes 集群非常简单，只需以下步骤：
 
 ```bash
-$ curl -sfL  https://raw.githubusercontent.com/labring/sealos/v4.2.0/scripts/install.sh \
-    | sh -s v4.2.0 labring/sealos
+$ curl -sfL  https://raw.githubusercontent.com/labring/sealos/v4.3.0/scripts/install.sh \
+    | sh -s v4.3.0 labring/sealos
 # 创建一个集群
 $ sealos run labring/kubernetes:v1.25.0-4.2.0 labring/helm:v3.8.2 labring/calico:v3.24.1 \
      --masters 192.168.64.2,192.168.64.22,192.168.64.20 \

--- a/docs/4.0/i18n/zh-Hans/lifecycle-management/quick-start/installation.md
+++ b/docs/4.0/i18n/zh-Hans/lifecycle-management/quick-start/installation.md
@@ -25,7 +25,7 @@ VERSION=`curl -s https://api.github.com/repos/labring/sealos/releases/latest | g
 
 ```bash
 curl -sfL https://raw.githubusercontent.com/labring/sealos/${VERSION}/scripts/install.sh |
-  sh - ${VERSION} labring/sealos
+  sh -s ${VERSION} labring/sealos
 
 ```
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b6356db</samp>

### Summary
:arrow_up::bug::globe_with_meridians:

<!--
1.  :arrow_up: This emoji indicates an upgrade or improvement of something, such as a tool or a feature. In this case, it represents the update of the sealos installation script URL and version from v4.2.0 to v4.3.0, which is an upgrade of the tool and its functionality.
2. :bug: This emoji indicates a bug fix or a correction of something that was not working properly. In this case, it represents the addition of the `-s` option to the `sh` command, which fixes a typo that would cause the installation script to fail without it.
3. :globe_with_meridians: This emoji indicates a change related to internationalization or localization, such as a translation or a cultural adaptation. In this case, it represents the changes made to the Chinese documentation of running a Kubernetes cluster with sealos and binary auto download, which are localization changes for the Chinese audience.
-->
This pull request updates the sealos installation script URL and version to v4.3.0 and fixes a typo in the `sh` command in both the English and Chinese documentation of lifecycle management and quick start. These changes improve the accuracy and usability of the documentation.

> _`sealos` updated_
> _English and Chinese docs synced_
> _autumn of fixes_

### Walkthrough
*  Update sealos installation script URL and version from v4.2.0 to v4.3.0 in both English and Chinese documentation of running a Kubernetes cluster with sealos ([link](https://github.com/labring/sealos/pull/3646/files?diff=unified&w=0#diff-256a9289adc79e3fd9f2ce0e0843d5903e26293286c1205aef05a57508ece263L36-R37), [link](https://github.com/labring/sealos/pull/3646/files?diff=unified&w=0#diff-d26d8e35aa961265f883fd4cd34325a09c1a8131392f3d3a9942e1f800dda848L36-R37))
*  Add `-s` option to `sh` command in both English and Chinese documentation of binary auto download to fix a typo that would cause the installation script to fail ([link](https://github.com/labring/sealos/pull/3646/files?diff=unified&w=0#diff-f44082587c1c607f27a95bc328916e886023a9fedf54c404bd651ed45a28e510L28-R28), [link](https://github.com/labring/sealos/pull/3646/files?diff=unified&w=0#diff-13b6a10b6eb1b7cce0f3e97ef37e7e3934fbb2e27bab831d406d468678c93d4fL28-R28))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
