### PR TITLE
Increase adminer proxy-body size.

### DIFF
--- a/controllers/terminal/controllers/ingress.go
+++ b/controllers/terminal/controllers/ingress.go
@@ -43,6 +43,8 @@ func (r *TerminalReconciler) createNginxIngress(terminal *terminalv1.Terminal, h
 			"nginx.ingress.kubernetes.io/rewrite-target":         "/",
 			"nginx.ingress.kubernetes.io/proxy-send-timeout":     "86400",
 			"nginx.ingress.kubernetes.io/proxy-read-timeout":     "86400",
+			"nginx.ingress.kubernetes.io/proxy-body-size":        "256m",
+			"nginx.ingress.kubernetes.io/proxy-buffer-size":      "64k",
 			"nginx.ingress.kubernetes.io/enable-cors":            "true",
 			"nginx.ingress.kubernetes.io/cors-allow-origin":      cors,
 			"nginx.ingress.kubernetes.io/cors-allow-methods":     "PUT, GET, POST, PATCH, OPTIONS",


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b1f4371</samp>

### Summary
:arrow_up::file_folder::wrench:

<!--
1.  :arrow_up: This emoji can be used to indicate that the change increases some limits or values.
2.  :file_folder: This emoji can be used to represent files or data that are uploaded or transferred through the ingress.
3.  :wrench: This emoji can be used to signify that the change is a configuration or adjustment of the ingress settings.
-->
Increase nginx ingress limits for large file uploads. Add annotations to `ingress.go` to configure the `proxy-body-size` and `proxy-buffer-size` parameters for the nginx ingress controller deployment.

> _`nginx` ingress grows_
> _Large files can pass through now_
> _Autumn of errors_

### Walkthrough
* Increase the limits for uploading large files through the nginx ingress controller by adding two annotations to the deployment ([link](https://github.com/labring/sealos/pull/3663/files?diff=unified&w=0#diff-65673d58ecf0453347e31602461ad302917dc6e7dced011b8168fb73624020baR46-R47))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
