### PR TITLE
feat: add update operation request

### DIFF
--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -101,8 +101,8 @@ jobs:
           sed -i "s#latest#${BuildFromTag}#g" etc/sealos/desktop-config.yaml
           
           sudo bash init.sh amd64 
-          sudo sealos build -t ${{ steps.prepare.outputs.repo }}:${{ steps.prepare.outputs.tag_name }}-amd64 -f Kubefile
-          sudo sealos build -t ${{ steps.prepare.outputs.repo }}:latest-amd64 -f Kubefile
+          sudo sealos build -t ${{ steps.prepare.outputs.repo }}:${{ steps.prepare.outputs.tag_name }}-amd64 --platform linux/amd64 -f Kubefile
+          sudo sealos build -t ${{ steps.prepare.outputs.repo }}:latest-amd64 --platform linux/amd64 -f Kubefile
           
           
           # delete old registry cache
@@ -110,8 +110,8 @@ jobs:
           sudo rm -rf tars
           
           sudo bash init.sh arm64 
-          sudo sealos build -t ${{ steps.prepare.outputs.repo }}:${{ steps.prepare.outputs.tag_name }}-arm64 -f Kubefile
-          sudo sealos build -t ${{ steps.prepare.outputs.repo }}:latest-arm64 -f Kubefile
+          sudo sealos build -t ${{ steps.prepare.outputs.repo }}:${{ steps.prepare.outputs.tag_name }}-arm64 --platform linux/arm64 -f Kubefile
+          sudo sealos build -t ${{ steps.prepare.outputs.repo }}:latest-arm64 --platform linux/arm64 -f Kubefile
           
       - name: Manifest Cluster Images
         # if push to master, then patch images to ghcr.io


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4fe137b</samp>

### Summary
🔄🗑️🌐

<!--
1.  🔄 - This emoji represents the update action that is performed on the rolebinding of a user. It conveys the idea of changing or replacing something with a newer version.
2.  🗑️ - This emoji represents the deletion action that is performed on the old rolebinding of a user. It conveys the idea of removing or discarding something that is no longer needed or wanted.
3.  🌐 - This emoji represents the multi-arch feature that is enabled for the sealos cloud images. It conveys the idea of supporting different platforms or architectures, such as amd64, arm64, etc.
-->
This pull request adds multi-arch support for the cloud images and implements rolebinding update logic for the user controller. It modifies the `.github/workflows/cloud.yml` file to enable cross-platform builds and the `controllers/user/controllers/operationrequest_controller.go` file to handle operation requests with the `Update` action.

> _We are the sealos, we rule the cloud_
> _We update roles with power and sound_
> _We delete and create, we record our fate_
> _We build for all platforms, we manifest our wrath_

### Walkthrough
*  Add `--platform` flag to `sealos build` command for multi-arch support ([link](https://github.com/labring/sealos/pull/3802/files?diff=unified&w=0#diff-7e4159d358d73ce740ffdf0b5737ccb6965692a7d3cea96bbb2a1ba054ea229eL104-R105), [link](https://github.com/labring/sealos/pull/3802/files?diff=unified&w=0#diff-7e4159d358d73ce740ffdf0b5737ccb6965692a7d3cea96bbb2a1ba054ea229eL113-R114))
* Implement rolebinding update logic for user controller ([link](https://github.com/labring/sealos/pull/3802/files?diff=unified&w=0#diff-4b3ed640dce61f210438de8a143cbec511f2d8d52268050c2e1016de68a75a5aL151-R158))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
