### PR TITLE
launchpad imagePullPolicy

### DIFF
--- a/frontend/providers/applaunchpad/src/mock/apps.ts
+++ b/frontend/providers/applaunchpad/src/mock/apps.ts
@@ -110,7 +110,7 @@ spec:
             limits:
               cpu: 30m
               memory: 300Mi
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           volumeMounts:
             - name: desktop-app-demo-volume
               mountPath: /config.yaml

--- a/frontend/providers/applaunchpad/src/utils/deployYaml2Json.ts
+++ b/frontend/providers/applaunchpad/src/utils/deployYaml2Json.ts
@@ -90,7 +90,7 @@ export const json2DeployCr = (data: AppEditType, type: 'deployment' | 'statefuls
         containerPort: str2Num(data.containerOutPort)
       }
     ],
-    imagePullPolicy: 'IfNotPresent'
+    imagePullPolicy: 'Always'
   };
   const configMapVolumeMounts = data.configMapList.map((item) => ({
     name: pathToNameFormat(item.mountPath),


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a0d77fc</samp>

### Summary
🔄🆙🛠️

<!--
1.  🔄 This emoji means refresh or reload, and it can be used to indicate that the container always pulls the latest image from the registry, instead of using a cached one.
2.  🆙 This emoji means up or update, and it can be used to indicate that the app is updated frequently and needs to run the most recent version.
3.  🛠️ This emoji means tool or fix, and it can be used to indicate that the function was modified to match the change in the container spec.
-->
Changed the `imagePullPolicy` of the container spec to `Always` in two files: `apps.ts` and `deployYaml2Json.ts`. This ensures that the container always runs the latest version of the app.

> _`imagePullPolicy`_
> _Always fetches latest app_
> _No stale container_

### Walkthrough
*  Set `imagePullPolicy` to `Always` for the container spec of the app deployment ([link](https://github.com/labring/sealos/pull/3775/files?diff=unified&w=0#diff-5c80769f3f6ac325238e5bcd92976418dfe9473a1a3ff93e8b7f190270712d36L113-R113), [link](https://github.com/labring/sealos/pull/3775/files?diff=unified&w=0#diff-9ab86159facb4b23aba0fce56898aa5ad9d4b2347685afe9ac476f763b8e1a63L93-R93)). This ensures that the container always pulls the latest image from the registry, instead of using a cached one if it exists. This change affects both the original YAML file (`frontend/providers/applaunchpad/src/mock/apps.ts`) and the function that converts it to a JSON object (`frontend/providers/applaunchpad/src/utils/deployYaml2Json.ts`).


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
