### PR TITLE
feat:template develop dryrun deploy

### DIFF
--- a/frontend/providers/template/public/locales/en/common.json
+++ b/frontend/providers/template/public/locales/en/common.json
@@ -154,6 +154,7 @@
     "Preview": "Preview",
     "Configure Form": "Configure Form",
     "YAML File": "YAML File",
-    "Template Development": "Template Development"
+    "Template Development": "Template Development",
+    "Dryrun Deploy": "Dryrun Deploy"
   }
 }

--- a/frontend/providers/template/public/locales/zh/common.json
+++ b/frontend/providers/template/public/locales/zh/common.json
@@ -160,6 +160,7 @@
     "Preview": "预览",
     "Configure Form": "配置表单",
     "YAML File": "YAML 文件",
-    "Template Development": "模板开发"
+    "Template Development": "模板开发",
+    "Dryrun Deploy": "试运行部署"
   }
 }

--- a/frontend/providers/template/src/api/app.ts
+++ b/frontend/providers/template/src/api/app.ts
@@ -1,4 +1,6 @@
 import { POST } from '@/services/request';
 
-export const postDeployApp = (yamlList: string[]) => POST('/api/applyApp', { yamlList });
+export const postDeployApp = (yamlList: string[], type: 'create' | 'replace' | 'dryrun') =>
+  POST('/api/applyApp', { yamlList, type });
+
 export const getTemplate = (templateName: string) => POST('/api/getTemplate', { templateName });

--- a/frontend/providers/template/src/pages/api/applyApp.ts
+++ b/frontend/providers/template/src/pages/api/applyApp.ts
@@ -5,7 +5,11 @@ import { ApiResp } from '@/services/kubernet';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
-  const { yamlList }: { yamlList: string[] } = req.body;
+  const { yamlList, type = 'create' } = req.body as {
+    yamlList: string[];
+    type: 'create' | 'replace' | 'dryrun';
+  };
+
   if (!yamlList || yamlList.length < 2) {
     jsonRes(res, {
       code: 500,
@@ -18,7 +22,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       kubeconfig: await authSession(req.headers)
     });
 
-    const applyRes = await applyYamlList(yamlList, 'create');
+    const applyRes = await applyYamlList(yamlList, type);
 
     jsonRes(res, { data: applyRes.map((item) => item.kind) });
   } catch (err: any) {

--- a/frontend/providers/template/src/pages/deploy/index.tsx
+++ b/frontend/providers/template/src/pages/deploy/index.tsx
@@ -143,7 +143,7 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
         return JSYAML.dump(_item);
       });
 
