### PR TITLE
docs: fix sealos gen Clusterfile

### DIFF
--- a/docs/4.0/docs/lifecycle-management/operations/run-cluster/gen-apply-cluster.md
+++ b/docs/4.0/docs/lifecycle-management/operations/run-cluster/gen-apply-cluster.md
@@ -43,6 +43,7 @@ spec:
     - amd64
   image:
   - labring/kubernetes:v1.24.0
+  - labring/helm:v3.8.2
   - labring/calico:v3.24.1
   ssh:
     passwd: xxx

--- a/docs/4.0/i18n/zh-Hans/lifecycle-management/operations/run-cluster/gen-apply-cluster.md
+++ b/docs/4.0/i18n/zh-Hans/lifecycle-management/operations/run-cluster/gen-apply-cluster.md
@@ -43,6 +43,7 @@ spec:
     - amd64
   image:
   - labring/kubernetes:v1.24.0
+  - labring/helm:v3.8.2
   - labring/calico:v3.24.1
   ssh:
     passwd: xxx


### PR DESCRIPTION
`sealos gen labring/kubernetes:v1.25.0 labring/helm:v3.8.2 labring/calico:v3.24.1`
generated Clusterfile should be include labring/helm:v3.8.2