### PR TITLE
fix skip not Running pod

### DIFF
--- a/controllers/resources/controllers/monitor_controller.go
+++ b/controllers/resources/controllers/monitor_controller.go
@@ -293,9 +293,9 @@ func (r *MonitorReconciler) podResourceUsage(ctx context.Context, dbClient datab
 	}
 	for _, pod := range podList.Items {
 		// TODO pending status need skip?
-		//if pod.Status.Phase != corev1.PodRunning /*&& pod.Status.Phase != corev1.PodPending*/ {
-		//	continue
-		//}
+		if pod.Status.Phase != corev1.PodRunning /*&& pod.Status.Phase != corev1.PodPending*/ {
+			continue
+		}
 		for _, container := range pod.Spec.Containers {
 			if cpuRequest, ok := container.Resources.Limits[corev1.ResourceCPU]; ok {
 				rs[corev1.ResourceCPU].Add(cpuRequest)


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 11b7484</samp>

### Summary
🐛📊🚀

<!--
1.  🐛 - This emoji represents a bug fix, as the change is intended to resolve an issue of inaccurate metrics that could affect the performance and reliability of the cluster.
2.  📊 - This emoji represents data or statistics, as the change is related to the collection and exposure of resource usage metrics, which are a form of data that can be used for analysis and monitoring.
3.  🚀 - This emoji represents an improvement or enhancement, as the change is expected to improve the accuracy and quality of the metrics reported by the monitor controller, which could benefit the users and operators of the cluster.
-->
Uncomment code in `monitor_controller.go` to filter out non-running pods from resource usage metrics. This improves the accuracy of the monitor controller's metrics.

> _`Monitor` skips pods_
> _Not running, metrics are wrong_
> _Autumn leaves falling_

### Walkthrough
*  Uncomment code to skip non-running pods when calculating resource usage metrics ([link](https://github.com/labring/sealos/pull/3672/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL296-R298)). This fixes the issue of inaccurate metrics reported by the monitor controller in `monitor_controller.go`. The monitor controller collects and exposes the resource usage metrics of the nodes and pods in the cluster.


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