-      const result = await postDeployApp(yamls);
+      const result = await postDeployApp(yamls, 'create');
 
       toast({
         title: t(applySuccess),
@@ -246,8 +246,7 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
           justifyContent={'start'}
           alignItems={'center'}
           backgroundColor={'rgba(255, 255, 255)'}
-          backdropBlur={'100px'}
-        >
+          backdropBlur={'100px'}>
           <Box cursor={'pointer'} onClick={() => router.push('/')}>
             <MyIcon ml={'46px'} name="arrowLeft" color={'#24282C'} w={'16px'} h={'16px'}></MyIcon>
           </Box>
@@ -256,8 +255,7 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
             fontWeight={500}
             fontSize={16}
             textDecoration={'none'}
-            color={'#7B838B'}
-          >
+            color={'#7B838B'}>
             <BreadcrumbItem textDecoration={'none'}>
               <BreadcrumbLink _hover={{ color: '#219BF4', textDecoration: 'none' }} href="/">
                 {t('Template List')}
@@ -276,8 +274,7 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
           flexDirection={'column'}
           width={'100%'}
           flexGrow={1}
-          backgroundColor={'rgba(255, 255, 255, 0.90)'}
-        >
+          backgroundColor={'rgba(255, 255, 255, 0.90)'}>
           <Header
             templateDetail={templateDetail}
             appName={''}

--- a/frontend/providers/template/src/pages/develop/components/BreadCrumbHeader.tsx
+++ b/frontend/providers/template/src/pages/develop/components/BreadCrumbHeader.tsx
@@ -1,18 +1,9 @@
 import MyIcon from '@/components/Icon';
-import {
-  Flex,
-  Button,
-  Text,
-  Box,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  Breadcrumb
-} from '@chakra-ui/react';
-import { t } from 'i18next';
-import { useRouter } from 'next/router';
+import { Box, Breadcrumb, BreadcrumbItem, BreadcrumbLink, Button, Flex } from '@chakra-ui/react';
 import { useTranslation } from 'next-i18next';
+import { useRouter } from 'next/router';
 
-const BreadCrumbHeader = () => {
+const BreadCrumbHeader = ({ applyCb }: { applyCb: () => void }) => {
   const router = useRouter();
   const { t } = useTranslation();
 
@@ -23,8 +14,7 @@ const BreadCrumbHeader = () => {
       justifyContent={'start'}
       alignItems={'center'}
       backgroundColor={'rgba(255, 255, 255)'}
-      backdropBlur={'100px'}
-    >
+      backdropBlur={'100px'}>
       <Box cursor={'pointer'} onClick={() => router.push('/')}>
         <MyIcon name="arrowLeft" color={'#24282C'} w={'16px'} h={'16px'}></MyIcon>
       </Box>
@@ -33,8 +23,7 @@ const BreadCrumbHeader = () => {
         fontWeight={500}
         fontSize={16}
         textDecoration={'none'}
-        color={'#7B838B'}
-      >
+        color={'#7B838B'}>
         <BreadcrumbItem textDecoration={'none'}>
           <BreadcrumbLink _hover={{ color: '#219BF4', textDecoration: 'none' }} href="/">
             {t('Template List')}
@@ -46,6 +35,9 @@ const BreadCrumbHeader = () => {
           </BreadcrumbLink>
         </BreadcrumbItem>
       </Breadcrumb>
+      <Button ml="auto" px={4} minW={'120px'} h={'34px'} variant={'primary'} onClick={applyCb}>
+        {t('develop.Dryrun Deploy')}
+      </Button>
     </Flex>
   );
 };

--- a/frontend/providers/template/src/pages/develop/components/Form.tsx
+++ b/frontend/providers/template/src/pages/develop/components/Form.tsx
@@ -37,8 +37,7 @@ const Form = ({
                     w="200px"
                     className="template-dynamic-label"
                     color={'#333'}
-                    userSelect={'none'}
-                  >
+                    userSelect={'none'}>
                     {item?.label}
                     {item?.required && (
                       <Text ml="2px" color={'#E53E3E'}>
@@ -51,7 +50,6 @@ const Form = ({
                     maxW={'500px'}
                     ml={'20px'}
                     defaultValue={item?.default}
-                    autoFocus={true}
                     placeholder={item?.description}
                     {...register(item?.key, {
                       required: item?.required
@@ -68,16 +66,14 @@ const Form = ({
           alignItems="center"
           h={'100%'}
           w={'100%'}
-          flexDirection="column"
-        >
+          flexDirection="column">
           <Flex
             border={'1px dashed #9CA2A8'}
             borderRadius="50%"
             w={'48px'}
             h={'48px'}
             justifyContent="center"
-            alignItems={'center'}
-          >
+            alignItems={'center'}>
             <MyIcon color={'#7B838B'} name="empty"></MyIcon>
           </Flex>
           <Text mt={'12px'} fontSize={14} color={'#5A646E'}>


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 69b732a</samp>

### Summary
🚀🛠️🌐

<!--
1.  🚀 This emoji represents the new feature of dryrun deploy, which allows users to test their app deployment without applying the changes. It conveys the idea of launching or testing something new and exciting.
2. 🛠️ This emoji represents the various fixes and improvements made to the code formatting, UI, and error handling. It conveys the idea of repairing or building something better and more reliable.
3. 🌐 This emoji represents the addition of the Chinese translation for the dryrun deploy button text. It conveys the idea of supporting multiple languages and cultures and expanding the reach of the app.
-->
This pull request adds a new feature to the frontend of the sealos template provider, which allows users to perform dry run deployments of their templates. It modifies the `applyApp` API endpoint, the `postDeployApp` function, the `kubernetes.ts` service, and the `Develop` and `BreadCrumbHeader` components to support this feature. It also adds the corresponding button text to the `common.json` files for the English and Chinese locales. Additionally, it fixes some minor formatting and UI issues in the `Form` and `EditApp` components.

> _If you want to deploy an app with YAML_
> _But you're not sure if it will go well_
> _You can use `dryRun` mode_
> _To test the code_
> _And avoid any cluster mishap or hell_

### Walkthrough
*  Add a new feature to allow users to test the deployment of a template without applying it to the cluster (dryrun deploy) ([link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-e1a68b10638f46dc7d377b07266b0578c63bbab3a85509fd956813bee3a9af7eR157), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-737eca34a0ed34c29324bb943ff6732e50b0b251c8a3fa001cda67382b2bb15eR163), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-8f8fc21142cd97f0f7a10835b73b8ae299f52705cfc9d76fc5204cf6b414c2baL3-R5), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-ddb612006cfa7a2faacff0fd45fa8e831b281432913a077ba8b8a608be7070dcL8-R12), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-ddb612006cfa7a2faacff0fd45fa8e831b281432913a077ba8b8a608be7070dcL21-R25), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-888bad66256fa519d098cf0f7ddf7eefbbc28b132220094e3ec079c2fae4125aL146-R146), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-e10d3bc6db4fffeb3994a151c2ac858c383856d8fb920594222e0bff9b6ae35aL2-R6), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-e10d3bc6db4fffeb3994a151c2ac858c383856d8fb920594222e0bff9b6ae35aR38-R40), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-073ebdbc11446d7181ee4c02c0ea8ac50587ffb816c91ab532043fbaed052557L19-R39), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-073ebdbc11446d7181ee4c02c0ea8ac50587ffb816c91ab532043fbaed052557L119-R167), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-073ebdbc11446d7181ee4c02c0ea8ac50587ffb816c91ab532043fbaed052557L127-R173), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-073ebdbc11446d7181ee4c02c0ea8ac50587ffb816c91ab532043fbaed052557L190-R239), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-1399c05ed7b4639e736cef5c7c1fc256c5840a5370a280a37cfb38c2d3b62081L56-R57), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-1399c05ed7b4639e736cef5c7c1fc256c5840a5370a280a37cfb38c2d3b62081L71-R72), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-1399c05ed7b4639e736cef5c7c1fc256c5840a5370a280a37cfb38c2d3b62081L154-R155), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-1399c05ed7b4639e736cef5c7c1fc256c5840a5370a280a37cfb38c2d3b62081R171-R172))
  * Add a new type parameter to the postDeployApp function in `frontend/providers/template/src/api/app.ts` to indicate the mode of deployment ('create', 'replace', or 'dryrun') ([link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-8f8fc21142cd97f0f7a10835b73b8ae299f52705cfc9d76fc5204cf6b414c2baL3-R5))
  * Add a new type property to the request body of the handler function in `frontend/providers/template/public/locales/en/common.json` to pass the mode of deployment to the backend service ([link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-ddb612006cfa7a2faacff0fd45fa8e831b281432913a077ba8b8a608be7070dcL8-R12))
  * Pass the type property from the request body to the applyYamlList function in `frontend/providers/template/src/services/backend/kubernetes.ts`, which handles the actual deployment logic ([link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-ddb612006cfa7a2faacff0fd45fa8e831b281432913a077ba8b8a608be7070dcL21-R25))
  * Add a new possible value 'dryrun' to the type parameter of the applyYamlList function in `frontend/providers/template/src/services/backend/kubernetes.ts`, which calls the CreateYaml function with the 'All' value for the dryRun parameter if the type is 'dryrun' ([link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-1399c05ed7b4639e736cef5c7c1fc256c5840a5370a280a37cfb38c2d3b62081L154-R155), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-1399c05ed7b4639e736cef5c7c1fc256c5840a5370a280a37cfb38c2d3b62081R171-R172))
  * Add a new optional parameter dryRun to the CreateYaml function in `frontend/providers/template/src/services/backend/kubernetes.ts`, which can be either 'All' or undefined, and pass it to the client.create method, which handles the actual API call to the cluster ([link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-1399c05ed7b4639e736cef5c7c1fc256c5840a5370a280a37cfb38c2d3b62081L56-R57), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-1399c05ed7b4639e736cef5c7c1fc256c5840a5370a280a37cfb38c2d3b62081L71-R72))
  * Add a new key-value pair to the common.json files for the English and Chinese locales, with the key "Dryrun Deploy" and the corresponding values, to display a button text for the dryrun deploy feature ([link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-e1a68b10638f46dc7d377b07266b0578c63bbab3a85509fd956813bee3a9af7eR157), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-737eca34a0ed34c29324bb943ff6732e50b0b251c8a3fa001cda67382b2bb15eR163))
  * Add a new import for the editModeMap constant from the constants/editApp file, and a new applyCb prop to the BreadCrumbHeader component in `frontend/providers/template/src/pages/develop/components/BreadCrumbHeader.tsx`, which is a callback function for the dryrun deploy feature ([link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-e10d3bc6db4fffeb3994a151c2ac858c383856d8fb920594222e0bff9b6ae35aL2-R6))
  * Add a new Button component to the BreadCrumbHeader component in `frontend/providers/template/src/pages/develop/components/BreadCrumbHeader.tsx`, with the text "Dryrun Deploy" and the applyCb prop function as the onClick handler ([link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-e10d3bc6db4fffeb3994a151c2ac858c383856d8fb920594222e0bff9b6ae35aR38-R40))
  * Add new state variables for the loading, errorMessage, title, applyBtnText, applyMessage, applySuccess, and applyError to the Develop component in `frontend/providers/template/src/pages/develop/index.tsx`, which are used for the dryrun deploy feature and the error handling logic ([link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-073ebdbc11446d7181ee4c02c0ea8ac50587ffb816c91ab532043fbaed052557L19-R39))
  * Add a new submitSuccess function that calls the postDeployApp function with the 'dryrun' mode and displays a toast message with the result, and a new submitError function that displays a toast message with the error message from the form validation, to the Develop component in `frontend/providers/template/src/pages/develop/index.tsx`, and pass them to the formHook.handleSubmit method as callbacks ([link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-073ebdbc11446d7181ee4c02c0ea8ac50587ffb816c91ab532043fbaed052557L119-R167))
  * Add the applyCb prop to the BreadCrumbHeader component and pass the formHook.handleSubmit method with the submitSuccess and submitError callbacks, to the Develop component in `frontend/providers/template/src/pages/develop/index.tsx`, to trigger the dryrun deploy feature when the button is clicked ([link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-073ebdbc11446d7181ee4c02c0ea8ac50587ffb816c91ab532043fbaed052557L127-R173))
  * Add the Loading component and the ErrorModal component to the render output of the Develop component in `frontend/providers/template/src/pages/develop/index.tsx`, to show the loading state and the error message when the dryrun deploy feature is executed ([link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-073ebdbc11446d7181ee4c02c0ea8ac50587ffb816c91ab532043fbaed052557L190-R239))
