### PR TITLE
modify GiB to GB

### DIFF
--- a/frontend/providers/costcenter/src/constants/payment.ts
+++ b/frontend/providers/costcenter/src/constants/payment.ts
@@ -89,8 +89,8 @@ export const START_TIME = new Date(2023, 0, 1);
 export const END_TIME = endOfDay(new Date());
 export const valuationMap = new Map([
   ['cpu', { unit: 'Core', scale: 1000, bg: '#33BABB', idx: 0 }],
-  ['memory', { unit: 'GiB', scale: 1024, bg: '#36ADEF', idx: 1 }],
-  ['storage', { unit: 'GiB', scale: 1024, bg: '#8172D8', idx: 2 }],
+  ['memory', { unit: 'GB', scale: 1024, bg: '#36ADEF', idx: 1 }],
+  ['storage', { unit: 'GB', scale: 1024, bg: '#8172D8', idx: 2 }],
   ['gpu', { unit: 'GPU', scale: 1000, bg: '#89CD11', idx: 3 }]
   // ['network', { unit: 'M', scale: 1, bg: '#89CD11', idx: 4 }]
 ]);

--- a/frontend/providers/costcenter/src/pages/valuation/index.tsx
+++ b/frontend/providers/costcenter/src/pages/valuation/index.tsx
@@ -1,14 +1,4 @@
-import {
-  Box,
-  Flex,
-  Heading,
-  Text,
-  Img,
-  Stack,
-  PopoverArrow,
-  position,
-  Tooltip
-} from '@chakra-ui/react';
+import { Box, Flex, Heading, Text, Img, Stack } from '@chakra-ui/react';
 import letter_icon from '@/assert/format_letter_spacing_standard_black.svg';
 import { QueryClient, dehydrate, useQuery } from '@tanstack/react-query';
 import request from '@/service/request';


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c00caa5</samp>

### Summary
🔄🗑️🧹

<!--
1.  🔄 - This emoji can be used to represent the change in the unit of memory and storage, as it indicates that something was switched or converted from one thing to another. Alternatively, one could also use 🔀 or 🎛️ for this change.
2. 🗑️ - This emoji can be used to represent the removal of the unused imports, as it indicates that something was deleted or discarded. Alternatively, one could also use ❌ or 🚫 for this change.
3. 🧹 - This emoji can be used to represent the improvement in the code readability and maintainability, as it indicates that something was cleaned or tidied up. Alternatively, one could also use 🌟 or ✨ for this change.
-->
The pull request updates the unit of memory and storage in the `frontend/providers/costcenter` module from GiB to GB, and removes some unused imports from the valuation page. These changes aim to improve the accuracy and clarity of the cost center dashboard.

> _`valuationMap` changed_
> _From GiB to GB units_
> _Autumn leaves falling_

### Walkthrough
* Change the unit of memory and storage from GiB to GB in the valuationMap constant ([link](https://github.com/labring/sealos/pull/3736/files?diff=unified&w=0#diff-0e13a3f7cbc82a4b65fa3628942ac1faed7984d412bdfbf661c5e323b91bba4fL92-R93)). This affects the frontend/providers/costcenter/src/constants/payment.ts file and the valuation page, where the resource consumption and cost are displayed and calculated based on the standard unit used in the cost center dashboard.


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
