### PR TITLE
fix(main): fix: skip pulling app image

### DIFF
--- a/pkg/apply/processor/interface.go
+++ b/pkg/apply/processor/interface.go
@@ -191,7 +191,7 @@ func MountClusterImages(bdah buildah.Interface, cluster *v2.Cluster, skipApp boo
 				hasRootfsType = true
 			}
 		}
-		if imageType != "" && imageType != string(v2.RootfsImage) && imageType != string(v2.PatchImage) && skipApp {
+		if (imageType == "" || imageType == string(v2.AppImage)) && skipApp {
 			// then it's an application type image
 			continue
 		}

--- a/pkg/apply/processor/scale.go
+++ b/pkg/apply/processor/scale.go
@@ -162,11 +162,11 @@ func (c *ScaleProcessor) preProcess(cluster *v2.Cluster) error {
 	if err != nil {
 		return err
 	}
-	// cluster status might be overwrite by inappropriate usage, add mounts if loss.
-	if err = MountClusterImages(c.Buildah, cluster, true); err != nil {
-		return err
-	}
 	if c.IsScaleUp {
+		// cluster status might be overwrite by inappropriate usage, add mounts if loss.
+		if err = MountClusterImages(c.Buildah, cluster, true); err != nil {
+			return err
+		}
 		if cluster.GetRootfsImage().KubeVersion() == "" {
 			return fmt.Errorf("rootfs image not found kube version")
 		}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 32e6961</samp>

### Summary
:recycle::zap::mountain:

<!--
1.  :recycle: - This emoji represents the simplification and refactoring of the logic in the `MountClusterImages` function.
2.  :zap: - This emoji represents the improvement of the performance and efficiency of the `preProcess` function by moving the call to `MountClusterImages` inside the `if c.IsScaleUp` block.
3.  :mountain: - This emoji represents the mount operation that is performed by the `MountClusterImages` function.
-->
This pull request improves the logic and performance of the `MountClusterImages` function in the `pkg/apply/processor` package. It simplifies the image type check in `interface.go` and avoids unnecessary mount operations in `scale.go`.

> _`MountClusterImages`_
> _Only when scaling up cluster -_
> _Winter pruning_

### Walkthrough
*  Simplify the logic of checking the image type in `MountClusterImages` ([link](https://github.com/labring/sealos/pull/3649/files?diff=unified&w=0#diff-e15477f77cdbc75f95e348325d3bddf96c09883af9db451ef2adf8b60694bd30L194-R194))
*  Move the call to `MountClusterImages` inside the scale-up block in `preProcess` to avoid unnecessary mount operations ([link](https://github.com/labring/sealos/pull/3649/files?diff=unified&w=0#diff-d48ba8412842b9224105abdc78efc6af4031a5e68498f66ace1f9de18d3ec438L165-R169))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
