### PR TITLE
feature(main): sealos run uing defualt ssh port

### DIFF
--- a/pkg/apply/run.go
+++ b/pkg/apply/run.go
@@ -117,7 +117,7 @@ func (r *ClusterArgs) runArgs(cmd *cobra.Command, args *RunArgs, imageList []str
 
 	r.cluster.SetNewImages(imageList)
 
-	defaultPort := strconv.Itoa(int(defaultSSHPort(r.cluster.Spec.SSH.Port)))
+	defaultPort := defaultSSHPort(r.cluster.Spec.SSH.Port)
 	masters := stringsutil.SplitRemoveEmpty(args.Cluster.Masters, ",")
 	nodes := stringsutil.SplitRemoveEmpty(args.Cluster.Nodes, ",")
 	r.hosts = []v2.Host{}
@@ -139,7 +139,7 @@ func (r *ClusterArgs) runArgs(cmd *cobra.Command, args *RunArgs, imageList []str
 }
 
 func (r *ClusterArgs) setHostWithIpsPort(ips []string, roles []string) {
-	defaultPort := strconv.Itoa(int(defaultSSHPort(r.cluster.Spec.SSH.Port)))
+	defaultPort := defaultSSHPort(r.cluster.Spec.SSH.Port)
 	hostMap := map[string]*v2.Host{}
 	for i := range ips {
 		ip, port := iputils.GetHostIPAndPortOrDefault(ips[i], defaultPort)
@@ -165,9 +165,9 @@ func (r *ClusterArgs) setHostWithIpsPort(ips []string, roles []string) {
 	}
 }
 
-func defaultSSHPort(port uint16) uint16 {
+func defaultSSHPort(port uint16) string {
 	if port == 0 {
 		port = v2.DefaultSSHPort
 	}
-	return port
+	return strconv.Itoa(int(port))
 }

--- a/pkg/apply/scale.go
+++ b/pkg/apply/scale.go
@@ -17,7 +17,6 @@ package apply
 import (
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -126,7 +125,7 @@ func verifyAndSetNodes(cmd *cobra.Command, cluster *v2.Cluster, scaleArgs *Scale
 		}
 	}
 
-	defaultPort := strconv.Itoa(int(cluster.Spec.SSH.Port))
+	defaultPort := defaultSSHPort(cluster.Spec.SSH.Port)
 
 	var hosts []v2.Host
 	var hasMaster bool
@@ -226,7 +225,7 @@ func deleteNodes(cluster *v2.Cluster, scaleArgs *ScaleArgs) error {
 		return fmt.Errorf("master0 machine cannot be deleted")
 	}
 
-	defaultPort := strconv.Itoa(int(cluster.Spec.SSH.Port))
+	defaultPort := defaultSSHPort(cluster.Spec.SSH.Port)
 
 	hostsSet := sets.NewString()
 

--- a/pkg/apply/utils.go
+++ b/pkg/apply/utils.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/labring/sealos/pkg/constants"
@@ -141,7 +140,7 @@ func GetNewImages(currentCluster, desiredCluster *v2.Cluster) []string {
 }
 
 func CheckAndInitialize(cluster *v2.Cluster) {
-	cluster.Spec.SSH.Port = defaultSSHPort(cluster.Spec.SSH.Port)
+	cluster.Spec.SSH.Port = cluster.Spec.SSH.DefaultPort()
 
 	if cluster.Spec.SSH.Pk == "" {
 		cluster.Spec.SSH.Pk = filepath.Join(constants.GetHomeDir(), ".ssh", "id_rsa")
@@ -152,7 +151,7 @@ func CheckAndInitialize(cluster *v2.Cluster) {
 		sshClient := ssh.NewSSHClient(&clusterSSH, true)
 
 		localIpv4 := iputils.GetLocalIpv4()
-		defaultPort := strconv.Itoa(int(cluster.Spec.SSH.Port))
+		defaultPort := defaultSSHPort(cluster.Spec.SSH.Port)
 		addr := net.JoinHostPort(localIpv4, defaultPort)
 
 		cluster.Spec.Hosts = append(cluster.Spec.Hosts, v2.Host{

--- a/pkg/registry/helpers/helpers.go
+++ b/pkg/registry/helpers/helpers.go
@@ -43,16 +43,14 @@ func GetRegistryInfo(sshInterface ssh.Interface, rootfs, defaultRegistry string)
 	etcPath := path.Join(rootfs, constants.EtcDirName, RegistryCustomConfig)
 	out, err := sshInterface.Cmd(defaultRegistry, fmt.Sprintf("cat %s", etcPath))
 	if err != nil {
-		logger.Warn("load registry config error: %+v", err)
-		logger.Info("use default registry config")
+		logger.Warn("load registry config error: %+v, using default registry config", err)
 		return DefaultConfig
 	}
 	logger.Debug("registry config data info: %s", string(out))
 	readConfig := &v1beta1.RegistryConfig{}
 	err = yaml.Unmarshal(out, &readConfig)
 	if err != nil {
-		logger.Warn("read registry config path error: %+v", err)
-		logger.Info("use default registry config")
+		logger.Warn("read registry config path error: %+v, using default registry config", err)
 		return DefaultConfig
 	}
 	if readConfig.IP == "" {

--- a/pkg/registry/helpers/helpers.go
+++ b/pkg/registry/helpers/helpers.go
@@ -41,10 +41,15 @@ func GetRegistryInfo(sshInterface ssh.Interface, rootfs, defaultRegistry string)
 		Data:     constants.DefaultRegistryData,
 	}
 	etcPath := path.Join(rootfs, constants.EtcDirName, RegistryCustomConfig)
-	out, _ := sshInterface.Cmd(defaultRegistry, fmt.Sprintf("cat %s", etcPath))
+	out, err := sshInterface.Cmd(defaultRegistry, fmt.Sprintf("cat %s", etcPath))
+	if err != nil {
+		logger.Warn("load registry config error: %+v", err)
+		logger.Info("use default registry config")
+		return DefaultConfig
+	}
 	logger.Debug("registry config data info: %s", string(out))
 	readConfig := &v1beta1.RegistryConfig{}
-	err := yaml.Unmarshal(out, &readConfig)
+	err = yaml.Unmarshal(out, &readConfig)
 	if err != nil {
 		logger.Warn("read registry config path error: %+v", err)
 		logger.Info("use default registry config")

--- a/pkg/ssh/sshcmd.go
+++ b/pkg/ssh/sshcmd.go
@@ -118,6 +118,7 @@ func (c *Client) Cmd(host, cmd string) ([]byte, error) {
 		d, err := exec.RunBashCmd(cmd)
 		return []byte(d), err
 	}
+	logger.Debug("start to exec `%s` on %s", cmd, host)
 	client, session, err := c.Connect(host)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ssh session for %s: %v", host, err)

--- a/pkg/types/v1beta1/cluster.go
+++ b/pkg/types/v1beta1/cluster.go
@@ -219,6 +219,13 @@ type SSH struct {
 	Port     uint16 `json:"port,omitempty"`
 }
 
+func (s *SSH) DefaultPort() uint16 {
+	if s.Port != 0 {
+		return s.Port
+	}
+	return 22
+}
+
 type Host struct {
 	IPS   []string `json:"ips,omitempty"`
 	Roles []string `json:"roles,omitempty"`


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3fed538</samp>

### Summary
🐛🕵️🧹

<!--
1.  🐛 for fixing the error handling and potential panics in the `sshInterface.Cmd` function.
2.  🕵️ for adding the debug log to the `Cmd` function to help with troubleshooting and debugging.
3.  🧹 for cleaning up and simplifying the code related to SSH port handling.
-->
This pull request simplifies and improves the SSH port handling and error checking in the `apply` and `registry` packages. It changes the port variables and functions from integer to string, uses a common method to get the default port, and adds debug logs and error handling for the SSH commands. It affects the files `run.go`, `scale.go`, `utils.go`, `helpers.go`, `sshcmd.go`, and `cluster.go`.

> _To improve the SSH interface_
> _We added some error and trace_
> _We changed port to string_
> _And removed unused thing_
> _And used methods to avoid mistakes_

### Walkthrough
*  Simplify the port handling by using strings instead of integers and a helper function ([link](https://github.com/labring/sealos/pull/3791/files?diff=unified&w=0#diff-40da3b5e11ca4827ad6fb34ce791710b02c305a8ae225305ab7fe1b6829aa444L120-R120), [link](https://github.com/labring/sealos/pull/3791/files?diff=unified&w=0#diff-40da3b5e11ca4827ad6fb34ce791710b02c305a8ae225305ab7fe1b6829aa444L142-R142), [link](https://github.com/labring/sealos/pull/3791/files?diff=unified&w=0#diff-40da3b5e11ca4827ad6fb34ce791710b02c305a8ae225305ab7fe1b6829aa444L168-R172), [link](https://github.com/labring/sealos/pull/3791/files?diff=unified&w=0#diff-8fe05cc39facc6cb2eee1c2e149a90fbcb2f65efb5992253a9bc12b6a68f844cL20), [link](https://github.com/labring/sealos/pull/3791/files?diff=unified&w=0#diff-8fe05cc39facc6cb2eee1c2e149a90fbcb2f65efb5992253a9bc12b6a68f844cL129-R128), [link](https://github.com/labring/sealos/pull/3791/files?diff=unified&w=0#diff-8fe05cc39facc6cb2eee1c2e149a90fbcb2f65efb5992253a9bc12b6a68f844cL229-R228), [link](https://github.com/labring/sealos/pull/3791/files?diff=unified&w=0#diff-49999a5031dbbbe7123f98c24b2d12012e6261ebdc5c728fd20df40f3dec6219L23), [link](https://github.com/labring/sealos/pull/3791/files?diff=unified&w=0#diff-49999a5031dbbbe7123f98c24b2d12012e6261ebdc5c728fd20df40f3dec6219L144-R143), [link](https://github.com/labring/sealos/pull/3791/files?diff=unified&w=0#diff-49999a5031dbbbe7123f98c24b2d12012e6261ebdc5c728fd20df40f3dec6219L155-R154), [link](https://github.com/labring/sealos/pull/3791/files?diff=unified&w=0#diff-35334f6468e96f899bc4bf46cf748223d1df25bab6f89e5ee932f9776089f789R222-R228))
* Add error checking and logging to the `sshInterface.Cmd` function in `pkg/registry/helpers/helpers.go` ([link](https://github.com/labring/sealos/pull/3791/files?diff=unified&w=0#diff-c715ba40ef3ad13cbeb98f95dc5ff9b5ee084c8ae1cb96cc0db81a9d292be761L44-R53))
* Add debug log to the `Cmd` function in `pkg/ssh/sshcmd.go` ([link](https://github.com/labring/sealos/pull/3791/files?diff=unified&w=0#diff-3f15f712b65d7a4b8940753983e5aeb0d1df2a076fec087e61cdfd9136ab9151R121))

