### PR TITLE
build(main): add test docker image

### DIFF
--- a/.github/workflows/e2e_test_core.yml
+++ b/.github/workflows/e2e_test_core.yml
@@ -52,7 +52,16 @@ jobs:
             E2E_sealos_runtime_version_124_test,
             E2E_sealos_runtime_version_125_test,
             E2E_sealos_runtime_version_126_test,
-            E2E_sealos_runtime_version_127_test
+            E2E_sealos_runtime_version_127_test,
+            E2E_sealos_runtime_version_docker_119_test,
+            E2E_sealos_runtime_version_docker_120_test,
+            E2E_sealos_runtime_version_docker_121_test,
+            E2E_sealos_runtime_version_docker_122_test,
+            E2E_sealos_runtime_version_docker_123_test,
+            E2E_sealos_runtime_version_docker_124_test,
+            E2E_sealos_runtime_version_docker_125_test,
+            E2E_sealos_runtime_version_docker_126_test,
+            E2E_sealos_runtime_version_docker_127_test
           ]
     runs-on: ubuntu-latest
     steps:

--- a/test/e2e/images_buildrun_feature_test.go
+++ b/test/e2e/images_buildrun_feature_test.go
@@ -67,7 +67,7 @@ var _ = Describe("E2E_sealos_images_buildrun_feature_test", func() {
 			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
 			err = fakeClient.CRI.Pull("docker.io/altinity/clickhouse-operator:0.18.4")
 			utils.CheckErr(err, fmt.Sprintf("failed to pull image docker.io/altinity/clickhouse-operator:0.18.4: %v", err))
-			err = fakeClient.CRI.ImageList()
+			_, err = fakeClient.CRI.ImageList()
 			utils.CheckErr(err, fmt.Sprintf("failed to list images: %v", err))
 			err = fakeClient.CRI.HasImage("sealos.hub:5000/altinity/clickhouse-operator:0.18.4")
 			utils.CheckErr(err, fmt.Sprintf("failed to validate image sealos.hub:5000/altinity/clickhouse-operator:0.18.4: %v", err))

--- a/test/e2e/images_buildrun_test.go
+++ b/test/e2e/images_buildrun_test.go
@@ -62,7 +62,7 @@ var _ = Describe("E2E_sealos_images_buildrun_test", func() {
 			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
 			err = fakeClient.CRI.Pull("docker.io/altinity/clickhouse-operator:0.18.4")
 			utils.CheckErr(err, fmt.Sprintf("failed to pull image docker.io/altinity/clickhouse-operator:0.18.4: %v", err))
-			err = fakeClient.CRI.ImageList()
+			_, err = fakeClient.CRI.ImageList()
 			utils.CheckErr(err, fmt.Sprintf("failed to list images: %v", err))
 			err = fakeClient.CRI.HasImage("sealos.hub:5000/altinity/clickhouse-operator:0.18.4")
 			utils.CheckErr(err, fmt.Sprintf("failed to validate image sealos.hub:5000/altinity/clickhouse-operator:0.18.4: %v", err))

--- a/test/e2e/runtime_version_119_test.go
+++ b/test/e2e/runtime_version_119_test.go
@@ -41,6 +41,8 @@ var _ = Describe("E2E_sealos_runtime_version_119_test", func() {
 			}()
 			err = fakeClient.Cluster.Run(images...)
 			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+			err = checkVersionImageList(fakeClient)
+			utils.CheckErr(err, fmt.Sprintf("failed to check version image list: %v", err))
 		})
 	})
 

--- a/test/e2e/runtime_version_120_test.go
+++ b/test/e2e/runtime_version_120_test.go
@@ -41,6 +41,8 @@ var _ = Describe("E2E_sealos_runtime_version_120_test", func() {
 			}()
 			err = fakeClient.Cluster.Run(images...)
 			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+			err = checkVersionImageList(fakeClient)
+			utils.CheckErr(err, fmt.Sprintf("failed to check version image list: %v", err))
 		})
 	})
 

--- a/test/e2e/runtime_version_121_test.go
+++ b/test/e2e/runtime_version_121_test.go
@@ -41,6 +41,8 @@ var _ = Describe("E2E_sealos_runtime_version_121_test", func() {
 			}()
 			err = fakeClient.Cluster.Run(images...)
 			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+			err = checkVersionImageList(fakeClient)
+			utils.CheckErr(err, fmt.Sprintf("failed to check version image list: %v", err))
 		})
 	})
 

