### PR TITLE
fix: dnsDomain does not take effect in kubelet

### DIFF
--- a/pkg/runtime/kubernetes/types/default_kubeadm_config.go
+++ b/pkg/runtime/kubernetes/types/default_kubeadm_config.go
@@ -115,7 +115,7 @@ authorization:
     cacheAuthorizedTTL: 5m0s
     cacheUnauthorizedTTL: 30s
 cgroupsPerQOS: true
-clusterDomain: cluster.local
+#clusterDomain: cluster.local
 configMapAndSecretChangeDetectionStrategy: Watch
 containerLogMaxFiles: 5
 containerLogMaxSize: 10Mi


### PR DESCRIPTION
fix BUG #3799 

set 'clusterDomain' in kubelet empty, it will be set the same with 'dnsDomain' in kubeadm,
both of them are set 'cluster.local' as default if you leave them empty.