### PR TITLE
set the monitor collection retention time

### DIFF
--- a/controllers/pkg/database/interface.go
+++ b/controllers/pkg/database/interface.go
@@ -33,6 +33,7 @@ type Interface interface {
 	GetBillingCount(accountType accountv1.Type, startTime, endTime time.Time) (count, amount int64, err error)
 	GenerateMeteringData(startTime, endTime time.Time, prices map[string]common.Price) error
 	InsertMonitor(ctx context.Context, monitors ...*common.Monitor) error
+	DropMonitorCollectionsOlderThan(days int) error
 	Disconnect(ctx context.Context) error
 	Creator
 }

--- a/controllers/pkg/database/mongodb_test.go
+++ b/controllers/pkg/database/mongodb_test.go
@@ -240,12 +240,12 @@ func TestMongoDB_getBillingCollection(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := &MongoDB{
-				URL:          tt.fields.URL,
-				Client:       tt.fields.Client,
-				DBName:       tt.fields.DBName,
-				MonitorConn:  tt.fields.MonitorConn,
-				MeteringConn: tt.fields.MeteringConn,
-				BillingConn:  tt.fields.BillingConn,
+				URL:               tt.fields.URL,
+				Client:            tt.fields.Client,
+				DBName:            tt.fields.DBName,
+				MonitorConnPrefix: tt.fields.MonitorConn,
+				MeteringConn:      tt.fields.MeteringConn,
+				BillingConn:       tt.fields.BillingConn,
 			}
 			if got := m.getBillingCollection(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getBillingCollection() = %v, want %v", got, tt.want)
@@ -273,12 +273,12 @@ func TestMongoDB_getMeteringCollection(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := &MongoDB{
-				URL:          tt.fields.URL,
-				Client:       tt.fields.Client,
-				DBName:       tt.fields.DBName,
-				MonitorConn:  tt.fields.MonitorConn,
-				MeteringConn: tt.fields.MeteringConn,
-				BillingConn:  tt.fields.BillingConn,
+				URL:               tt.fields.URL,
+				Client:            tt.fields.Client,
+				DBName:            tt.fields.DBName,
+				MonitorConnPrefix: tt.fields.MonitorConn,
+				MeteringConn:      tt.fields.MeteringConn,
+				BillingConn:       tt.fields.BillingConn,
 			}
 			if got := m.getMeteringCollection(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getMeteringCollection() = %v, want %v", got, tt.want)
@@ -307,12 +307,12 @@ func TestMongoDB_getMonitorCollection(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := &MongoDB{
-				URL:          tt.fields.URL,
-				Client:       tt.fields.Client,
-				DBName:       tt.fields.DBName,
-				MonitorConn:  tt.fields.MonitorConn,
-				MeteringConn: tt.fields.MeteringConn,
-				BillingConn:  tt.fields.BillingConn,
+				URL:               tt.fields.URL,
+				Client:            tt.fields.Client,
+				DBName:            tt.fields.DBName,
+				MonitorConnPrefix: tt.fields.MonitorConn,
+				MeteringConn:      tt.fields.MeteringConn,
+				BillingConn:       tt.fields.BillingConn,
 			}
 			if got := m.getMonitorCollection(tt.collTime); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getMonitorCollection() = %v, want %v", got, tt.want)
@@ -388,4 +388,21 @@ func TestMongoDB_GetAllPricesMap(t *testing.T) {
 		t.Fatalf("failed to get all prices map: %v", err)
 	}
 	t.Logf("pricesMap: %v", pricesMap)
+}
+
+func TestMongoDB_DropMonitorCollectionsOlderThan(t *testing.T) {
+	dbCTX := context.Background()
+	m, err := NewMongoDB(dbCTX, os.Getenv("MONGODB_URI"))
+	if err != nil {
+		t.Errorf("failed to connect mongo: error = %v", err)
+	}
+	defer func() {
+		if err = m.Disconnect(dbCTX); err != nil {
+			t.Errorf("failed to disconnect mongo: error = %v", err)
+		}
+	}()
+	// 0711
+	if err = m.DropMonitorCollectionsOlderThan(30); err != nil {
+		t.Fatalf("failed to drop monitor collections older than 30 days: %v", err)
+	}
 }

--- a/controllers/resources/metering/main.go
+++ b/controllers/resources/metering/main.go
@@ -22,6 +22,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/labring/sealos/controllers/pkg/utils"
+
 	"github.com/labring/sealos/controllers/pkg/common"
 
 	"github.com/labring/sealos/controllers/pkg/database"
@@ -32,14 +34,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//var once *sync.Once
-
 type Config struct {
 	// mongodb connect url
-	MongoConnectURI string
-	MongoUsername   string
-	MongoPassword   string
-
+	MongoConnectURI    string
+	MongoUsername      string
+	MongoPassword      string
+	RetentionDay       int64
+	PermanentRetention bool
 	// interval of metering resources
 	Interval time.Duration
 }
@@ -86,9 +87,34 @@ func ResourcesMetering() {
 			}
 		}
 	}()
+	if !config.PermanentRetention {
+		ticker := time.NewTicker(24 * time.Hour)
+		go func() {
+			for range ticker.C {
+				if err := DropMonitorCollectionOlder(); err != nil {
+					logger.Error("Failed to drop monitor collection older than %d days: %v", config.RetentionDay, err)
+				}
+			}
+		}()
+	}
 
 	<-ctx.Done()
 	logger.Info("program exit")
+}
+
+func DropMonitorCollectionOlder() error {
+	dbCtx := context.Background()
+	dbClient, err := database.NewMongoDB(dbCtx, config.MongoConnectURI)
+	if err != nil {
+		return fmt.Errorf("connect mongo client failed: %v", err)
+	}
+	defer func() {
+		err := dbClient.Disconnect(dbCtx)
+		if err != nil {
+			logger.Error("disconnect mongo client failed: %v", err)
+		}
+	}()
+	return dbClient.DropMonitorCollectionsOlderThan(int(config.RetentionDay))
 }
 
 func PreApply() error {
@@ -209,8 +235,10 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&showPath, "show-path", false, "enable show code path")
 	rootCmd.AddCommand(newStartCmd())
 	config = &Config{
-		MongoConnectURI: os.Getenv(database.MongoURI),
-		MongoUsername:   os.Getenv(database.MongoUsername),
-		MongoPassword:   os.Getenv(database.MongoPassword),
+		MongoConnectURI:    os.Getenv(database.MongoURI),
+		MongoUsername:      os.Getenv(database.MongoUsername),
+		MongoPassword:      os.Getenv(database.MongoPassword),
+		RetentionDay:       utils.GetInt64EnvWithDefault(database.RetentionDay, database.DefaultRetentionDay),
+		PermanentRetention: os.Getenv(database.PermanentRetention) == "true",
 	}
 }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bf9d3c2</samp>

