### PR TITLE
refactor(main): ssh interface instance func

### DIFF
--- a/pkg/apply/processor/interface.go
+++ b/pkg/apply/processor/interface.go
@@ -152,7 +152,7 @@ func ConfirmDeleteNodes() error {
 func MirrorRegistry(cluster *v2.Cluster, mounts []v2.MountImage) error {
 	registries := cluster.GetRegistryIPAndPortList()
 	logger.Debug("registry nodes is: %+v", registries)
-	sshClient := ssh.NewSSHClient(&cluster.Spec.SSH, true)
+	sshClient := ssh.NewSSHByCluster(cluster, true)
 	syncer := registry.New(constants.NewData(cluster.GetName()), sshClient, mounts)
 	return syncer.Sync(context.Background(), registries...)
 }

--- a/pkg/apply/reset.go
+++ b/pkg/apply/reset.go
@@ -77,9 +77,7 @@ func (r *ClusterArgs) resetArgs(args *ResetArgs) error {
 		nodes := stringsutil.SplitRemoveEmpty(args.Cluster.Nodes, ",")
 		r.hosts = []v2.Host{}
 
-		clusterSSH := r.cluster.GetSSH()
-		sshClient := ssh.NewSSHClient(&clusterSSH, true)
-
+		sshClient := ssh.NewSSHByCluster(r.cluster, true)
 		r.setHostWithIpsPort(masters, []string{v2.MASTER, GetHostArch(sshClient, masters[0])})
 		if len(nodes) > 0 {
 			r.setHostWithIpsPort(nodes, []string{v2.NODE, GetHostArch(sshClient, nodes[0])})

--- a/pkg/apply/run.go
+++ b/pkg/apply/run.go
@@ -121,8 +121,7 @@ func (r *ClusterArgs) runArgs(imageList []string, args *RunArgs) error {
 	nodes := stringsutil.SplitRemoveEmpty(args.Cluster.Nodes, ",")
 	r.hosts = []v2.Host{}
 
-	clusterSSH := r.cluster.GetSSH()
-	sshClient := ssh.NewSSHClient(&clusterSSH, true)
+	sshClient := ssh.NewSSHByCluster(r.cluster, true)
 	if len(masters) > 0 {
 		host, port := iputils.GetHostIPAndPortOrDefault(masters[0], defaultPort)
 		master0addr := net.JoinHostPort(host, port)

--- a/pkg/bootstrap/context.go
+++ b/pkg/bootstrap/context.go
@@ -59,7 +59,7 @@ func (ctx realContext) GetRemoter() remote.Interface {
 }
 
 func NewContextFrom(cluster *v2.Cluster) Context {
-	execer, _ := ssh.NewSSHByCluster(cluster, true)
+	execer := ssh.NewSSHByCluster(cluster, true)
 	envProcessor := env.NewEnvProcessor(cluster, cluster.Status.Mounts)
 	remoter := remote.New(cluster.GetName(), execer)
 	return &realContext{

--- a/pkg/checker/crictl_checker.go
+++ b/pkg/checker/crictl_checker.go
@@ -104,12 +104,7 @@ func (n *CRICtlChecker) Check(cluster *v2.Cluster, phase string) error {
 			pauseImage = mountImg.Env["sandboxImage"]
 		}
 	}
-	sshCtx, err := ssh.NewSSHByCluster(cluster, false)
-	if err != nil {
-		status.Error = fmt.Errorf("get ssh interface error: %w", err).Error()
-		return nil
-	}
-
+	sshCtx := ssh.NewSSHByCluster(cluster, false)
 	root := constants.NewData(cluster.Name).RootFSPath()
 	regInfo := helpers.GetRegistryInfo(sshCtx, root, cluster.GetRegistryIPAndPort())
 

--- a/pkg/checker/host_checker.go
+++ b/pkg/checker/host_checker.go
@@ -40,10 +40,7 @@ func (a HostChecker) Check(cluster *v2.Cluster, _ string) error {
 	if len(a.IPs) != 0 {
 		ipList = a.IPs
 	}
-	sshClient, err := ssh.NewSSHByCluster(cluster, false)
-	if err != nil {
-		return fmt.Errorf("checker: failed to create ssh client, %v", err)
-	}
+	sshClient := ssh.NewSSHByCluster(cluster, false)
 	if err := checkHostnameUnique(sshClient, ipList); err != nil {
 		return err
 	}

--- a/pkg/checker/registry_checker.go
+++ b/pkg/checker/registry_checker.go
@@ -87,11 +87,7 @@ func (n *RegistryChecker) Check(cluster *v2.Cluster, phase string) error {
 		}
 	}
 
-	sshCtx, err := ssh.NewSSHByCluster(cluster, false)
-	if err != nil {
-		status.Error = fmt.Errorf("get ssh interface error: %w", err).Error()
-		return nil
-	}
+	sshCtx := ssh.NewSSHByCluster(cluster, false)
 	root := constants.NewData(cluster.Name).RootFSPath()
 	regInfo := helpers.GetRegistryInfo(sshCtx, root, cluster.GetRegistryIPAndPort())
 	status.Auth = fmt.Sprintf("%s:%s", regInfo.Username, regInfo.Password)
@@ -100,7 +96,7 @@ func (n *RegistryChecker) Check(cluster *v2.Cluster, phase string) error {
 		Username: regInfo.Username,
 		Password: regInfo.Password,
 	}
-	_, err = crane.NewRegistry(status.RegistryDomain, cfg)
+	_, err := crane.NewRegistry(status.RegistryDomain, cfg)
 	if err != nil {
 		status.Error = fmt.Errorf("get registry interface error: %w", err).Error()
 		return nil

--- a/pkg/filesystem/rootfs/rootfs_default.go
+++ b/pkg/filesystem/rootfs/rootfs_default.go
@@ -51,8 +51,7 @@ func (f *defaultRootfs) getClusterName(cluster *v2.Cluster) string {
 }
 
 func (f *defaultRootfs) getSSH(cluster *v2.Cluster) ssh.Interface {
-	sshClient, _ := ssh.NewSSHByCluster(cluster, true)
-	return sshClient
+	return ssh.NewSSHByCluster(cluster, true)
 }
 
 func (f *defaultRootfs) mountRootfs(cluster *v2.Cluster, ipList []string) error {

--- a/pkg/guest/guest.go
+++ b/pkg/guest/guest.go
@@ -63,7 +63,7 @@ func (d *Default) Apply(cluster *v2.Cluster, mounts []v2.MountImage) error {
 			_ = fileutil.CleanFiles(kubeConfig)
 		}()
 	}
-	sshInterface := ssh.NewSSHClient(&cluster.Spec.SSH, true)
+	sshInterface := ssh.NewSSHByCluster(cluster, true)
 	for _, cmd := range guestCMD {
 		logger.Debug("exec guest command: %s", cmd)
 		if err := sshInterface.CmdAsync(cluster.GetMaster0IPAndPort(), envInterface.WrapperShell(cluster.GetMaster0IP(), cmd)); err != nil {

--- a/pkg/registry/password/apply.go
+++ b/pkg/registry/password/apply.go
@@ -132,7 +132,7 @@ func (r *RegistryPasswdResults) Validate() (*v1beta1.Cluster, error) {
 
 func (r *RegistryPasswdResults) Apply(cluster *v1beta1.Cluster) error {
 	if r.execer == nil {
-		r.execer = ssh.NewSSHClient(&cluster.Spec.SSH, true)
+		r.execer = ssh.NewSSHByCluster(cluster, true)
 	}
 	if r.upgrade == nil {
 		r.upgrade = NewUpgrade(cluster.Name, r.execer)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -126,7 +126,7 @@ func (k *KubeadmRuntime) DeleteMasters(mastersIPList []string) error {
 }
 
 func newKubeadmRuntime(cluster *v2.Cluster, kubeadm *KubeadmConfig) (Interface, error) {
-	sshClient, _ := ssh.NewSSHByCluster(cluster, true)
+	sshClient := ssh.NewSSHByCluster(cluster, true)
 	k := &KubeadmRuntime{
 		Mutex:         &sync.Mutex{},
 		Cluster:       cluster,

--- a/pkg/ssh/exec.go
+++ b/pkg/ssh/exec.go
@@ -54,7 +54,7 @@ func NewExecCmdFromIPs(cluster *v2.Cluster, ips []string) (Exec, error) {
 }
 
 func (e *Exec) RunCmd(cmd string) error {
-	sshClient := NewSSHClient(&e.cluster.Spec.SSH, true)
+	sshClient := NewSSHByCluster(e.cluster, true)
 	eg, _ := errgroup.WithContext(context.Background())
 	for _, ipAddr := range e.ipList {
 		ip := ipAddr
@@ -69,7 +69,7 @@ func (e *Exec) RunCmd(cmd string) error {
 }
 
 func (e *Exec) RunCopy(srcFilePath, dstFilePath string) error {
-	sshClient := NewSSHClient(&e.cluster.Spec.SSH, true)
+	sshClient := NewSSHByCluster(e.cluster, true)
 	eg, _ := errgroup.WithContext(context.Background())
 	for _, ipAddr := range e.ipList {
 		ip := ipAddr

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -168,15 +168,14 @@ func NewSSHClient(ssh *v2.SSH, isStdout bool) Interface {
 	return client
 }
 
-func NewSSHByCluster(cluster *v2.Cluster, isStdout bool) (Interface, error) {
+func NewSSHByCluster(cluster *v2.Cluster, isStdout bool) Interface {
 	cc := &clusterClient{
 		cluster:  cluster,
 		isStdout: isStdout,
 		configs:  make(map[string]*Option),
 		cache:    make(map[*Option]Interface),
 	}
-
-	return cc, nil
+	return cc
 }
 
 func WaitSSHReady(client Interface, _ int, hosts ...string) error {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8196f2b</samp>

### Summary
🔧🚀🐛

<!--
1.  🔧 - This emoji represents the refactoring and simplification of the code that uses the SSH client constructor.
2.  🚀 - This emoji represents the improvement of the performance and reliability of the SSH client creation based on cluster information.
3.  🐛 - This emoji represents the fixing of the variable shadowing issue in the crictl checker and the registry checker.
-->
Refactored the code to use a new function `NewSSHByCluster` that creates SSH clients based on cluster configuration. This simplifies the code and avoids duplication and unnecessary error handling. Fixed a variable shadowing issue in `pkg/checker/registry_checker.go`.

> _Sing, O Muse, of the valiant code review_
> _That refactored the `NewSSHClient` function_
> _And made it easier to create and use_
> _The swift and secure `NewSSHByCluster`._

### Walkthrough
*  Refactor the creation of SSH clients based on cluster information by using the `NewSSHByCluster` function instead of the `NewSSHClient` function in various functions across different files. This simplifies the code and avoids unnecessary error handling. ([link](https://github.com/labring/sealos/pull/3654/files?diff=unified&w=0#diff-e15477f77cdbc75f95e348325d3bddf96c09883af9db451ef2adf8b60694bd30L155-R155), [link](https://github.com/labring/sealos/pull/3654/files?diff=unified&w=0#diff-84e733345e24518c9f9777e5718a2c35fccef632dc06a9bdc2a25bb1dea47e08L80-R80), [link](https://github.com/labring/sealos/pull/3654/files?diff=unified&w=0#diff-40da3b5e11ca4827ad6fb34ce791710b02c305a8ae225305ab7fe1b6829aa444L124-R124), [link](https://github.com/labring/sealos/pull/3654/files?diff=unified&w=0#diff-c75becd8cca5a4edfbf87ea6c11f53792c2af3682279735a5b6368a224100d81L62-R62), [link](https://github.com/labring/sealos/pull/3654/files?diff=unified&w=0#diff-aa2fe32663dae9770dced36551fdc4a671dd56d4abeca198210ba8d1bf4f4ca4L107-R107), [link](https://github.com/labring/sealos/pull/3654/files?diff=unified&w=0#diff-c7a1923fa9549481cfe331bfdf14fb1367056d355db7d9c1a0501bf9e7e83db3L43-R43), [link](https://github.com/labring/sealos/pull/3654/files?diff=unified&w=0#diff-5c7fcb5d5095b8e5f7611ba601ff143825e1d615a0c32e73ecaea161d0007278L90-R90), [link](https://github.com/labring/sealos/pull/3654/files?diff=unified&w=0#diff-61493411683095682b775e1da8c4c1cca669f6a7807f480f6d747d4fb153fbe8L54-R54), [link](https://github.com/labring/sealos/pull/3654/files?diff=unified&w=0#diff-2fff8ad69185df503a777c91856e8cf472e5a5d16905d4a3a2e544873e889c46L66-R66), [link](https://github.com/labring/sealos/pull/3654/files?diff=unified&w=0#diff-a359b5dc4fd98c18922db1e0ffd551ae0021d9f6a51b220e7b36d345c40b3b94L135-R135), [link](https://github.com/labring/sealos/pull/3654/files?diff=unified&w=0#diff-e56f9bb947923c6f8bb4c995bf4b9469a0ed117276223d16b177dcb04399a4bcL129-R129), [link](https://github.com/labring/sealos/pull/3654/files?diff=unified&w=0#diff-3c4a25764d0e3b056d53aed2dda2ac0229827b5127d7b09e89fd912e19b16614L57-R57), [link](https://github.com/labring/sealos/pull/3654/files?diff=unified&w=0#diff-3c4a25764d0e3b056d53aed2dda2ac0229827b5127d7b09e89fd912e19b16614L72-R72))
* Update the `NewSSHByCluster` function in `pkg/ssh/ssh.go` to return an `Interface` instead of an `Interface` and an `error`, and remove the redundant return statement. This makes the function signature more consistent with the `NewSSHClient` function and the `Interface` interface. ([link](https://github.com/labring/sealos/pull/3654/files?diff=unified&w=0#diff-3303f911d20ef483b36a10b77c70879ce69969b77ef249e4c407fc49f5e9ff69L171-R171), [link](https://github.com/labring/sealos/pull/3654/files?diff=unified&w=0#diff-3303f911d20ef483b36a10b77c70879ce69969b77ef249e4c407fc49f5e9ff69L178-R178))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
