### PR TITLE
refactor(main): add spec for image label v2

### DIFF
--- a/pkg/apply/processor/create.go
+++ b/pkg/apply/processor/create.go
@@ -101,7 +101,6 @@ func (c *CreateProcessor) preProcess(cluster *v2.Cluster) error {
 	for i := range cluster.Status.Mounts {
 		cluster.Status.Mounts[i].Env = maps.MergeMap(cluster.Status.Mounts[i].Env, c.ExtraEnvs)
 	}
-
 	distribution := cluster.GetDistribution()
 	rt, err := factory.New(distribution, cluster, c.ClusterFile.GetRuntimeConfig())
 	if err != nil {

--- a/pkg/apply/processor/install.go
+++ b/pkg/apply/processor/install.go
@@ -134,7 +134,7 @@ func (c *InstallProcessor) PreProcess(cluster *v2.Cluster) error {
 			return err
 		}
 		if oci.OCIv1.Config.Labels != nil {
-			imageTypes.Insert(oci.OCIv1.Config.Labels[v2.ImageTypeKey])
+			imageTypes.Insert(maps.GetFromKeys(oci.OCIv1.Config.Labels, v2.ImageTypeKeys...))
 		} else {
 			imageTypes.Insert(string(v2.AppImage))
 		}
@@ -170,6 +170,7 @@ func (c *InstallProcessor) PreProcess(cluster *v2.Cluster) error {
 		cluster.SetMountImage(mount)
 		c.NewMounts = append(c.NewMounts, *mount)
 	}
+
 	distribution := cluster.GetDistribution()
 	rt, err := factory.New(distribution, cluster, c.ClusterFile.GetRuntimeConfig())
 	if err != nil {

--- a/pkg/apply/processor/interface.go
+++ b/pkg/apply/processor/interface.go
@@ -130,8 +130,9 @@ func OCIToImageMount(inspector imageInspector, mount *v2.MountImage) error {
 	mount.Cmd = newCMDs
 	mount.Labels = oci.OCIv1.Config.Labels
 	imageType := v2.AppImage
-	if mount.Labels[v2.ImageTypeKey] != "" {
-		imageType = v2.ImageType(mount.Labels[v2.ImageTypeKey])
+	typeKey := maps.GetFromKeys(mount.Labels, v2.ImageTypeKeys...)
+	if typeKey != "" {
+		imageType = v2.ImageType(typeKey)
 	}
 	mount.Type = imageType
 	return nil
@@ -182,8 +183,8 @@ func MountClusterImages(bdah buildah.Interface, cluster *v2.Cluster, skipApp boo
 		}
 		var imageType string
 		if info.OCIv1.Config.Labels != nil {
-			imageType = info.OCIv1.Config.Labels[v2.ImageTypeKey]
-			imageVersion := info.OCIv1.Config.Labels[v2.ImageTypeVersionKey]
+			imageType = maps.GetFromKeys(info.OCIv1.Config.Labels, v2.ImageTypeKeys...)
+			imageVersion := maps.GetFromKeys(info.OCIv1.Config.Labels, v2.ImageVersionKeys...)
 			if imageType == string(v2.RootfsImage) {
 				if !stringsutil.InList(imageVersion, v2.ImageVersionList) {
 					return fmt.Errorf("can't apply rootfs type images and version %s not %+v",

--- a/pkg/image/merge.go
+++ b/pkg/image/merge.go
@@ -58,8 +58,11 @@ func MergeDockerfileFromImages(imageObjList []map[string]v1.Image) (string, erro
 		for name, val := range oci {
 			imageNames = append(imageNames, name)
 			labels = maps.MergeMap(labels, val.Config.Labels)
-			if val.Config.Labels != nil && val.Config.Labels[v1beta1.ImageTypeKey] == string(v1beta1.RootfsImage) {
-				isRootfs = true
+
+			if val.Config.Labels != nil {
+				if key := maps.GetFromKeys(val.Config.Labels, v1beta1.ImageTypeKeys...); key == string(v1beta1.RootfsImage) {
+					isRootfs = true
+				}
 			}
 			envs = maps.MergeMap(envs, maps.ListToMap(val.Config.Env))
 			cmds = append(cmds, val.Config.Cmd...)
@@ -68,7 +71,7 @@ func MergeDockerfileFromImages(imageObjList []map[string]v1.Image) (string, erro
 	}
 	delete(envs, "PATH")
 	if isRootfs {
-		labels[v1beta1.ImageTypeKey] = string(v1beta1.RootfsImage)
+		maps.SetKeys(labels, v1beta1.ImageTypeKeys, string(v1beta1.RootfsImage))
 	}
 	for i, label := range labels {
 		labels[i] = "\"" + escapeDollarSign(label, false) + "\""

--- a/pkg/types/v1beta1/cluster.go
+++ b/pkg/types/v1beta1/cluster.go
@@ -15,6 +15,8 @@
 package v1beta1
 
 import (
+	"path"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
@@ -50,16 +52,15 @@ type RegistryConfig struct {
 type ImageType string
 
 const (
-	AppImage                    ImageType = "application"
-	RootfsImage                 ImageType = "rootfs"
-	PatchImage                  ImageType = "patch"
-	ImageKubeVersionKey                   = "version"
-	ImageVIPKey                           = "vip"
-	ImageKubeLvscareImageKey              = "image"
-	ImageTypeKey                          = "sealos.io.type"
-	ImageTypeVersionKey                   = "sealos.io.version"
-	ImageKubeVersionEnvSysKey             = "SEALOS_SYS_KUBE_VERSION"
-	ImageSealosVersionEnvSysKey           = "SEALOS_SYS_SEALOS_VERSION"
+	AppImage                 ImageType = "application"
+	RootfsImage              ImageType = "rootfs"
+	PatchImage               ImageType = "patch"
+	ImageKubeVersionKey                = "version"
+	ImageVIPKey                        = "vip"
+	ImageKubeLvscareImageKey           = "image"
+
+	ImageKubeVersionEnvSysKey   = "SEALOS_SYS_KUBE_VERSION"
+	ImageSealosVersionEnvSysKey = "SEALOS_SYS_SEALOS_VERSION"
 )
 
 const (
@@ -68,6 +69,19 @@ const (
 )
 
 var ImageVersionList = []string{ImageTypeVersionKeyV1Beta1, ImageTypeVersionKeyV1Beta2}
+
+var (
+	imageTypeKey           = "sealos.io.type"
+	imageVersionKey        = "sealos.io.version"
+	imageDistributionKey   = "sealos.io.distribution"
+	imageTypeKeyV2         = path.Join(GroupName, "type")
+	imageVersionKeyV2      = path.Join(GroupName, "version")
+	imageDistributionKeyV2 = path.Join(GroupName, "distribution")
+)
+
+var ImageTypeKeys = []string{imageTypeKey, imageTypeKeyV2}
+var ImageVersionKeys = []string{imageVersionKey, imageVersionKeyV2}
+var ImageDistributionKeys = []string{imageDistributionKey, imageDistributionKeyV2}
 
 type MountImage struct {
 	Name       string            `json:"name"`

--- a/pkg/types/v1beta1/helper.go
+++ b/pkg/types/v1beta1/helper.go
@@ -103,12 +103,3 @@ func DeleteCondition(conditions []ClusterCondition, conditionType string) []Clus
 	conditions = newConditions
 	return conditions
 }
-
-func In(key string, slice []string) bool {
-	for _, s := range slice {
-		if key == s {
-			return true
-		}
-	}
-	return false
-}

--- a/pkg/types/v1beta1/utils.go
+++ b/pkg/types/v1beta1/utils.go
@@ -19,6 +19,8 @@ package v1beta1
 import (
 	"fmt"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/Masterminds/semver/v3"
 
 	"github.com/labring/sealos/pkg/utils/iputils"
@@ -262,7 +264,7 @@ func (c *Cluster) HasAppImage() bool {
 func (c *Cluster) GetRolesByIP(ip string) []string {
 	var routes []string
 	for _, host := range c.Spec.Hosts {
-		if In(ip, host.IPS) {
+		if slices.Contains(host.IPS, ip) {
 			return host.Roles
 		}
 	}
@@ -272,7 +274,7 @@ func (c *Cluster) GetRolesByIP(ip string) []string {
 func (c *Cluster) GetDistribution() string {
 	root := c.GetRootfsImage()
 	if root != nil {
-		return root.Labels["sealos.io.distribution"]
+		return maps.GetFromKeys(root.Labels, ImageDistributionKeys...)
 	}
 	return ""
 }

--- a/pkg/utils/maps/maps.go
+++ b/pkg/utils/maps/maps.go
@@ -79,3 +79,19 @@ func DeepMerge(dst, src *map[string]interface{}) {
 		(*dst)[srcK] = dV
 	}
 }
+
+func GetFromKeys(m map[string]string, keys ...string) string {
+	for _, k := range keys {
+		if v, ok := m[k]; ok && v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func SetKeys(m map[string]string, keys []string, value string) map[string]string {
+	for _, v := range keys {
+		m[v] = value
+	}
+	return m
+}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4d15c17</samp>

### Summary
🏷️🛠️🧹

<!--
1.  🏷️ - This emoji represents the use and modification of OCI labels, which are key-value pairs that store metadata about the images. This emoji is suitable for the first, second, and fourth changes, which deal with getting and setting the image type and distribution labels from the OCI labels map.
2. 🛠️ - This emoji represents the improvement and compatibility of the sealos image processing functions, which use OCI images to store cluster components and configurations. This emoji is suitable for the third and fourth changes, which refactor and enhance the functions that deal with OCI images in `pkg/apply/processor/install.go` and `pkg/image/merge.go`.
3. 🧹 - This emoji represents the removal of redundant constants and the addition of new constants for image label keys. This emoji is suitable for the fifth change, which cleans up and clarifies the sealos image metadata in the `v1beta1` package.
-->
This pull request improves the handling of OCI image labels in sealos, a tool for installing and managing Kubernetes clusters. It adds new helper functions to extract image metadata from the labels, and updates the existing functions to use them. It also supports multiple label keys for image type and distribution, to be compatible with different versions of sealos images.

> _We're sealos sailors, we work with OCI_
> _We pull and merge the images with `v2.GetValuesFromMap`_
> _We heave and ho, we make the labels agree_
> _We set the type and distribution with `image.sealos.io`_

### Walkthrough
*  Support multiple keys for image type, image version, and image distribution labels in OCI images ([link](https://github.com/labring/sealos/pull/3816/files?diff=unified&w=0#diff-dc16722036c8f44c78015609d3ab3424d2f4d09543296a24d98e6ebea7a2dbb9L137-R137), [link](https://github.com/labring/sealos/pull/3816/files?diff=unified&w=0#diff-e15477f77cdbc75f95e348325d3bddf96c09883af9db451ef2adf8b60694bd30L133-R135), [link](https://github.com/labring/sealos/pull/3816/files?diff=unified&w=0#diff-e15477f77cdbc75f95e348325d3bddf96c09883af9db451ef2adf8b60694bd30L185-R187), [link](https://github.com/labring/sealos/pull/3816/files?diff=unified&w=0#diff-4abc543353728140b07763972a9451026d1ba3e9b6be68eb387160c9a51b1cd5L61-R65), [link](https://github.com/labring/sealos/pull/3816/files?diff=unified&w=0#diff-4abc543353728140b07763972a9451026d1ba3e9b6be68eb387160c9a51b1cd5L71-R74), [link](https://github.com/labring/sealos/pull/3816/files?diff=unified&w=0#diff-24d4208e4143491e275db180879b141295e21323990c368f7530ba4124c00441L275-R294))
* Remove unused constants for image type and image version labels from `ImageType` type in `pkg/types/v1beta1/cluster.go` ([link](https://github.com/labring/sealos/pull/3816/files?diff=unified&w=0#diff-35334f6468e96f899bc4bf46cf748223d1df25bab6f89e5ee932f9776089f789L53-R61))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