### Summary
🗑️🔄🕒

<!--
1.  🗑️ - This emoji represents the action of dropping or deleting old data, which is the main purpose of the data retention policy feature.
2.  🔄 - This emoji represents the action of refactoring or changing existing code, which is done in the test functions and the `MonitorConn` field.
3.  🕒 - This emoji represents the concept of time or duration, which is relevant for the retention day settings and the goroutine that runs periodically.
-->
This pull request implements data retention policy features for the metering service using MongoDB. It adds a new method to the `database` interface and its MongoDB implementation to drop old monitor collections based on retention day settings and a permanent retention flag. It also refactors the test functions for the MongoDB struct and adds a new test function for the new method. It uses environment variables, a new `utils` package, and a goroutine to run the feature in the main metering service file.

> _Oh, we are the metering crew, we measure and we store_
> _We keep the data in MongoDB, but not forevermore_
> _We drop the old collections with `DropMonitorCollectionsOlderThan`_
> _And sing this shanty as we work, heave ho and count to ten_

### Walkthrough
*  Add data retention policy for metering service ([link](https://github.com/labring/sealos/pull/3737/files?diff=unified&w=0#diff-5bb8f60e9081274e83387c8fb929e8dccb2ab7675781e07fd4eb0ee77461a4feR36), [link](https://github.com/labring/sealos/pull/3737/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46R21), [link](https://github.com/labring/sealos/pull/3737/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46L44-R52), [link](https://github.com/labring/sealos/pull/3737/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46L55-R66), [link](https://github.com/labring/sealos/pull/3737/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46L588-R593), [link](https://github.com/labring/sealos/pull/3737/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46R660-R681), [link](https://github.com/labring/sealos/pull/3737/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46L668-R701), [link](https://github.com/labring/sealos/pull/3737/files?diff=unified&w=0#diff-a126f522b0bf02974f6f06cb25dcf2bd66f62276b372d5fbfc93959f7e15c136R392-R408), [link](https://github.com/labring/sealos/pull/3737/files?diff=unified&w=0#diff-7b41d7c379e687468c6d660ee2d0ec2e2f74263b043b0ab23b7b99015a05f45cR25-R26), [link](https://github.com/labring/sealos/pull/3737/files?diff=unified&w=0#diff-7b41d7c379e687468c6d660ee2d0ec2e2f74263b043b0ab23b7b99015a05f45cL35-R43), [link](https://github.com/labring/sealos/pull/3737/files?diff=unified&w=0#diff-7b41d7c379e687468c6d660ee2d0ec2e2f74263b043b0ab23b7b99015a05f45cR90-R99), [link](https://github.com/labring/sealos/pull/3737/files?diff=unified&w=0#diff-7b41d7c379e687468c6d660ee2d0ec2e2f74263b043b0ab23b7b99015a05f45cR105-R119), [link](https://github.com/labring/sealos/pull/3737/files?diff=unified&w=0#diff-7b41d7c379e687468c6d660ee2d0ec2e2f74263b043b0ab23b7b99015a05f45cL212-R242))
* Update test functions in `mongodb_test.go` to use `MonitorConnPrefix` field instead of `MonitorConn` field ([link](https://github.com/labring/sealos/pull/3737/files?diff=unified&w=0#diff-a126f522b0bf02974f6f06cb25dcf2bd66f62276b372d5fbfc93959f7e15c136L243-R248), [link](https://github.com/labring/sealos/pull/3737/files?diff=unified&w=0#diff-a126f522b0bf02974f6f06cb25dcf2bd66f62276b372d5fbfc93959f7e15c136L276-R281), [link](https://github.com/labring/sealos/pull/3737/files?diff=unified&w=0#diff-a126f522b0bf02974f6f06cb25dcf2bd66f62276b372d5fbfc93959f7e15c136L310-R315))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
