### PR TITLE
fix: remove copying kubeconfig file

### DIFF
--- a/pkg/guest/guest.go
+++ b/pkg/guest/guest.go
@@ -43,7 +43,7 @@ func NewGuestManager() (Interface, error) {
 
 func (d *Default) Apply(cluster *v2.Cluster, mounts []v2.MountImage, targetHosts []string) error {
 	envWrapper := env.NewEnvProcessor(cluster)
-	execer := ssh.NewCacheClientFromCluster(cluster, true)
+	execer := ssh.NewSSHByCluster(cluster, true)
 
 	for i, m := range mounts {
 		switch {

--- a/pkg/guest/guest.go
+++ b/pkg/guest/guest.go
@@ -17,7 +17,6 @@ package guest
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"golang.org/x/sync/errgroup"
@@ -25,10 +24,8 @@ import (
 	"github.com/labring/sealos/fork/golang/expansion"
 	"github.com/labring/sealos/pkg/constants"
 	"github.com/labring/sealos/pkg/env"
-	"github.com/labring/sealos/pkg/runtime/types"
 	"github.com/labring/sealos/pkg/ssh"
 	v2 "github.com/labring/sealos/pkg/types/v1beta1"
-	fileutil "github.com/labring/sealos/pkg/utils/file"
 	"github.com/labring/sealos/pkg/utils/maps"
 	stringsutil "github.com/labring/sealos/pkg/utils/strings"
 )
@@ -45,25 +42,8 @@ func NewGuestManager() (Interface, error) {
 }
 
 func (d *Default) Apply(cluster *v2.Cluster, mounts []v2.MountImage, targetHosts []string) error {
-	kubeConfig := filepath.Join(constants.GetHomeDir(), ".kube", "config")
-	if !fileutil.IsExist(kubeConfig) {
-		adminFile := constants.NewPathResolver(cluster.Name).AdminFile()
-		data, err := fileutil.ReadAll(adminFile)
-		if err != nil {
-			return fmt.Errorf("read admin.conf error in guest: %w", err)
-		}
-		master0IP := cluster.GetMaster0IP()
-		outData := strings.ReplaceAll(string(data), types.DefaultAPIServerDomain, master0IP)
-		if err = fileutil.WriteFile(kubeConfig, []byte(outData)); err != nil {
-			return err
-		}
-		defer func() {
-			_ = fileutil.CleanFiles(kubeConfig)
-		}()
-	}
-
 	envWrapper := env.NewEnvProcessor(cluster)
-	execer := ssh.NewSSHByCluster(cluster, true)
+	execer := ssh.NewCacheClientFromCluster(cluster, true)
 
 	for i, m := range mounts {
 		switch {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e89abc3</samp>

### Summary
🗑️🛠️🐝

<!--
1.  🗑️ - This emoji means "wastebasket" and can be used to indicate that unused and redundant code was removed or deleted.
2.  🛠️ - This emoji means "hammer and wrench" and can be used to indicate that something was fixed, improved, or simplified, such as the `NewGuestManager` function.
3.  🐝 - This emoji means "honeybee" and can be used to indicate that something was made more efficient, productive, or streamlined, such as avoiding unnecessary file operations for guest clusters.
-->
Refactored the `guest` package to remove unused code and simplify guest cluster management. Eliminated unnecessary kubeconfig file operations in `pkg/guest/guest.go`.

> _`guest` package trimmed_
> _no more kubeconfig hassle_
> _spring cleaning is done_

### Walkthrough
* Remove code that handled kubeconfig file in `NewGuestManager` function ([link](https://github.com/labring/sealos/pull/3809/files?diff=unified&w=0#diff-2fff8ad69185df503a777c91856e8cf472e5a5d16905d4a3a2e544873e889c46L48-L64)) as it was redundant and unnecessary
* Remove unused packages `path/filepath`, `github.com/labring/sealos/pkg/runtime/types`, and `github.com/labring/sealos/pkg/utils/file` from `guest` package ([link](https://github.com/labring/sealos/pull/3809/files?diff=unified&w=0#diff-2fff8ad69185df503a777c91856e8cf472e5a5d16905d4a3a2e544873e889c46L20), [link](https://github.com/labring/sealos/pull/3809/files?diff=unified&w=0#diff-2fff8ad69185df503a777c91856e8cf472e5a5d16905d4a3a2e544873e889c46L28-R28))