--- a/test/e2e/runtime_version_123_test.go
+++ b/test/e2e/runtime_version_123_test.go
@@ -41,6 +41,8 @@ var _ = Describe("E2E_sealos_runtime_version_123_test", func() {
 			}()
 			err = fakeClient.Cluster.Run(images...)
 			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+			err = checkVersionImageList(fakeClient)
+			utils.CheckErr(err, fmt.Sprintf("failed to check version image list: %v", err))
 		})
 	})
 

--- a/test/e2e/runtime_version_124_test.go
+++ b/test/e2e/runtime_version_124_test.go
@@ -41,6 +41,8 @@ var _ = Describe("E2E_sealos_runtime_version_124_test", func() {
 			}()
 			err = fakeClient.Cluster.Run(images...)
 			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+			err = checkVersionImageList(fakeClient)
+			utils.CheckErr(err, fmt.Sprintf("failed to check version image list: %v", err))
 		})
 	})
 

--- a/test/e2e/runtime_version_125_test.go
+++ b/test/e2e/runtime_version_125_test.go
@@ -41,6 +41,8 @@ var _ = Describe("E2E_sealos_runtime_version_125_test", func() {
 			}()
 			err = fakeClient.Cluster.Run(images...)
 			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+			err = checkVersionImageList(fakeClient)
+			utils.CheckErr(err, fmt.Sprintf("failed to check version image list: %v", err))
 		})
 	})
 

--- a/test/e2e/runtime_version_126_test.go
+++ b/test/e2e/runtime_version_126_test.go
@@ -41,6 +41,8 @@ var _ = Describe("E2E_sealos_runtime_version_126_test", func() {
 			}()
 			err = fakeClient.Cluster.Run(images...)
 			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+			err = checkVersionImageList(fakeClient)
+			utils.CheckErr(err, fmt.Sprintf("failed to check version image list: %v", err))
 		})
 	})
 

--- a/test/e2e/runtime_version_127_test.go
+++ b/test/e2e/runtime_version_127_test.go
@@ -41,6 +41,8 @@ var _ = Describe("E2E_sealos_runtime_version_127_test", func() {
 			}()
 			err = fakeClient.Cluster.Run(images...)
 			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+			err = checkVersionImageList(fakeClient)
+			utils.CheckErr(err, fmt.Sprintf("failed to check version image list: %v", err))
 		})
 	})
 

