### PR TITLE
fix: remove unexpected mergo options

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -157,8 +157,7 @@ func getMergeConfigData(path string, data []byte) ([]byte, error) {
 			return nil, fmt.Errorf("failed to unmarshal config: %v", err)
 		}
 		if err := mergo.Merge(&configMap, &mergeConfigMap,
-			mergo.WithOverwriteWithEmptyValue, mergo.WithOverrideEmptySlice,
-			mergo.WithAppendSlice, mergo.WithTypeCheck, mergo.WithSliceDeepCopy,
+			mergo.WithOverwriteWithEmptyValue, mergo.WithTypeCheck,
 		); err != nil {
 			return nil, fmt.Errorf("merge: %v", err)
 		}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b70b39b</samp>

Simplified the config map merging logic in `pkg/config/config.go` by removing unnecessary options. This was part of a pull request to refactor and optimize the config package of sealos.