### PR TITLE
Feat: add gpu prices alias

### DIFF
--- a/controllers/account/config/rbac/role.yaml
+++ b/controllers/account/config/rbac/role.yaml
@@ -18,6 +18,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+- apiGroups:
   - account.sealos.io
   resources:
   - accountbalances

--- a/controllers/account/controllers/billingrecordquery_controller.go
+++ b/controllers/account/controllers/billingrecordquery_controller.go
@@ -22,6 +22,8 @@ import (
 	"os"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+
 	"github.com/labring/sealos/controllers/pkg/common/gpu"
 
 	"github.com/labring/sealos/controllers/pkg/common"
@@ -152,7 +154,7 @@ func (r *BillingRecordQueryReconciler) ReconcilePriceQuery(ctx context.Context, 
 	}
 	priceQuery.Status.BillingRecords = make([]accountv1.BillingRecord, 0)
 	alias, err := gpu.GetGPUAlias(r.Client)
-	if err != nil {
+	if errors.IsNotFound(err) {
 		r.Logger.Error(err, "get gpu alias failed")
 	}
 	for property, v := range pricesMap {

--- a/controllers/account/controllers/billingrecordquery_controller.go
+++ b/controllers/account/controllers/billingrecordquery_controller.go
@@ -22,6 +22,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/labring/sealos/controllers/pkg/common/gpu"
+
 	"github.com/labring/sealos/controllers/pkg/common"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -52,6 +54,8 @@ type BillingRecordQueryReconciler struct {
 //+kubebuilder:rbac:groups=account.sealos.io,resources=pricequeries,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=account.sealos.io,resources=pricequeries/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=account.sealos.io,resources=pricequeries/finalizers,verbs=update
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=configmaps/status,verbs=get
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -147,7 +151,16 @@ func (r *BillingRecordQueryReconciler) ReconcilePriceQuery(ctx context.Context, 
 		pricesMap = common.DefaultPrices
 	}
 	priceQuery.Status.BillingRecords = make([]accountv1.BillingRecord, 0)
+	alias, err := gpu.GetGPUAlias(r.Client)
+	if err != nil {
+		r.Logger.Error(err, "get gpu alias failed")
+	}
 	for property, v := range pricesMap {
+		if common.IsGpuResource(property) && alias != nil {
+			if propertyAlias := alias[common.GetGpuResourceProduct(property)]; propertyAlias != "" {
+				property = string(common.NewGpuResource(propertyAlias))
+			}
+		}
 		priceQuery.Status.BillingRecords = append(priceQuery.Status.BillingRecords, accountv1.BillingRecord{
 			ResourceType: property,
 			Price:        v.Price,

--- a/controllers/account/deploy/manifests/deploy.yaml.tmpl
+++ b/controllers/account/deploy/manifests/deploy.yaml.tmpl
@@ -652,6 +652,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+- apiGroups:
   - account.sealos.io
   resources:
   - accountbalances

--- a/controllers/pkg/common/resources.go
+++ b/controllers/pkg/common/resources.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strings"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -130,10 +131,21 @@ const (
 	PropertyInfraDisk   = "infra-disk"
 )
 
+// GpuResourcePrefix GPUResource = gpu- + gpu.Product ; ex. gpu-tesla-v100
+const GpuResourcePrefix = "gpu-"
+
 const ResourceGPU corev1.ResourceName = gpu.NvidiaGpuKey
 
 func NewGpuResource(product string) corev1.ResourceName {
-	return corev1.ResourceName("gpu-" + product)
+	return corev1.ResourceName(GpuResourcePrefix + product)
+}
+
+func IsGpuResource(resource string) bool {
+	return strings.HasPrefix(resource, GpuResourcePrefix)
+}
+
+func GetGpuResourceProduct(resource string) string {
+	return strings.TrimPrefix(resource, GpuResourcePrefix)
 }
 
 var (


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6451770</samp>

### Summary
📜🎮🛠️

<!--
1.  📜 - This emoji represents the addition of new RBAC rules to the role and deployment files, which are like permissions or contracts for the controller.
2.  🎮 - This emoji represents the enhancement of the billingrecordquery controller to support GPU resources, which are like gaming devices or graphics cards.
3.  🛠️ - This emoji represents the update of the common package to handle GPU resources more consistently and conveniently, which is like a tool or improvement.
-->
This pull request adds support for GPU resources to the account controller, which is responsible for querying the billing records of users. It modifies the `billingrecordquery_controller.go` file and the common package to handle GPU aliases and usage. It also updates the RBAC rules in the `role.yaml` and `deploy.yaml.tmpl` files to allow the controller to access the `configmaps/status` resource.

> _To bill for the GPUs that are used_
> _The `billingrecordquery` was improved_
> _It reads from a `configmap`_
> _The aliases that match_
> _The `gpu` package that was newly moved_

### Walkthrough
*  Add a new function to query the GPU alias data from the node-gpu-info configmap and use it to replace the GPU product names with user-friendly aliases in the billing records ([link](https://github.com/labring/sealos/pull/3747/files?diff=unified&w=0#diff-86d8d3e3c5437a16535b518a2119bb44ab128dff71b975031641b945d850eb11L150-R163), [link](https://github.com/labring/sealos/pull/3747/files?diff=unified&w=0#diff-d18b6a87d8be8db668ff42c15bea6107757bda983123798750396eaf82f918ecR137-R165))
*  Add and modify some constants and functions to check and manipulate GPU resources and products in the common package ([link](https://github.com/labring/sealos/pull/3747/files?diff=unified&w=0#diff-4766b3b00bd1d2cd9279874228122ee5f286a902fd6edab4c47751b8a70cf053L133-R150))
*  Add the required RBAC permissions for the account controller to access the configmaps and configmaps/status resources in the core API group, both in the role.yaml file and the deploy.yaml.tmpl file ([link](https://github.com/labring/sealos/pull/3747/files?diff=unified&w=0#diff-692ae5af1fa1de7cc9a448545795d0e7d5bdf981f9ef3d09b8441f0c0c6f98f1R21-R26), [link](https://github.com/labring/sealos/pull/3747/files?diff=unified&w=0#diff-86d8d3e3c5437a16535b518a2119bb44ab128dff71b975031641b945d850eb11R57-R58), [link](https://github.com/labring/sealos/pull/3747/files?diff=unified&w=0#diff-11c0253bf67d2025a97d6953bad0e237ce9ac7a60d0a35ae1e277e934ceaea0eR655-R660))
*  Add the necessary import statements to use the json, strings, and gpu packages in the billingrecordquery_controller.go and nvidia.go files ([link](https://github.com/labring/sealos/pull/3747/files?diff=unified&w=0#diff-86d8d3e3c5437a16535b518a2119bb44ab128dff71b975031641b945d850eb11R25-R26), [link](https://github.com/labring/sealos/pull/3747/files?diff=unified&w=0#diff-d18b6a87d8be8db668ff42c15bea6107757bda983123798750396eaf82f918ecR20-R21), [link](https://github.com/labring/sealos/pull/3747/files?diff=unified&w=0#diff-4766b3b00bd1d2cd9279874228122ee5f286a902fd6edab4c47751b8a70cf053R21))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
