### PR TITLE
refactor(main): using new runtime interface

### DIFF
--- a/pkg/apply/gen.go
+++ b/pkg/apply/gen.go
@@ -56,7 +56,7 @@ func NewClusterFromGenArgs(cmd *cobra.Command, args *RunArgs, imageNames []strin
 	if err != nil {
 		return nil, err
 	}
-	return rtInterface.GetKubeadmConfig()
+	return rtInterface.GetConfig()
 }
 
 func genImageInfo(imageName string) (*v1beta1.MountImage, error) {

--- a/pkg/apply/processor/create.go
+++ b/pkg/apply/processor/create.go
@@ -151,11 +151,11 @@ func (c *CreateProcessor) Init(_ *v2.Cluster) error {
 
 func (c *CreateProcessor) Join(cluster *v2.Cluster) error {
 	logger.Info("Executing pipeline Join in CreateProcessor.")
-	err := c.Runtime.JoinMasters(cluster.GetMasterIPAndPortList()[1:])
+	err := c.Runtime.ScaleMasters(cluster.GetMasterIPAndPortList()[1:], nil)
 	if err != nil {
 		return err
 	}
-	err = c.Runtime.JoinNodes(cluster.GetNodeIPAndPortList())
+	err = c.Runtime.ScaleNodes(cluster.GetNodeIPAndPortList(), nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/apply/processor/create.go
+++ b/pkg/apply/processor/create.go
@@ -151,11 +151,11 @@ func (c *CreateProcessor) Init(_ *v2.Cluster) error {
 
 func (c *CreateProcessor) Join(cluster *v2.Cluster) error {
 	logger.Info("Executing pipeline Join in CreateProcessor.")
-	err := c.Runtime.ScaleMasters(cluster.GetMasterIPAndPortList()[1:], nil)
+	err := c.Runtime.ScaleUp(cluster.GetMasterIPAndPortList()[1:], nil)
 	if err != nil {
 		return err
 	}
-	err = c.Runtime.ScaleNodes(cluster.GetNodeIPAndPortList(), nil)
+	err = c.Runtime.ScaleUp(nil, cluster.GetNodeIPAndPortList())
 	if err != nil {
 		return err
 	}

--- a/pkg/apply/processor/create.go
+++ b/pkg/apply/processor/create.go
@@ -151,11 +151,7 @@ func (c *CreateProcessor) Init(_ *v2.Cluster) error {
 
 func (c *CreateProcessor) Join(cluster *v2.Cluster) error {
 	logger.Info("Executing pipeline Join in CreateProcessor.")
-	err := c.Runtime.ScaleUp(cluster.GetMasterIPAndPortList()[1:], nil)
-	if err != nil {
-		return err
-	}
-	err = c.Runtime.ScaleUp(nil, cluster.GetNodeIPAndPortList())
+	err := c.Runtime.ScaleUp(cluster.GetMasterIPAndPortList()[1:], cluster.GetNodeIPAndPortList())
 	if err != nil {
 		return err
 	}

--- a/pkg/apply/processor/install.go
+++ b/pkg/apply/processor/install.go
@@ -184,7 +184,7 @@ func (c *InstallProcessor) UpgradeIfNeed(cluster *v2.Cluster) error {
 		if version == "" {
 			continue
 		}
-		err := c.Runtime.UpgradeCluster(version)
+		err := c.Runtime.Upgrade(version)
 		if err != nil {
 			logger.Error("upgrade cluster failed")
 			return err

--- a/pkg/apply/processor/scale.go
+++ b/pkg/apply/processor/scale.go
@@ -116,11 +116,8 @@ func (c *ScaleProcessor) RunGuest(cluster *v2.Cluster) error {
 
 func (c *ScaleProcessor) Delete(cluster *v2.Cluster) error {
 	logger.Info("Executing pipeline Delete in ScaleProcessor.")
-	err := c.Runtime.ScaleDown(c.MastersToDelete, nil)
+	err := c.Runtime.ScaleDown(c.MastersToDelete, c.NodesToDelete)
 	if err != nil {
-		return err
-	}
-	if err = c.Runtime.ScaleDown(nil, c.NodesToDelete); err != nil {
 		return err
 	}
 	if len(c.MastersToDelete) > 0 {
@@ -131,11 +128,7 @@ func (c *ScaleProcessor) Delete(cluster *v2.Cluster) error {
 
 func (c *ScaleProcessor) Join(cluster *v2.Cluster) error {
 	logger.Info("Executing pipeline Join in ScaleProcessor.")
-	err := c.Runtime.ScaleUp(c.MastersToJoin, nil)
-	if err != nil {
-		return err
-	}
-	err = c.Runtime.ScaleUp(nil, c.NodesToJoin)
+	err := c.Runtime.ScaleUp(c.MastersToJoin, c.NodesToJoin)
 	if err != nil {
 		return err
 	}

--- a/pkg/apply/processor/scale.go
+++ b/pkg/apply/processor/scale.go
@@ -116,11 +116,11 @@ func (c *ScaleProcessor) RunGuest(cluster *v2.Cluster) error {
 
 func (c *ScaleProcessor) Delete(cluster *v2.Cluster) error {
 	logger.Info("Executing pipeline Delete in ScaleProcessor.")
-	err := c.Runtime.DeleteMasters(c.MastersToDelete)
+	err := c.Runtime.ScaleMasters(nil, c.MastersToDelete)
 	if err != nil {
 		return err
 	}
-	if err = c.Runtime.DeleteNodes(c.NodesToDelete); err != nil {
+	if err = c.Runtime.ScaleNodes(nil, c.NodesToDelete); err != nil {
 		return err
 	}
 	if len(c.MastersToDelete) > 0 {
@@ -131,11 +131,11 @@ func (c *ScaleProcessor) Delete(cluster *v2.Cluster) error {
 
 func (c *ScaleProcessor) Join(cluster *v2.Cluster) error {
 	logger.Info("Executing pipeline Join in ScaleProcessor.")
-	err := c.Runtime.JoinMasters(c.MastersToJoin)
+	err := c.Runtime.ScaleMasters(c.MastersToJoin, nil)
 	if err != nil {
 		return err
 	}
-	err = c.Runtime.JoinNodes(c.NodesToJoin)
+	err = c.Runtime.ScaleNodes(c.NodesToJoin, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/apply/processor/scale.go
+++ b/pkg/apply/processor/scale.go
@@ -116,11 +116,11 @@ func (c *ScaleProcessor) RunGuest(cluster *v2.Cluster) error {
 
 func (c *ScaleProcessor) Delete(cluster *v2.Cluster) error {
 	logger.Info("Executing pipeline Delete in ScaleProcessor.")
-	err := c.Runtime.ScaleMasters(nil, c.MastersToDelete)
+	err := c.Runtime.ScaleDown(c.MastersToDelete, nil)
 	if err != nil {
 		return err
 	}
-	if err = c.Runtime.ScaleNodes(nil, c.NodesToDelete); err != nil {
+	if err = c.Runtime.ScaleDown(nil, c.NodesToDelete); err != nil {
 		return err
 	}
 	if len(c.MastersToDelete) > 0 {
@@ -131,11 +131,11 @@ func (c *ScaleProcessor) Delete(cluster *v2.Cluster) error {
 
 func (c *ScaleProcessor) Join(cluster *v2.Cluster) error {
 	logger.Info("Executing pipeline Join in ScaleProcessor.")
-	err := c.Runtime.ScaleMasters(c.MastersToJoin, nil)
+	err := c.Runtime.ScaleUp(c.MastersToJoin, nil)
 	if err != nil {
 		return err
 	}
-	err = c.Runtime.ScaleNodes(c.NodesToJoin, nil)
+	err = c.Runtime.ScaleUp(nil, c.NodesToJoin)
 	if err != nil {
 		return err
 	}

--- a/pkg/client-go/kubernetes/expansion_test.go
+++ b/pkg/client-go/kubernetes/expansion_test.go
@@ -46,7 +46,7 @@ func TestGetKubeadmConfig(t *testing.T) {
 			ke := NewKubeExpansion(tt.args.client)
 			got, err := ke.FetchKubeadmConfig(context.Background())
 			if (err != nil) != tt.wantErr {
-				t.Errorf("GetKubeadmConfig() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("GetConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			t.Logf("%+v", got)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -94,13 +94,13 @@ func (k *KubeadmRuntime) Reset() error {
 	return k.reset()
 }
 func (k *KubeadmRuntime) ScaleUp(newMasterIPList []string, newNodeIPList []string) error {
-	if newMasterIPList != nil && len(newMasterIPList) != 0 {
+	if len(newMasterIPList) != 0 {
 		logger.Info("%s will be added as master", newMasterIPList)
 		if err := k.joinMasters(newMasterIPList); err != nil {
 			return err
 		}
 	}
-	if newNodeIPList != nil && len(newNodeIPList) != 0 {
+	if len(newNodeIPList) != 0 {
 		logger.Info("%s will be added as worker", newNodeIPList)
 		if err := k.joinNodes(newNodeIPList); err != nil {
 			return err
@@ -111,13 +111,13 @@ func (k *KubeadmRuntime) ScaleUp(newMasterIPList []string, newNodeIPList []strin
 }
 
 func (k *KubeadmRuntime) ScaleDown(deleteMastersIPList []string, deleteNodesIPList []string) error {
-	if deleteMastersIPList != nil && len(deleteMastersIPList) != 0 {
+	if len(deleteMastersIPList) != 0 {
 		logger.Info("master %s will be deleted", deleteMastersIPList)
 		if err := k.deleteMasters(deleteMastersIPList); err != nil {
 			return err
 		}
 	}
-	if deleteNodesIPList != nil && len(deleteNodesIPList) != 0 {
+	if len(deleteNodesIPList) != 0 {
 		logger.Info("worker %s will be deleted", deleteNodesIPList)
 		return k.deleteNodes(deleteNodesIPList)
 	}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -96,7 +96,9 @@ func (k *KubeadmRuntime) Reset() error {
 func (k *KubeadmRuntime) ScaleUp(newMasterIPList []string, newNodeIPList []string) error {
 	if newMasterIPList != nil && len(newMasterIPList) != 0 {
 		logger.Info("%s will be added as master", newMasterIPList)
-		return k.joinMasters(newMasterIPList)
+		if err := k.joinMasters(newMasterIPList); err != nil {
+			return err
+		}
 	}
 	if newNodeIPList != nil && len(newNodeIPList) != 0 {
 		logger.Info("%s will be added as worker", newNodeIPList)
@@ -105,20 +107,20 @@ func (k *KubeadmRuntime) ScaleUp(newMasterIPList []string, newNodeIPList []strin
 		}
 		return k.copyNodeKubeConfig(newNodeIPList)
 	}
-	logger.Warn("no nodes will be scaled up")
 	return nil
 }
 
 func (k *KubeadmRuntime) ScaleDown(deleteMastersIPList []string, deleteNodesIPList []string) error {
 	if deleteMastersIPList != nil && len(deleteMastersIPList) != 0 {
 		logger.Info("master %s will be deleted", deleteMastersIPList)
-		return k.deleteMasters(deleteMastersIPList)
+		if err := k.deleteMasters(deleteMastersIPList); err != nil {
+			return err
+		}
 	}
 	if deleteNodesIPList != nil && len(deleteNodesIPList) != 0 {
 		logger.Info("worker %s will be deleted", deleteNodesIPList)
 		return k.deleteNodes(deleteNodesIPList)
 	}
-	logger.Warn("no nodes will be scaled down")
 	return nil
 }
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bd2b914</samp>

### Summary
🔧🚀🧪

<!--
1.  🔧 - This emoji represents the refactoring and unification of the runtime interface and logic, as well as the simplification of the scaling and upgrading methods. It conveys the idea of fixing and improving the code quality and structure.
2.  🚀 - This emoji represents the enhancement of the cluster operations and the performance improvement of the scaling and upgrading methods. It conveys the idea of launching and expanding the cluster faster and more reliably.
3.  🧪 - This emoji represents the updating and passing of the test cases to reflect the changes in the runtime interface and logic. It conveys the idea of testing and verifying the code functionality and correctness.
-->
Refactored the `pkg/apply/processor` and `pkg/runtime` packages to simplify and unify the interface and logic of cluster operations. Renamed and replaced some methods to make them more generic and consistent. Updated the test cases to reflect the changes.

> _Sing, O Muse, of the valiant deeds of the code warriors_
> _Who refactored the runtime package with skill and wisdom_
> _And made the interface of cluster operations more consistent_
> _Like Hephaestus, who forged the weapons of the gods with artistry_

### Walkthrough
*  Refactor the runtime interface to use more generic and consistent methods ([link](https://github.com/labring/sealos/pull/3691/files?diff=unified&w=0#diff-b4c7028460ee8a2207d8376a99e5b1ad4cc3db7178e77f2e1038ea0fff506eb2L58-R58), [link](https://github.com/labring/sealos/pull/3691/files?diff=unified&w=0#diff-a198a9c7960d3df36d37378bc12c9b6095f19934739f72cc0c3e79d7a44e2442L148-R152), [link](https://github.com/labring/sealos/pull/3691/files?diff=unified&w=0#diff-dc16722036c8f44c78015609d3ab3424d2f4d09543296a24d98e6ebea7a2dbb9L183-R183), [link](https://github.com/labring/sealos/pull/3691/files?diff=unified&w=0#diff-d48ba8412842b9224105abdc78efc6af4031a5e68498f66ace1f9de18d3ec438L94-R98), [link](https://github.com/labring/sealos/pull/3691/files?diff=unified&w=0#diff-d48ba8412842b9224105abdc78efc6af4031a5e68498f66ace1f9de18d3ec438L109-R113), [link](https://github.com/labring/sealos/pull/3691/files?diff=unified&w=0#diff-5f7bd837713caa25c157491508e7c9bcd591ebe08027a266321262b7f75c8dc5L49-R49), [link](https://github.com/labring/sealos/pull/3691/files?diff=unified&w=0#diff-e56f9bb947923c6f8bb4c995bf4b9469a0ed117276223d16b177dcb04399a4bcL60-R60), [link](https://github.com/labring/sealos/pull/3691/files?diff=unified&w=0#diff-e56f9bb947923c6f8bb4c995bf4b9469a0ed117276223d16b177dcb04399a4bcL83-R89), [link](https://github.com/labring/sealos/pull/3691/files?diff=unified&w=0#diff-e56f9bb947923c6f8bb4c995bf4b9469a0ed117276223d16b177dcb04399a4bcL97-R121), [link](https://github.com/labring/sealos/pull/3691/files?diff=unified&w=0#diff-e56f9bb947923c6f8bb4c995bf4b9469a0ed117276223d16b177dcb04399a4bcL171-R167))
  * Replace `GetKubeadmConfig` with `GetConfig` in `pkg/apply/gen.go`, `pkg/apply/processor/install.go`, and `pkg/client-go/kubernetes/expansion_test.go` ([link](https://github.com/labring/sealos/pull/3691/files?diff=unified&w=0#diff-b4c7028460ee8a2207d8376a99e5b1ad4cc3db7178e77f2e1038ea0fff506eb2L58-R58), [link](https://github.com/labring/sealos/pull/3691/files?diff=unified&w=0#diff-dc16722036c8f44c78015609d3ab3424d2f4d09543296a24d98e6ebea7a2dbb9L183-R183), [link](https://github.com/labring/sealos/pull/3691/files?diff=unified&w=0#diff-5f7bd837713caa25c157491508e7c9bcd591ebe08027a266321262b7f75c8dc5L49-R49), [link](https://github.com/labring/sealos/pull/3691/files?diff=unified&w=0#diff-e56f9bb947923c6f8bb4c995bf4b9469a0ed117276223d16b177dcb04399a4bcL60-R60))
  * Replace `JoinNodes`, `DeleteNodes`, `JoinMasters`, and `DeleteMasters` with `ScaleNodes` and `ScaleMasters` in `pkg/apply/processor/create.go`, `pkg/apply/processor/scale.go`, and `pkg/runtime/runtime.go` ([link](https://github.com/labring/sealos/pull/3691/files?diff=unified&w=0#diff-a198a9c7960d3df36d37378bc12c9b6095f19934739f72cc0c3e79d7a44e2442L148-R152), [link](https://github.com/labring/sealos/pull/3691/files?diff=unified&w=0#diff-d48ba8412842b9224105abdc78efc6af4031a5e68498f66ace1f9de18d3ec438L94-R98), [link](https://github.com/labring/sealos/pull/3691/files?diff=unified&w=0#diff-d48ba8412842b9224105abdc78efc6af4031a5e68498f66ace1f9de18d3ec438L109-R113), [link](https://github.com/labring/sealos/pull/3691/files?diff=unified&w=0#diff-e56f9bb947923c6f8bb4c995bf4b9469a0ed117276223d16b177dcb04399a4bcL83-R89), [link](https://github.com/labring/sealos/pull/3691/files?diff=unified&w=0#diff-e56f9bb947923c6f8bb4c995bf4b9469a0ed117276223d16b177dcb04399a4bcL97-R121))
  * Replace `UpgradeCluster` with `Upgrade` in `pkg/apply/processor/install.go` and `pkg/runtime/runtime.go` ([link](https://github.com/labring/sealos/pull/3691/files?diff=unified&w=0#diff-dc16722036c8f44c78015609d3ab3424d2f4d09543296a24d98e6ebea7a2dbb9L183-R183), [link](https://github.com/labring/sealos/pull/3691/files?diff=unified&w=0#diff-e56f9bb947923c6f8bb4c995bf4b9469a0ed117276223d16b177dcb04399a4bcL171-R167))
* Update the test cases to reflect the changes in the runtime interface ([link](https://github.com/labring/sealos/pull/3691/files?diff=unified&w=0#diff-5f7bd837713caa25c157491508e7c9bcd591ebe08027a266321262b7f75c8dc5L49-R49))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
