### PR TITLE
feat: quota for costcenter

### DIFF
--- a/frontend/providers/costcenter/public/locales/en/common.json
+++ b/frontend/providers/costcenter/public/locales/en/common.json
@@ -136,5 +136,9 @@
   },
   "pay with stripe": "Pay With Stripe",
   "pay with wechat": "Pay With Wechat",
-  "Pay Minimum Tips": "The amount need to be more than 10 when paying with Stripe"
+  "Pay Minimum Tips": "The amount need to be more than 10 when paying with Stripe",
+  "Source Quota": "Source Quota",
+  "Total Quota": "total",
+  "Used Quota": "used",
+  "Remaining Quota": "remaining"
 }

--- a/frontend/providers/costcenter/public/locales/zh/common.json
+++ b/frontend/providers/costcenter/public/locales/zh/common.json
@@ -136,5 +136,9 @@
   },
   "pay with wechat": "微信支付",
   "pay with stripe": "Stripe 支付",
-  "Pay Minimum Tips": "使用Stripe支付时，购买额度不低于10"
+  "Pay Minimum Tips": "使用Stripe支付时，购买额度不低于10",
+  "Source Quota": "资源配额",
+  "Total Quota": "总计",
+  "used Quota": "已用",
+  "Remaining Quota": "剩余"
 }

--- a/frontend/providers/costcenter/src/components/MyTooltip.tsx
+++ b/frontend/providers/costcenter/src/components/MyTooltip.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Tooltip, TooltipProps } from '@chakra-ui/react';
+
+const MyTooltip = ({ children, ...props }: TooltipProps) => {
+  return (
+    <Tooltip
+      bg={'white'}
+      arrowShadowColor={' rgba(0,0,0,0.1)'}
+      hasArrow
+      arrowSize={12}
+      offset={[20, 15]}
+      color={'myGray.800'}
+      px={4}
+      py={2}
+      borderRadius={'8px'}
+      whiteSpace={'pre-wrap'}
+      {...props}
+    >
+      {children}
+    </Tooltip>
+  );
+};
+
+export default MyTooltip;

