### PR TITLE
fix: setup logger after setting runtimeRootDir

### DIFF
--- a/cmd/sealos/cmd/root.go
+++ b/cmd/sealos/cmd/root.go
@@ -108,8 +108,6 @@ func setRequireBuildahAnnotation(cmd *cobra.Command) {
 }
 
 func onBootOnDie() {
-	logger.CfgConsoleAndFileLogger(debug, constants.LogPath(), "sealos", false)
-	sreglog.CfgConsoleAndFileLogger(debug, constants.LogPath(), "sealos", false)
 	val, err := system.Get(system.DataRootConfigKey)
 	errExit(err)
 	constants.DefaultClusterRootFsDir = val
@@ -122,11 +120,14 @@ func onBootOnDie() {
 		constants.WorkDir(),
 	}
 	errExit(file.MkDirs(rootDirs...))
+
+	logger.CfgConsoleAndFileLogger(debug, constants.LogPath(), "sealos", false)
+	sreglog.CfgConsoleAndFileLogger(debug, constants.LogPath(), "sealos", false)
 }
 
 func errExit(err error) {
 	if err != nil {
-		logger.Error(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 01ebd5d</samp>

Refactor logger initialization in `cmd` package to avoid conflicts and errors. Move logger setup from `setRequireBuildahAnnotation` to package level and use correct `debug` flag and `constants.LogPath()` value.