### PR TITLE
Feat: adapt multi namespace account

### DIFF
--- a/controllers/account/api/v1/account_types.go
+++ b/controllers/account/api/v1/account_types.go
@@ -27,6 +27,11 @@ const (
 	AccountSystemNamespaceEnv = "ACCOUNT_SYSTEM_NAMESPACE"
 )
 
+const (
+	Name  = "name"
+	Owner = "owner"
+)
+
 /*
    paymentService          AccountController    wechatpay
          |                     |                    |

--- a/controllers/account/api/v1/accountbalance_types.go
+++ b/controllers/account/api/v1/accountbalance_types.go
@@ -46,16 +46,18 @@ type Costs map[string]int64
 
 // AccountBalanceSpec defines the desired state of AccountBalance
 type AccountBalanceSpec struct {
-	OrderID string      `json:"order_id" bson:"order_id"`
-	Owner   string      `json:"owner" bson:"owner"`
-	Time    metav1.Time `json:"time" bson:"time"`
-	Type    Type        `json:"type" bson:"type"`
-	Costs   Costs       `json:"costs,omitempty" bson:"costs,omitempty"`
-	// TODO will delete field in future
-	//Timestamp int64 `json:"timestamp,omitempty"`
-	Amount  int64  `json:"amount,omitempty" bson:"amount"`
-	Details string `json:"details,omitempty" bson:"details,omitempty"`
-	//ResourceInfoList meteringcommonv1.ResourceInfoList `json:"resourceInfoList,omitempty"`
+	Time                     metav1.Time `json:"time" bson:"time"`
+	AccountBalanceSpecInline `json:",inline" bson:",inline"`
+}
+
+type AccountBalanceSpecInline struct {
+	OrderID   string `json:"order_id" bson:"order_id"`
+	Owner     string `json:"owner" bson:"owner"`
+	Namespace string `json:"namespace,omitempty" bson:"namespace,omitempty"`
+	Type      Type   `json:"type" bson:"type"`
+	Costs     Costs  `json:"costs,omitempty" bson:"costs,omitempty"`
+	Amount    int64  `json:"amount,omitempty" bson:"amount"`
+	Details   string `json:"details,omitempty" bson:"details,omitempty"`
 }
 
 // AccountBalanceStatus defines the observed state of AccountBalance

--- a/controllers/account/api/v1/billingrecordquery_types.go
+++ b/controllers/account/api/v1/billingrecordquery_types.go
@@ -29,6 +29,7 @@ type BillingRecordQuerySpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 	Page      int         `json:"page"`
 	PageSize  int         `json:"pageSize"`
+	Namespace string      `json:"namespace,omitempty"`
 	StartTime metav1.Time `json:"startTime"`
 	EndTime   metav1.Time `json:"endTime"`
 	OrderID   string      `json:"orderID,omitempty"`
@@ -44,6 +45,7 @@ type BillingRecordQueryStatus struct {
 	RechargeAmount  int64                `json:"rechargeAmount"`
 	DeductionAmount Costs                `json:"deductionAmount,omitempty"`
 	Items           []AccountBalanceSpec `json:"item,omitempty"`
+	Status          string               `json:"status"`
 }
 
 //+kubebuilder:object:root=true

--- a/controllers/account/api/v1/debt_webhook.go
+++ b/controllers/account/api/v1/debt_webhook.go
@@ -165,7 +165,7 @@ func checkOption(ctx context.Context, logger logr.Logger, c client.Client, nsNam
 	}
 	logger.V(1).Info("check user namespace", "ns", ns.Name, "user", user)
 	accountList := AccountList{}
-	if err := c.List(ctx, &accountList, client.MatchingFields{"name": user}); err != nil {
+	if err := c.List(ctx, &accountList, client.MatchingFields{Name: user}); err != nil {
 		logger.Error(err, "get account error", "user", user)
 		return admission.ValidationResponse(true, err.Error())
 	}

--- a/controllers/account/api/v1/debt_webhook.go
+++ b/controllers/account/api/v1/debt_webhook.go
@@ -172,7 +172,7 @@ func checkOption(ctx context.Context, logger logr.Logger, c client.Client, nsNam
 
 	for _, account := range accountList.Items {
 		if account.Status.Balance < account.Status.DeductionBalance {
-			return admission.ValidationResponse(false, fmt.Sprintf(common.MessageFormat, common.CodeInsufficientBalance, fmt.Sprintf("account balance less than 0,now account is %.2f¥", GetAccountDebtBalance(account))))
+			return admission.ValidationResponse(false, fmt.Sprintf(common.MessageFormat, common.CodeInsufficientBalance, fmt.Sprintf("account balance less than 0,now account is %.2f¥. Please recharge the user %s.", GetAccountDebtBalance(account), user)))
 		}
 	}
 	return admission.Allowed(fmt.Sprintf("pass user %s , namespace %s", user, ns.Name))

--- a/controllers/account/config/crd/bases/account.sealos.io_accountbalances.yaml
+++ b/controllers/account/config/crd/bases/account.sealos.io_accountbalances.yaml
@@ -40,7 +40,6 @@ spec:
             description: AccountBalanceSpec defines the desired state of AccountBalance
             properties:
               amount:
-                description: TODO will delete field in future Timestamp int64 `json:"timestamp,omitempty"`
                 format: int64
                 type: integer
               costs:
@@ -49,6 +48,8 @@ spec:
                   type: integer
                 type: object
               details:
+                type: string
+              namespace:
                 type: string
               order_id:
                 type: string

--- a/controllers/account/config/crd/bases/account.sealos.io_billingrecordqueries.yaml
+++ b/controllers/account/config/crd/bases/account.sealos.io_billingrecordqueries.yaml
@@ -39,6 +39,8 @@ spec:
               endTime:
                 format: date-time
                 type: string
+              namespace:
+                type: string
               orderID:
                 type: string
               page:
@@ -72,8 +74,6 @@ spec:
                   description: AccountBalanceSpec defines the desired state of AccountBalance
                   properties:
                     amount:
-                      description: TODO will delete field in future Timestamp int64
-                        `json:"timestamp,omitempty"`
                       format: int64
                       type: integer
                     costs:
@@ -82,6 +82,8 @@ spec:
                         type: integer
                       type: object
                     details:
+                      type: string
+                    namespace:
                       type: string
                     order_id:
                       type: string
@@ -104,6 +106,8 @@ spec:
               rechargeAmount:
                 format: int64
                 type: integer
+              status:
+                type: string
               totalCount:
                 description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
                   of cluster Important: Run "make" to regenerate code after modifying
@@ -112,6 +116,7 @@ spec:
             required:
             - pageLength
             - rechargeAmount
+            - status
             - totalCount
             type: object
         type: object

--- a/controllers/account/controllers/account_controller.go
+++ b/controllers/account/controllers/account_controller.go
@@ -203,11 +203,12 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		err = dbClient.SaveBillingsWithAccountBalance(&accountv1.AccountBalanceSpec{
 			Time: metav1.Time{Time: now},
 			AccountBalanceSpecInline: accountv1.AccountBalanceSpecInline{
-				OrderID: id,
-				Amount:  payment.Spec.Amount,
-				Owner:   getUsername(payment.Namespace),
-				Type:    accountv1.Recharge,
-				Details: payment.ToJSON(),
+				OrderID:   id,
+				Amount:    payment.Spec.Amount,
+				Namespace: payment.Namespace,
+				Owner:     getUsername(payment.Namespace),
+				Type:      accountv1.Recharge,
+				Details:   payment.ToJSON(),
 			},
 		})
 		if err != nil {

--- a/controllers/account/controllers/account_controller.go
+++ b/controllers/account/controllers/account_controller.go
@@ -251,7 +251,8 @@ func (r *AccountReconciler) syncAccount(ctx context.Context, name, accountNamesp
 	}
 	if account.GetAnnotations()[AccountAnnotationIgnoreQuota] != "true" {
 		if err := r.syncResourceQuotaAndLimitRange(ctx, userNamespace); err != nil {
-			return nil, fmt.Errorf("sync resource resourceQuota and limitRange failed: %v", err)
+			//return nil, fmt.Errorf("sync resource resourceQuota and limitRange failed: %v", err)
+			r.Logger.Error(err, "sync resource resourceQuota and limitRange failed")
 		}
 		//TODO delete after nodeport count quota already in resource-quota
 		if err := r.adaptNodePortCountQuota(ctx, userNamespace); err != nil {

--- a/controllers/account/controllers/account_controller.go
+++ b/controllers/account/controllers/account_controller.go
@@ -108,7 +108,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 	user := &userV1.User{}
 	if err := r.Get(ctx, client.ObjectKey{Namespace: req.Namespace, Name: req.Name}, user); err == nil {
-		_, err = r.syncAccount(ctx, user.Name, r.AccountSystemNamespace, "ns-"+user.Name)
+		_, err = r.syncAccount(ctx, GetUserOwner(user), r.AccountSystemNamespace, "ns-"+user.Name)
 		return ctrl.Result{}, err
 	} else if client.IgnoreNotFound(err) != nil {
 		return ctrl.Result{}, err
@@ -201,12 +201,14 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ctrl.Result{}, nil
 		}
 		err = dbClient.SaveBillingsWithAccountBalance(&accountv1.AccountBalanceSpec{
-			OrderID: id,
-			Amount:  payment.Spec.Amount,
-			Owner:   getUsername(payment.Namespace),
-			Time:    metav1.Time{Time: now},
-			Type:    accountv1.Recharge,
-			Details: payment.ToJSON(),
+			Time: metav1.Time{Time: now},
+			AccountBalanceSpecInline: accountv1.AccountBalanceSpecInline{
+				OrderID: id,
+				Amount:  payment.Spec.Amount,
+				Owner:   getUsername(payment.Namespace),
+				Type:    accountv1.Recharge,
+				Details: payment.ToJSON(),
+			},
 		})
 		if err != nil {
 			r.Logger.Error(err, "save billings failed", "id", id, "payment", payment)
@@ -224,6 +226,14 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func GetUserOwner(user *userV1.User) string {
+	own := user.Annotations[userV1.UserLabelOwnerKey]
+	if own == "" {
+		return user.Name
+	}
+	return own
 }
 
 func (r *AccountReconciler) syncAccount(ctx context.Context, name, accountNamespace string, userNamespace string) (*accountv1.Account, error) {
@@ -521,14 +531,8 @@ func (r *AccountReconciler) initBalance(account *accountv1.Account) (err error) 
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *AccountReconciler) SetupWithManager(mgr ctrl.Manager, rateOpts controller.Options) error {
-	const controllerName = "account_controller"
-	r.Logger = ctrl.Log.WithName(controllerName)
-	r.Logger.V(1).Info("init reconcile controller account")
-
-	r.AccountSystemNamespace = os.Getenv(ACCOUNTNAMESPACEENV)
-	if r.AccountSystemNamespace == "" {
-		r.AccountSystemNamespace = DEFAULTACCOUNTNAMESPACE
-	}
+	r.Logger = ctrl.Log.WithName("account_controller")
+	r.AccountSystemNamespace = utils.GetEnvWithDefault(ACCOUNTNAMESPACEENV, DEFAULTACCOUNTNAMESPACE)
 	if r.MongoDBURI = os.Getenv(database.MongoURI); r.MongoDBURI == "" {
 		return fmt.Errorf("mongo url is empty")
 	}

--- a/controllers/account/controllers/billing_controller.go
+++ b/controllers/account/controllers/billing_controller.go
@@ -156,7 +156,7 @@ func (r *BillingReconciler) billingWithHourTime(ctx context.Context, queryTime t
 			// create accountbalance
 			accountBalance := v12.AccountBalance{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      getUsername(ownNs) + "-" + queryTime.Format("20060102150405"),
+					Name:      getUsername(ownNs) + ns + "-" + queryTime.Format("20060102150405"),
 					Namespace: r.AccountSystemNamespace,
 				},
 				Spec: v12.AccountBalanceSpec{

--- a/controllers/account/controllers/billingrecordquery_controller.go
+++ b/controllers/account/controllers/billingrecordquery_controller.go
@@ -22,6 +22,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/labring/sealos/controllers/pkg/utils"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/labring/sealos/controllers/pkg/common/gpu"
@@ -45,9 +47,10 @@ import (
 // BillingRecordQueryReconciler reconciles a BillingRecordQuery object
 type BillingRecordQueryReconciler struct {
 	client.Client
-	Scheme     *runtime.Scheme
-	Logger     logr.Logger
-	MongoDBURI string
+	Scheme                 *runtime.Scheme
+	Logger                 logr.Logger
+	MongoDBURI             string
+	AccountSystemNamespace string
 }
 
 //+kubebuilder:rbac:groups=account.sealos.io,resources=billingrecordqueries,verbs=get;list;watch;create;update;patch;delete
@@ -109,6 +112,13 @@ func (r *BillingRecordQueryReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 
+	if err = r.Get(ctx, client.ObjectKey{Name: getUsername(billingRecordQuery.Namespace), Namespace: r.AccountSystemNamespace}, &accountv1.Account{}); err != nil {
+		if errors.IsNotFound(err) {
+			billingRecordQuery.Status.Status = "Please use the master account to query"
+			return ctrl.Result{}, r.Status().Update(ctx, billingRecordQuery)
+		}
+		return ctrl.Result{}, err
+	}
 	err = dbClient.QueryBillingRecords(billingRecordQuery, getUsername(billingRecordQuery.Namespace))
 	if err != nil {
 		r.Logger.Error(err, "query billing records failed")
@@ -134,6 +144,7 @@ func (r *BillingRecordQueryReconciler) SetupWithManager(mgr ctrl.Manager, rateOp
 		return fmt.Errorf("env %s is empty", database.MongoURI)
 	}
 	r.Logger = log.Log.WithName("billingrecordquery-controller")
+	r.AccountSystemNamespace = utils.GetEnvWithDefault(ACCOUNTNAMESPACEENV, DEFAULTACCOUNTNAMESPACE)
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&accountv1.BillingRecordQuery{}).
 		Watches(&source.Kind{Type: &accountv1.PriceQuery{}}, &handler.EnqueueRequestForObject{}).

--- a/controllers/account/controllers/cache/cache.go
+++ b/controllers/account/controllers/cache/cache.go
@@ -43,9 +43,9 @@ func SetupCache(mgr ctrl.Manager) error {
 		field        string
 		extractValue client.IndexerFunc
 	}{
-		{ns, "metadata.name", nsNameFunc},
-		{ns, "metadata.labels." + v1.UserLabelOwnerKey, nsOwnerFunc},
-		{account, "metadata.name", accountNameFunc}} {
+		{ns, accountv1.Name, nsNameFunc},
+		{ns, accountv1.Owner, nsOwnerFunc},
+		{account, accountv1.Name, accountNameFunc}} {
 		if err := mgr.GetFieldIndexer().IndexField(context.TODO(), idx.obj, idx.field, idx.extractValue); err != nil {
 			return err
 		}

--- a/controllers/account/controllers/cache/cache.go
+++ b/controllers/account/controllers/cache/cache.go
@@ -17,6 +17,8 @@ package cache
 import (
 	"context"
 
+	v1 "github.com/labring/sealos/controllers/user/api/v1"
+
 	accountv1 "github.com/labring/sealos/controllers/account/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -28,14 +30,25 @@ func SetupCache(mgr ctrl.Manager) error {
 	accountNameFunc := func(obj client.Object) []string {
 		return []string{obj.(*accountv1.Account).Name}
 	}
-
 	ns := &corev1.Namespace{}
 	nsNameFunc := func(obj client.Object) []string {
 		return []string{obj.(*corev1.Namespace).Name}
 	}
-
-	if err := mgr.GetFieldIndexer().IndexField(context.TODO(), ns, "name", nsNameFunc); err != nil {
-		return err
+	nsOwnerFunc := func(obj client.Object) []string {
+		return []string{obj.(*corev1.Namespace).Labels[v1.UserLabelOwnerKey]}
 	}
-	return mgr.GetFieldIndexer().IndexField(context.TODO(), account, "name", accountNameFunc)
+
+	for _, idx := range []struct {
+		obj          client.Object
+		field        string
+		extractValue client.IndexerFunc
+	}{
+		{ns, "metadata.name", nsNameFunc},
+		{ns, "metadata.labels." + v1.UserLabelOwnerKey, nsOwnerFunc},
+		{account, "metadata.name", accountNameFunc}} {
+		if err := mgr.GetFieldIndexer().IndexField(context.TODO(), idx.obj, idx.field, idx.extractValue); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/controllers/account/controllers/debt_controller.go
+++ b/controllers/account/controllers/debt_controller.go
@@ -118,11 +118,9 @@ func (r *DebtReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		r.Logger.Error(err, "get own ns list error")
 		return ctrl.Result{}, fmt.Errorf("get own ns list error: %v", err)
 	}
-	for i := range nsList {
-		if err := r.reconcileDebtStatus(ctx, debt, account, nsList[i]); err != nil {
-			r.Logger.Error(err, "reconcile debt status error")
-			return ctrl.Result{}, err
-		}
+	if err := r.reconcileDebtStatus(ctx, debt, account, nsList); err != nil {
+		r.Logger.Error(err, "reconcile debt status error")
+		return ctrl.Result{}, err
 	}
 	//Debt Detection Cycle
 	return ctrl.Result{Requeue: true, RequeueAfter: r.DebtDetectionCycle}, nil
@@ -138,7 +136,7 @@ NormalPeriod -> WarningPeriod -> ApproachingDeletionPeriod -> ImmediateDeletePer
 
 欠费后到完全删除的总周期=WarningPeriodSeconds+ApproachingDeletionPeriodSeconds+ImmediateDeletePeriodSeconds+FinalDeletePeriodSeconds
 */
