### PR TITLE
Feat: gpu quota

### DIFF
--- a/controllers/account/controllers/account_controller.go
+++ b/controllers/account/controllers/account_controller.go
@@ -319,8 +319,14 @@ func (r *AccountReconciler) adaptGpuQuota(ctx context.Context, nsName string) er
 	quota := common.GetDefaultResourceQuota(nsName, ResourceQuotaPrefix+nsName)
 	return retry.Retry(10, 1*time.Second, func() error {
 		_, err := controllerutil.CreateOrUpdate(ctx, r.Client, quota, func() error {
+			if _, ok := quota.Spec.Hard[common.ResourceRequestGpu]; !ok {
+				quota.Spec.Hard[common.ResourceRequestGpu] = resource.MustParse(utils.GetEnvWithDefault(common.QuotaLimitsGPU, common.DefaultQuotaLimitsGPU))
+			}
+			if _, ok := quota.Spec.Hard[common.ResourceLimitGpu]; !ok {
+				quota.Spec.Hard[common.ResourceLimitGpu] = resource.MustParse(utils.GetEnvWithDefault(common.QuotaLimitsGPU, common.DefaultQuotaLimitsGPU))
+			}
 			if _, ok := quota.Spec.Hard[common.ResourceGPU]; !ok {
-				quota.Spec.Hard[common.ResourceGPU] = resource.MustParse(utils.GetEnvWithDefault(common.QuotaLimitsGPU, common.DefaultQuotaLimitsGPU))
+				delete(quota.Spec.Hard, common.ResourceGPU)
 			}
 			return nil
 		})

--- a/controllers/account/controllers/account_controller.go
+++ b/controllers/account/controllers/account_controller.go
@@ -253,6 +253,7 @@ func (r *AccountReconciler) syncAccount(ctx context.Context, name, accountNamesp
 		if err := r.syncResourceQuotaAndLimitRange(ctx, userNamespace); err != nil {
 			return nil, fmt.Errorf("sync resource resourceQuota and limitRange failed: %v", err)
 		}
+		//TODO delete after gpu quota already in resource-quota
 		if err := r.adaptGpuQuota(ctx, userNamespace); err != nil {
 			r.Logger.Error(err, "adapt gpu quota failed")
 		}
@@ -324,9 +325,6 @@ func (r *AccountReconciler) adaptGpuQuota(ctx context.Context, nsName string) er
 			}
 			if _, ok := quota.Spec.Hard[common.ResourceLimitGpu]; !ok {
 				quota.Spec.Hard[common.ResourceLimitGpu] = resource.MustParse(utils.GetEnvWithDefault(common.QuotaLimitsGPU, common.DefaultQuotaLimitsGPU))
-			}
-			if _, ok := quota.Spec.Hard[common.ResourceGPU]; !ok {
-				delete(quota.Spec.Hard, common.ResourceGPU)
 			}
 			return nil
 		})

