### PR TITLE
fix: billing total pages and count

### DIFF
--- a/controllers/pkg/database/mongodb.go
+++ b/controllers/pkg/database/mongodb.go
@@ -361,6 +361,8 @@ func (m *MongoDB) queryBillingRecordsByOrderID(billingRecordQuery *accountv1.Bil
 	}
 
 	billingRecordQuery.Status.Items = billingRecords
+	billingRecordQuery.Status.PageLength = 1
+	billingRecordQuery.Status.TotalCount = len(billingRecords)
 	return nil
 }
 
@@ -530,6 +532,10 @@ func (m *MongoDB) QueryBillingRecords(billingRecordQuery *accountv1.BillingRecor
 	}
 
 	totalPages := (totalCount + billingRecordQuery.Spec.PageSize - 1) / billingRecordQuery.Spec.PageSize
+	if totalCount == 0 {
+		totalPages = 1
+		totalCount = len(billingRecords)
+	}
 	billingRecordQuery.Status.Items, billingRecordQuery.Status.PageLength, billingRecordQuery.Status.TotalCount,
 		billingRecordQuery.Status.RechargeAmount, billingRecordQuery.Status.DeductionAmount = billingRecords, totalPages, totalCount, totalRechargeAmount, totalDeductionAmount
 	return nil


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c26243b</samp>

### Summary
🐛🔎🚫

<!--
1.  🐛 - This emoji is commonly used to indicate a bug fix or a problem that has been resolved. In this case, it represents the pagination bug for billing record query that was fixed.
2.  🔎 - This emoji is often used to signify search, filter, or zoom functions. In this case, it represents the query filtering by order ID feature that was improved or fixed.
3.  🚫 - This emoji can mean no, stop, or forbidden. In this case, it represents the query status that correctly shows no records when the query returns no results.
-->
Fix pagination bug for billing record query in `mongodb.go`. Improve query status accuracy and user experience when filtering or searching for billing records.

> _A bug in the billing record query_
> _Made pagination go quite awry_
> _It failed to detect_
> _The filter effect_
> _Or when no records would apply_

### Walkthrough
* Fix pagination bug for billing record query by setting page length and total count according to query filter and result ([link](https://github.com/labring/sealos/pull/3709/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46R364-R365), [link](https://github.com/labring/sealos/pull/3709/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46R535-R538)) in `mongodb.go`


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