-func (r *DebtReconciler) reconcileDebtStatus(ctx context.Context, debt *accountv1.Debt, account *accountv1.Account, userNamespace string) error {
+func (r *DebtReconciler) reconcileDebtStatus(ctx context.Context, debt *accountv1.Debt, account *accountv1.Account, userNamespaceList []string) error {
 	oweamount := account.Status.Balance - account.Status.DeductionBalance
 	//更新间隔秒钟数
 	updateIntervalSeconds := time.Now().UTC().Unix() - debt.Status.LastUpdateTimestamp
@@ -159,7 +157,7 @@ func (r *DebtReconciler) reconcileDebtStatus(ctx context.Context, debt *accountv
 			return nil
 		}
 		update = SetDebtStatus(debt, accountv1.WarningPeriod)
-		if err := r.sendWarningNotice(ctx, userNamespace); err != nil {
+		if err := r.sendWarningNotice(ctx, userNamespaceList); err != nil {
 			r.Logger.Error(err, "send warning notice error")
 		}
 	case accountv1.WarningPeriod:
@@ -182,7 +180,7 @@ func (r *DebtReconciler) reconcileDebtStatus(ctx context.Context, debt *accountv
 			return nil
 		}
 		update = SetDebtStatus(debt, accountv1.ApproachingDeletionPeriod)
-		if err := r.sendApproachingDeletionNotice(ctx, userNamespace); err != nil {
+		if err := r.sendApproachingDeletionNotice(ctx, userNamespaceList); err != nil {
 			r.Logger.Error(err, "sendApproachingDeletionNotice error")
 		}
 
@@ -205,10 +203,10 @@ func (r *DebtReconciler) reconcileDebtStatus(ctx context.Context, debt *accountv
 			return nil
 		}
 		update = SetDebtStatus(debt, accountv1.ImminentDeletionPeriod)
-		if err := r.sendImminentDeletionNotice(ctx, userNamespace); err != nil {
+		if err := r.sendImminentDeletionNotice(ctx, userNamespaceList); err != nil {
 			r.Logger.Error(err, "sendImminentDeletionNotice error")
 		}
-		if err := r.SuspendUserResource(ctx, userNamespace); err != nil {
+		if err := r.SuspendUserResource(ctx, userNamespaceList); err != nil {
 			return err
 		}
 	case accountv1.ImminentDeletionPeriod:
@@ -223,7 +221,7 @@ func (r *DebtReconciler) reconcileDebtStatus(ctx context.Context, debt *accountv
 		if oweamount >= 0 {
 			update = SetDebtStatus(debt, accountv1.NormalPeriod)
 			// 恢复用户资源
-			if err := r.ResumeUserResource(ctx, userNamespace); err != nil {
+			if err := r.ResumeUserResource(ctx, userNamespaceList); err != nil {
 				return err
 			}
 			//TODO 撤销最终删除消息通知
@@ -235,10 +233,10 @@ func (r *DebtReconciler) reconcileDebtStatus(ctx context.Context, debt *accountv
 		}
 		// TODO 暂时只暂停资源，后续会添加真正删除全部资源逻辑, 或直接删除namespace
 		update = SetDebtStatus(debt, accountv1.FinalDeletionPeriod)
-		if err := r.sendFinalDeletionNotice(ctx, userNamespace); err != nil {
+		if err := r.sendFinalDeletionNotice(ctx, userNamespaceList); err != nil {
 			r.Error(err, "sendFinalDeletionNotice error")
 		}
-		if err := r.SuspendUserResource(ctx, userNamespace); err != nil {
+		if err := r.SuspendUserResource(ctx, userNamespaceList); err != nil {
 			return err
 		}
 	case accountv1.FinalDeletionPeriod:
@@ -251,12 +249,12 @@ func (r *DebtReconciler) reconcileDebtStatus(ctx context.Context, debt *accountv
 			update = SetDebtStatus(debt, accountv1.NormalPeriod)
 
 			// TODO 暂时非真正完全删除，仍可恢复用户资源，后续会添加真正删除全部资源逻辑，不在执行恢复逻辑
-			if err := r.ResumeUserResource(ctx, userNamespace); err != nil {
+			if err := r.ResumeUserResource(ctx, userNamespaceList); err != nil {
 				return err
 			}
 			break
 		}
-		if err := r.SuspendUserResource(ctx, userNamespace); err != nil {
+		if err := r.SuspendUserResource(ctx, userNamespaceList); err != nil {
 			return err
 		}
 	//兼容老版本
@@ -327,60 +325,68 @@ var NoticeTemplate = map[int]string{
 	FinalDeletionNotice:       "The system has completely deleted all your resources, please recharge in time to avoid affecting your normal use.",
 }
 
-func (r *DebtReconciler) sendNotice(ctx context.Context, namespace string, noticeType int) error {
+func (r *DebtReconciler) sendNotice(ctx context.Context, noticeType int, namespaces []string) error {
 	now := time.Now().UTC().Unix()
 	ntf := v1.Notification{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "debt-notice" + strconv.Itoa(noticeType),
-			Namespace: namespace,
+			Name: "debt-notice" + strconv.Itoa(noticeType),
 		},
 		Spec: v1.NotificationSpec{
 			Title:      "Debt Notice",
 			Message:    NoticeTemplate[noticeType],
 			From:       "Debt-System",
 			Importance: v1.High,
+			Timestamp:  now,
 		},
 	}
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, &ntf, func() error {
-		ntf.Spec.Timestamp = now
-		return nil
-	})
-	return err
-}
-
-func (r *DebtReconciler) sendWarningNotice(ctx context.Context, namespace string) error {
-	return r.sendNotice(ctx, namespace, WarningNotice)
-}
-
-func (r *DebtReconciler) sendApproachingDeletionNotice(ctx context.Context, namespace string) error {
-	return r.sendNotice(ctx, namespace, ApproachingDeletionNotice)
-}
-
-func (r *DebtReconciler) sendImminentDeletionNotice(ctx context.Context, namespace string) error {
-	return r.sendNotice(ctx, namespace, ImminentDeletionNotice)
-}
-
-func (r *DebtReconciler) sendFinalDeletionNotice(ctx context.Context, namespace string) error {
-	return r.sendNotice(ctx, namespace, FinalDeletionNotice)
-}
-
-func (r *DebtReconciler) SuspendUserResource(ctx context.Context, namespace string) error {
-	return r.updateNamespaceStatus(ctx, namespace, accountv1.SuspendDebtNamespaceAnnoStatus)
-}
-
-func (r *DebtReconciler) ResumeUserResource(ctx context.Context, namespace string) error {
-	return r.updateNamespaceStatus(ctx, namespace, accountv1.ResumeDebtNamespaceAnnoStatus)
-}
-
-func (r *DebtReconciler) updateNamespaceStatus(ctx context.Context, namespace, status string) error {
-	ns := &corev1.Namespace{}
-	err := r.Get(ctx, types.NamespacedName{Name: namespace, Namespace: r.accountSystemNamespace}, ns)
-	if err != nil {
-		return err
+	for i := range namespaces {
+		ntf.Namespace = namespaces[i]
+		if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, &ntf, func() error {
+			return nil
+		}); err != nil {
+			return err
+		}
 	}
-	// 交给namespace controller处理
-	ns.Annotations[accountv1.DebtNamespaceAnnoStatusKey] = status
-	return r.Client.Update(ctx, ns)
+	return nil
+}
+
+func (r *DebtReconciler) sendWarningNotice(ctx context.Context, namespaces []string) error {
+	return r.sendNotice(ctx, WarningNotice, namespaces)
+}
+
+func (r *DebtReconciler) sendApproachingDeletionNotice(ctx context.Context, namespaces []string) error {
+	return r.sendNotice(ctx, ApproachingDeletionNotice, namespaces)
+}
+
+func (r *DebtReconciler) sendImminentDeletionNotice(ctx context.Context, namespaces []string) error {
+	return r.sendNotice(ctx, ImminentDeletionNotice, namespaces)
+}
+
+func (r *DebtReconciler) sendFinalDeletionNotice(ctx context.Context, namespaces []string) error {
+	return r.sendNotice(ctx, FinalDeletionNotice, namespaces)
+}
+
+func (r *DebtReconciler) SuspendUserResource(ctx context.Context, namespaces []string) error {
+	return r.updateNamespaceStatus(ctx, accountv1.SuspendDebtNamespaceAnnoStatus, namespaces)
+}
+
+func (r *DebtReconciler) ResumeUserResource(ctx context.Context, namespaces []string) error {
+	return r.updateNamespaceStatus(ctx, accountv1.ResumeDebtNamespaceAnnoStatus, namespaces)
+}
+
+func (r *DebtReconciler) updateNamespaceStatus(ctx context.Context, status string, namespaces []string) error {
+	for i := range namespaces {
+		ns := &corev1.Namespace{}
+		if err := r.Get(ctx, types.NamespacedName{Name: namespaces[i], Namespace: r.accountSystemNamespace}, ns); err != nil {
+			return err
+		}
+		// 交给namespace controller处理
+		ns.Annotations[accountv1.DebtNamespaceAnnoStatusKey] = status
+		if err := r.Client.Update(ctx, ns); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/account/controllers/transfer_controller.go
+++ b/controllers/account/controllers/transfer_controller.go
@@ -126,12 +126,14 @@ func (r *TransferReconciler) TransferOutSaver(ctx context.Context, transfer *acc
 		Namespace: r.AccountSystemNamespace,
 	}
 	balanceSpec := accountv1.AccountBalanceSpec{
-		OrderID: id,
-		Amount:  transfer.Spec.Amount,
-		Owner:   getUsername(transfer.Namespace),
-		Time:    metav1.Time{Time: time.Now().UTC()},
-		Type:    accountv1.TransferOut,
-		Details: transfer.ToJSON(),
+		Time: metav1.Time{Time: time.Now().UTC()},
+		AccountBalanceSpecInline: accountv1.AccountBalanceSpecInline{
+			OrderID: id,
+			Amount:  transfer.Spec.Amount,
+			Owner:   getUsername(transfer.Namespace),
+			Type:    accountv1.TransferOut,
+			Details: transfer.ToJSON(),
+		},
 	}
 	from := accountv1.AccountBalance{
 		ObjectMeta: objMeta,
@@ -186,12 +188,14 @@ func (r *TransferReconciler) TransferInSaver(ctx context.Context, transfer *acco
 		Namespace: r.AccountSystemNamespace,
 	}
 	balanceSpec := accountv1.AccountBalanceSpec{
-		OrderID: id,
-		Amount:  transfer.Spec.Amount,
-		Owner:   getUsername(transfer.Spec.To),
-		Time:    metav1.Time{Time: time.Now().UTC()},
-		Type:    accountv1.TransferIn,
-		Details: transfer.ToJSON(),
+		Time: metav1.Time{Time: time.Now().UTC()},
+		AccountBalanceSpecInline: accountv1.AccountBalanceSpecInline{
+			OrderID: id,
+			Amount:  transfer.Spec.Amount,
+			Owner:   getUsername(transfer.Spec.To),
+			Type:    accountv1.TransferIn,
+			Details: transfer.ToJSON(),
+		},
 	}
 	to := accountv1.AccountBalance{
 		ObjectMeta: objMeta,

--- a/controllers/account/deploy/manifests/deploy.yaml.tmpl
+++ b/controllers/account/deploy/manifests/deploy.yaml.tmpl
@@ -46,7 +46,6 @@ spec:
             description: AccountBalanceSpec defines the desired state of AccountBalance
             properties:
               amount:
-                description: TODO will delete field in future Timestamp int64 `json:"timestamp,omitempty"`
                 format: int64
                 type: integer
               costs:
@@ -55,6 +54,8 @@ spec:
                   type: integer
                 type: object
               details:
+                type: string
+              namespace:
                 type: string
               order_id:
                 type: string
@@ -219,6 +220,8 @@ spec:
               endTime:
                 format: date-time
                 type: string
+              namespace:
+                type: string
               orderID:
                 type: string
               page:
@@ -252,8 +255,6 @@ spec:
                   description: AccountBalanceSpec defines the desired state of AccountBalance
                   properties:
                     amount:
-                      description: TODO will delete field in future Timestamp int64
-                        `json:"timestamp,omitempty"`
                       format: int64
                       type: integer
                     costs:
@@ -262,6 +263,8 @@ spec:
                         type: integer
                       type: object
                     details:
+                      type: string
+                    namespace:
                       type: string
                     order_id:
                       type: string
@@ -284,6 +287,8 @@ spec:
               rechargeAmount:
                 format: int64
                 type: integer
+              status:
+                type: string
               totalCount:
                 description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
                   of cluster Important: Run "make" to regenerate code after modifying
@@ -292,6 +297,7 @@ spec:
             required:
             - pageLength
             - rechargeAmount
+            - status
             - totalCount
             type: object
         type: object

--- a/controllers/pkg/database/interface.go
+++ b/controllers/pkg/database/interface.go
@@ -24,7 +24,7 @@ import (
 
 type Interface interface {
 	//InitDB() error
-	GetMeteringOwnerTimeResult(queryTime time.Time, queryCategories, queryProperties []string, queryOwner string) (*MeteringOwnerTimeResult, error)
+	GetMeteringOwnerTimeResult(queryTime time.Time, queryCategories, queryProperties []string) (*MeteringOwnerTimeResult, error)
 	GetBillingLastUpdateTime(owner string, _type accountv1.Type) (bool, time.Time, error)
 	SaveBillingsWithAccountBalance(accountBalanceSpec *accountv1.AccountBalanceSpec) error
 	QueryBillingRecords(billingRecordQuery *accountv1.BillingRecordQuery, owner string) error
@@ -46,7 +46,7 @@ type Creator interface {
 }
 
 type MeteringOwnerTimeResult struct {
-	Owner  string           `bson:"owner"`
+	//Owner  string           `bson:"owner"`
 	Time   time.Time        `bson:"time"`
 	Amount int64            `bson:"amount"`
 	Costs  map[string]int64 `bson:"costs"`

--- a/controllers/pkg/database/mongodb.go
+++ b/controllers/pkg/database/mongodb.go
@@ -67,12 +67,10 @@ type MongoDB struct {
 }
 
 type AccountBalanceSpecBSON struct {
-	OrderID string          `json:"order_id" bson:"order_id"`
-	Owner   string          `json:"owner" bson:"owner"`
-	Time    time.Time       `json:"time" bson:"time"`
-	Type    accountv1.Type  `json:"type" bson:"type"`
-	Costs   accountv1.Costs `json:"costs,omitempty" bson:"costs,omitempty"`
-	Amount  int64           `json:"amount,omitempty" bson:"amount"`
+	// Time    metav1.Time `json:"time" bson:"time"`
+	// time字段如果为time.Time类型无法转换为json crd，所以使用metav1.Time，但是使用metav1.Time无法插入到mongo中，所以需要转换为time.Time
+	Time                               time.Time `json:"time" bson:"time"`
+	accountv1.AccountBalanceSpecInline `json:",inline" bson:",inline"`
 }
 
 func (m *MongoDB) Disconnect(ctx context.Context) error {
@@ -103,22 +101,9 @@ func (m *MongoDB) GetBillingLastUpdateTime(owner string, _type accountv1.Type) (
 }
 
 func (m *MongoDB) SaveBillingsWithAccountBalance(accountBalanceSpec *accountv1.AccountBalanceSpec) error {
-	// Time    metav1.Time `json:"time" bson:"time"`
-	// time字段如果为time.Time类型无法转换为json crd，所以使用metav1.Time，但是使用metav1.Time无法插入到mongo中，所以需要转换为time.Time
-
-	accountBalanceTime := accountBalanceSpec.Time.Time
-
-	// Create BSON document
-	accountBalanceDoc := bson.M{
-		"order_id": accountBalanceSpec.OrderID,
-		"owner":    accountBalanceSpec.Owner,
-		"time":     accountBalanceTime.UTC(),
-		"type":     accountBalanceSpec.Type,
-		"costs":    accountBalanceSpec.Costs,
-		"amount":   accountBalanceSpec.Amount,
-	}
-	if accountBalanceSpec.Details != "" {
-		accountBalanceDoc["details"] = accountBalanceSpec.Details
+	accountBalanceDoc := AccountBalanceSpecBSON{
+		Time:                     accountBalanceSpec.Time.Time.UTC(),
+		AccountBalanceSpecInline: accountBalanceSpec.AccountBalanceSpecInline,
 	}
 	_, err := m.getBillingCollection().InsertOne(context.Background(), accountBalanceDoc)
 	return err
@@ -355,12 +340,8 @@ func (m *MongoDB) queryBillingRecordsByOrderID(billingRecordQuery *accountv1.Bil
 			return fmt.Errorf("failed to decode billing record: %w", err)
 		}
 		billingRecord := accountv1.AccountBalanceSpec{
-			OrderID: bsonRecord.OrderID,
-			Owner:   bsonRecord.Owner,
-			Time:    metav1.NewTime(bsonRecord.Time),
-			Type:    bsonRecord.Type,
-			Costs:   bsonRecord.Costs,
-			Amount:  bsonRecord.Amount,
+			Time:                     metav1.NewTime(bsonRecord.Time),
+			AccountBalanceSpecInline: bsonRecord.AccountBalanceSpecInline,
 		}
 		billingRecords = append(billingRecords, billingRecord)
 	}
@@ -381,25 +362,20 @@ func (m *MongoDB) QueryBillingRecords(billingRecordQuery *accountv1.BillingRecor
 
 	billingColl := m.getBillingCollection()
 	timeMatchValue := bson.D{primitive.E{Key: "$gte", Value: billingRecordQuery.Spec.StartTime.Time}, primitive.E{Key: "$lte", Value: billingRecordQuery.Spec.EndTime.Time}}
+	matchValue := bson.D{
+		primitive.E{Key: "time", Value: timeMatchValue},
+		primitive.E{Key: "owner", Value: owner},
+	}
+	if billingRecordQuery.Spec.Type != -1 {
+		matchValue = append(matchValue, primitive.E{Key: "type", Value: billingRecordQuery.Spec.Type})
+	}
+	if billingRecordQuery.Spec.Namespace != "" {
+		matchValue = append(matchValue, primitive.E{Key: "namespace", Value: billingRecordQuery.Spec.Namespace})
+	}
 	matchStage := bson.D{
 		primitive.E{
-			Key: "$match", Value: bson.D{
-				primitive.E{Key: "time", Value: timeMatchValue},
-				primitive.E{Key: "owner", Value: owner},
-			},
+			Key: "$match", Value: matchValue,
 		},
-	}
-
-	if billingRecordQuery.Spec.Type != -1 {
-		matchStage = bson.D{
-			primitive.E{
-				Key: "$match", Value: bson.D{
-					primitive.E{Key: "time", Value: timeMatchValue},
-					primitive.E{Key: "owner", Value: owner},
-					primitive.E{Key: "type", Value: billingRecordQuery.Spec.Type},
-				},
-			},
-		}
 	}
 
 	// Pipeline for getting the paginated data
@@ -464,12 +440,8 @@ func (m *MongoDB) QueryBillingRecords(billingRecordQuery *accountv1.BillingRecor
 			return fmt.Errorf("failed to decode billing record: %w", err)
 		}
 		billingRecord := accountv1.AccountBalanceSpec{
-			OrderID: bsonRecord.OrderID,
-			Owner:   bsonRecord.Owner,
-			Time:    metav1.NewTime(bsonRecord.Time),
-			Type:    bsonRecord.Type,
-			Costs:   bsonRecord.Costs,
-			Amount:  bsonRecord.Amount,
+			Time:                     metav1.NewTime(bsonRecord.Time),
+			AccountBalanceSpecInline: bsonRecord.AccountBalanceSpecInline,
 		}
 		billingRecords = append(billingRecords, billingRecord)
 	}

--- a/controllers/pkg/database/mongodb.go
+++ b/controllers/pkg/database/mongodb.go
@@ -124,7 +124,7 @@ func (m *MongoDB) SaveBillingsWithAccountBalance(accountBalanceSpec *accountv1.A
 	return err
 }
 
-func (m *MongoDB) GetMeteringOwnerTimeResult(queryTime time.Time, queryCategories, queryProperties []string, queryOwner string) (*MeteringOwnerTimeResult, error) {
+func (m *MongoDB) GetMeteringOwnerTimeResult(queryTime time.Time, queryCategories, queryProperties []string) (*MeteringOwnerTimeResult, error) {
 	matchValue := bson.M{
 		"time":     queryTime,
 		"category": bson.M{"$in": queryCategories},
@@ -149,7 +149,7 @@ func (m *MongoDB) GetMeteringOwnerTimeResult(queryTime time.Time, queryCategorie
 			"costs":       bson.M{"$push": bson.M{"k": "$property", "v": "$propertyTotal"}},
 		}}},
 		bson.D{{Key: "$addFields", Value: bson.M{
-			"owner":  queryOwner,
+			//"owner":  queryOwner,
 			"time":   queryTime,
 			"amount": "$amountTotal",
 			"costs":  bson.M{"$arrayToObject": "$costs"},

--- a/controllers/pkg/database/mongodb_test.go
+++ b/controllers/pkg/database/mongodb_test.go
@@ -23,10 +23,11 @@ import (
 	"time"
 
 	"github.com/dustin/go-humanize"
+	"sigs.k8s.io/yaml"
+
 	accountv1 "github.com/labring/sealos/controllers/account/api/v1"
 	"go.mongodb.org/mongo-driver/mongo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/yaml"
 )
 
 func TestMongoDB_GetMeteringOwnerTimeResult(t *testing.T) {
@@ -66,14 +67,13 @@ func TestMongoDB_QueryBillingRecords(t *testing.T) {
 		}
 	}()
 
-	// 2023-05-09T05:00:00.000+00:00
-	queryTime := time.Date(2023, 5, 9, 5, 0, 0, 0, time.UTC)
-
+	testTime := time.Date(2021, 1, 1, 0, 0, 0, 0, time.Local)
+	startTime, endTime := metav1.Time{Time: testTime}, metav1.Time{Time: testTime.Add(3 * humanize.Day)}
 	// page 1 pageSize 1 type -1
 	query1 := &accountv1.BillingRecordQuery{
 		Spec: accountv1.BillingRecordQuerySpec{
-			StartTime: metav1.Time{Time: queryTime},
-			EndTime:   metav1.Time{Time: queryTime.Add(3 * humanize.Day)},
+			StartTime: startTime,
+			EndTime:   endTime,
 			Page:      1,
 			PageSize:  1,
 			//OrderID:   "random_order_id_1",
@@ -84,8 +84,8 @@ func TestMongoDB_QueryBillingRecords(t *testing.T) {
 	// page 1 pageSize 5 type 1
 	query2 := &accountv1.BillingRecordQuery{
 		Spec: accountv1.BillingRecordQuerySpec{
-			StartTime: metav1.Time{Time: queryTime},
-			EndTime:   metav1.Time{Time: queryTime.Add(3 * humanize.Day)},
+			StartTime: startTime,
+			EndTime:   endTime,
 			Page:      1,
 			PageSize:  5,
 			//OrderID:   "random_order_id_1",
@@ -96,8 +96,8 @@ func TestMongoDB_QueryBillingRecords(t *testing.T) {
 	// page 1 pageSize 5 type 0
 	query3 := &accountv1.BillingRecordQuery{
 		Spec: accountv1.BillingRecordQuerySpec{
-			StartTime: metav1.Time{Time: queryTime},
-			EndTime:   metav1.Time{Time: queryTime.Add(3 * humanize.Day)},
+			StartTime: startTime,
+			EndTime:   endTime,
 			Page:      1,
 			PageSize:  5,
 			//OrderID:   "random_order_id_1",
@@ -113,12 +113,22 @@ func TestMongoDB_QueryBillingRecords(t *testing.T) {
 		},
 	}
 
-	billingRecordQueryList := []*accountv1.BillingRecordQuery{
-		query1, query2, query3, query4,
+	query5 := &accountv1.BillingRecordQuery{
+		Spec: accountv1.BillingRecordQuerySpec{
+			StartTime: startTime,
+			EndTime:   endTime,
+			Page:      2,
+			PageSize:  5,
+			Namespace: "ns-vd1k1dk3",
+			Type:      1,
+		},
 	}
 
+	billingRecordQueryList := []*accountv1.BillingRecordQuery{
+		query1, query2, query3, query4, query5,
+	}
 	for _, billingRecordQuery := range billingRecordQueryList {
-		err = m.QueryBillingRecords(billingRecordQuery, "ns-vd1k1dk3")
+		err = m.QueryBillingRecords(billingRecordQuery, "vd1k1dk3")
 		if err != nil {
 			t.Errorf("failed to query billing records: error = %v", err)
 		}
@@ -126,9 +136,11 @@ func TestMongoDB_QueryBillingRecords(t *testing.T) {
 		if err != nil {
 			t.Errorf("failed to marshal billingRecordQuery: error = %v", err)
 		}
-		t.Logf("billingRecordQuery: %s", string(data))
+		t.Logf("billingRecordQuery: %s\n", string(data))
 	}
 }
+
+var testTime = time.Date(2023, 5, 9, 5, 0, 0, 0, time.UTC)
 
 func TestMongoDB_SaveBillingsWithAccountBalance(t *testing.T) {
 	type fields struct {
@@ -146,27 +158,33 @@ func TestMongoDB_SaveBillingsWithAccountBalance(t *testing.T) {
 	// Generate a large number of AccountBalanceSpec data
 	numRecords := 10
 	accountBalanceSpecs := make([]*accountv1.AccountBalanceSpec, numRecords+10)
+
 	for i := 0; i < numRecords; i++ {
 		accountBalanceSpecs[i] = &accountv1.AccountBalanceSpec{
-			OrderID: fmt.Sprintf("random_order_id_%d", i+1),
-			Owner:   "ns-vd1k1dk3",
-			Time:    metav1.Time{Time: time.Date(2023, 5, 9, 5, 0, 0, 0, time.UTC)},
-			Type:    0,
-			Costs: map[string]int64{
-				"cpu":     int64(1000 + i),
-				"memory":  int64(2000 + i),
-				"storage": int64(3000 + i),
+			Time: metav1.Time{Time: testTime},
+			AccountBalanceSpecInline: accountv1.AccountBalanceSpecInline{
+				OrderID:   fmt.Sprintf("random_order_id_%d", i+1),
+				Namespace: "ns-vd1k1dk3",
+				Owner:     "vd1k1dk3",
+				Type:      0,
+				Costs: map[string]int64{
+					"cpu":     int64(1000 + i),
+					"memory":  int64(2000 + i),
+					"storage": int64(3000 + i),
+				},
+				Amount: int64(6000 + 3*i),
 			},
-			Amount: int64(6000 + 3*i),
 		}
 	}
 	for i := 10; i < numRecords+10; i++ {
 		accountBalanceSpecs[i] = &accountv1.AccountBalanceSpec{
-			OrderID: fmt.Sprintf("random_order_id_recharge%d", i+1),
-			Owner:   "ns-vd1k1dk3",
-			Time:    metav1.Time{Time: time.Date(2023, 5, 9, 5, 0, 0, 0, time.UTC)},
-			Type:    1,
-			Amount:  int64(1000 + i),
+			Time: metav1.Time{Time: testTime},
+			AccountBalanceSpecInline: accountv1.AccountBalanceSpecInline{
+				OrderID: fmt.Sprintf("random_order_id_recharge%d", i+1),
+				Owner:   "vd1k1dk3",
+				Type:    1,
+				Amount:  int64(1000 + i),
+			},
 		}
 	}
 

--- a/controllers/pkg/database/mongodb_test.go
+++ b/controllers/pkg/database/mongodb_test.go
@@ -43,17 +43,10 @@ func TestMongoDB_GetMeteringOwnerTimeResult(t *testing.T) {
 		}
 	}()
 
-	// 2023-04-30T17:00:00.000+00:00
-	queryTime := time.Date(2023, 7, 14, 04, 0, 0, 0, time.UTC)
+	now := time.Now()
+	queryTime := time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), 0, 0, 0, time.Local).UTC().Add(-time.Hour)
 
-	//[]string{"ns-vd1k1dk3", "ns-cv46sqlr", "ns-wu8nptea", "ns-a2sh413v", "ns-l8ad16ee"}
-	got, err := m.GetMeteringOwnerTimeResult(queryTime, []string{"ns-vd1k1dk3"}, []string{"cpu", "memory", "storage"}, "ns-vd1k1dk3")
-	if err != nil {
-		t.Errorf("failed to get metering owner time result: error = %v", err)
-	}
-	t.Logf("got: %v", got)
-
-	got, err = m.GetMeteringOwnerTimeResult(queryTime, []string{"ns-7wdqa36k"}, nil, "ns-7wdqa36k")
+	got, err := m.GetMeteringOwnerTimeResult(queryTime, []string{"ns-0nfm8mkr"}, nil)
 	if err != nil {
 		t.Errorf("failed to get metering owner time result: error = %v", err)
 	}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 439e96f</samp>

### Summary
🚀🛠️🧪

<!--
1.  🚀 This emoji represents a new feature or improvement, such as adding support for querying billing records by namespace, updating the debt webhook logic, or syncing the account and user resources.
2.  🛠️ This emoji represents a bug fix or refactoring, such as fixing the import statements, simplifying the database interface, or using the inline account balance spec type.
3.  🧪 This emoji represents a test or code quality improvement, such as enhancing the return message, improving the environment variable and logging handling, or updating the mongodb_test file.
-->
This pull request adds a feature to the sealos account API that allows querying billing records by user namespace and type. It also refactors the account balance spec type, updates the database and cache packages, and improves the logic and code style of several controllers and webhooks. The main files affected are `controllers/account/api/v1/billingrecordquery_types.go`, `controllers/account/controllers/billingrecordquery_controller.go`, `controllers/pkg/database/mongodb.go`, and `controllers/account/api/v1/accountbalance_types.go`.

> _We are the sealos, we control the billing_
> _We query by namespace, we sync by label_
> _We refactor the types, we index the cache_
> _We reconcile the debt, we meter the time_

### Walkthrough
*  Add namespace field to account balance and billing record types and functions to support querying billing records by namespace ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-4ff708db7db13c1b861cf04cb30e45c1537f1de638e23a141980523a151f6bc7L49-R62), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-5bf539795f3e21fe33978652b0e9424625e6a485a363720770339b17e6fa8549R32), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L204-R211), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-2cae722bbe8482079dc4646e6a3f15ef57b710f8144877a5c387cc58da4c85eeL180-R171), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-137c0f053e888c2137678bb1b1b3e57f4164696ab87a9966d2047db2c3184540L129-R136), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-137c0f053e888c2137678bb1b1b3e57f4164696ab87a9966d2047db2c3184540L189-R198), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-5bb8f60e9081274e83387c8fb929e8dccb2ab7675781e07fd4eb0ee77461a4feL27-R27), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-5bb8f60e9081274e83387c8fb929e8dccb2ab7675781e07fd4eb0ee77461a4feL49-R49), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46L70-R73), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46L106-R112), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46L384-R380), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46L467-R444), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-a126f522b0bf02974f6f06cb25dcf2bd66f62276b372d5fbfc93959f7e15c136L123-R131), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-a126f522b0bf02974f6f06cb25dcf2bd66f62276b372d5fbfc93959f7e15c136L156-R187))
*  Add status field to billing record query status type and function to provide more feedback to the user about the query result ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-5bf539795f3e21fe33978652b0e9424625e6a485a363720770339b17e6fa8549R48), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-86d8d3e3c5437a16535b518a2119bb44ab128dff71b975031641b945d850eb11R115-R121))
*  Replace the use of user annotation with user label owner key to label the user namespace and account resource, and use it in the cache, controller, and database packages ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-e240069d1b78e1e32ee1fc0d1387fbe54aea40bbaa70873d6d6ec80ee5062717R25-R26), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-e240069d1b78e1e32ee1fc0d1387fbe54aea40bbaa70873d6d6ec80ee5062717R88-R90), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-e240069d1b78e1e32ee1fc0d1387fbe54aea40bbaa70873d6d6ec80ee5062717L102-L104), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-e240069d1b78e1e32ee1fc0d1387fbe54aea40bbaa70873d6d6ec80ee5062717L157-R168), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L111-R111), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-2cae722bbe8482079dc4646e6a3f15ef57b710f8144877a5c387cc58da4c85eeL100-R108), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-2cae722bbe8482079dc4646e6a3f15ef57b710f8144877a5c387cc58da4c85eeL272-R220), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-da134272ed4ee5b4eb437042a1c08ef615b2a0aec5b12b211df77978a6b2bde3R20-R21), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-da134272ed4ee5b4eb437042a1c08ef615b2a0aec5b12b211df77978a6b2bde3L31-R53))
*  Add helper functions to get the user owner from the user annotation, the own namespace list of the user, and the user namespace from the namespace name, and use them in the controller and webhook packages ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-e240069d1b78e1e32ee1fc0d1387fbe54aea40bbaa70873d6d6ec80ee5062717R143-R146), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4R231-R238), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-2cae722bbe8482079dc4646e6a3f15ef57b710f8144877a5c387cc58da4c85eeL100-R108))
*  Refactor the Reconcile function in the debt controller package to iterate over the own namespace list of the user and call the reconcileDebtStatus function for each namespace, and modify the reconcileDebtStatus function to accept a userNamespace parameter ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-8fc7d7a46552d16d295481d2bf26c8896ad0327f2592539fb877286270b5625bL116-R126), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-8fc7d7a46552d16d295481d2bf26c8896ad0327f2592539fb877286270b5625bL134-R146))
*  Refactor the billingWithHourTime function in the billing controller package to iterate over the namespace list and generate the billing records for each namespace, and modify the Reconcile function to use a helper function to get the namespace list ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-2cae722bbe8482079dc4646e6a3f15ef57b710f8144877a5c387cc58da4c85eeL161-R146), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-2cae722bbe8482079dc4646e6a3f15ef57b710f8144877a5c387cc58da4c85eeL100-R108))
*  Refactor the SetupCache function in the cache package to use a loop to iterate over the index fields and values, and add a new index field for the user label owner key ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-da134272ed4ee5b4eb437042a1c08ef615b2a0aec5b12b211df77978a6b2bde3L31-R53))
*  Refactor the GetMeteringOwnerTimeResult function in the database package to remove the owner field from the function signature and the aggregation pipeline, and modify the test function to remove the query owner parameter ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-5bb8f60e9081274e83387c8fb929e8dccb2ab7675781e07fd4eb0ee77461a4feL27-R27), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-5bb8f60e9081274e83387c8fb929e8dccb2ab7675781e07fd4eb0ee77461a4feL49-R49), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46L152-R137), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-a126f522b0bf02974f6f06cb25dcf2bd66f62276b372d5fbfc93959f7e15c136L46-R53))
*  Refactor the QueryBillingRecords function in the database package to use a single match value for the match stage of the aggregation pipeline, and add the namespace and type fields to the match value, and modify the test function to add a new query with the namespace and type parameters ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46L384-R380), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-a126f522b0bf02974f6f06cb25dcf2bd66f62276b372d5fbfc93959f7e15c136L123-R131))
*  Add a condition to the debt webhook handler function to check if the request namespace is a user namespace and if it is in the whitelist, and allow the request without further checks ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-e240069d1b78e1e32ee1fc0d1387fbe54aea40bbaa70873d6d6ec80ee5062717R88-R90))
*  Add a condition to the Reconcile function in the billing record query controller package to check if the account resource of the user exists in the account system namespace, and update the query status with a message to use the master account to query ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-86d8d3e3c5437a16535b518a2119bb44ab128dff71b975031641b945d850eb11R115-R121))
*  Add a field to the BillingRecordQueryReconciler type to store the account system namespace, and use it in the Reconcile function to get the account resource of the user ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-86d8d3e3c5437a16535b518a2119bb44ab128dff71b975031641b945d850eb11L48-R53), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-86d8d3e3c5437a16535b518a2119bb44ab128dff71b975031641b945d850eb11R115-R121))
*  Add a statement to the SetupWithManager function in the billing record query controller package to get the account system namespace from the environment variable using the utils.GetEnvWithDefault function ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-86d8d3e3c5437a16535b518a2119bb44ab128dff71b975031641b945d850eb11R147))
*  Add a test time variable to the mongodb_test file in the database package to define the base time for the query billing records tests, and use it in the test functions to replace the hard-coded query time ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-a126f522b0bf02974f6f06cb25dcf2bd66f62276b372d5fbfc93959f7e15c136L136-R144), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-a126f522b0bf02974f6f06cb25dcf2bd66f62276b372d5fbfc93959f7e15c136L46-R53), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-a126f522b0bf02974f6f06cb25dcf2bd66f62276b372d5fbfc93959f7e15c136L76-R76), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-a126f522b0bf02974f6f06cb25dcf2bd66f62276b372d5fbfc93959f7e15c136L94-R88), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-a126f522b0bf02974f6f06cb25dcf2bd66f62276b372d5fbfc93959f7e15c136L106-R100), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-a126f522b0bf02974f6f06cb25dcf2bd66f62276b372d5fbfc93959f7e15c136L156-R187))
*  Remove a redundant import statement for the userV1 package in the debt webhook package, which was already imported with an alias in the previous line ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-e240069d1b78e1e32ee1fc0d1387fbe54aea40bbaa70873d6d6ec80ee5062717L33))
*  Remove a redundant condition to the debt webhook handler function, which checks if the request is in the whitelist ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-e240069d1b78e1e32ee1fc0d1387fbe54aea40bbaa70873d6d6ec80ee5062717L102-L104))
*  Remove the commented out code in the Reconcile function in the billing controller package, which syncs the resource quota for the user namespace, and in the syncQueryRoleAndRoleBinding function, which creates the role and role binding for the user to query the billing records ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-2cae722bbe8482079dc4646e6a3f15ef57b710f8144877a5c387cc58da4c85eeL153-R126), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-2cae722bbe8482079dc4646e6a3f15ef57b710f8144877a5c387cc58da4c85eeL217-L255))
*  Remove the owner field from the MeteringOwnerTimeResult type in the database package, which defines the structure of the metering owner time result ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-5bb8f60e9081274e83387c8fb929e8dccb2ab7675781e07fd4eb0ee77461a4feL49-R49))
*  Modify the return message of the checkOption function in the debt webhook package to add the namespace information to the message ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-e240069d1b78e1e32ee1fc0d1387fbe54aea40bbaa70873d6d6ec80ee5062717L174-R178))
*  Modify the Reconcile function in the account controller package to replace the use of the user name with the user owner to sync the account, and to use a helper function to get the user owner from the user annotation ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L111-R111), [link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4R231-R238))
*  Modify the syncAccount function in the account controller package to comment out the return statement when the resource quota and limit range sync fails, and log the error instead ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L254-R265))
*  Modify the SetupWithManager function in the account controller package to replace the use of os.Getenv with utils.GetEnvWithDefault to get the account system namespace, and remove the redundant logging statement ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L523-R535))
*  Modify the SetupWithManager function in the billing controller package to replace the use of the user annotation with the user label to filter the namespace create events, and add a condition to check if the user label matches the namespace name ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-2cae722bbe8482079dc4646e6a3f15ef57b710f8144877a5c387cc58da4c85eeL272-R220))
*  Modify the import statements in the mongodb_test file in the database package to reorder them to follow the Go conventions, and remove the accountv1 alias as it is redundant ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-a126f522b0bf02974f6f06cb25dcf2bd66f62276b372d5fbfc93959f7e15c136L26-R30))
*  Add constants for the name and owner fields of the account resource in the `controllers/account/api/v1/account_types.go` file, which are used as index keys in the cache package ([link](https://github.com/labring/sealos/pull/3828/files?diff=unified&w=0#diff-9a954adb0f037b9c43d5dda396006bdafadd0619290fc89ff497bba21fa2f348R30-R34))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
