### PR TITLE
test(main): using registry.cn-hongkong.aliyuncs.com

### DIFF
--- a/.github/workflows/e2e_test_apply.yml
+++ b/.github/workflows/e2e_test_apply.yml
@@ -45,7 +45,7 @@ jobs:
         id: apply_test
         shell: bash
         env:
-          SEALOS_E2E_TEST_IMAGE_NAME: hub.sealos.cn/labring/kubernetes:v1.25.6
+          SEALOS_E2E_TEST_IMAGE_NAME: registry.cn-hongkong.aliyuncs.com/labring/kubernetes:v1.25.6
           SEALOS_E2E_TEST_PATCH_IMAGE_TAR: /tmp/sealos/images/patch-${{ matrix.arch }}.tar.gz
           SEALOS_E2E_TEST_PATCH_IMAGE_NAME: ghcr.io/labring/sealos-patch:${{ env.GIT_COMMIT_SHORT_SHA }}-${{ matrix.arch }}
           SEALOS_E2E_TEST_SEALOS_BIN_PATH: /tmp/sealos/bin/sealos

--- a/test/e2e/suites/infra/check.go
+++ b/test/e2e/suites/infra/check.go
@@ -34,7 +34,7 @@ type FakeInfra struct {
 	InfraDriver    string
 	TestDir        string
 	/*
-		if baseImageName ond baseImageTar both not set, use default ImageName (hub.sealos.cn/labring/kubernetes:v1.25.6) .
+		if baseImageName ond baseImageTar both not set, use default ImageName (registry.cn-hongkong.aliyuncs.com/labring/kubernetes:v1.25.6) .
 		if ImageTar is set, will use tar to load image; else if baseImageName is set, will pull image with baseImageName.
 		if patchImageTar is set, will use tar to load patch image; else if patchImageName is set, will pull image with patchImageName.
 		if patchImageTar and patchImageName are both set, will use patchImageTar to load image.

--- a/test/e2e/testhelper/settings/common.go
+++ b/test/e2e/testhelper/settings/common.go
@@ -39,14 +39,14 @@ const (
 const GzSuffix = ".gz"
 
 const (
-	DefaultTestImageName  = "hub.sealos.cn/labring/kubernetes:v1.25.0"
+	DefaultTestImageName  = "registry.cn-hongkong.aliyuncs.com/labring/kubernetes:v1.25.0"
 	DefaultTestImageTar   = "/tmp/kubernetes-v1.25.0.tar.gz"
-	DefaultPatchImageName = "hub.sealos.cn/labring/kubernetes:v1.25.0-patch"
+	DefaultPatchImageName = "registry.cn-hongkong.aliyuncs.com/labring/kubernetes:v1.25.0-patch"
 	DefaultPatchImageTar  = "/tmp/kubernetes-v1.25.0-patch.tar.gz"
-	HelmImageName         = "hub.sealos.cn/labring/helm:v3.8.2"
-	CalicoImageName       = "hub.sealos.cn/labring/calico:v3.25.0"
-	DefaultImageRepo      = "hub.sealos.cn/labring"
-	DockerIoRepo          = "docker.io"
+	HelmImageName         = "registry.cn-hongkong.aliyuncs.com/labring/helm:v3.8.2"
+	CalicoImageName       = "registry.cn-hongkong.aliyuncs.com/labring/calico:v3.25.0"
+	DefaultImageRepo      = "registry.cn-hongkong.aliyuncs.com/labring"
+	DockerIoRepo          = "registry.cn-hongkong.aliyuncs.com"
 	DefaultInfraDriver    = AliyunInfraDriver
 	AliyunInfraDriver     = "aliyun"
 	AWSInfraDriver        = "aws"


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 05b58c1</samp>

### Summary
:globe_with_meridians::memo::recycle:

<!--
1.  :globe_with_meridians: This emoji represents the change in the image registry to a different region or location, which may affect the network performance or availability of the images.
2.  :memo: This emoji represents the change in the comment or documentation to match the code, which may improve the readability or clarity of the code.
3.  :recycle: This emoji represents the change in the constants to reuse the same image registry, which may reduce the duplication or inconsistency of the code.
-->
Changed the image registry for the end-to-end test workflow and related constants and comments. This was done to improve the network performance and reliability of the tests.

> _`SEALOS_E2E_TEST`_
> _Switches image registry_
> _Snowy network woes_

### Walkthrough
* Change the image registry for the end-to-end test workflow to avoid network issues ([link](https://github.com/labring/sealos/pull/3697/files?diff=unified&w=0#diff-96496a1660b6f6172d5bc3e79e74fafa75dc7c81656e153c5e85ff90991524b1L48-R48), [link](https://github.com/labring/sealos/pull/3697/files?diff=unified&w=0#diff-7fce8fd889335a59196c61f6ab2f3f753ea45a2e87369d1f1f9cde18a3149dc5L37-R37), [link](https://github.com/labring/sealos/pull/3697/files?diff=unified&w=0#diff-08bd1523c3c44430b7b80773e27d2f5b30857c0513fcfb2205bc74329cc01c60L42-R49))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
