### PR TITLE
add rbac for desktop.

### DIFF
--- a/controllers/user/deploy/manifests/rbac.yaml
+++ b/controllers/user/deploy/manifests/rbac.yaml
@@ -1,73 +1,3 @@
----
-## 新建管理员,只允许创建管理员
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: sealos-user-create-role
-rules:
-  - apiGroups:
-      - user.sealos.io
-    resources:
-      - 'usergroupbindings'
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - patch
-      - update
----
-## 新增、删除用户，管理员只允许移入移除用户
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: sealos-user-manager-role
-rules:
-  - apiGroups:
-      - user.sealos.io
-    resources:
-      - 'usergroupbindings'
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - patch
-      - update
-  - apiGroups:
-      - user.sealos.io
-    resources:
-      - 'users'
-    verbs:
-      - list
-      - get
-      - watch
----
-##普通用户创建namespace,usergroup
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: sealos-user-user-role
-rules:
-  - apiGroups:
-      - user.sealos.io
-    resources:
-      - 'usergroupbindings'
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - patch
-      - update
-  - apiGroups:
-      - user.sealos.io
-    resources:
-      - 'usergroups'
-    verbs:
-      - create
-      - delete
-      - deletecollection
-      - patch
-      - update
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -80,3 +10,60 @@ subjects:
   - kind: ServiceAccount
     name: user-controller-manager
     namespace: user-system
+---
+# permissions for end users to edit users.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: user-editor-role
+rules:
+  - apiGroups:
+      - user.sealos.io
+    resources:
+      - users
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - user.sealos.io
+    resources:
+      - users/status
+    verbs:
+      - get
+---
+# permissions for end users to edit operationrequests.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: operationrequest-editor-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: user
+    app.kubernetes.io/part-of: user
+    app.kubernetes.io/managed-by: kustomize
+  name: operationrequest-editor-role
+rules:
+  - apiGroups:
+      - user.sealos.io
+    resources:
+      - operationrequests
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - user.sealos.io
+    resources:
+      - operationrequests/status
+    verbs:
+      - get

--- a/frontend/desktop/deploy/manifests/rbac.yaml
+++ b/frontend/desktop/deploy/manifests/rbac.yaml
@@ -1,23 +1,24 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: ClusterRoleBinding
 metadata:
-  name: auth-system-manager-role
-rules:
-  - apiGroups: ["user.sealos.io"]
-    resources: ["users"]
-    verbs: ["list", "get", "create", "update", "patch", "watch"]
-  - apiGroups: ["user.sealos.io"]
-    resources: ["users/status"]
-    verbs: ["list", "get", "create", "update", "patch", "watch"]
+  name: desktop-user-editor-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: user-editor-role
+subjects:
+  - kind: ServiceAccount
+    name: desktop-frontend
+    namespace: sealos
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: auth-system-manager-role-binding
+  name: desktop-operationrequest-editor-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: auth-system-manager-role
+  name: operationrequest-editor-role
 subjects:
   - kind: ServiceAccount
     name: desktop-frontend


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ada3965</samp>

### Summary
🔀🆕🛠️

<!--
1.  🔀 - This emoji represents the change of moving the original code from one file to another, and the switch of the cluster role binding from one role to another. It implies a shuffling or rearranging of the existing code.
2.  🆕 - This emoji represents the change of adding two new cluster roles and cluster role bindings, and the new resources of labels and status to the rules. It implies a creation or introduction of new code.
3.  🛠️ - This emoji represents the change of updating the cluster role binding to use the new user-editor-role instead of the auth-system-manager-role, and the refactoring of the RBAC configuration for the user-system namespace. It implies a fixing or improvement of the existing code.
-->
This pull request updates the RBAC configuration for the user-system namespace to support the new user and operation request CRDs and controllers. It creates two new cluster roles and cluster role bindings for editing users and operation requests, and moves the existing RBAC resources from the frontend/desktop module to the controllers/user module. It also changes the cluster role binding for the desktop frontend service account to use the new user-editor-role.

> _`user-system` splits_
> _roles and bindings for CRDs_
> _autumn leaves fall fast_

### Walkthrough
*  Split user and operation request permissions into separate cluster roles and cluster role bindings ([link](https://github.com/labring/sealos/pull/3825/files?diff=unified&w=0#diff-332f4c05540120506400d3ef39f143c0cd014bf32afa5cab24a87bcd69e006e2L1-R69))
*  Move RBAC resources for user-system namespace from frontend/desktop/deploy/manifests/rbac.yaml to controllers/user/deploy/manifests/rbac.yaml ([link](https://github.com/labring/sealos/pull/3825/files?diff=unified&w=0#diff-19c4e5d640621be4e6409ea99997f3f6b056f551605615f13860a42e1c98f13cL2-R24))
*  Update cluster role binding for desktop frontend service account to use user-editor-role instead of auth-system-manager-role ([link](https://github.com/labring/sealos/pull/3825/files?diff=unified&w=0#diff-19c4e5d640621be4e6409ea99997f3f6b056f551605615f13860a42e1c98f13cL2-R24))
*  Add labels and status resources to cluster role rules for user and operation request CRDs ([link](https://github.com/labring/sealos/pull/3825/files?diff=unified&w=0#diff-332f4c05540120506400d3ef39f143c0cd014bf32afa5cab24a87bcd69e006e2L1-R69))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
