### PR TITLE
fix: ignore signal killed when context cancelled

### DIFF
--- a/pkg/filesystem/registry/sync.go
+++ b/pkg/filesystem/registry/sync.go
@@ -75,7 +75,10 @@ func (s *impl) Sync(ctx context.Context, hosts ...string) error {
 		go func(ctx context.Context, host string) {
 			logger.Debug("running temporary registry on host %s", host)
 			if err := s.ssh.CmdAsyncWithContext(ctx, host, getRegistryServeCommand(s.pathResolver, defaultTemporaryPort)); err != nil {
-				logger.Error(err)
+				// ignore expected signal killed error when context cancel
+				if !strings.Contains(err.Error(), "signal: killed") {
+					logger.Error(err)
+				}
 			}
 		}(cmdCtx, hosts[i])
 	}


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e5c9b0</samp>

Avoid logging errors when stopping temporary registry. The change adds a check for signal killed errors in `pkg/filesystem/registry/sync.go` and only logs other errors.