### PR TITLE
feature(main): using 22 default port

### DIFF
--- a/pkg/apply/run.go
+++ b/pkg/apply/run.go
@@ -117,7 +117,7 @@ func (r *ClusterArgs) runArgs(cmd *cobra.Command, args *RunArgs, imageList []str
 
 	r.cluster.SetNewImages(imageList)
 
-	defaultPort := strconv.Itoa(int(r.cluster.Spec.SSH.Port))
+	defaultPort := strconv.Itoa(int(defaultSSHPort(r.cluster.Spec.SSH.Port)))
 	masters := stringsutil.SplitRemoveEmpty(args.Cluster.Masters, ",")
 	nodes := stringsutil.SplitRemoveEmpty(args.Cluster.Nodes, ",")
 	r.hosts = []v2.Host{}
@@ -139,10 +139,11 @@ func (r *ClusterArgs) runArgs(cmd *cobra.Command, args *RunArgs, imageList []str
 }
 
 func (r *ClusterArgs) setHostWithIpsPort(ips []string, roles []string) {
-	defaultPort := strconv.Itoa(int(r.cluster.Spec.SSH.Port))
+	defaultPort := strconv.Itoa(int(defaultSSHPort(r.cluster.Spec.SSH.Port)))
 	hostMap := map[string]*v2.Host{}
 	for i := range ips {
 		ip, port := iputils.GetHostIPAndPortOrDefault(ips[i], defaultPort)
+		logger.Debug("defaultPort: %s", defaultPort)
 		socket := fmt.Sprintf("%s:%s", ip, port)
 		if stringsutil.In(socket, r.cluster.GetAllIPS()) {
 			continue
@@ -162,4 +163,11 @@ func (r *ClusterArgs) setHostWithIpsPort(ips []string, roles []string) {
 		}
 		r.hosts = append(r.hosts, *host)
 	}
+}
+
+func defaultSSHPort(port uint16) uint16 {
+	if port == 0 {
+		port = v2.DefaultSSHPort
+	}
+	return port
 }

--- a/pkg/apply/run_test.go
+++ b/pkg/apply/run_test.go
@@ -167,7 +167,7 @@ func TestNewApplierFromArgs(t *testing.T) {
 					},
 					Spec: v2.ClusterSpec{
 						Hosts: []v2.Host{
-							{IPS: []string{iputils.LocalIP(addr) + ":0"}, Roles: []string{v2.MASTER, GetHostArch(ssh.NewSSHClient(&v2.SSH{}, true), iputils.LocalIP(addr)+":0")}},
+							{IPS: []string{iputils.LocalIP(addr) + ":22"}, Roles: []string{v2.MASTER, GetHostArch(ssh.NewSSHClient(&v2.SSH{}, true), iputils.LocalIP(addr)+":22")}},
 						},
 						Image: []string{"labring/kubernetes:v1.24.0"},
 						SSH:   v2.SSH{},

--- a/pkg/apply/utils.go
+++ b/pkg/apply/utils.go
@@ -141,9 +141,7 @@ func GetNewImages(currentCluster, desiredCluster *v2.Cluster) []string {
 }
 
 func CheckAndInitialize(cluster *v2.Cluster) {
-	if cluster.Spec.SSH.Port == 0 {
-		cluster.Spec.SSH.Port = v2.DefaultSSHPort
-	}
+	cluster.Spec.SSH.Port = defaultSSHPort(cluster.Spec.SSH.Port)
 
 	if cluster.Spec.SSH.Pk == "" {
 		cluster.Spec.SSH.Pk = filepath.Join(constants.GetHomeDir(), ".ssh", "id_rsa")


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1fab2bb</samp>

### Summary
🔧🚪🐛

<!--
1.  🔧 - This emoji represents a wrench, which can be used to indicate a change or improvement to some existing code or functionality. In this case, the `CheckAndInitialize` function was refactored to use a helper function instead of repeating the same logic.
2.  🚪 - This emoji represents a door, which can be used to indicate a change or addition of a port or an entry point. In this case, the `defaultSSHPort` function sets the default SSH port for the cluster and the hosts, which is an important parameter for establishing SSH connections.
3.  🐛 - This emoji represents a bug, which can be used to indicate a change or fix that addresses a bug or an issue. In this case, the debug log statement was added to show the port used for SSH connections, which can help troubleshoot any potential problems or errors related to SSH.
-->
Use a helper function to set the default SSH port for cluster and hosts. Refactor `CheckAndInitialize` function in `pkg/apply/utils.go` to avoid code duplication.

> _`defaultSSHPort` /_
> _A helper for consistency /_
> _Logs in the autumn_

### Walkthrough
*  Simplify and log SSH port logic for cluster and hosts
  * Use `defaultSSHPort` function to check and set SSH port in `runArgs` ([link](https://github.com/labring/sealos/pull/3759/files?diff=unified&w=0#diff-40da3b5e11ca4827ad6fb34ce791710b02c305a8ae225305ab7fe1b6829aa444L120-R120), [link](https://github.com/labring/sealos/pull/3759/files?diff=unified&w=0#diff-40da3b5e11ca4827ad6fb34ce791710b02c305a8ae225305ab7fe1b6829aa444L142-R146))
  * Add `defaultSSHPort` function to `pkg/apply/run.go` ([link](https://github.com/labring/sealos/pull/3759/files?diff=unified&w=0#diff-40da3b5e11ca4827ad6fb34ce791710b02c305a8ae225305ab7fe1b6829aa444R167-R173))
  * Use `defaultSSHPort` function to check and set SSH port in `CheckAndInitialize` ([link](https://github.com/labring/sealos/pull/3759/files?diff=unified&w=0#diff-49999a5031dbbbe7123f98c24b2d12012e6261ebdc5c728fd20df40f3dec6219L144-R144))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
