### PR TITLE
add frontend arm64 docker image

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -110,6 +110,7 @@ jobs:
         with:
           context: ./frontend
           file: ./frontend/Dockerfile
+          platforms: linux/amd64,linux/arm64
           build-args: |
             name=${{ env.MODULE_NAME }}
             path=${{ matrix.module }}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 93da621</samp>

### Summary
🐳🏗️🚀

<!--
1.  🐳 - This emoji represents the docker/build-push-action step and the use of Docker to create container images.
2.  🏗️ - This emoji represents the build process and the creation of multi-architecture images using the platforms argument.
3.  🚀 - This emoji represents the push process and the deployment of the images to a registry or a platform.
-->
This pull request enables multi-architecture support for the frontend docker image by adding the `platforms` argument to the `docker/build-push-action` step in `.github/workflows/frontend.yml`.

> _`docker/build-push`_
> _Multi-architecture images_
> _Snowflakes of hardware_

### Walkthrough
* Enable multi-architecture image building for the frontend application by adding the platforms argument to the docker/build-push-action step ([link](https://github.com/labring/sealos/pull/3789/files?diff=unified&w=0#diff-ffe3a297ed15e9a79846161a3731a580511bf13c6b5cc5a9e03ddcbd8515fdeeR113))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
