### PR TITLE
test: add e2e kubernetes v1.28 test

### DIFF
--- a/.github/workflows/e2e_test_core.yml
+++ b/.github/workflows/e2e_test_core.yml
@@ -53,6 +53,7 @@ jobs:
             E2E_sealos_runtime_version_125_test,
             E2E_sealos_runtime_version_126_test,
             E2E_sealos_runtime_version_127_test,
+            E2E_sealos_runtime_version_128_test,
             E2E_sealos_runtime_version_docker_119_test,
             E2E_sealos_runtime_version_docker_120_test,
             E2E_sealos_runtime_version_docker_121_test,
@@ -61,7 +62,8 @@ jobs:
             E2E_sealos_runtime_version_docker_124_test,
             E2E_sealos_runtime_version_docker_125_test,
             E2E_sealos_runtime_version_docker_126_test,
-            E2E_sealos_runtime_version_docker_127_test
+            E2E_sealos_runtime_version_docker_127_test,
+            E2E_sealos_runtime_version_docker_128_test
           ]
     runs-on: ubuntu-latest
     steps:

--- a/test/e2e/runtime_version_128_test.go
+++ b/test/e2e/runtime_version_128_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/labring/sealos/test/e2e/suites/operators"
+	"github.com/labring/sealos/test/e2e/testhelper/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("E2E_sealos_runtime_version_128_test", func() {
+	var (
+		fakeClient *operators.FakeClient
+		err        error
+	)
+	fakeClient = operators.NewFakeClient("")
+
+	Context("sealos run for many version", func() {
+		It("sealos apply single by containerd v1.28.0", func() {
+			images := []string{"labring/kubernetes:v1.28.0"}
+			defer func() {
+				err = fakeClient.Cluster.Reset()
+				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))
+			}()
+			err = fakeClient.Cluster.Run(images...)
+			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+		})
+	})
+
+})

--- a/test/e2e/runtime_version_128_test.go
+++ b/test/e2e/runtime_version_128_test.go
@@ -41,6 +41,8 @@ var _ = Describe("E2E_sealos_runtime_version_128_test", func() {
 			}()
 			err = fakeClient.Cluster.Run(images...)
 			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+			err = checkVersionImageList(fakeClient)
+			utils.CheckErr(err, fmt.Sprintf("failed to check version image list: %v", err))
 		})
 	})
 

--- a/test/e2e/runtime_version_docker_128_test.go
+++ b/test/e2e/runtime_version_docker_128_test.go
@@ -41,6 +41,8 @@ var _ = Describe("E2E_sealos_runtime_version_docker_128_test", func() {
 			}()
 			err = fakeClient.Cluster.Run(images...)
 			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+			err = checkVersionImageList(fakeClient)
+			utils.CheckErr(err, fmt.Sprintf("failed to check version image list: %v", err))
 		})
 	})
 

--- a/test/e2e/runtime_version_docker_128_test.go
+++ b/test/e2e/runtime_version_docker_128_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/labring/sealos/test/e2e/suites/operators"
+	"github.com/labring/sealos/test/e2e/testhelper/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("E2E_sealos_runtime_version_docker_128_test", func() {
+	var (
+		fakeClient *operators.FakeClient
+		err        error
+	)
+	fakeClient = operators.NewFakeClient("")
+
+	Context("sealos run for many version", func() {
+		It("sealos apply single by docker v1.28.0", func() {
+			images := []string{"labring/kubernetes-docker:v1.28.0"}
+			defer func() {
+				err = fakeClient.Cluster.Reset()
+				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))
+			}()
+			err = fakeClient.Cluster.Run(images...)
+			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+		})
+	})
+
+})


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f01c29c</samp>

### Summary
:sparkles::whale::package:

<!--
1.  :sparkles: This emoji represents the addition of new features or tests, and can be used to highlight the new test suites for different runtime and Kubernetes versions.
2.  :whale: This emoji represents the docker runtime, and can be used to distinguish the test suite that uses the docker image from the one that uses the containerd image.
3.  :package: This emoji represents the containerd runtime, and can be used to distinguish the test suite that uses the containerd image from the one that uses the docker image.
-->
This pull request adds two new test files for testing the sealos cluster run command with different runtime and Kubernetes versions. The files are `test/e2e/runtime_version_128_test.go` and `test/e2e/runtime_version_docker_128_test.go`, and they use the containerd and docker runtimes respectively.

> _`sealos` cluster run_
> _testing different runtimes_
> _autumn of `v1.28`_

### Walkthrough
*  Add test suites for sealos cluster run command with different runtime and Kubernetes versions ([link](https://github.com/labring/sealos/pull/3687/files?diff=unified&w=0#diff-c961186b6ca6247a4c7ae1253183dbaa07c438d35be2500d40e3a56bad8e307eR1-R47), [link](https://github.com/labring/sealos/pull/3687/files?diff=unified&w=0#diff-997900b990afaf996316a0686ce8e5f6d948f1547c6c3c508db8632f7ba28a9bR1-R47))
  - Create `test/e2e/runtime_version_128_test.go` for testing containerd runtime and Kubernetes v1.28.0 ([link](https://github.com/labring/sealos/pull/3687/files?diff=unified&w=0#diff-c961186b6ca6247a4c7ae1253183dbaa07c438d35be2500d40e3a56bad8e307eR1-R47))
  - Create `test/e2e/runtime_version_docker_128_test.go` for testing docker runtime and Kubernetes v1.28.0 ([link](https://github.com/labring/sealos/pull/3687/files?diff=unified&w=0#diff-997900b990afaf996316a0686ce8e5f6d948f1547c6c3c508db8632f7ba28a9bR1-R47))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