--- a/frontend/providers/costcenter/src/components/valuation/predictCard.tsx
+++ b/frontend/providers/costcenter/src/components/valuation/predictCard.tsx
@@ -31,7 +31,7 @@ export default function PredictCard() {
     }));
   }, [state.cpu, state.memory, state.storage, gpuEnabled, total]);
   return (
-    <Flex borderX={'0.5px solid #DEE0E2'}>
+    <Flex border={'1px solid #DEE0E2'} borderRadius={'4px'} overflow={'hidden'}>
       {leastCost.map((item) => (
         <Flex
           key={item.name}

--- a/frontend/providers/costcenter/src/components/valuation/quota.tsx
+++ b/frontend/providers/costcenter/src/components/valuation/quota.tsx
@@ -1,0 +1,68 @@
+import { valuationMap } from '@/constants/payment';
+import { UserQuoteItemType } from '@/pages/api/getQuota';
+import request from '@/service/request';
+import useEnvStore from '@/stores/env';
+import { ApiResp } from '@/types';
+import { Flex } from '@chakra-ui/react';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import MyTooltip from '../MyTooltip';
+
+export default function Quota() {
+  const { t } = useTranslation();
+  const { data } = useQuery(['quota'], () =>
+    request<any, ApiResp<{ quota: UserQuoteItemType[] }>>('/api/getQuota')
+  );
+  const quota = (data?.data?.quota || []).flatMap((_quota) => {
+    const x = valuationMap.get(_quota.type);
+    if (!x) return [];
+    return [
+      {
+        ..._quota,
+        unit: x.unit,
+        bg: x.bg
+      }
+    ];
+  });
+  const gpuEnabled = useEnvStore((s) => s.gpuEnabled);
+  return (
+    <Flex borderX={'1px solid #DEE0E2'} borderRadius={'4px'} overflow={'hidden'}>
+      {quota
+        .filter((x) => gpuEnabled || x.type !== 'gpu')
+        .map((item) => (
+          <Flex
+            key={item.type}
+            flex={1}
+            position="relative"
+            borderX={'0.5px solid #DEE0E2'}
+            borderY={'1px solid #DEE0E2'}
+            bg={'#F1F4F6'}
+            direction={'column'}
+          >
+            <Flex justify={'center'} align={'center'} h={'42px'} borderBottom={'1px solid #DEE0E2'}>
+              {item.type}
+            </Flex>
+            <Flex justify={'center'} align={'center'} h={'68px'}>
+              <MyTooltip
+                hasArrow={true}
+                placement="top"
+                label={`${t('Total Quota')}: ${item.limit} ${item.unit}
+${t('Used Quota')}: ${item.used} ${item.unit}
+${t('Remaining Quota')}: ${item.limit - item.used} ${item.unit}
+`}
+                whiteSpace={'pre-wrap'}
+              >
+                <Flex w="168px" h="6px" bg="#DEE0E2" borderRadius={'4px'} overflow={'hidden'}>
+                  <Flex
+                    borderRadius={'4px'}
+                    w={Math.floor((item.used * 100) / item.limit) + '%'}
+                    bg={item.bg}
+                  />
+                </Flex>
+              </MyTooltip>
+            </Flex>
+          </Flex>
+        ))}
+    </Flex>
+  );
+}

--- a/frontend/providers/costcenter/src/pages/api/getQuota.ts
+++ b/frontend/providers/costcenter/src/pages/api/getQuota.ts
@@ -1,0 +1,109 @@
+import { authSession } from '@/service/backend/auth';
+import { jsonRes } from '@/service/backend/response';
+import * as k8s from '@kubernetes/client-node';
+import type { NextApiRequest, NextApiResponse } from 'next';
+export default async function handler(req: NextApiRequest, resp: NextApiResponse) {
+  try {
+    const kc = await authSession(req.headers);
+
+    // get user account payment amount
+    const user = kc.getCurrentUser();
+    if (user === null) {
+      return jsonRes(resp, { code: 403, message: 'user null' });
+    }
+    const namespace = 'ns-' + user.name;
+    const quota = await getUserQuota(kc, namespace);
+    return jsonRes(resp, {
+      code: 200,
+      data: { quota }
+    });
+  } catch (error) {
+    console.log(error);
+    jsonRes(resp, { code: 500, message: 'get price error' });
+  }
+}
+export type UserQuoteItemType = {
+  type: 'cpu' | 'memory' | 'storage' | 'gpu';
+  used: number;
+  limit: number;
+};
+/**
+ * cpu format
+ */
+export const cpuFormatToM = (cpu: string) => {
+  if (!cpu || cpu === '0') {
+    return 0;
+  }
+  let value = parseFloat(cpu);
+
+  if (/n/gi.test(cpu)) {
+    value = value / 1000 / 1000;
+  } else if (/u/gi.test(cpu)) {
+    value = value / 1000;
+  } else if (/m/gi.test(cpu)) {
+    value = value;
+  } else {
+    value = value * 1000;
+  }
+  if (value < 0.1) return 0;
+  return Number(value.toFixed(4));
+};
+
+/**
+ * memory format
+ */
+export const memoryFormatToMi = (memory: string) => {
+  if (!memory || memory === '0') {
+    return 0;
+  }
+
+  let value = parseFloat(memory);
+
+  if (/Ki/gi.test(memory)) {
+    value = value / 1024;
+  } else if (/Mi/gi.test(memory)) {
+    value = value;
+  } else if (/Gi/gi.test(memory)) {
+    value = value * 1024;
+  } else if (/Ti/gi.test(memory)) {
+    value = value * 1024 * 1024;
+  } else {
+    console.log('Invalid memory value');
+    value = 0;
+  }
+
+  return Number(value.toFixed(2));
+};
+
+export async function getUserQuota(
+  kc: k8s.KubeConfig,
+  namespace: string
+): Promise<UserQuoteItemType[]> {
+  const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
+
+  const data = await k8sApi.readNamespacedResourceQuota(`quota-${namespace}`, namespace);
+  const status = data?.body?.status;
+  if (!status) return [];
+  return [
+    {
+      type: 'cpu',
+      limit: cpuFormatToM(status?.hard?.['limits.cpu'] || '') / 1000,
+      used: cpuFormatToM(status?.used?.['limits.cpu'] || '') / 1000
+    },
+    {
+      type: 'memory',
+      limit: memoryFormatToMi(status?.hard?.['limits.memory'] || '') / 1024,
+      used: memoryFormatToMi(status?.used?.['limits.memory'] || '') / 1024
+    },
+    {
+      type: 'storage',
+      limit: memoryFormatToMi(status?.hard?.['requests.storage'] || '') / 1024,
+      used: memoryFormatToMi(status?.used?.['requests.storage'] || '') / 1024
+    },
+    {
+      type: 'gpu',
+      limit: Number(status?.hard?.['limits.nvidia.com/gpu'] || 0),
+      used: Number(status?.used?.['limits.nvidia.com/gpu'] || 0)
+    }
+  ];
+}

--- a/frontend/providers/costcenter/src/pages/valuation/index.tsx
+++ b/frontend/providers/costcenter/src/pages/valuation/index.tsx
@@ -1,4 +1,14 @@
-import { Box, Flex, Heading, Text, Img, Stack } from '@chakra-ui/react';
+import {
+  Box,
+  Flex,
+  Heading,
+  Text,
+  Img,
+  Stack,
+  PopoverArrow,
+  position,
+  Tooltip
+} from '@chakra-ui/react';
 import letter_icon from '@/assert/format_letter_spacing_standard_black.svg';
 import { QueryClient, dehydrate, useQuery } from '@tanstack/react-query';
 import request from '@/service/request';
@@ -16,6 +26,7 @@ import NotFound from '@/components/notFound';
 import PredictCard from '@/components/valuation/predictCard';
 import useEnvStore from '@/stores/env';
 import CurrencySymbol from '@/components/CurrencySymbol';
+import Quota from '@/components/valuation/quota';
 type CardItem = {
   title: string;
   price: number[];
@@ -180,7 +191,11 @@ function Valuation() {
             <Text mr={'17px '}>{t('Next month cost estimation')}</Text>
             <OuterLink text={t('Predict Detail')} href={'#'}></OuterLink>
           </Flex>
-          <PredictCard></PredictCard>
+          <PredictCard />
+        </Flex>
+        <Flex mt={'36px'} direction={'column'}>
+          <Text mb="20px">{t('Source Quota')}</Text>
+          <Quota />
         </Flex>
       </Flex>
     </Flex>


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a9d0e86</samp>

### Summary
🌐🛠️📊

<!--
1.  🌐 - This emoji represents the localization changes, as it is often used to indicate different languages or regions.
2.  🛠️ - This emoji represents the component and UI changes, as it is often used to indicate tools or construction.
3.  📊 - This emoji represents the data and API changes, as it is often used to indicate charts or statistics.
-->
This pull request adds a tooltip and a quota feature to the valuation page of the costcenter frontend. The tooltip provides more information about the valuation metrics, and the quota shows the user's resource usage and limits. The pull request also adds localization files, a custom tooltip component, and an API handler to support the new features. The pull request also makes some minor style adjustments to the valuation page.

> _`Quota` is the limit of your power_
> _`Tooltip` reveals the secrets of the hour_
> _You face the doom of the `PredictCard`_
> _You need the `MyTooltip` to break the guard_

### Walkthrough
*  Add a new feature to show the user's source quota in the valuation page ([link](https://github.com/labring/sealos/pull/3734/files?diff=unified&w=0#diff-ddf1e5a0c76f63d4db94a3179dcab3071ca8daf70f0603a89e17379d489125e3R1-R68), [link](https://github.com/labring/sealos/pull/3734/files?diff=unified&w=0#diff-ea1e3f129e232a8b03031cee76608a1c46fd2878855cd60190bfc9d599cea438R1-R109), [link](https://github.com/labring/sealos/pull/3734/files?diff=unified&w=0#diff-244a68651117c45a381484e7dc796c9ecf7acac2fef32dace7bf1c58d715b8a3R29), [link](https://github.com/labring/sealos/pull/3734/files?diff=unified&w=0#diff-244a68651117c45a381484e7dc796c9ecf7acac2fef32dace7bf1c58d715b8a3L183-R199))
  - Create a new component `Quota` that fetches and renders the user's quota data from the backend API ([link](https://github.com/labring/sealos/pull/3734/files?diff=unified&w=0#diff-ddf1e5a0c76f63d4db94a3179dcab3071ca8daf70f0603a89e17379d489125e3R1-R68))
  - Create a new API handler `/api/getQuota` that authenticates the user and gets the user's resource quota from the Kubernetes cluster ([link](https://github.com/labring/sealos/pull/3734/files?diff=unified&w=0#diff-ea1e3f129e232a8b03031cee76608a1c46fd2878855cd60190bfc9d599cea438R1-R109))
  - Import and use the `Quota` component in the `valuation/index.tsx` file and add some margins and text ([link](https://github.com/labring/sealos/pull/3734/files?diff=unified&w=0#diff-244a68651117c45a381484e7dc796c9ecf7acac2fef32dace7bf1c58d715b8a3R29), [link](https://github.com/labring/sealos/pull/3734/files?diff=unified&w=0#diff-244a68651117c45a381484e7dc796c9ecf7acac2fef32dace7bf1c58d715b8a3L183-R199))
* Add a new component `MyTooltip` that customizes the appearance and behavior of the `Tooltip` component from the `@chakra-ui/react` library ([link](https://github.com/labring/sealos/pull/3734/files?diff=unified&w=0#diff-2264414285150cf954ee822c7b54a783470171907150d41d81015ab955e52320R1-R24), [link](https://github.com/labring/sealos/pull/3734/files?diff=unified&w=0#diff-244a68651117c45a381484e7dc796c9ecf7acac2fef32dace7bf1c58d715b8a3L1-R11))
  - Set some default props for the tooltip, such as the background color, arrow size, padding, border radius, and white space ([link](https://github.com/labring/sealos/pull/3734/files?diff=unified&w=0#diff-2264414285150cf954ee822c7b54a783470171907150d41d81015ab955e52320R1-R24))
  - Import and use the `Tooltip` component in the `valuation/index.tsx` file ([link](https://github.com/labring/sealos/pull/3734/files?diff=unified&w=0#diff-244a68651117c45a381484e7dc796c9ecf7acac2fef32dace7bf1c58d715b8a3L1-R11))
* Modify the `PredictCard` component to add a border and a border radius to the flex container that wraps the least cost items ([link](https://github.com/labring/sealos/pull/3734/files?diff=unified&w=0#diff-aacdb95056ff4f53c9e60f4d80210372a3c92d01f1041fd3b3070c432b017af0L34-R34))
  - Make the component more consistent with the design mockup and the other components in the page ([link](https://github.com/labring/sealos/pull/3734/files?diff=unified&w=0#diff-aacdb95056ff4f53c9e60f4d80210372a3c92d01f1041fd3b3070c432b017af0L34-R34))
* Add some new keys and values to the English and Chinese localization files for the costcenter frontend ([link](https://github.com/labring/sealos/pull/3734/files?diff=unified&w=0#diff-22a0af9ffd00ea2fcfdc0db3fb38d437eb615c51f91a38ba0c3c100b20a09ddbR139-R142), [link](https://github.com/labring/sealos/pull/3734/files?diff=unified&w=0#diff-54169e3c66c9921e2d46d2574fd77362a7f5e405e054acb1938dcf5c275e6c83R139-R142))
  - The keys are related to the source quota feature and the values are translated from the English ones ([link](https://github.com/labring/sealos/pull/3734/files?diff=unified&w=0#diff-22a0af9ffd00ea2fcfdc0db3fb38d437eb615c51f91a38ba0c3c100b20a09ddbR139-R142), [link](https://github.com/labring/sealos/pull/3734/files?diff=unified&w=0#diff-54169e3c66c9921e2d46d2574fd77362a7f5e405e054acb1938dcf5c275e6c83R139-R142))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
