### PR TITLE
add default nodeport count limit.

### DIFF
--- a/controllers/pkg/common/resources.go
+++ b/controllers/pkg/common/resources.go
@@ -227,17 +227,19 @@ func GetDefaultLimitRange(ns, name string) *corev1.LimitRange {
 }
 
 const (
-	QuotaLimitsCPU     = "QUOTA_Limits_CPU"
-	QuotaLimitsMemory  = "QUOTA_Limits_MEMORY"
-	QuotaLimitsStorage = "QUOTA_Limits_Storage"
-	QuotaLimitsGPU     = "QUOTA_Limits_GPU"
+	QuotaLimitsCPU       = "QUOTA_LIMITS_CPU"
+	QuotaLimitsMemory    = "QUOTA_LIMITS_MEMORY"
+	QuotaLimitsStorage   = "QUOTA_LIMITS_STORAGE"
+	QuotaLimitsGPU       = "QUOTA_LIMITS_GPU"
+	QuotaLimitsNodePorts = "QUOTA_LIMITS_NODE_PORTS"
 )
 
 const (
-	DefaultQuotaLimitsCPU     = "16"
-	DefaultQuotaLimitsMemory  = "64Gi"
-	DefaultQuotaLimitsStorage = "100Gi"
-	DefaultQuotaLimitsGPU     = "8"
+	DefaultQuotaLimitsCPU       = "16"
+	DefaultQuotaLimitsMemory    = "64Gi"
+	DefaultQuotaLimitsStorage   = "100Gi"
+	DefaultQuotaLimitsGPU       = "8"
+	DefaultQuotaLimitsNodePorts = "3"
 )
 
 func DefaultResourceQuotaHard() corev1.ResourceList {
@@ -248,6 +250,8 @@ func DefaultResourceQuotaHard() corev1.ResourceList {
 		corev1.ResourceLimitsMemory:           resource.MustParse(utils.GetEnvWithDefault(QuotaLimitsMemory, DefaultQuotaLimitsMemory)),
 		corev1.ResourceRequestsStorage:        resource.MustParse(utils.GetEnvWithDefault(QuotaLimitsStorage, DefaultQuotaLimitsStorage)),
 		corev1.ResourceLimitsEphemeralStorage: resource.MustParse(utils.GetEnvWithDefault(QuotaLimitsStorage, DefaultQuotaLimitsStorage)),
+		corev1.ResourceServicesNodePorts:      resource.MustParse(DefaultQuotaLimitsNodePorts),
+		//TODO storage.diskio.read, storage.diskio.write
 	}
 }
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 735e20d</samp>

### Summary
🚢🔧🎛️

<!--
1.  🚢 : This emoji can represent the shipping or delivery of a new feature, such as nodeport count quota, that enhances the functionality of the system.
2.  🔧 : This emoji can represent the adjustment or modification of an existing function, such as `syncAccount`, to use the new feature or resource type.
3.  🎛️ : This emoji can represent the configuration or tuning of the environment variables and default values for the quota limits, which gives the cluster administrator more flexibility and control over the system.
-->
Added nodeport count quota as a new resource type to limit the number of nodeports exposed by user namespaces. Modified `account_controller.go` and `resources.go` to handle the quota creation and update.

> _The nodeports are burning, the users are yearning_
> _For freedom and power, they face the final hour_
> _But the `syncAccount` is ruthless, it adapts the `nodeportCountQuota`_
> _And the cluster administrator reigns supreme, crushing their dreams_

### Walkthrough
*  Implement nodeport count quota for user namespaces ([link](https://github.com/labring/sealos/pull/3808/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L256-R258), [link](https://github.com/labring/sealos/pull/3808/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L319-R325), [link](https://github.com/labring/sealos/pull/3808/files?diff=unified&w=0#diff-4766b3b00bd1d2cd9279874228122ee5f286a902fd6edab4c47751b8a70cf053L230-R242), [link](https://github.com/labring/sealos/pull/3808/files?diff=unified&w=0#diff-4766b3b00bd1d2cd9279874228122ee5f286a902fd6edab4c47751b8a70cf053R253-R254))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
