### PR TITLE
feature(main): add sreg cache image

### DIFF
--- a/docs/4.0/docs/lifecycle-management/QA.md
+++ b/docs/4.0/docs/lifecycle-management/QA.md
@@ -82,7 +82,28 @@ ENV TZ=Asia/Shanghai
 sealos build --arch arm64 --build-arg TARGETOS=linux --build-arg TARGETARCH=arm64 -t test  -f Dockerfile .
 ```
 
-### Q4: Encounter the error "lgetxattr /var/lib/containers/storage/overlay/0c2afe770ec7870ad4639f18a1b50b3a84718f95c8907f3d54e14dbf0a01d50d/merged/dev/ptmx: no such device" during Sealos build. How to fix it?
+### Q4: How to Build Cluster Images Using Other Build Tools?
+
+If you want to use other container tools like Docker or Podman to build cluster images, you can utilize [sreg](https://github.com/labring/sreg) to cache the images.
+
+Follow these steps:
+
+1. Install sreg:
+   ```shell
+   wget https://github.com/labring/sreg/releases/download/v0.1.1/sreg_0.1.1_linux_amd64.tar.gz
+   tar -xzf sreg_0.1.1_linux_amd64.tar.gz sreg
+   mv sreg /usr/bin/
+   ```
+2. Cache the images:
+   ```shell
+   sreg save --registry-dir=registry .
+   ```
+3. Build the cluster image:
+   ```shell
+   docker build -t xxxx -f Sealfile .
+   ```
+
+### Q5: Encounter the error "lgetxattr /var/lib/containers/storage/overlay/0c2afe770ec7870ad4639f18a1b50b3a84718f95c8907f3d54e14dbf0a01d50d/merged/dev/ptmx: no such device" during Sealos build. How to fix it?
 
 This issue might be related to the version of `fuse-overlayfs`. We recommend downloading the latest version from [here](https://github.com/containers/fuse-overlayfs/releases) and replacing `/bin/fuse-overlayfs`.
 

--- a/docs/4.0/i18n/zh-Hans/lifecycle-management/QA.md
+++ b/docs/4.0/i18n/zh-Hans/lifecycle-management/QA.md
@@ -82,7 +82,28 @@ ENV TZ=Asia/Shanghai
 sealos build --arch arm64 --build-arg TARGETOS=linux --build-arg TARGETARCH=arm64 -t test  -f Dockerfile .
 ```
 
-### Q4：执行Sealos构建时遇到“lgetxattr /var/lib/containers/storage/overlay/0c2afe770ec7870ad4639f18a1b50b3a84718f95c8907f3d54e14dbf0a01d50d/merged/dev/ptmx: no such device”错误？
+### Q4：如何使用其他构建工具构建集群镜像？
+
+如果您想使用 Docker 或 Podman 等其他容器工具来构建集群镜像，您可以借助 [sreg](https://github.com/labring/sreg) 来缓存镜像。
+
+以下是操作步骤：
+
+1. 安装 sreg：
+   ```shell
+   wget https://github.com/labring/sreg/releases/download/v0.1.1/sreg_0.1.1_linux_amd64.tar.gz
+   tar -xzf sreg_0.1.1_linux_amd64.tar.gz sreg
+   mv sreg /usr/bin/
+   ```
+2. 缓存镜像：
+   ```shell
+   sreg save --registry-dir=registry .
+   ```
+3. 构建集群镜像：
+   ```shell
+   docker build -t xxxx -f Sealfile .
+   ```
+
+### Q5：执行Sealos构建时遇到“lgetxattr /var/lib/containers/storage/overlay/0c2afe770ec7870ad4639f18a1b50b3a84718f95c8907f3d54e14dbf0a01d50d/merged/dev/ptmx: no such device”错误？
 
 这个问题可能与`fuse-overlayfs`的版本有关。建议您从[这里](https://github.com/containers/fuse-overlayfs/releases)下载最新版本下载并替换`/bin/fuse-overlayfs`。
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c982280</samp>

### Summary
:sparkles::whale::globe_with_meridians:

<!--
1.  :sparkles: This emoji represents the addition of a new feature or enhancement, which in this case is the new Q4 in both versions of the document.
2.  :whale: This emoji represents the use of Docker or other container tools, which are mentioned in the new Q4 as alternative ways to build cluster images with sreg.
3.  :globe_with_meridians: This emoji represents the translation or localization of content, which in this case is the new Q4 in the Chinese version of the document.
-->
This pull request updates the QA document in both English and Chinese versions, adding a new section on how to use different container tools to build cluster images with `sreg`.

> _`QA` document grows_
> _New question on build tools_
> _Autumn of options_

### Walkthrough
*  Add a new question and answer (Q4) to the QA document, explaining how to use other build tools like Docker or Podman to build cluster images with sreg ([link](https://github.com/labring/sealos/pull/3715/files?diff=unified&w=0#diff-cac3e7881dc81ec8a9881c761253ec6d556c90a23de8e63c39ecc27cda65479eL85-R107), [link](https://github.com/labring/sealos/pull/3715/files?diff=unified&w=0#diff-96e0b8f0535c6be19a5627d93ec84b9b7e8a9426fda878814cfbf6386ec68b49L85-R107))
  * Update the English version in `docs/4.0/docs/lifecycle-management/QA.md` ([link](https://github.com/labring/sealos/pull/3715/files?diff=unified&w=0#diff-cac3e7881dc81ec8a9881c761253ec6d556c90a23de8e63c39ecc27cda65479eL85-R107))
  * Update the Chinese version in `docs/4.0/i18n/zh-Hans/lifecycle-management/QA.md`, translating the content from the English version ([link](https://github.com/labring/sealos/pull/3715/files?diff=unified&w=0#diff-96e0b8f0535c6be19a5627d93ec84b9b7e8a9426fda878814cfbf6386ec68b49L85-R107))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
