### PR TITLE
Added a network probe to sense the network environment and adjust the license policy.

### DIFF
--- a/controllers/licenseissuer/.env
+++ b/controllers/licenseissuer/.env
@@ -1,5 +1,4 @@
 # set the environment variables when local testing
-MONITOR= ""
-CAN_CONNECT_TO_EXTERNAL_NETWORK= ""
-MONGO_URI= ""
-PASSWORD_SALT= ""
+MONGO_URI= 
+PASSWORD_SALT= 
+NAMESPACE= 

--- a/controllers/licenseissuer/config/manager/manager.yaml
+++ b/controllers/licenseissuer/config/manager/manager.yaml
@@ -74,16 +74,6 @@ spec:
         imagePullPolicy: Always
         name: manager
         env:
-        - name: CAN_CONNECT_TO_EXTERNAL_NETWORK
-          valueFrom:
-            secretKeyRef:
-              key: canConnectToExternalNetwork
-              name: licenseissuer-env
-        - name: MONITOR
-          valueFrom:
-            secretKeyRef:
-              key: isMonitor
-              name: licenseissuer-env
         - name: MONGO_URI
           valueFrom: 
             secretKeyRef:

--- a/controllers/licenseissuer/deploy/Kubefile
+++ b/controllers/licenseissuer/deploy/Kubefile
@@ -17,6 +17,7 @@ ENV NotificationURL "https://license.sealos.io/notify"
 ENV RegisterURL "https://license.sealos.io/register"
 ENV CloudSyncURL "https://license.sealos.io/datasync"
 ENV LicenseMonitorURL "https://license.sealos.io/license"
+ENV NetworkProbeURL "https://license.sealos.io/probe"
 
 
 

--- a/controllers/licenseissuer/deploy/manifests/configmaps.yaml
+++ b/controllers/licenseissuer/deploy/manifests/configmaps.yaml
@@ -22,7 +22,8 @@ data:
       "NotificationURL": "https://license.sealos.io/notify",
       "RegisterURL": "https://license.sealos.io/register",
       "CloudSyncURL": "https://license.sealos.io/datasync",
-      "LicenseMonitorURL": "https://license.sealos.io/license"
+      "LicenseMonitorURL": "https://license.sealos.io/license",
+      "NetworkProbeURL": "https://license.sealos.io/probe"
     }
 kind: ConfigMap
 metadata:

--- a/controllers/licenseissuer/deploy/manifests/customconfig.yaml.tmpl
+++ b/controllers/licenseissuer/deploy/manifests/customconfig.yaml.tmpl
@@ -4,8 +4,6 @@ metadata:
   name: licenseissuer-env
   namespace: sealos-system
 stringData:
-  canConnectToExternalNetwork: "{{ .canConnectToExternalNetwork }}"
-  isMonitor: "{{ .enableMonitor }}"
   MongoURI: "{{ .MongoURI }}"
   PasswordSalt: "{{ .PasswordSalt }}"
   MongoUserDB: "{{ .MongoUserDB }}"

--- a/controllers/licenseissuer/deploy/manifests/customconfig.yaml.tmpl
+++ b/controllers/licenseissuer/deploy/manifests/customconfig.yaml.tmpl
@@ -20,7 +20,8 @@ data:
       "NotificationURL": "{{ .NotificationURL }}",
       "RegisterURL": "{{ .RegisterURL }}",
       "CloudSyncURL": "{{ .CloudSyncURL }}",
-      "LicenseMonitorURL": "{{ .LicenseMonitorURL }}"
+      "LicenseMonitorURL": "{{ .LicenseMonitorURL }}",
+      "NetworkProbeURL": "{{ .NetworkProbeURL }}",
     }
 kind: ConfigMap
 metadata:

--- a/controllers/licenseissuer/deploy/manifests/deploy.yaml
+++ b/controllers/licenseissuer/deploy/manifests/deploy.yaml
@@ -493,16 +493,6 @@ spec:
         command:
         - /launcher
         env:
-        - name: CAN_CONNECT_TO_EXTERNAL_NETWORK
-          valueFrom:
-            secretKeyRef:
-              key: canConnectToExternalNetwork
-              name: licenseissuer-env
-        - name: MONITOR
-          valueFrom:
-            secretKeyRef:
-              key: isMonitor
-              name: licenseissuer-env
         - name: MONGO_URI
           valueFrom:
             secretKeyRef:

--- a/controllers/licenseissuer/internal/controller/license_controller.go
+++ b/controllers/licenseissuer/internal/controller/license_controller.go
@@ -137,7 +137,7 @@ func (r *LicenseReconciler) CheckLicense(ctx context.Context) (string, map[strin
 		return util.DuplicateLicenseMessage, nil, false
 	}
 	// Check if the license is valid
-	if options.GetEnvOptions().NetworkConfiguration == "true" {
+	if options.GetNetWorkOptions().EnableExternalNetWork {
 		payload, ok := util.LicenseCheckOnExternalNetwork(ctx, r.Client, r.license)
 		if !ok {
 			return util.InvalidLicenseMessage, nil, false

--- a/controllers/licenseissuer/internal/controller/util/collect.go
+++ b/controllers/licenseissuer/internal/controller/util/collect.go
@@ -80,7 +80,13 @@ type collect struct {
 	DailyClusterUsage DailyClusterUsage
 	CollectorInfo     CollectorInfo
 
-	options Options
+	options OptionsReadOnly
+}
+
+func NewCollect(o OptionsReadOnly) *collect {
+	return &collect{
+		options: o,
+	}
 }
 
 func (c *collect) collectWork(instance *TaskInstance) error {

--- a/controllers/licenseissuer/internal/controller/util/collect.go
+++ b/controllers/licenseissuer/internal/controller/util/collect.go
@@ -69,7 +69,7 @@ type ClusterResource struct {
 	Disk   string `json:"disk"`
 }
 
-type collect struct {
+type Collect struct {
 	url string
 	// resource collect time of last
 	lastTimeForResource int64
@@ -83,13 +83,13 @@ type collect struct {
 	options OptionsReadOnly
 }
 
-func NewCollect(o OptionsReadOnly) *collect {
-	return &collect{
+func NewCollect(o OptionsReadOnly) *Collect {
+	return &Collect{
 		options: o,
 	}
 }
 
-func (c *collect) collectWork(instance *TaskInstance) error {
+func (c *Collect) collectWork(instance *TaskInstance) error {
 	uid, urlMap, err := GetUIDURL(instance.ctx, instance.Client)
 	if err != nil {
 		instance.logger.Error(err, "failed to get uid and url")
@@ -112,7 +112,7 @@ func (c *collect) collectWork(instance *TaskInstance) error {
 	return nil
 }
 
-func (c *collect) collectResource(instance *TaskInstance) error {
+func (c *Collect) collectResource(instance *TaskInstance) error {
 	tnr := TotalNodesResource{}
 	err := c.getNodeResource(instance, &tnr)
 	if err != nil {
@@ -132,7 +132,7 @@ func (c *collect) collectResource(instance *TaskInstance) error {
 	return nil
 }
 
-func (c *collect) collectUsage(instance *TaskInstance) error {
+func (c *Collect) collectUsage(instance *TaskInstance) error {
 	err := c.getUsageYesterday(instance)
 	if err != nil {
 		instance.logger.Info("failed to get usage yesterday")
@@ -156,7 +156,7 @@ func (tnr *TotalNodesResource) getCPUMemoryResource(node *corev1.Node) {
 	tnr.TotalCPU.Add(nodeCPU)
 }
 
-func (c *collect) getUsageYesterday(instance *TaskInstance) error {
+func (c *Collect) getUsageYesterday(instance *TaskInstance) error {
 	MongoURI := c.options.GetEnvOptions().MongoURI
 	dailyClusterUsage := DailyClusterUsage{}
 	db, err := database.NewMongoDB(instance.ctx, MongoURI)
@@ -197,7 +197,7 @@ func GetYesterdayAndTodayMidnight() (time.Time, time.Time) {
 	return midnightYesterday, midnightToday
 }
 
-func (c *collect) doResourceCollect(instance *TaskInstance) error {
+func (c *Collect) doResourceCollect(instance *TaskInstance) error {
 	err := c.collectResource(instance)
 	if err != nil {
 		return err
@@ -212,7 +212,7 @@ func (c *collect) doResourceCollect(instance *TaskInstance) error {
 	return nil
 }
 
-func (c *collect) doUsageCollect(instance *TaskInstance) error {
+func (c *Collect) doUsageCollect(instance *TaskInstance) error {
 	err := c.collectUsage(instance)
 	if err != nil {
 		return err
@@ -227,7 +227,7 @@ func (c *collect) doUsageCollect(instance *TaskInstance) error {
 	return nil
 }
 
-func (c *collect) getPVResource(instance *TaskInstance, tnr *TotalNodesResource) error {
+func (c *Collect) getPVResource(instance *TaskInstance, tnr *TotalNodesResource) error {
 	pvList := &corev1.PersistentVolumeList{}
 	err := instance.List(instance.ctx, pvList)
 	if err != nil {
@@ -241,7 +241,7 @@ func (c *collect) getPVResource(instance *TaskInstance, tnr *TotalNodesResource)
 	return nil
 }
 
-func (c *collect) getNodeResource(instance *TaskInstance, tnr *TotalNodesResource) error {
+func (c *Collect) getNodeResource(instance *TaskInstance, tnr *TotalNodesResource) error {
 	nodeList := &corev1.NodeList{}
 	err := instance.List(instance.ctx, nodeList)
 	if err != nil {

--- a/controllers/licenseissuer/internal/controller/util/const.go
+++ b/controllers/licenseissuer/internal/controller/util/const.go
@@ -73,12 +73,14 @@ const (
 	PeriodicPolicy          = "Periodic"
 	PeriodicWithProbePolicy = "PeriodicWithProbe"
 	OncePolicy              = "Once"
+	OnceWithProbePolicy     = "OnceWithProbe"
 )
 
 const (
 	Collector     task = "Collector"
 	DataSync      task = "DataSync"
 	Init          task = "Init"
+	Register      task = "Register"
 	Notice        task = "Notice"
 	NoticeCleanup task = "NoticeCleanup"
 	NetWorkConfig task = "NetWorkConfig"

--- a/controllers/licenseissuer/internal/controller/util/const.go
+++ b/controllers/licenseissuer/internal/controller/util/const.go
@@ -38,6 +38,7 @@ const (
 	RegisterURL       = "RegisterURL"
 	CloudSyncURL      = "CloudSyncURL"
 	LicenseMonitorURL = "LicenseMonitorURL"
+	NetworkProbeURL   = "NetworkProbeURL"
 	// Add more url here
 )
 
@@ -69,6 +70,17 @@ const (
 )
 
 const (
-	PeriodicPolicy = "Periodic"
-	OncePolicy     = "Once"
+	PeriodicPolicy          = "Periodic"
+	PeriodicWithProbePolicy = "PeriodicWithProbe"
+	OncePolicy              = "Once"
+)
+
+const (
+	Collector     task = "Collector"
+	DataSync      task = "DataSync"
+	Init          task = "Init"
+	Notice        task = "Notice"
+	NoticeCleanup task = "NoticeCleanup"
+	NetWorkConfig task = "NetWorkConfig"
+	// Add more tasks here
 )

--- a/controllers/licenseissuer/internal/controller/util/datasync.go
+++ b/controllers/licenseissuer/internal/controller/util/datasync.go
@@ -21,11 +21,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-type datasycn struct {
+type DataSycn struct {
 }
 
-func NewDataSync() *datasycn {
-	return &datasycn{}
+func NewDataSync() *DataSycn {
+	return &DataSycn{}
 }
 
 type SyncRequest struct {
@@ -45,7 +45,7 @@ type Config struct {
 	// Add other fields here to support future expansion needs.
 }
 
-func (d *datasycn) sync(instance *TaskInstance) error {
+func (d *DataSycn) sync(instance *TaskInstance) error {
 	uid, urlMap, err := GetUIDURL(instance.ctx, instance.Client)
 	if err != nil {
 		instance.logger.Info("failed to get uid and url map")
@@ -80,7 +80,7 @@ func (d *datasycn) sync(instance *TaskInstance) error {
 	return nil
 }
 
-func (d *datasycn) updateConfigMap(instance *TaskInstance, new map[string]string, id types.NamespacedName) error {
+func (d *DataSycn) updateConfigMap(instance *TaskInstance, new map[string]string, id types.NamespacedName) error {
 	configMap := &corev1.ConfigMap{}
 	err := instance.Client.Get(instance.ctx, id, configMap)
 	if err != nil {

--- a/controllers/licenseissuer/internal/controller/util/datasync.go
+++ b/controllers/licenseissuer/internal/controller/util/datasync.go
@@ -24,6 +24,10 @@ import (
 type datasycn struct {
 }
 
+func NewDataSync() *datasycn {
+	return &datasycn{}
+}
+
 type SyncRequest struct {
 	UID string `json:"uid"`
 }
@@ -44,7 +48,7 @@ type Config struct {
 func (d *datasycn) sync(instance *TaskInstance) error {
 	uid, urlMap, err := GetUIDURL(instance.ctx, instance.Client)
 	if err != nil {
-		instance.logger.Error(err, "failed to get uid and url")
+		instance.logger.Info("failed to get uid and url map")
 		return err
 	}
 	// pull sync data from cloud
@@ -53,13 +57,13 @@ func (d *datasycn) sync(instance *TaskInstance) error {
 	}
 	body, err := Pull(urlMap[CloudSyncURL], syncRequest)
 	if err != nil {
-		instance.logger.Error(err, "failed to pull sync request")
+		instance.logger.Info("failed to pull sync data from cloud")
 		return err
 	}
 	var syncResponse map[string]string
 	err = Convert(body.Body, &syncResponse)
 	if err != nil {
-		instance.logger.Error(err, "failed to convert sync response")
+		instance.logger.Info("failed to convert sync response")
 		return err
 	}
 	// update configmap
@@ -69,7 +73,7 @@ func (d *datasycn) sync(instance *TaskInstance) error {
 	})
 
 	if err != nil {
-		instance.logger.Error(err, "failed to update configmap")
+		instance.logger.Info("failed to update configmap")
 		return err
 	}
 
@@ -80,13 +84,13 @@ func (d *datasycn) updateConfigMap(instance *TaskInstance, new map[string]string
 	configMap := &corev1.ConfigMap{}
 	err := instance.Client.Get(instance.ctx, id, configMap)
 	if err != nil {
-		instance.logger.Error(err, "failed to get configmap")
+		instance.logger.Info("failed to get configmap")
 		return err
 	}
 	if IsConfigMapChanged(new, configMap) {
 		err = instance.Client.Update(instance.ctx, configMap)
 		if err != nil {
-			instance.logger.Error(err, "failed to update configmap")
+			instance.logger.Info("failed to update configmap")
 			return err
 		}
 	}

--- a/controllers/licenseissuer/internal/controller/util/external.go
+++ b/controllers/licenseissuer/internal/controller/util/external.go
@@ -37,6 +37,18 @@ type HTTPResponse struct {
 	Body        []byte
 }
 
+// The Get method is used to handle "GET" request.
+func Get(url string) (HTTPResponse, error) {
+	body, err := CommunicateWithCloud("GET", url, nil)
+	if err != nil {
+		return HTTPResponse{}, fmt.Errorf("communicateWithCloud: %w", err)
+	}
+	if !IsSuccessfulStatusCode(body.StatusCode) {
+		return HTTPResponse{}, fmt.Errorf("error status: %s", http.StatusText(body.StatusCode))
+	}
+	return body, nil
+}
+
 // The Push method is used to handle one-way interaction, that is,
 // there is no need to obtain information from the cloud, only need to send information to the cloud.
 func Push(url string, content interface{}) error {

--- a/controllers/licenseissuer/internal/controller/util/init.go
+++ b/controllers/licenseissuer/internal/controller/util/init.go
@@ -33,19 +33,19 @@ type RegisterRequest struct {
 
 // The following code is used to implement the instance of sub-task which is used to
 // initialize the cluster uuid and preset root user for mongoDB
-type initTask struct {
+type InitTask struct {
 	options OptionsReadOnly
 	probe   InitProbe
 }
 
-func NewInitTask(o OptionsReadOnly) *initTask {
-	return &initTask{
+func NewInitTask(o OptionsReadOnly) *InitTask {
+	return &InitTask{
 		options: o,
 		probe:   GetInitProbe(),
 	}
 }
 
-func (t *initTask) initWork(instance *TaskInstance) error {
+func (t *InitTask) initWork(instance *TaskInstance) error {
 	// register function is idempotent
 	err := t.register(instance)
 	if err != nil {
@@ -59,7 +59,7 @@ func (t *initTask) initWork(instance *TaskInstance) error {
 // 1. check if the cluster has been registered
 // 2. store cluster-info to k8s
 
-func (t *initTask) register(instance *TaskInstance) error {
+func (t *InitTask) register(instance *TaskInstance) error {
 	ClusterInfo := createClusterInfo()
 	// step 1
 	// check if the cluster has been registered
@@ -83,7 +83,7 @@ func (t *initTask) register(instance *TaskInstance) error {
 }
 
 // check if the cluster has been registered.
-func (t *initTask) checkRegister(instance *TaskInstance) (bool, error) {
+func (t *InitTask) checkRegister(instance *TaskInstance) (bool, error) {
 	info := &corev1.Secret{}
 	err := instance.Get(instance.ctx, types.NamespacedName{
 		Name:      ClusterInfo,

--- a/controllers/licenseissuer/internal/controller/util/init.go
+++ b/controllers/licenseissuer/internal/controller/util/init.go
@@ -47,6 +47,7 @@ func NewInitTask(o OptionsReadOnly) *initTask {
 }
 
 func (t *initTask) initWork(instance *TaskInstance) error {
+	// register function is idempotent
 	err := t.register(instance)
 	if err != nil {
 		instance.logger.Info("failed to register", "err", err)

--- a/controllers/licenseissuer/internal/controller/util/notice.go
+++ b/controllers/licenseissuer/internal/controller/util/notice.go
@@ -29,9 +29,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// the notice task is used to get the notification from the cloud.
+// the NoticeWork task is used to get the notification from the cloud.
 // And then send the notification to the cluster.
-type notice struct {
+type NoticeWork struct {
 	lastTime int64
 }
 
@@ -58,7 +58,7 @@ func (nr *NotificationRequest) setTimestamp(timestamp int64) *NotificationReques
 	return nr
 }
 
-func (n *notice) noticeWork(instance *TaskInstance) error {
+func (n *NoticeWork) noticeWork(instance *TaskInstance) error {
 	// init
 	receiver := ntf.NewReceiver(instance.ctx, instance.Client)
 	manager := ntf.NewNotificationManager(instance.ctx, instance.Client,
@@ -137,11 +137,11 @@ func GetUID(ctx context.Context, client client.Client) (string, error) {
 	return uid, nil
 }
 
-func NewNotice() *notice {
-	return &notice{lastTime: time.Now().Add(-7 * time.Hour).Unix()}
+func NewNotice() *NoticeWork {
+	return &NoticeWork{lastTime: time.Now().Add(-7 * time.Hour).Unix()}
 }
 
-func (n *notice) getEvents(instance *TaskInstance, body []byte) ([]ntf.Event, error) {
+func (n *NoticeWork) getEvents(instance *TaskInstance, body []byte) ([]ntf.Event, error) {
 	var resps []NotificationResponse
 	var events []ntf.Event
 	err := Convert(body, &resps)
@@ -166,16 +166,16 @@ func (n *notice) getEvents(instance *TaskInstance, body []byte) ([]ntf.Event, er
 	return events, nil
 }
 
-// the noticeCleaner task is used to clean the notification in the cluster periodically.
-type noticeCleaner struct {
+// the NoticeCleaner task is used to clean the notification in the cluster periodically.
+type NoticeCleaner struct {
 	lastTime int64
 }
 
-func NewNoticeCleaner() *noticeCleaner {
-	return &noticeCleaner{lastTime: time.Now().Unix()}
+func NewNoticeCleaner() *NoticeCleaner {
+	return &NoticeCleaner{lastTime: time.Now().Unix()}
 }
 
-func (nc *noticeCleaner) cleanWork(instance *TaskInstance) error {
+func (nc *NoticeCleaner) cleanWork(instance *TaskInstance) error {
 	// catch all notification in the cluster
 	notifications := &notificationv1.NotificationList{}
 
@@ -206,7 +206,7 @@ func (nc *noticeCleaner) cleanWork(instance *TaskInstance) error {
 	return nil
 }
 
-func (nc *noticeCleaner) getNotificationsExpired(instance *TaskInstance) ([]notificationv1.Notification, error) {
+func (nc *NoticeCleaner) getNotificationsExpired(instance *TaskInstance) ([]notificationv1.Notification, error) {
 	notifications := &notificationv1.NotificationList{}
 	err := instance.List(instance.ctx, notifications)
 	if err != nil {
@@ -244,7 +244,7 @@ const maxChannelSize = 500
 
 type FilterFunc func(string) bool
 
-func (n *notice) getUserNamespace(instance *TaskInstance, opt FilterFunc) []string {
+func (n *NoticeWork) getUserNamespace(instance *TaskInstance, opt FilterFunc) []string {
 	namespaceList := &corev1.NamespaceList{}
 	err := instance.List(instance.ctx, namespaceList)
 	if err != nil {

--- a/controllers/licenseissuer/internal/controller/util/options.go
+++ b/controllers/licenseissuer/internal/controller/util/options.go
@@ -41,7 +41,6 @@ type OptionsReadOnly interface {
 }
 
 type OptionsReadWrite interface {
-	OptionsReadOnly
 	SetNetworkConfig(flag bool)
 }
 
@@ -140,13 +139,12 @@ func (o *OperatorOptions) initOptions() {
 	o.RunnableOptions.Policy[Notice] = PeriodicWithProbePolicy
 	o.RunnableOptions.Period[Notice] = 3 * time.Hour
 
-	o.RunnableOptions.Policy[NoticeCleanup] = PeriodicWithProbePolicy
+	o.RunnableOptions.Policy[NoticeCleanup] = PeriodicPolicy
 	o.RunnableOptions.Period[NoticeCleanup] = 24 * time.Hour
 
-	//o.RunnableOptions.Policy[Probe] = PeriodicWithProbePolicy
-	//o.RunnableOptions.Period[Probe] = 30 * time.Minute
+	o.RunnableOptions.Policy[NetWorkConfig] = PeriodicPolicy
+	o.RunnableOptions.Period[NetWorkConfig] = 30 * time.Second
 	// Add more tasks Policy and Period here
-
 }
 
 // The EnvOptions is used to store environment variables.

--- a/controllers/licenseissuer/internal/controller/util/options.go
+++ b/controllers/licenseissuer/internal/controller/util/options.go
@@ -128,8 +128,10 @@ func (o *OperatorOptions) initOptions() {
 	o.DBOptions.initOptions()
 	o.NetWorkOptions.initOptions()
 
+	// allow developer to choose the policy and period of the task
 	o.RunnableOptions.Policy[Init] = OncePolicy
-	//allow developer to choose the policy and period of the task
+	o.RunnableOptions.Period[Init] = 0
+
 	o.RunnableOptions.Policy[Collector] = PeriodicWithProbePolicy
 	o.RunnableOptions.Period[Collector] = 8 * time.Hour
 
@@ -144,6 +146,9 @@ func (o *OperatorOptions) initOptions() {
 
 	o.RunnableOptions.Policy[NetWorkConfig] = PeriodicPolicy
 	o.RunnableOptions.Period[NetWorkConfig] = 30 * time.Minute
+
+	o.RunnableOptions.Policy[Register] = OnceWithProbePolicy
+	o.RunnableOptions.Period[Register] = 5 * time.Minute
 	// Add more tasks Policy and Period here
 }
 

--- a/controllers/licenseissuer/internal/controller/util/options.go
+++ b/controllers/licenseissuer/internal/controller/util/options.go
@@ -143,7 +143,7 @@ func (o *OperatorOptions) initOptions() {
 	o.RunnableOptions.Period[NoticeCleanup] = 24 * time.Hour
 
 	o.RunnableOptions.Policy[NetWorkConfig] = PeriodicPolicy
-	o.RunnableOptions.Period[NetWorkConfig] = 30 * time.Second
+	o.RunnableOptions.Period[NetWorkConfig] = 30 * time.Minute
 	// Add more tasks Policy and Period here
 }
 

--- a/controllers/licenseissuer/internal/controller/util/options.go
+++ b/controllers/licenseissuer/internal/controller/util/options.go
@@ -26,12 +26,23 @@ type task string
 
 // A interface for options to implement read-only access.
 type Options interface {
+	OptionsReadOnly
+	OptionsReadWrite
+}
+
+type OptionsReadOnly interface {
 	GetPolicy(name task) string
 	GetPeriod(name task) time.Duration
 	GetDefaultPeriod() time.Duration
 	GetEnvOptions() EnvOptions
+	GetNetWorkOptions() NetWorkOptions
 	GetRunnableOptions() RunnableOptions
 	GetDBOptions() DBOptions
+}
+
+type OptionsReadWrite interface {
+	OptionsReadOnly
+	SetNetworkConfig(flag bool)
 }
 
 // a singleton instance of Options
@@ -46,6 +57,16 @@ func GetOptions() Options {
 	return options
 }
 
+// GetOptionsReadOnly returns the singleton instance of OptionsReadOnly.
+func GetOptionsReadOnly() OptionsReadOnly {
+	return GetOptions()
+}
+
+// GetOptionsReadWrite returns the singleton instance of OptionsReadWrite.
+func GetOptionsReadWrite() OptionsReadWrite {
+	return GetOptions()
+}
+
 // The OperatorOptions struct is used to make configuration options available to
 // licenseissuer operators.
 type OperatorOptions struct {
@@ -55,6 +76,12 @@ type OperatorOptions struct {
 	DBOptions DBOptions
 	// The RunnableOptions is used to store options for the Runnable instance
 	RunnableOptions RunnableOptions
+	// The NetWorkOptions is used to store options for the NetWork instance
+	NetWorkOptions NetWorkOptions
+}
+
+func (o *OperatorOptions) SetNetworkConfig(flag bool) {
+	o.NetWorkOptions.EnableExternalNetWork = flag
 }
 
 func (o *OperatorOptions) GetPolicy(tkname task) string {
@@ -86,6 +113,9 @@ func (o *OperatorOptions) GetRunnableOptions() RunnableOptions {
 func (o *OperatorOptions) GetDBOptions() DBOptions {
 	return o.DBOptions
 }
+func (o *OperatorOptions) GetNetWorkOptions() NetWorkOptions {
+	return o.NetWorkOptions
+}
 
 func NewOptions() *OperatorOptions {
 	o := &OperatorOptions{}
@@ -97,29 +127,31 @@ func (o *OperatorOptions) initOptions() {
 	o.EnvOptions.initOptions()
 	o.RunnableOptions.initOptions()
 	o.DBOptions.initOptions()
+	o.NetWorkOptions.initOptions()
 
 	o.RunnableOptions.Policy[Init] = OncePolicy
-	if o.EnvOptions.MonitorConfiguration == "true" {
-		//allow developer to choose the policy and period of the task
-		o.RunnableOptions.Policy[Collector] = PeriodicPolicy
-		o.RunnableOptions.Period[Collector] = 8 * time.Hour
-		o.RunnableOptions.Policy[DataSync] = PeriodicPolicy
-		o.RunnableOptions.Period[DataSync] = 1 * time.Hour
-		o.RunnableOptions.Policy[Notice] = PeriodicPolicy
-		o.RunnableOptions.Period[Notice] = 3 * time.Hour
-		o.RunnableOptions.Policy[NoticeCleanup] = PeriodicPolicy
-		o.RunnableOptions.Period[NoticeCleanup] = 24 * time.Hour
-		// Add more tasks Policy and Period here
-	}
+	//allow developer to choose the policy and period of the task
+	o.RunnableOptions.Policy[Collector] = PeriodicWithProbePolicy
+	o.RunnableOptions.Period[Collector] = 8 * time.Hour
+
+	o.RunnableOptions.Policy[DataSync] = PeriodicWithProbePolicy
+	o.RunnableOptions.Period[DataSync] = 1 * time.Hour
+
+	o.RunnableOptions.Policy[Notice] = PeriodicWithProbePolicy
+	o.RunnableOptions.Period[Notice] = 3 * time.Hour
+
+	o.RunnableOptions.Policy[NoticeCleanup] = PeriodicWithProbePolicy
+	o.RunnableOptions.Period[NoticeCleanup] = 24 * time.Hour
+
+	//o.RunnableOptions.Policy[Probe] = PeriodicWithProbePolicy
+	//o.RunnableOptions.Period[Probe] = 30 * time.Minute
+	// Add more tasks Policy and Period here
+
 }
 
 // The EnvOptions is used to store environment variables.
 type EnvOptions struct {
-	// NetworkConfiguration is used to distinguish between
-	// external and internal networks.
-	NetworkConfiguration string
 
-	MonitorConfiguration string
 	// The MongoURI is used to connect to the MongoDB database.
 	MongoURI string
 
@@ -131,8 +163,6 @@ type EnvOptions struct {
 }
 
 func (eo *EnvOptions) initOptions() {
-	eo.NetworkConfiguration = os.Getenv("CAN_CONNECT_TO_EXTERNAL_NETWORK")
-	eo.MonitorConfiguration = os.Getenv("MONITOR")
 	eo.MongoURI = os.Getenv("MONGO_URI")
 	eo.SaltKey = os.Getenv("PASSWORD_SALT")
 	eo.Namespace = os.Getenv("NAMESPACE")
@@ -149,14 +179,15 @@ type RunnableOptions struct {
 	DefaultPeriod time.Duration
 }
 
-const (
-	Collector     task = "Collector"
-	DataSync      task = "DataSync"
-	Init          task = "Init"
-	Notice        task = "Notice"
-	NoticeCleanup task = "NoticeCleanup"
-	// Add more tasks here
-)
+type NetWorkOptions struct {
+	// EnableExternalNetWork is used to distinguish between
+	// external and internal networks.
+	EnableExternalNetWork bool
+}
+
+func (no *NetWorkOptions) initOptions() {
+	no.EnableExternalNetWork = false
+}
 
 func (ro *RunnableOptions) initOptions() {
 	ro.Policy = make(map[task]string)

--- a/controllers/licenseissuer/internal/controller/util/prob.go
+++ b/controllers/licenseissuer/internal/controller/util/prob.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import "sync"
+
+// Probe is an interface for a probe check
+type Probe interface {
+	Probe() bool
+}
+
+// ProbeFor return the Probe interface for the given task type
+func ProbeFor(taskType task) Probe {
+	switch taskType {
+	case Collector, DataSync, Notice:
+		return ProbeForInit()
+	case NetWorkConfig:
+		return ProbeForNetWork()
+	default:
+		return nil
+	}
+}
+
+// NetworkProbe is an interface for a network probe check
+
+type NetworkProbe interface {
+	Probe
+	ProbeForNetWork(url string)
+}
+
+type networkProbe struct {
+	options OptionsReadWrite
+}
+
+type networkConfig struct {
+	url string
+	np  NetworkProbe
+}
+
+func NewNetworkConfig() *networkConfig {
+	return &networkConfig{
+		np: GetNetworkProbe(),
+	}
+}
+
+func (n *networkConfig) probe(instance *TaskInstance) error {
+	urlMap, err := GetURL(instance.ctx, instance.Client)
+	if err != nil {
+		instance.logger.Info("get url error", "error", err)
+		return err
+	}
+	n.url = urlMap[NetworkProbeURL]
+	n.np.ProbeForNetWork(n.url)
+	return nil
+}
+
+func (n *networkProbe) Probe() bool {
+	return options.GetNetWorkOptions().EnableExternalNetWork
+}
+
+func (n *networkProbe) ProbeForNetWork(url string) {
+	_, err := Get(url)
+	if err != nil {
+		// The network is not available
+		n.options.SetNetworkConfig(false)
+		return
+	}
+	// The network is available
+	n.options.SetNetworkConfig(true)
+}
+
+var onceForNetworkProbe sync.Once
+var networkProbeInstance networkProbe
+
+var _ NetworkProbe = &networkProbe{}
+var _ Probe = &networkProbe{}
+
+func GetNetworkProbe() NetworkProbe {
+	onceForNetworkProbe.Do(func() {
+		networkProbeInstance = networkProbe{
+			options: GetOptionsReadWrite(),
+		}
+	})
+	return &networkProbeInstance
+}
+
+func ProbeForNetWork() Probe {
+	return GetNetworkProbe()
+}

--- a/controllers/licenseissuer/internal/controller/util/prob.go
+++ b/controllers/licenseissuer/internal/controller/util/prob.go
@@ -48,18 +48,18 @@ type networkProbe struct {
 	options OptionsReadWrite
 }
 
-type networkConfig struct {
+type NetworkConfig struct {
 	url string
 	np  NetworkProbe
 }
 
-func NewNetworkConfig() *networkConfig {
-	return &networkConfig{
+func NewNetworkConfig() *NetworkConfig {
+	return &NetworkConfig{
 		np: GetNetworkProbe(),
 	}
 }
 
-func (n *networkConfig) probe(instance *TaskInstance) error {
+func (n *NetworkConfig) probe(instance *TaskInstance) error {
 	urlMap, err := GetURL(instance.ctx, instance.Client)
 	if err != nil {
 		instance.logger.Info("get url error", "error", err)
@@ -109,7 +109,7 @@ type RegisterProbe interface {
 	SetFlag(flag bool)
 }
 
-type register struct {
+type RegisterWork struct {
 	probe RegisterProbe
 }
 
@@ -130,24 +130,24 @@ func GetRegisterProbe() RegisterProbe {
 	return &registerProbeInstance
 }
 
-func NewRegister() *register {
-	return &register{
+func NewRegister() *RegisterWork {
+	return &RegisterWork{
 		probe: GetRegisterProbe(),
 	}
 }
 
-func (r *register) register(instance *TaskInstance) error {
+func (r *RegisterWork) register(instance *TaskInstance) error {
 	return r.registerToCloud(instance)
 }
 
-func (r *register) registerToCloud(instance *TaskInstance) error {
+func (r *RegisterWork) registerToCloud(instance *TaskInstance) error {
 	uid, urlMap, err := GetUIDURL(instance.ctx, instance.Client)
 	if err != nil {
 		instance.logger.Info("get uid and url error", "error", err)
 		return err
 	}
 	rr := RegisterRequest{
-		UID: string(uid),
+		UID: uid,
 	}
 	// send info to cloud
 	err = Push(urlMap[RegisterURL], rr)

--- a/controllers/licenseissuer/internal/controller/util/prob.go
+++ b/controllers/licenseissuer/internal/controller/util/prob.go
@@ -24,12 +24,10 @@ type Probe interface {
 }
 
 // ProbeFor return the Probe interface for the given task type
-func ProbeFor(taskType task) Probe {
+func ProbeFor(taskType task) []Probe {
 	switch taskType {
 	case Collector, DataSync, Notice:
-		return ProbeForInit()
-	case NetWorkConfig:
-		return ProbeForNetWork()
+		return []Probe{ProbeForInit(), ProbeForNetWork()}
 	default:
 		return nil
 	}

--- a/controllers/licenseissuer/internal/controller/util/runnable.go
+++ b/controllers/licenseissuer/internal/controller/util/runnable.go
@@ -59,7 +59,7 @@ func Once(_ context.Context, _ time.Duration, t Task) error {
 }
 
 // OnceWithProbe func is used to run a task only once.
-func OnceWithProbe(ctx context.Context, preiod time.Duration, t Task) error {
+func OnceWithProbe(ctx context.Context, period time.Duration, t Task) error {
 	for {
 		select {
 		case <-ctx.Done():
@@ -67,13 +67,13 @@ func OnceWithProbe(ctx context.Context, preiod time.Duration, t Task) error {
 		default:
 			if !t.Probe() {
 				(t.Log()).Info("the probe is not ready, try again after some time")
-				time.Sleep(preiod)
+				time.Sleep(period)
 				continue
 			}
 			err := t.Run()
 			if err != nil {
 				(t.Log()).Error(err, "failed to run task")
-				time.Sleep(preiod)
+				time.Sleep(period)
 				continue
 			}
 		}

--- a/controllers/licenseissuer/internal/controller/util/runnable.go
+++ b/controllers/licenseissuer/internal/controller/util/runnable.go
@@ -137,7 +137,7 @@ type TaskInstance struct {
 	ctx    context.Context
 	policy string
 	period time.Duration
-	probe  Probe
+	probe  []Probe
 }
 
 var _ manager.Runnable = &TaskInstance{}
@@ -181,8 +181,13 @@ func (ti *TaskInstance) Log() *logr.Logger {
 }
 
 func (ti *TaskInstance) Probe() bool {
-	if ti.probe == nil {
+	if len(ti.probe) == 0 {
 		return false
 	}
-	return ti.probe.Probe()
+	for _, p := range ti.probe {
+		if !p.Probe() {
+			return false
+		}
+	}
+	return true
 }

--- a/deploy/cloud/manifests/free-license.yaml
+++ b/deploy/cloud/manifests/free-license.yaml
@@ -2,6 +2,7 @@ apiVersion: infostream.sealos.io/v1
 kind: License
 metadata:
   name: license
+  namespace: ns-admin
 spec:
   uid: admin
   # nosemgrep: generic.secrets.security.detected-jwt-token.detected-jwt-token


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 09d1461</samp>

### Summary
🌐🛠️📄

<!--
1.  🌐 - This emoji represents the network probe check feature, which is a major new feature that verifies the network connectivity of the license issuer controller and updates the network configuration option accordingly. This emoji also represents the network-related changes in the code, such as the `NetworkProbeURL` environment variable and configmap, the `Get` function, and the `NetWorkOptions` struct and methods.
2.  🛠️ - This emoji represents the refactoring and improvement of the code, such as the `OptionsReadOnly` and `OptionsReadWrite` interfaces, the constructor functions, and the log level changes. This emoji also represents the reliability and security of the license issuer controller, which are enhanced by the probe checks for the init and the network tasks.
3.  📄 - This emoji represents the changes in the custom resource definitions and the templates, such as the `namespace` field in the `FreeLicense` resource, and the `NetworkProbeURL` in the `LicenseIssuerConfig` configmap and the `customconfig.yaml.tmpl` template. This emoji also represents the documentation and communication of the license issuer controller, which are improved by the notice and notice cleanup tasks.
-->
This pull request adds a new feature to the license issuer controller that periodically performs a network probe check to verify the network connectivity of the controller. The pull request also refactors the code to improve the readability, maintainability, and security of the controller, and updates the configuration files and manifests to support the new feature. The pull request mainly affects the `controllers/licenseissuer/internal/controller/util` package, which contains the utility functions and types for the controller, and the `controllers/licenseissuer/deploy` directory, which contains the deployment files and manifests for the controller. The pull request also modifies some files in the `controllers/licenseissuer/internal/controller` package and the `deploy/cloud/manifests` directory.

> _We are the license issuers of the sealos cluster_
> _We probe the network to verify our power_
> _We use the options to configure our tasks_
> _We sync the data and send the notice faster_

### Walkthrough
*  Add the network probe check feature to detect the network availability of the license issuer controller ([link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-bc41987f199cfa1e67d1a6b401fd74c9373d181be91894d25d92bdf71e63c540L25-R26),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-7c1a18ed4f66152a3b9b5662b44117b6df2431c05a5f1c3242ef1586a6eb3524L23-R24),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-252532f462fce5f86a27a9c8d6327465943d4e1dc49c5323bf2ecc139fbf9adeL140-R140),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-d6694648159f56721eba95e37dec6193b7d553ff6099442d0c7d203dbbe5ca30R41),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-d6694648159f56721eba95e37dec6193b7d553ff6099442d0c7d203dbbe5ca30L72-R86),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-32adc54a63a36e97508e611d7b2d99aef97bb3e4c15183b0251d386b9d21ce06R40-R51),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-a2dd759e0615f8294c627a181ddf066247d3e4091982659adc89fcbfb09d37b9R21),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-a2dd759e0615f8294c627a181ddf066247d3e4091982659adc89fcbfb09d37b9L37-R56),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-a2dd759e0615f8294c627a181ddf066247d3e4091982659adc89fcbfb09d37b9L53-R64),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-a2dd759e0615f8294c627a181ddf066247d3e4091982659adc89fcbfb09d37b9L59-R70),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-a2dd759e0615f8294c627a181ddf066247d3e4091982659adc89fcbfb09d37b9L69-R83),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-a2dd759e0615f8294c627a181ddf066247d3e4091982659adc89fcbfb09d37b9L80-R91),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-a2dd759e0615f8294c627a181ddf066247d3e4091982659adc89fcbfb09d37b9L86-R97),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-a2dd759e0615f8294c627a181ddf066247d3e4091982659adc89fcbfb09d37b9L99-R110),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-a2dd759e0615f8294c627a181ddf066247d3e4091982659adc89fcbfb09d37b9R136-R168),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-22fb1820466f572d76033ba032440419ded2b28888ed2e6aad53d3101440e751L29-R46),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-22fb1820466f572d76033ba032440419ded2b28888ed2e6aad53d3101440e751R59-R68),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-22fb1820466f572d76033ba032440419ded2b28888ed2e6aad53d3101440e751L58-R85),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-22fb1820466f572d76033ba032440419ded2b28888ed2e6aad53d3101440e751R115-R117),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-22fb1820466f572d76033ba032440419ded2b28888ed2e6aad53d3101440e751L100-R152),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-22fb1820466f572d76033ba032440419ded2b28888ed2e6aad53d3101440e751L134-L135),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-22fb1820466f572d76033ba032440419ded2b28888ed2e6aad53d3101440e751L152-R189),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-31875cb385d53e97c134c716b739675d815ecbbab7bf6dc879d65c8ae20223d8R1-R101),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-4d944b0cd144b572240100d4e0aee9b16e6cec6db7b771516917580e58267595R46),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-4d944b0cd144b572240100d4e0aee9b16e6cec6db7b771516917580e58267595R79-R100),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-4d944b0cd144b572240100d4e0aee9b16e6cec6db7b771516917580e58267595R126),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-4d944b0cd144b572240100d4e0aee9b16e6cec6db7b771516917580e58267595R140),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-4d944b0cd144b572240100d4e0aee9b16e6cec6db7b771516917580e58267595R152-R153),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-4d944b0cd144b572240100d4e0aee9b16e6cec6db7b771516917580e58267595L136-R172),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-4d944b0cd144b572240100d4e0aee9b16e6cec6db7b771516917580e58267595L156-R192))
  * Add the `NetworkProbeURL` environment variable and configmap key to store the URL for the network probe check ([link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-b4511a7abc516cfb1955af533ce91b67c27dc03a134658a3bbf30e2052614d9cL2-R4),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-927f5e074d21e616995c71f76c4db50ad95bef6a1753ba51a4016facee2f7a39R20),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-bc41987f199cfa1e67d1a6b401fd74c9373d181be91894d25d92bdf71e63c540L25-R26),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-7c1a18ed4f66152a3b9b5662b44117b6df2431c05a5f1c3242ef1586a6eb3524L23-R24),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-d6694648159f56721eba95e37dec6193b7d553ff6099442d0c7d203dbbe5ca30R41))
  * Add the `NetWorkOptions` struct and the `OptionsReadOnly` and `OptionsReadWrite` interfaces to store and access the network configuration options ([link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-22fb1820466f572d76033ba032440419ded2b28888ed2e6aad53d3101440e751L29-R46),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-22fb1820466f572d76033ba032440419ded2b28888ed2e6aad53d3101440e751R59-R68),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-22fb1820466f572d76033ba032440419ded2b28888ed2e6aad53d3101440e751L58-R85),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-22fb1820466f572d76033ba032440419ded2b28888ed2e6aad53d3101440e751R115-R117),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-22fb1820466f572d76033ba032440419ded2b28888ed2e6aad53d3101440e751L100-R152),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-22fb1820466f572d76033ba032440419ded2b28888ed2e6aad53d3101440e751L152-R189))
  * Add the `Get` function to handle the "GET" request to the external network ([link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-32adc54a63a36e97508e611d7b2d99aef97bb3e4c15183b0251d386b9d21ce06R40-R51))
  * Add the `Probe`, `NetworkProbe`, and `InitProbe` interfaces and the `ProbeFor`, `ProbeForNetWork`, and `ProbeForInit` functions to perform the probe checks for the init and the network tasks ([link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-a2dd759e0615f8294c627a181ddf066247d3e4091982659adc89fcbfb09d37b9R136-R168),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-31875cb385d53e97c134c716b739675d815ecbbab7bf6dc879d65c8ae20223d8R1-R101))
  * Add the `networkProbe`, `networkConfig`, and `Flag` structs and the `GetNetworkProbe`, `GetInitProbe`, `NewNetworkConfig`, and `NewDataSync` functions to implement the probe checks for the init and the network tasks ([link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-df07dcf98fa35b21ec61fcd91fc6e6c7c7a7834de5cd8a7e81c07f2eea116873R27-R30),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-31875cb385d53e97c134c716b739675d815ecbbab7bf6dc879d65c8ae20223d8R1-R101))
  * Add the `probe` field and the `Probe` method to the `TaskInstance` struct to store and check the probe status for the tasks ([link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-4d944b0cd144b572240100d4e0aee9b16e6cec6db7b771516917580e58267595R126),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-4d944b0cd144b572240100d4e0aee9b16e6cec6db7b771516917580e58267595R140),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-4d944b0cd144b572240100d4e0aee9b16e6cec6db7b771516917580e58267595L156-R192))
  * Add the `PeriodicWithProbe` function and the `PeriodicWithProbePolicy` constant to run the tasks periodically only if the probe check is successful ([link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-d6694648159f56721eba95e37dec6193b7d553ff6099442d0c7d203dbbe5ca30L72-R86),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-4d944b0cd144b572240100d4e0aee9b16e6cec6db7b771516917580e58267595R46),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-4d944b0cd144b572240100d4e0aee9b16e6cec6db7b771516917580e58267595R79-R100),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-4d944b0cd144b572240100d4e0aee9b16e6cec6db7b771516917580e58267595R152-R153))
  * Add the `NetWorkConfig` constant and the `NetWorkConfig` case to the `Start` and the `Run` methods of the `TaskInstance` struct to run the network probe check task ([link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-d6694648159f56721eba95e37dec6193b7d553ff6099442d0c7d203dbbe5ca30L72-R86),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-4d944b0cd144b572240100d4e0aee9b16e6cec6db7b771516917580e58267595R46),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-4d944b0cd144b572240100d4e0aee9b16e6cec6db7b771516917580e58267595L136-R172))
  * Add the `ProbeFor` function call to the `init` function to get and store the probe check for the tasks ([link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-4d944b0cd144b572240100d4e0aee9b16e6cec6db7b771516917580e58267595R126))
  * Add the `probe.Completed` method call to the `initWork` method to mark the init task as completed ([link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-a2dd759e0615f8294c627a181ddf066247d3e4091982659adc89fcbfb09d37b9L69-R83))
  * Add the `namespace` field to the `free-license.yaml` file to make it explicit and consistent with the other custom resource definitions ([link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-a57c237d3aa854c2219ff7f43f57881847aa2d1993b04a40b4741516bedcaa9eR5))
* Simplify the `.env` file by removing the unused variables and adding the `NAMESPACE` variable ([link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-b4511a7abc516cfb1955af533ce91b67c27dc03a134658a3bbf30e2052614d9cL2-R4))
* Change the log level from `Error` to `Info` for the non-critical errors that may indicate the network probe check failure ([link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-df07dcf98fa35b21ec61fcd91fc6e6c7c7a7834de5cd8a7e81c07f2eea116873L47-R51),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-df07dcf98fa35b21ec61fcd91fc6e6c7c7a7834de5cd8a7e81c07f2eea116873L56-R60),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-df07dcf98fa35b21ec61fcd91fc6e6c7c7a7834de5cd8a7e81c07f2eea116873L62-R66),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-df07dcf98fa35b21ec61fcd91fc6e6c7c7a7834de5cd8a7e81c07f2eea116873L72-R76),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-df07dcf98fa35b21ec61fcd91fc6e6c7c7a7834de5cd8a7e81c07f2eea116873L83-R87),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-df07dcf98fa35b21ec61fcd91fc6e6c7c7a7834de5cd8a7e81c07f2eea116873L89-R93),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-a2dd759e0615f8294c627a181ddf066247d3e4091982659adc89fcbfb09d37b9L59-R70),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-a2dd759e0615f8294c627a181ddf066247d3e4091982659adc89fcbfb09d37b9L69-R83),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-a2dd759e0615f8294c627a181ddf066247d3e4091982659adc89fcbfb09d37b9L80-R91),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-cf5d0da13b5de20d2fd51530764dcd7352daa6f65e03b2c491746045297e4e85L69-R69),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-cf5d0da13b5de20d2fd51530764dcd7352daa6f65e03b2c491746045297e4e85L78-R78),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-cf5d0da13b5de20d2fd51530764dcd7352daa6f65e03b2c491746045297e4e85L85-R85),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-cf5d0da13b5de20d2fd51530764dcd7352daa6f65e03b2c491746045297e4e85L92-L96),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-cf5d0da13b5de20d2fd51530764dcd7352daa6f65e03b2c491746045297e4e85L150-R149),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-cf5d0da13b5de20d2fd51530764dcd7352daa6f65e03b2c491746045297e4e85R174-R177),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-cf5d0da13b5de20d2fd51530764dcd7352daa6f65e03b2c491746045297e4e85L181-R184),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-cf5d0da13b5de20d2fd51530764dcd7352daa6f65e03b2c491746045297e4e85L187-R190),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-cf5d0da13b5de20d2fd51530764dcd7352daa6f65e03b2c491746045297e4e85L198-R201),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-cf5d0da13b5de20d2fd51530764dcd7352daa6f65e03b2c491746045297e4e85L210-R213),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-cf5d0da13b5de20d2fd51530764dcd7352daa6f65e03b2c491746045297e4e85L248-R251))
* Change the receiver type from `initTask` to `*initTask` for the `initWork`, `checkRegister`, and `registerToCloud` methods to improve the performance and memory efficiency ([link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-a2dd759e0615f8294c627a181ddf066247d3e4091982659adc89fcbfb09d37b9L53-R64),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-a2dd759e0615f8294c627a181ddf066247d3e4091982659adc89fcbfb09d37b9L86-R97),[link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-a2dd759e0615f8294c627a181ddf066247d3e4091982659adc89fcbfb09d37b9L99-R110))
* Remove the log message and the error return when caching the namespace fails to simplify the code and avoid unnecessary interruption ([link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-cf5d0da13b5de20d2fd51530764dcd7352daa6f65e03b2c491746045297e4e85L92-L96))
* Remove the initialization of the `NetworkConfiguration` and `MonitorConfiguration` fields from the `initOptions` method of the `EnvOptions` struct, which are no longer used by the code ([link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-22fb1820466f572d76033ba032440419ded2b28888ed2e6aad53d3101440e751L134-L135))
* Remove the `waitForInit` function, which is no longer needed by the code ([link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-4d944b0cd144b572240100d4e0aee9b16e6cec6db7b771516917580e58267595L156-R192))
* Change the return value of the `Once` function from `err` to `nil` to simplify the code and avoid unnecessary error handling ([link](https://github.com/labring/sealos/pull/3764/files?diff=unified&w=0#diff-4d944b0cd144b572240100d4e0aee9b16e6cec6db7b771516917580e58267595L57-R62))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