--- a/test/e2e/runtime_version_docker_119_test.go
+++ b/test/e2e/runtime_version_docker_119_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
-var _ = Describe("E2E_sealos_runtime_version_122_test", func() {
+var _ = Describe("E2E_sealos_runtime_version_docker_119_test", func() {
 	var (
 		fakeClient *operators.FakeClient
 		err        error
@@ -33,8 +33,8 @@ var _ = Describe("E2E_sealos_runtime_version_122_test", func() {
 	fakeClient = operators.NewFakeClient("")
 
 	Context("sealos run for many version", func() {
-		It("sealos apply single by containerd v1.22.0", func() {
-			images := []string{"labring/kubernetes:v1.22.0"}
+		It("sealos apply single by docker v1.19.0", func() {
+			images := []string{"labring/kubernetes-docker:v1.19.0"}
 			defer func() {
 				err = fakeClient.Cluster.Reset()
 				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))

--- a/test/e2e/runtime_version_docker_120_test.go
+++ b/test/e2e/runtime_version_docker_120_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
-var _ = Describe("E2E_sealos_runtime_version_122_test", func() {
+var _ = Describe("E2E_sealos_runtime_version_docker_120_test", func() {
 	var (
 		fakeClient *operators.FakeClient
 		err        error
@@ -33,8 +33,8 @@ var _ = Describe("E2E_sealos_runtime_version_122_test", func() {
 	fakeClient = operators.NewFakeClient("")
 
 	Context("sealos run for many version", func() {
-		It("sealos apply single by containerd v1.22.0", func() {
-			images := []string{"labring/kubernetes:v1.22.0"}
+		It("sealos apply single by docker v1.20.0", func() {
+			images := []string{"labring/kubernetes-docker:v1.20.0"}
 			defer func() {
 				err = fakeClient.Cluster.Reset()
 				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))

--- a/test/e2e/runtime_version_docker_121_test.go
+++ b/test/e2e/runtime_version_docker_121_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
-var _ = Describe("E2E_sealos_runtime_version_122_test", func() {
+var _ = Describe("E2E_sealos_runtime_version_docker_121_test", func() {
 	var (
 		fakeClient *operators.FakeClient
 		err        error
@@ -33,8 +33,8 @@ var _ = Describe("E2E_sealos_runtime_version_122_test", func() {
 	fakeClient = operators.NewFakeClient("")
 
 	Context("sealos run for many version", func() {
-		It("sealos apply single by containerd v1.22.0", func() {
-			images := []string{"labring/kubernetes:v1.22.0"}
+		It("sealos apply single by docker v1.21.0", func() {
+			images := []string{"labring/kubernetes-docker:v1.21.0"}
 			defer func() {
 				err = fakeClient.Cluster.Reset()
 				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))

--- a/test/e2e/runtime_version_docker_122_test.go
+++ b/test/e2e/runtime_version_docker_122_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
-var _ = Describe("E2E_sealos_runtime_version_122_test", func() {
+var _ = Describe("E2E_sealos_runtime_version_docker_122_test", func() {
 	var (
 		fakeClient *operators.FakeClient
 		err        error
@@ -33,8 +33,8 @@ var _ = Describe("E2E_sealos_runtime_version_122_test", func() {
 	fakeClient = operators.NewFakeClient("")
 
 	Context("sealos run for many version", func() {
-		It("sealos apply single by containerd v1.22.0", func() {
-			images := []string{"labring/kubernetes:v1.22.0"}
+		It("sealos apply single by docker v1.22.0", func() {
+			images := []string{"labring/kubernetes-docker:v1.22.0"}
 			defer func() {
 				err = fakeClient.Cluster.Reset()
 				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))

--- a/test/e2e/runtime_version_docker_123_test.go
+++ b/test/e2e/runtime_version_docker_123_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
-var _ = Describe("E2E_sealos_runtime_version_122_test", func() {
+var _ = Describe("E2E_sealos_runtime_version_docker_123_test", func() {
 	var (
 		fakeClient *operators.FakeClient
 		err        error
@@ -33,8 +33,8 @@ var _ = Describe("E2E_sealos_runtime_version_122_test", func() {
 	fakeClient = operators.NewFakeClient("")
 
 	Context("sealos run for many version", func() {
-		It("sealos apply single by containerd v1.22.0", func() {
-			images := []string{"labring/kubernetes:v1.22.0"}
+		It("sealos apply single by docker v1.23.0", func() {
+			images := []string{"labring/kubernetes-docker:v1.23.0"}
 			defer func() {
 				err = fakeClient.Cluster.Reset()
 				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))

--- a/test/e2e/runtime_version_docker_124_test.go
+++ b/test/e2e/runtime_version_docker_124_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
-var _ = Describe("E2E_sealos_runtime_version_122_test", func() {
+var _ = Describe("E2E_sealos_runtime_version_docker_124_test", func() {
 	var (
 		fakeClient *operators.FakeClient
 		err        error
@@ -33,8 +33,8 @@ var _ = Describe("E2E_sealos_runtime_version_122_test", func() {
 	fakeClient = operators.NewFakeClient("")
 
 	Context("sealos run for many version", func() {
-		It("sealos apply single by containerd v1.22.0", func() {
-			images := []string{"labring/kubernetes:v1.22.0"}
+		It("sealos apply single by docker v1.24.0", func() {
+			images := []string{"labring/kubernetes-docker:v1.24.0"}
 			defer func() {
 				err = fakeClient.Cluster.Reset()
 				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))

--- a/test/e2e/runtime_version_docker_125_test.go
+++ b/test/e2e/runtime_version_docker_125_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
-var _ = Describe("E2E_sealos_runtime_version_122_test", func() {
+var _ = Describe("E2E_sealos_runtime_version_docker_125_test", func() {
 	var (
 		fakeClient *operators.FakeClient
 		err        error
@@ -33,8 +33,8 @@ var _ = Describe("E2E_sealos_runtime_version_122_test", func() {
 	fakeClient = operators.NewFakeClient("")
 
 	Context("sealos run for many version", func() {
-		It("sealos apply single by containerd v1.22.0", func() {
-			images := []string{"labring/kubernetes:v1.22.0"}
+		It("sealos apply single by docker v1.25.0", func() {
+			images := []string{"labring/kubernetes-docker:v1.25.0"}
 			defer func() {
 				err = fakeClient.Cluster.Reset()
 				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))

--- a/test/e2e/runtime_version_docker_126_test.go
+++ b/test/e2e/runtime_version_docker_126_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
-var _ = Describe("E2E_sealos_runtime_version_122_test", func() {
+var _ = Describe("E2E_sealos_runtime_version_docker_126_test", func() {
 	var (
 		fakeClient *operators.FakeClient
 		err        error
@@ -33,8 +33,8 @@ var _ = Describe("E2E_sealos_runtime_version_122_test", func() {
 	fakeClient = operators.NewFakeClient("")
 
 	Context("sealos run for many version", func() {
-		It("sealos apply single by containerd v1.22.0", func() {
-			images := []string{"labring/kubernetes:v1.22.0"}
+		It("sealos apply single by docker v1.26.0", func() {
+			images := []string{"labring/kubernetes-docker:v1.26.0"}
 			defer func() {
 				err = fakeClient.Cluster.Reset()
 				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))

--- a/test/e2e/runtime_version_docker_127_test.go
+++ b/test/e2e/runtime_version_docker_127_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
-var _ = Describe("E2E_sealos_runtime_version_122_test", func() {
+var _ = Describe("E2E_sealos_runtime_version_docker_127_test", func() {
 	var (
 		fakeClient *operators.FakeClient
 		err        error
@@ -33,8 +33,8 @@ var _ = Describe("E2E_sealos_runtime_version_122_test", func() {
 	fakeClient = operators.NewFakeClient("")
 
 	Context("sealos run for many version", func() {
-		It("sealos apply single by containerd v1.22.0", func() {
-			images := []string{"labring/kubernetes:v1.22.0"}
+		It("sealos apply single by docker v1.27.0", func() {
+			images := []string{"labring/kubernetes-docker:v1.27.0"}
 			defer func() {
 				err = fakeClient.Cluster.Reset()
 				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))

--- a/test/e2e/suites/operators/cri.go
+++ b/test/e2e/suites/operators/cri.go
@@ -19,6 +19,8 @@ package operators
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/util/json"
+
 	"github.com/labring/sealos/test/e2e/testhelper/cmd"
 )
 
@@ -42,17 +44,25 @@ func (f *fakeCRIClient) Pull(name string) error {
 	}
 	return f.SealosCmd.CRIImagePull(name)
 }
-func (f *fakeCRIClient) ImageList() error {
+func (f *fakeCRIClient) ImageList() (*ImageStruct, error) {
 	if f.SealosCmd.CriBinPath == "" {
 		if err := f.SealosCmd.SetCriBinPath(); err != nil {
-			return err
+			return nil, err
 		}
 	}
-	_, err := f.SealosCmd.CRIImageList(true)
-	return err
+	data, err := f.SealosCmd.CRIImageList(false)
+	if err != nil {
+		return nil, err
+	}
+	var image ImageStruct
+	err = json.Unmarshal(data, &image)
+	if err != nil {
+		return nil, err
+	}
+	return &image, nil
 }
 func (f *fakeCRIClient) HasImage(name string) error {
-	data, err := f.SealosCmd.CRIImageList(false)
+	data, err := f.ImageList()
 	if err != nil {
 		return err
 	}

--- a/test/e2e/suites/operators/interface.go
+++ b/test/e2e/suites/operators/interface.go
@@ -16,23 +16,6 @@ limitations under the License.
 
 package operators
 
-type DisplayImage struct {
-	ID           string   `json:"id"`
-	Names        []string `json:"names"`
-	Digest       string   `json:"digest"`
-	Createdat    string   `json:"createdat"`
-	Size         string   `json:"size"`
-	Created      int      `json:"created"`
-	Createdatraw string   `json:"createdatraw"`
-	Readonly     bool     `json:"readonly"`
-}
-type BuildOptions struct {
-	Compress     bool
-	MaxPullProcs int
-	Pull         string
-	SaveImage    bool
-}
-
 type FakeImageInterface interface {
 	ListImages(display bool) ([]DisplayImage, error)
 	PullImage(images ...string) error
@@ -51,7 +34,7 @@ type FakeImageInterface interface {
 
 type FakeCRIInterface interface {
 	Pull(name string) error
-	ImageList() error
+	ImageList() (*ImageStruct, error)
 	HasImage(name string) error
 }
 

--- a/test/e2e/suites/operators/types.go
+++ b/test/e2e/suites/operators/types.go
@@ -14,9 +14,32 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cmd
+package operators
+
+type DisplayImage struct {
+	ID           string   `json:"id"`
+	Names        []string `json:"names"`
+	Digest       string   `json:"digest"`
+	Createdat    string   `json:"createdat"`
+	Size         string   `json:"size"`
+	Created      int      `json:"created"`
+	Createdatraw string   `json:"createdatraw"`
+	Readonly     bool     `json:"readonly"`
+}
+type BuildOptions struct {
+	Compress     bool
+	MaxPullProcs int
+	Pull         string
+	SaveImage    bool
+}
 
 type PodStruct struct {
+	//var pod PodStruct
+	//err = json.Unmarshal(data, &pod)
+	//if err != nil {
+	//	return nil, err
+	//}
+	//return &pod, nil
 	Items []struct {
 		ID       string `json:"id"`
 		Metadata struct {
@@ -34,6 +57,12 @@ type PodStruct struct {
 }
 
 type ImageStruct struct {
+	//	var image ImageStruct
+	//	err = json.Unmarshal(data, &image)
+	//	if err != nil {
+	//	return nil, err
+	//}
+	//	return &image, nil
 	Images []struct {
 		ID          string      `json:"id"`
 		RepoTags    []string    `json:"repoTags"`
@@ -47,6 +76,12 @@ type ImageStruct struct {
 }
 
 type ProcessStruct struct {
+	//var process ProcessStruct
+	//	err = json.Unmarshal(data, &process)
+	//	if err != nil {
+	//		return nil, err
+	//	}
+	//	return &process, nil
 	Containers []struct {
 		ID           string `json:"id"`
 		PodSandboxID string `json:"podSandboxId"`

--- a/test/e2e/testhelper/cmd/sealosCmd.go
+++ b/test/e2e/testhelper/cmd/sealosCmd.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"os"
 
-	"k8s.io/apimachinery/pkg/util/json"
-
 	"github.com/labring/sealos/test/e2e/testhelper/settings"
 
 	"github.com/labring/sealos/test/e2e/testhelper/utils"
@@ -59,9 +57,9 @@ type ImageService interface {
 }
 
 type CRICycle interface {
-	CRIImageList(display bool) (*ImageStruct, error)
-	CRIProcessList(display bool) (*ProcessStruct, error)
-	CRIPodList(display bool) (*PodStruct, error)
+	CRIImageList(display bool) ([]byte, error)
+	CRIProcessList(display bool) ([]byte, error)
+	CRIPodList(display bool) ([]byte, error)
 	CRIImagePull(name string) error
 }
 
@@ -178,37 +176,19 @@ func (s *SealosCmd) ImageRemove(images ...string) error {
 func (s *SealosCmd) ImageInspect(image string) error {
 	return s.Executor.AsyncExec(s.BinPath, "inspect", image)
 }
-func (s *SealosCmd) CRIImageList(display bool) (*ImageStruct, error) {
+func (s *SealosCmd) CRIImageList(display bool) ([]byte, error) {
 	if display {
 		return nil, s.Executor.AsyncExec(s.CriBinPath, "images")
 	}
-	data, err := s.Executor.Exec(s.CriBinPath, "images", "-o", "json")
-	if err != nil {
-		return nil, err
-	}
-	var image ImageStruct
-	err = json.Unmarshal(data, &image)
-	if err != nil {
-		return nil, err
-	}
-	return &image, nil
+	return s.Executor.Exec(s.CriBinPath, "images", "-o", "json")
 }
-func (s *SealosCmd) CRIProcessList(display bool) (*ProcessStruct, error) {
+func (s *SealosCmd) CRIProcessList(display bool) ([]byte, error) {
 	if display {
 		return nil, s.Executor.AsyncExec(s.CriBinPath, "ps", "-a")
 	}
-	data, err := s.Executor.Exec(s.CriBinPath, "ps", "-a", "-o", "json")
-	if err != nil {
-		return nil, err
-	}
-	var process ProcessStruct
-	err = json.Unmarshal(data, &process)
-	if err != nil {
-		return nil, err
-	}
-	return &process, nil
+	return s.Executor.Exec(s.CriBinPath, "ps", "-a", "-o", "json")
 }
-func (s *SealosCmd) CRIPodList(display bool) (*PodStruct, error) {
+func (s *SealosCmd) CRIPodList(display bool) ([]byte, error) {
 	if display {
 		return nil, s.Executor.AsyncExec(s.CriBinPath, "pods")
 	}
@@ -216,12 +196,7 @@ func (s *SealosCmd) CRIPodList(display bool) (*PodStruct, error) {
 	if err != nil {
 		return nil, err
 	}
-	var pod PodStruct
-	err = json.Unmarshal(data, &pod)
-	if err != nil {
-		return nil, err
-	}
-	return &pod, nil
+	return data, nil
 }
 func (s *SealosCmd) CRIImagePull(name string) error {
 	return s.Executor.AsyncExec(s.CriBinPath, "pull", name)

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2023 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/onsi/gomega"
+
+	"github.com/labring/sealos/pkg/utils/logger"
+	"github.com/labring/sealos/test/e2e/suites/operators"
+	"github.com/labring/sealos/test/e2e/testhelper/utils"
+)
+
+func checkVersionImageList(fakeClient *operators.FakeClient) error {
+	displayImages, err := fakeClient.CRI.ImageList()
+	utils.CheckErr(err, fmt.Sprintf("failed to list images: %v", err))
+	gomega.Expect(displayImages).NotTo(gomega.BeNil())
+	errors := make([]string, 0)
+	for _, image := range displayImages.Images {
+		for _, tag := range image.RepoTags {
+			if strings.HasPrefix(tag, "sealos.hub:5000") {
+				logger.Info("crictl image is: %v", tag)
+				continue
+			}
+			registries := []string{
+				"k8s.gcr.io",
+				"registry.k8s.io",
+			}
+			for _, registry := range registries {
+				if strings.HasPrefix(tag, registry) {
+					logger.Warn("crictl image is not in registry: %v", tag)
+					errors = append(errors, tag)
+					continue
+				}
+			}
+			logger.Warn("crictl image is not in registry not k8s image: %v", tag)
+		}
+	}
+	if len(errors) > 0 {
+		return fmt.Errorf("crictl image is not in registry: %v", errors)
+	}
+	return nil
+}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 361b9b8</samp>

### Summary
🐳🧪🆙

<!--
1.  🐳 - This emoji represents Docker, the container runtime that was added as a new option for testing different Kubernetes versions. It also conveys the idea of running containers and images, which are relevant for the e2e tests.
2.  🧪 - This emoji represents testing, which is the main purpose of the changes. It also conveys the idea of experimenting with different scenarios and verifying the expected outcomes.
3.  🆙 - This emoji represents upgrading, which is what the changes do by adding more test cases for newer Kubernetes versions. It also conveys the idea of improving and enhancing the quality and coverage of the tests.
-->
This pull request adds more end-to-end tests for different versions of Kubernetes using Docker as the container runtime. It also fixes some linting issues in the existing tests. It modifies the `.github/workflows/e2e_test_core.yml` file to run the new tests and adds 18 new files in the `test/e2e` directory that contain the test suites for each Kubernetes version. It also adds a helper function `checkVersionImageList` that verifies the expected images are present after running the cluster.

> _`e2e` tests grow_
> _Kubernetes versions abound_
> _Docker in winter_

### Walkthrough
*  Add more test cases for different Kubernetes versions using Docker as the container runtime ([link](https://github.com/labring/sealos/pull/3693/files?diff=unified&w=0#diff-ba1d49071a00190331cbec05b1b76f5821a8ffac3ce1998d77de7e5d287bbd38L55-R64), [link](https://github.com/labring/sealos/pull/3693/files?diff=unified&w=0#diff-85e99ec0f035b3350377258876aab02638af6de847310563256c90fe006a1257R1-R49)-[link](https://github.com/labring/sealos/pull/3693/files?diff=unified&w=0#diff-425b53a14d38b33d97e632f701bd98845c298155d3b4f20e4a2c49506446d2cbR1-R49))
*  Fix linting issues by avoiding unused assignments in `test/e2e/images_buildrun_feature_test.go` and `test/e2e/images_buildrun_test.go` ([link](https://github.com/labring/sealos/pull/3693/files?diff=unified&w=0#diff-1cae1a80daa62ebfda2533c4f2954fd7b50aa679eb7f5c01505aeedf6de6a8adL70-R70), [link](https://github.com/labring/sealos/pull/3693/files?diff=unified&w=0#diff-9ee24976e65b9b64f6cf5a1f3f434424dfddc1823d0423c3bffafddfd2084c83L65-R65))
*  Add checks for image list after running the cluster with different Kubernetes versions in `test/e2e/runtime_version_119_test.go` to `test/e2e/runtime_version_127_test.go` ([link](https://github.com/labring/sealos/pull/3693/files?diff=unified&w=0#diff-96efe7eb173910c53bc282d86382c2a6741afc2559b2b52d044653fca9b2735eR44-R45)-[link](https://github.com/labring/sealos/pull/3693/files?diff=unified&w=0#diff-2f252f6b72206ca5b9d64c78924d11ca5d108b94c5d979e8d21c2431d6ea5343R44-R45))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
