### PR TITLE
Fix adminer&terminal.

### DIFF
--- a/controllers/db/adminer/controllers/ingress.go
+++ b/controllers/db/adminer/controllers/ingress.go
@@ -48,6 +48,8 @@ func (r *AdminerReconciler) createNginxIngress(adminer *adminerv1.Adminer, host 
 			"nginx.ingress.kubernetes.io/rewrite-target":         "/",
 			"nginx.ingress.kubernetes.io/proxy-send-timeout":     "86400",
 			"nginx.ingress.kubernetes.io/proxy-read-timeout":     "86400",
+			"nginx.ingress.kubernetes.io/proxy-body-size":        "256m",
+			"nginx.ingress.kubernetes.io/proxy-buffer-size":      "64k",
 			"nginx.ingress.kubernetes.io/enable-cors":            "true",
 			"nginx.ingress.kubernetes.io/cors-allow-origin":      cors,
 			"nginx.ingress.kubernetes.io/cors-allow-methods":     "PUT, GET, POST, PATCH, OPTIONS",

--- a/controllers/terminal/controllers/ingress.go
+++ b/controllers/terminal/controllers/ingress.go
@@ -43,7 +43,7 @@ func (r *TerminalReconciler) createNginxIngress(terminal *terminalv1.Terminal, h
 			"nginx.ingress.kubernetes.io/rewrite-target":         "/",
 			"nginx.ingress.kubernetes.io/proxy-send-timeout":     "86400",
 			"nginx.ingress.kubernetes.io/proxy-read-timeout":     "86400",
-			"nginx.ingress.kubernetes.io/proxy-body-size":        "256m",
+			"nginx.ingress.kubernetes.io/proxy-body-size":        "32m",
 			"nginx.ingress.kubernetes.io/proxy-buffer-size":      "64k",
 			"nginx.ingress.kubernetes.io/enable-cors":            "true",
 			"nginx.ingress.kubernetes.io/cors-allow-origin":      cors,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 77b21ce</samp>

### Summary
📄🐚🛡️

<!--
1.  📄 - This emoji can represent the files that are uploaded or downloaded through the adminer service, and the need to increase the request body size and buffer size for this service.
2.  🐚 - This emoji can represent the shell access that is provided by the terminal service, and the need to decrease the request body size for this service to prevent memory issues or attacks.
3.  🛡️ - This emoji can represent the security and protection aspect of the nginx ingress controller, which acts as a reverse proxy and load balancer for the services in the cluster.
-->
This pull request adjusts the nginx ingress controller annotations for the adminer and terminal services. The changes allow larger file transfers for the adminer service, which is a database management tool, and limit the request body size for the terminal service, which is a web-based shell access.

> _`nginx` adjusts size_
> _proxying requests for pods_
> _autumn leaves fall fast_

### Walkthrough
*  Increase the request body size and buffer size for the adminer service to enable larger file uploads and downloads ([link](https://github.com/labring/sealos/pull/3664/files?diff=unified&w=0#diff-44dc187f58de7720191eb28da48ab842d8edd63fe0779a4a146db0dfc103d8d3R51-R52))
*  Decrease the request body size for the terminal service to prevent memory issues or denial of service attacks ([link](https://github.com/labring/sealos/pull/3664/files?diff=unified&w=0#diff-65673d58ecf0453347e31602461ad302917dc6e7dced011b8168fb73624020baL46-R46))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