* Remove some extra spaces at the end of some properties of some components in various files, which are minor formatting changes that do not affect the functionality ([link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-888bad66256fa519d098cf0f7ddf7eefbbc28b132220094e3ec079c2fae4125aL249-R249), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-888bad66256fa519d098cf0f7ddf7eefbbc28b132220094e3ec079c2fae4125aL259-R258), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-888bad66256fa519d098cf0f7ddf7eefbbc28b132220094e3ec079c2fae4125aL279-R277), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-e10d3bc6db4fffeb3994a151c2ac858c383856d8fb920594222e0bff9b6ae35aL26-R17), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-e10d3bc6db4fffeb3994a151c2ac858c383856d8fb920594222e0bff9b6ae35aL36-R26), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-c9b3ffabd272e13b5b67e82e7e738ad79346146076b5fd9e645950b0487aa23aL40-R40), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-c9b3ffabd272e13b5b67e82e7e738ad79346146076b5fd9e645950b0487aa23aL71-R69), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-c9b3ffabd272e13b5b67e82e7e738ad79346146076b5fd9e645950b0487aa23aL79-R76), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-073ebdbc11446d7181ee4c02c0ea8ac50587ffb816c91ab532043fbaed052557L138-R183), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-073ebdbc11446d7181ee4c02c0ea8ac50587ffb816c91ab532043fbaed052557L167-R211))
* Remove the autoFocus property of the Input component in the Form component of `frontend/providers/template/src/pages/develop/components/Form.tsx`, which is a minor UI change that prevents the input from automatically getting focus when the form is rendered ([link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-c9b3ffabd272e13b5b67e82e7e738ad79346146076b5fd9e645950b0487aa23aL54))
* Remove the explicit export of the Develop component from `frontend/providers/template/src/pages/develop/index.tsx`, which is a minor code simplification as the component is already the default export function ([link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-073ebdbc11446d7181ee4c02c0ea8ac50587ffb816c91ab532043fbaed052557L201-L202))
* Remove the unused import for the t function from i18next and the Header component from various files, which are minor code cleanups that reduce the unnecessary dependencies ([link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-e10d3bc6db4fffeb3994a151c2ac858c383856d8fb920594222e0bff9b6ae35aL2-R6), [link](https://github.com/labring/sealos/pull/3778/files?diff=unified&w=0#diff-073ebdbc11446d7181ee4c02c0ea8ac50587ffb816c91ab532043fbaed052557L1-R8))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
