### PR TITLE
fix e2e apply test result issue commit

### DIFF
--- a/.github/workflows/e2e_test_apply.yml
+++ b/.github/workflows/e2e_test_apply.yml
@@ -23,7 +23,8 @@ jobs:
       matrix:
         arch: [ arm64, amd64 ]
     outputs:
-      test_result: ${{ steps.apply_test.outputs.test_result }}
+      test_arm64_result: ${{ steps.apply_test.outputs.test_arm64_result }}
+      test_amd64_result: ${{ steps.apply_test.outputs.test_amd64_result }}
     steps:
       - name: Download sealos binary
         uses: actions/download-artifact@v3


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ca859b1</samp>

### Summary
🚀🛠️🧪

<!--
1.  🚀 This emoji conveys the idea of speeding up the testing process by running tests in parallel on different architectures. It also suggests a sense of innovation and exploration, as arm64 is a relatively new and emerging platform for Kubernetes.
2.  🛠️ This emoji implies that the change is related to fixing or improving something, in this case the testing workflow and the support for arm64. It also suggests a sense of craftsmanship and quality, as the change involves using a tool (sealos) to deploy Kubernetes clusters more easily and reliably.
3.  🧪 This emoji indicates that the change is related to testing, experimentation, or verification. It also suggests a sense of curiosity and discovery, as the change involves testing different scenarios and outcomes on different architectures.
-->
Split `apply_test` output by architecture and use as inputs for `e2e_test` job. This enables parallel testing of sealos on amd64 and arm64 architectures.

> _`apply_test` splits_
> _two architectures to test_
> _sealos in autumn_

### Walkthrough
* Split the output of `apply_test` job into two variables, `apply_test_result_amd64` and `apply_test_result_arm64`, for each architecture ([link](https://github.com/labring/sealos/pull/3823/files?diff=unified&w=0#diff-96496a1660b6f6172d5bc3e79e74fafa75dc7c81656e153c5e85ff90991524b1L26-R27))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
