### PR TITLE
feat: docs add theme classic navbar.json

### DIFF
--- a/docs/website/i18n/zh-Hans/docusaurus-theme-classic/footer.json
+++ b/docs/website/i18n/zh-Hans/docusaurus-theme-classic/footer.json
@@ -1,0 +1,54 @@
+{
+  "link.title.Community": {
+    "message": "社区",
+    "description": "The title of the footer links column with title=Community in the footer"
+  },
+  "link.title.More": {
+    "message": "更多",
+    "description": "The title of the footer links column with title=More in the footer"
+  },
+  "link.item.label.Stack Overflow": {
+    "message": "Stack Overflow",
+    "description": "The label of footer link with label=Stack Overflow linking to https://stackoverflow.com/questions/tagged/sealos"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/labring/sealos"
+  },
+  "copyright": {
+    "message": "Copyright © 2023 sealos. 使用 Docusaurus 搭建。",
+    "description": "The footer copyright"
+  },
+  "link.title.Labring": {
+    "message": "Labring",
+    "description": "The title of the footer links column with title=Labring in the footer"
+  },
+  "link.item.label.Company": {
+    "message": "Company",
+    "description": "The label of footer link with label=Company linking to /company"
+  },
+  "link.item.label.Laf FaaS": {
+    "message": "开箱即用的云函数",
+    "description": "The label of footer link with label=Laf FaaS linking to https://github.com/labring/laf"
+  },
+  "link.item.label.Contributing": {
+    "message": "参与贡献",
+    "description": "The label of footer link with label=Contributing linking to https://github.com/labring/sealos/blob/main/CONTRIBUTING.md"
+  },
+  "link.item.label.CloudImages": {
+    "message": "集群镜像",
+    "description": "The label of footer link with label=CloudImages linking to https://hub.docker.com/u/labring"
+  },
+  "link.item.label.CloudNativeLab": {
+    "message": "云原生实验室",
+    "description": "The label of footer link with label=CloudNativeLab linking to https://icloudnative.io"
+  },
+  "link.item.label.Discord": {
+    "message": "Discord",
+    "description": "The label of footer link with label=Discord linking to https://discord.gg/7bPNZfsjJu"
+  },
+  "link.item.label.Blog": {
+    "message": "博客",
+    "description": "The label of footer link with label=Blog linking to /blog"
+  }
+}

--- a/docs/website/i18n/zh-Hans/docusaurus-theme-classic/navbar.json
+++ b/docs/website/i18n/zh-Hans/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,18 @@
+{
+  "item.label.Docs": {
+    "message": "文档",
+    "description": "Navbar item with label Docs"
+  },
+  "item.label.Contact": {
+    "message": "商务合作",
+    "description": "Navbar item with label Contact"
+  },
+  "logo.alt": {
+    "message": "sealos",
+    "description": "The alt text of navbar logo"
+  },
+  "item.label.Start Now": {
+    "message": "在线使用",
+    "description": "Navbar item with label Start Now"
+  }
+}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4e87106</samp>

### Summary
🌐🌟🛠️

<!--
1.  🌐 - This emoji represents the global or international aspect of the change, as it adds a new language option for the website. It also implies that the website is accessible and inclusive for different audiences and regions.
2.  🌟 - This emoji represents the improvement or enhancement of the change, as it adds a localized and user-friendly version of the website for Chinese users. It also implies that the website is attractive and appealing for potential customers or users.
3.  🛠️ - This emoji represents the tool or utility aspect of the change, as it relates to the core functionality and purpose of sealos as a Kubernetes installer and management tool. It also implies that the website is reliable and professional for showcasing the product.
-->
The code adds Chinese translations for the footer and navbar of the sealos website. This improves the accessibility and usability of the website for Chinese users.

> _`sealos` website_
> _Chinese translation added_
> _autumn of k8s_

### Walkthrough
* Translate the footer and navbar of the sealos website into Chinese ([link](https://github.com/labring/sealos/pull/3694/files?diff=unified&w=0#diff-af69b443a4b3e7d59c94e65d25f6af3b79b231b9f9da5dd1ba7ae4d7b56d72b0L1-R53), [link](https://github.com/labring/sealos/pull/3694/files?diff=unified&w=0#diff-d6ccf165b8603dc305b30e9325e125273f1acd1fb1594ecf5e5ac1be1bc093a4L1-R17))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
