### PR TITLE
fix: imagePullPolicy

### DIFF
--- a/frontend/providers/applaunchpad/src/mock/apps.ts
+++ b/frontend/providers/applaunchpad/src/mock/apps.ts
@@ -110,7 +110,7 @@ spec:
             limits:
               cpu: 30m
               memory: 300Mi
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: desktop-app-demo-volume
               mountPath: /config.yaml

--- a/frontend/providers/applaunchpad/src/utils/deployYaml2Json.ts
+++ b/frontend/providers/applaunchpad/src/utils/deployYaml2Json.ts
@@ -90,7 +90,7 @@ export const json2DeployCr = (data: AppEditType, type: 'deployment' | 'statefuls
         containerPort: str2Num(data.containerOutPort)
       }
     ],
-    imagePullPolicy: 'Always'
+    imagePullPolicy: 'IfNotPresent'
   };
   const configMapVolumeMounts = data.configMapList.map((item) => ({
     name: pathToNameFormat(item.mountPath),


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8807d11</samp>

### Summary
🐳🚀🛠️

<!--
1.  🐳 - This emoji represents the container image and the Docker registry. It can be used to indicate a change related to the imagePullPolicy or the image name or tag.
2.  🚀 - This emoji represents the deployment process and the speed or efficiency of launching the application. It can be used to indicate a change that improves the performance or reliability of the deployment.
3.  🛠️ - This emoji represents the utility functions and the code quality or maintenance. It can be used to indicate a change that fixes a bug, refactors the code, or adds a feature to the utility.
-->
Changed the `imagePullPolicy` of container specs to `IfNotPresent` in the frontend code that handles application deployment. This can improve the performance and efficiency of the deployment process.

> _`imagePullPolicy`_
> _Changed to `IfNotPresent` -_
> _Less network in spring_

### Walkthrough
*  Change `imagePullPolicy` of container spec from `Always` to `IfNotPresent` to reduce network traffic and speed up deployment ([link](https://github.com/labring/sealos/pull/3768/files?diff=unified&w=0#diff-5c80769f3f6ac325238e5bcd92976418dfe9473a1a3ff93e8b7f190270712d36L113-R113), [link](https://github.com/labring/sealos/pull/3768/files?diff=unified&w=0#diff-9ab86159facb4b23aba0fce56898aa5ad9d4b2347685afe9ac476f763b8e1a63L93-R93))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
