### PR TITLE
fix: admission controller, rename secret

### DIFF
--- a/controllers/admission/cmd/main.go
+++ b/controllers/admission/cmd/main.go
@@ -45,6 +45,7 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
+	//utilruntime.Must(netv1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/controllers/admission/config/certmanager/certificate.yaml
+++ b/controllers/admission/config/certmanager/certificate.yaml
@@ -36,4 +36,4 @@ spec:
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: webhook-server-cert # this secret will not be prefixed, since it's not managed by kustomize
+  secretName: admission-webhook-server-cert # this secret will not be prefixed, since it's not managed by kustomize

--- a/controllers/admission/config/default/manager_webhook_patch.yaml
+++ b/controllers/admission/config/default/manager_webhook_patch.yaml
@@ -20,4 +20,4 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: webhook-server-cert
+          secretName: admission-webhook-server-cert

--- a/controllers/admission/deploy/manifests/deploy.yaml.tmpl
+++ b/controllers/admission/deploy/manifests/deploy.yaml.tmpl
@@ -344,7 +344,7 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: webhook-server-cert
+          secretName: admission-webhook-server-cert
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -365,7 +365,7 @@ spec:
   issuerRef:
     kind: Issuer
     name: admission-selfsigned-issuer
-  secretName: webhook-server-cert
+  secretName: admission-webhook-server-cert
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a493d7e</samp>

### Summary
:memo::truck::wrench:

<!--
1.  :memo: for commenting out the unused scheme
2.  :truck: for renaming the secret name
3.  :wrench: for updating the template file
-->
This pull request updates the secret name and template for the admission webhook server certificate to make it more flexible and consistent. It also removes an unused scheme from the admission webhook controller.

> _Sing, O Muse, of the cunning code review_
> _That fixed the errors and conflicts anew_
> _In the admission webhook controller's scheme_
> _And the secret name of its certificate._

### Walkthrough
*  Remove unused netv1 scheme from admission webhook controller ([link](https://github.com/labring/sealos/pull/3703/files?diff=unified&w=0#diff-03f4cc75479be78b2e722a42a2fa0ae9392e5df7f0370a8ddd5f6209eab9aea6R48))
*  Rename secret name for webhook server certificate to `admission-webhook-server-cert` to avoid conflicts and improve clarity ([link](https://github.com/labring/sealos/pull/3703/files?diff=unified&w=0#diff-eba044c1beda8fc2574eae4e7113acf1848759669beba0c491913d3abff3a059L39-R39), [link](https://github.com/labring/sealos/pull/3703/files?diff=unified&w=0#diff-75f1e1433ec220f22fa10a4715e9f52eabd47a2ace06ad2dc8d15bf07a996b70L23-R23), [link](https://github.com/labring/sealos/pull/3703/files?diff=unified&w=0#diff-b736b546ee9a810ec268252f57f7b1b96a6c11765bc3775ba77fd6e71fc926afL347-R347), [link](https://github.com/labring/sealos/pull/3703/files?diff=unified&w=0#diff-b736b546ee9a810ec268252f57f7b1b96a6c11765bc3775ba77fd6e71fc926afL368-R368))
*  Update references to secret name for webhook server certificate in `config/certmanager/certificate.yaml`, `config/default/manager_webhook_patch.yaml`, and `deploy/manifests/deploy.yaml.tmpl` to match the new name ([link](https://github.com/labring/sealos/pull/3703/files?diff=unified&w=0#diff-eba044c1beda8fc2574eae4e7113acf1848759669beba0c491913d3abff3a059L39-R39), [link](https://github.com/labring/sealos/pull/3703/files?diff=unified&w=0#diff-75f1e1433ec220f22fa10a4715e9f52eabd47a2ace06ad2dc8d15bf07a996b70L23-R23), [link](https://github.com/labring/sealos/pull/3703/files?diff=unified&w=0#diff-b736b546ee9a810ec268252f57f7b1b96a6c11765bc3775ba77fd6e71fc926afL347-R347), [link](https://github.com/labring/sealos/pull/3703/files?diff=unified&w=0#diff-b736b546ee9a810ec268252f57f7b1b96a6c11765bc3775ba77fd6e71fc926afL368-R368))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