--- a/controllers/account/controllers/debt_controller.go
+++ b/controllers/account/controllers/debt_controller.go
@@ -382,7 +382,7 @@ func (r *DebtReconciler) SetupWithManager(mgr ctrl.Manager, rateOpts controller.
 	r.accountSystemNamespace = utils.GetEnvWithDefault(accountv1.AccountSystemNamespaceEnv, "account-system")
 	r.accountNamespace = utils.GetEnvWithDefault(ACCOUNTNAMESPACEENV, "sealos-system")
 	setDefaultDebtPeriodWaitSecond()
-	debtDetectionCycleSecond := utils.GetIntEnvWithDefault(DebtDetectionCycleEnv, 60)
+	debtDetectionCycleSecond := utils.GetInt64EnvWithDefault(DebtDetectionCycleEnv, 60)
 	r.DebtDetectionCycle = time.Duration(debtDetectionCycleSecond) * time.Second
 
 	/*
@@ -410,10 +410,10 @@ func setDefaultDebtPeriodWaitSecond() {
 		ImminentDeletionPeriod:    IminentDeletionPeriodWaitSecond,
 		FinalDeletionPeriod:       FinalDeletionPeriodWaitSecond,
 	*/
-	DebtConfig[accountv1.WarningPeriod] = utils.GetIntEnvWithDefault(string(accountv1.WarningPeriod), 0*accountv1.DaySecond)
-	DebtConfig[accountv1.ApproachingDeletionPeriod] = utils.GetIntEnvWithDefault(string(accountv1.ApproachingDeletionPeriod), 4*accountv1.DaySecond)
-	DebtConfig[accountv1.ImminentDeletionPeriod] = utils.GetIntEnvWithDefault(string(accountv1.ImminentDeletionPeriod), 3*accountv1.DaySecond)
-	DebtConfig[accountv1.FinalDeletionPeriod] = utils.GetIntEnvWithDefault(string(accountv1.FinalDeletionPeriod), 7*accountv1.DaySecond)
+	DebtConfig[accountv1.WarningPeriod] = utils.GetInt64EnvWithDefault(string(accountv1.WarningPeriod), 0*accountv1.DaySecond)
+	DebtConfig[accountv1.ApproachingDeletionPeriod] = utils.GetInt64EnvWithDefault(string(accountv1.ApproachingDeletionPeriod), 4*accountv1.DaySecond)
+	DebtConfig[accountv1.ImminentDeletionPeriod] = utils.GetInt64EnvWithDefault(string(accountv1.ImminentDeletionPeriod), 3*accountv1.DaySecond)
+	DebtConfig[accountv1.FinalDeletionPeriod] = utils.GetInt64EnvWithDefault(string(accountv1.FinalDeletionPeriod), 7*accountv1.DaySecond)
 }
 
 type OnlyCreatePredicate struct {

--- a/controllers/pkg/common/resources.go
+++ b/controllers/pkg/common/resources.go
@@ -20,6 +20,8 @@ import (
 	"math"
 	"time"
 
+	"github.com/labring/sealos/controllers/pkg/utils"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/labring/sealos/controllers/pkg/common/gpu"
@@ -207,18 +209,27 @@ func GetDefaultLimitRange(ns, name string) *corev1.LimitRange {
 	}
 }
 
+const (
+	QuotaLimitsCPU     = "QUOTA_Limits_CPU"
+	QuotaLimitsMemory  = "QUOTA_Limits_MEMORY"
+	QuotaLimitsStorage = "QUOTA_Limits_Storage"
+	QuotaLimitsGPU     = "QUOTA_Limits_GPU"
+)
+
+const (
+	DefaultQuotaLimitsCPU     = "16"
+	DefaultQuotaLimitsMemory  = "64Gi"
+	DefaultQuotaLimitsStorage = "100Gi"
+	DefaultQuotaLimitsGPU     = "8"
+)
+
 func DefaultResourceQuotaHard() corev1.ResourceList {
 	return corev1.ResourceList{
-		//corev1.ResourceRequestsCPU:    resource.MustParse("100"),
-		corev1.ResourceLimitsCPU: resource.MustParse("16"),
-		//corev1.ResourceRequestsMemory: resource.MustParse("100"),
-		corev1.ResourceLimitsMemory: resource.MustParse("64Gi"),
-		//For all PVCs, the total demand for storage resources cannot exceed this value
-		corev1.ResourceRequestsStorage: resource.MustParse("100Gi"),
-		//"limit.storage": resource.MustParse("100Gi"),
-		//Local ephemeral storage
-		corev1.ResourceLimitsEphemeralStorage: resource.MustParse("100Gi"),
-		//corev1.ResourceRequestsEphemeralStorage: resource.MustParse("100Gi"),
+		ResourceGPU:                           resource.MustParse(utils.GetEnvWithDefault(QuotaLimitsGPU, DefaultQuotaLimitsGPU)),
+		corev1.ResourceLimitsCPU:              resource.MustParse(utils.GetEnvWithDefault(QuotaLimitsCPU, DefaultQuotaLimitsCPU)),
+		corev1.ResourceLimitsMemory:           resource.MustParse(utils.GetEnvWithDefault(QuotaLimitsMemory, DefaultQuotaLimitsMemory)),
+		corev1.ResourceRequestsStorage:        resource.MustParse(utils.GetEnvWithDefault(QuotaLimitsStorage, DefaultQuotaLimitsStorage)),
+		corev1.ResourceLimitsEphemeralStorage: resource.MustParse(utils.GetEnvWithDefault(QuotaLimitsStorage, DefaultQuotaLimitsStorage)),
 	}
 }
 

--- a/controllers/pkg/common/resources.go
+++ b/controllers/pkg/common/resources.go
@@ -134,6 +134,11 @@ const (
 
 const ResourceGPU corev1.ResourceName = gpu.NvidiaGpuKey
 
+const (
+	ResourceRequestGpu corev1.ResourceName = "requests." + gpu.NvidiaGpuKey
+	ResourceLimitGpu   corev1.ResourceName = "limits." + gpu.NvidiaGpuKey
+)
+
 func NewGpuResource(product string) corev1.ResourceName {
 	return corev1.ResourceName("gpu-" + product)
 }
@@ -225,7 +230,8 @@ const (
 
 func DefaultResourceQuotaHard() corev1.ResourceList {
 	return corev1.ResourceList{
-		ResourceGPU:                           resource.MustParse(utils.GetEnvWithDefault(QuotaLimitsGPU, DefaultQuotaLimitsGPU)),
+		ResourceRequestGpu:                    resource.MustParse(utils.GetEnvWithDefault(QuotaLimitsGPU, DefaultQuotaLimitsGPU)),
+		ResourceLimitGpu:                      resource.MustParse(utils.GetEnvWithDefault(QuotaLimitsGPU, DefaultQuotaLimitsGPU)),
 		corev1.ResourceLimitsCPU:              resource.MustParse(utils.GetEnvWithDefault(QuotaLimitsCPU, DefaultQuotaLimitsCPU)),
 		corev1.ResourceLimitsMemory:           resource.MustParse(utils.GetEnvWithDefault(QuotaLimitsMemory, DefaultQuotaLimitsMemory)),
 		corev1.ResourceRequestsStorage:        resource.MustParse(utils.GetEnvWithDefault(QuotaLimitsStorage, DefaultQuotaLimitsStorage)),

--- a/controllers/pkg/utils/env.go
+++ b/controllers/pkg/utils/env.go
@@ -20,21 +20,17 @@ import (
 )
 
 func GetEnvWithDefault(key, defaultValue string) string {
-	value, ok := os.LookupEnv(key)
-	if !ok || value == "" {
-		return defaultValue
+	if value, ok := os.LookupEnv(key); ok && value != "" {
+		return value
 	}
-	return value
+	return defaultValue
 }
 
-func GetIntEnvWithDefault(key string, defaultValue int64) int64 {
-	env, ok := os.LookupEnv(key)
-	if !ok || env == "" {
-		return defaultValue
+func GetInt64EnvWithDefault(key string, defaultValue int64) int64 {
+	if env, ok := os.LookupEnv(key); ok && env != "" {
+		if value, err := strconv.ParseInt(env, 10, 64); err == nil {
+			return value
+		}
 	}
-	value, err := strconv.ParseInt(env, 10, 64)
-	if err != nil {
-		return defaultValue
-	}
-	return value
+	return defaultValue
 }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2260c42</samp>

### Summary
🔄🚀🛠️

<!--
1.  🔄 This emoji represents a change or update, and can be used to indicate that the code has been simplified or refactored, or that the type or name of a function or variable has been changed.
2.  🚀 This emoji represents a feature or improvement, and can be used to indicate that the code has added support for a new resource or functionality, or that the performance or usability has been enhanced.
3.  🛠️ This emoji represents a fix or adjustment, and can be used to indicate that the code has fixed a bug, resolved an issue, or made a minor modification.
-->
This pull request adds support for GPU resources in the account controller and the default resource quota, and changes some environment variables from int to int64. It also simplifies some code in the `utils` package for reading the configuration from the environment variables. The files affected are `controllers/account/controllers/account_controller.go`, `controllers/account/controllers/debt_controller.go`, `controllers/pkg/common/resources.go`, and `controllers/pkg/utils/env.go`.

> _We read the env vars to configure our fate_
> _We sync the accounts and the quotas we create_
> _We change the types to int64 and make them all consistent_
> _We harness the power of the GPU, we are the code resistent_

### Walkthrough
*  Add a function `adaptGpuQuota` to create or update the resource quota for the GPU resource in the user namespace ([link](https://github.com/labring/sealos/pull/3751/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4R27-R29), [link](https://github.com/labring/sealos/pull/3751/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4R256-R258), [link](https://github.com/labring/sealos/pull/3751/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4R318-R330))
*  Use environment variables to configure the hard limit for the CPU, memory, storage, and GPU resources in the default resource quota ([link](https://github.com/labring/sealos/pull/3751/files?diff=unified&w=0#diff-4766b3b00bd1d2cd9279874228122ee5f286a902fd6edab4c47751b8a70cf053R23-R24), [link](https://github.com/labring/sealos/pull/3751/files?diff=unified&w=0#diff-4766b3b00bd1d2cd9279874228122ee5f286a902fd6edab4c47751b8a70cf053L210-R232))
*  Change the return type of `GetIntEnvWithDefault` to int64 and rename it to `GetInt64EnvWithDefault` for consistency ([link](https://github.com/labring/sealos/pull/3751/files?diff=unified&w=0#diff-8fc7d7a46552d16d295481d2bf26c8896ad0327f2592539fb877286270b5625bL385-R385), [link](https://github.com/labring/sealos/pull/3751/files?diff=unified&w=0#diff-8fc7d7a46552d16d295481d2bf26c8896ad0327f2592539fb877286270b5625bL413-R416), [link](https://github.com/labring/sealos/pull/3751/files?diff=unified&w=0#diff-1f4e3dc32237a636c2103563e260ecfbc5cff40ecf761dbf49bdf8be5cf5329dL23-R35))
*  Simplify the code of `GetEnvWithDefault` and `GetInt64EnvWithDefault` by using single if statements ([link](https://github.com/labring/sealos/pull/3751/files?diff=unified&w=0#diff-1f4e3dc32237a636c2103563e260ecfbc5cff40ecf761dbf49bdf8be5cf5329dL23-R35))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
