### PR TITLE
K3s runtime

### DIFF
--- a/cmd/sealos/cmd/cert.go
+++ b/cmd/sealos/cmd/cert.go
@@ -75,11 +75,8 @@ func newCertCmd() *cobra.Command {
 			if err := cf.Process(); err != nil {
 				return err
 			}
-			var distribution string
-			if cluster := cf.GetCluster(); cluster != nil {
-				distribution = cluster.GetDistribution()
-			}
-			rt, err := factory.New(distribution, cf.GetCluster(), cf.GetRuntimeConfig())
+
+			rt, err := factory.New(cf.GetCluster(), cf.GetRuntimeConfig())
 			if err != nil {
 				return fmt.Errorf("create runtime failed: %v", err)
 			}

--- a/cmd/sealos/cmd/gen.go
+++ b/cmd/sealos/cmd/gen.go
@@ -56,6 +56,7 @@ func newGenCmd() *cobra.Command {
 		Short:   "generate a Clusterfile with all default settings",
 		Long:    `generate a Clusterfile of the kubernetes cluster, which can be applied by 'sealos apply' command`,
 		Example: exampleGen,
+		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			data, err := apply.NewClusterFromGenArgs(cmd, genArgs, args)
 			if err != nil {
@@ -79,7 +80,7 @@ func newGenCmd() *cobra.Command {
 	setRequireBuildahAnnotation(genCmd)
 	genArgs.RegisterFlags(genCmd.Flags())
 	genCmd.Flags().StringVarP(&out, "output", "o", "", "print output to named file")
-	genCmd.Flags().String("distribution", "kubernetes", "kubernetes distribution")
+
 	return genCmd
 }
 

--- a/pkg/apply/gen.go
+++ b/pkg/apply/gen.go
@@ -49,16 +49,15 @@ func NewClusterFromGenArgs(cmd *cobra.Command, args *RunArgs, imageNames []strin
 		return nil, err
 	}
 	if !img.IsRootFs() {
-		return nil, fmt.Errorf("input first image %s is not kubernetes image", imageNames)
+		return nil, fmt.Errorf("the first image %s is not a rootfs type image", imageNames[0])
 	}
 	cluster.Status.Mounts = append(cluster.Status.Mounts, *img)
 
-	distribution, _ := cmd.Flags().GetString("distribution")
-	cfg, err := factory.NewRuntimeConfig(distribution)
+	cfg, err := factory.NewRuntimeConfig(cluster.GetDistribution())
 	if err != nil {
 		return nil, err
 	}
-	rt, err := factory.New(distribution, cluster, cfg)
+	rt, err := factory.New(cluster, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apply/processor/create.go
+++ b/pkg/apply/processor/create.go
@@ -101,8 +101,8 @@ func (c *CreateProcessor) preProcess(cluster *v2.Cluster) error {
 	for i := range cluster.Status.Mounts {
 		cluster.Status.Mounts[i].Env = maps.Merge(cluster.Status.Mounts[i].Env, c.ExtraEnvs)
 	}
-	distribution := cluster.GetDistribution()
-	rt, err := factory.New(distribution, cluster, c.ClusterFile.GetRuntimeConfig())
+
+	rt, err := factory.New(cluster, c.ClusterFile.GetRuntimeConfig())
 	if err != nil {
 		return fmt.Errorf("failed to init runtime, %v", err)
 	}

--- a/pkg/apply/processor/delete.go
+++ b/pkg/apply/processor/delete.go
@@ -85,8 +85,7 @@ func (d *DeleteProcessor) UndoBootstrap(cluster *v2.Cluster) error {
 }
 
 func (d *DeleteProcessor) Reset(cluster *v2.Cluster) error {
-	distribution := cluster.GetDistribution()
-	rt, err := factory.New(distribution, cluster, d.ClusterFile.GetRuntimeConfig())
+	rt, err := factory.New(cluster, d.ClusterFile.GetRuntimeConfig())
 	if err != nil {
 		return fmt.Errorf("failed to delete runtime, %v", err)
 	}

--- a/pkg/apply/processor/install.go
+++ b/pkg/apply/processor/install.go
@@ -171,8 +171,7 @@ func (c *InstallProcessor) PreProcess(cluster *v2.Cluster) error {
 		c.NewMounts = append(c.NewMounts, *mount)
 	}
 
-	distribution := cluster.GetDistribution()
-	rt, err := factory.New(distribution, cluster, c.ClusterFile.GetRuntimeConfig())
+	rt, err := factory.New(cluster, c.ClusterFile.GetRuntimeConfig())
 	if err != nil {
 		return fmt.Errorf("failed to init runtime, %v", err)
 	}

--- a/pkg/apply/processor/scale.go
+++ b/pkg/apply/processor/scale.go
@@ -202,13 +202,12 @@ func (c *ScaleProcessor) preProcess(cluster *v2.Cluster) error {
 	if err = SyncClusterStatus(cluster, c.Buildah, false); err != nil {
 		return err
 	}
-	distribution := cluster.GetDistribution()
 
 	var rt runtime.Interface
 	if c.IsScaleUp {
-		rt, err = factory.New(distribution, cluster, c.ClusterFile.GetRuntimeConfig())
+		rt, err = factory.New(cluster, c.ClusterFile.GetRuntimeConfig())
 	} else {
-		rt, err = factory.New(distribution, c.ClusterFile.GetCluster(), c.ClusterFile.GetRuntimeConfig())
+		rt, err = factory.New(c.ClusterFile.GetCluster(), c.ClusterFile.GetRuntimeConfig())
 	}
 	if err != nil {
 		return fmt.Errorf("failed to init runtime: %v", err)

--- a/pkg/apply/run.go
+++ b/pkg/apply/run.go
@@ -135,7 +135,7 @@ func (r *ClusterArgs) runArgs(cmd *cobra.Command, args *RunArgs, imageList []str
 		r.setHostWithIpsPort(nodes, []string{v2.NODE, GetHostArch(sshClient, node0addr)})
 	}
 	r.cluster.Spec.Hosts = append(r.cluster.Spec.Hosts, r.hosts...)
-	logger.Debug("cluster info: %v", r.cluster)
+
 	return nil
 }
 

--- a/pkg/runtime/factory/factory.go
+++ b/pkg/runtime/factory/factory.go
@@ -15,6 +15,7 @@
 package factory
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/labring/sealos/pkg/runtime"
@@ -24,7 +25,11 @@ import (
 	"github.com/labring/sealos/pkg/types/v1beta1"
 )
 
-func New(distribution string, cluster *v1beta1.Cluster, cfg runtime.Config) (runtime.Interface, error) {
+func New(cluster *v1beta1.Cluster, cfg runtime.Config) (runtime.Interface, error) {
+	if cluster == nil {
+		return nil, errors.New("cluster cannot be null")
+	}
+	distribution := cluster.GetDistribution()
 	switch distribution {
 	case kubernetes.Distribution, "kubeadm", "":
 		return kubernetes.New(cluster, cfg)

--- a/pkg/runtime/k3s/bootstrap.go
+++ b/pkg/runtime/k3s/bootstrap.go
@@ -79,7 +79,10 @@ func (k *K3s) writeJoinConfigWithCallbacks(runMode string, callbacks ...callback
 
 func (k *K3s) joinMaster(master string) error {
 	return k.runPipelines(fmt.Sprintf("join master %s", master),
-		func() error { return k.generateAndSendTokenFiles(master, "token") },
+		func() error {
+			// the rest masters are also running in agent mode, so agent-token file is needed.
+			return k.generateAndSendTokenFiles(master, "token", "agent-token")
+		},
 		func() error {
 			return k.sshClient.Copy(master, filepath.Join(k.pathResolver.TmpPath(), defaultJoinMastersFilename), defaultConfigPath)
 		},


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 061e111</samp>

### Summary
:recycle::wrench::fire:

<!--
1.  :recycle: This emoji represents the refactoring of the code, which improves the structure, readability, and maintainability of the code without changing its functionality.
2.  :wrench: This emoji represents the modification of the code, which changes the behavior or functionality of the code to fix a bug, add a feature, or enhance the performance.
3.  :fire: This emoji represents the removal of the code, which deletes unnecessary, redundant, or unused code to reduce the complexity and size of the codebase.
-->
This pull request refactors and simplifies the code of various functions and commands related to the sealos cluster management tool. It improves the error handling, readability, and user-friendliness of the code, and removes some unused or redundant imports and log statements. It also updates the cmd package to use the runtime factory package, and enforces the image name argument for the `sealos gen` command.

> _We're refactoring the code of the cluster_
> _To make it run more smooth and faster_
> _We'll preProcess, reset, and joinMaster_
> _Heave away, me lads and lasses_

### Walkthrough
*  Refactor the code to use the factory package to create different runtime instances based on the cluster distribution, instead of hardcoding the kubernetes runtime ([link](https://github.com/labring/sealos/pull/3837/files?diff=unified&w=0#diff-a1f0bb6d606941fb48edfcbed6a2141a70bade2705d363c2e34f2ecca9277240L27-R29), [link](https://github.com/labring/sealos/pull/3837/files?diff=unified&w=0#diff-a64a2ca3d3f264b05c5b417eebf264678a0b5cdcc11e7c9f4cc2a99054ba0738L27-R32))
*  Remove the unused import of "errors" package from the cmd package ([link](https://github.com/labring/sealos/pull/3837/files?diff=unified&w=0#diff-a1f0bb6d606941fb48edfcbed6a2141a70bade2705d363c2e34f2ecca9277240L18))
*  Remove the flag "distribution" from the newGenCmd function, as it is no longer needed after refactoring the code ([link](https://github.com/labring/sealos/pull/3837/files?diff=unified&w=0#diff-5203ef43da3f65a8c3b52759666c99e1dbc2d3cbf31ed235deee1be99f6ec546L82-R83))
*  Add the cobra.MinimumNArgs(1) argument to the newGenCmd function, to ensure that the command requires at least one argument, which is the image name ([link](https://github.com/labring/sealos/pull/3837/files?diff=unified&w=0#diff-5203ef43da3f65a8c3b52759666c99e1dbc2d3cbf31ed235deee1be99f6ec546R59))
*  Refactor the code of the NewClusterFromGenArgs function, to infer the distribution from the image name, and to use the factory package to create the runtime config ([link](https://github.com/labring/sealos/pull/3837/files?diff=unified&w=0#diff-b4c7028460ee8a2207d8376a99e5b1ad4cc3db7178e77f2e1038ea0fff506eb2L52-R60))
*  Remove the debug log statement that prints the cluster info from the runArgs function, as it is redundant and may leak sensitive information ([link](https://github.com/labring/sealos/pull/3837/files?diff=unified&w=0#diff-40da3b5e11ca4827ad6fb34ce791710b02c305a8ae225305ab7fe1b6829aa444L138-R138))
*  Refactor the code of the preProcess function in `pkg/apply/processor/create.go`, to use the runtime interface to check the cluster status, and to handle the error if the cluster object is null ([link](https://github.com/labring/sealos/pull/3837/files?diff=unified&w=0#diff-a198a9c7960d3df36d37378bc12c9b6095f19934739f72cc0c3e79d7a44e2442L104-R105))
*  Refactor the code of the PreProcess function in `pkg/apply/processor/install.go`, to use the runtime interface to check the cluster status, and to handle the error if the cluster object is null ([link](https://github.com/labring/sealos/pull/3837/files?diff=unified&w=0#diff-dc16722036c8f44c78015609d3ab3424d2f4d09543296a24d98e6ebea7a2dbb9L174-R174))
*  Refactor the code of the preProcess function in `pkg/apply/processor/scale.go`, to use the runtime interface to check the cluster status, and to handle the error if the cluster object is null ([link](https://github.com/labring/sealos/pull/3837/files?diff=unified&w=0#diff-d48ba8412842b9224105abdc78efc6af4031a5e68498f66ace1f9de18d3ec438L205-R210))
*  Refactor the code of the Reset function in `pkg/apply/processor/delete.go`, to use the runtime interface to delete the runtime resources from the cluster ([link](https://github.com/labring/sealos/pull/3837/files?diff=unified&w=0#diff-9824a9d8dc140a8c2c8b7e5e99677b466e2b5bea37bf7ae494892d127f3e409aL88-R88))
*  Refactor the code of the newCertCmd function in `cmd/sealos/cmd/cert.go`, to use the runtime interface to update the certificate SANs of the cluster, and to handle the error if the cluster object is null ([link](https://github.com/labring/sealos/pull/3837/files?diff=unified&w=0#diff-a1f0bb6d606941fb48edfcbed6a2141a70bade2705d363c2e34f2ecca9277240L49-R86))
*  Modify the code of the joinMaster function in `pkg/runtime/k3s/bootstrap.go`, to use the runtime interface to get the join token from the cluster ([link](https://github.com/labring/sealos/pull/3837/files?diff=unified&w=0#diff-481ba56b502b479282760464d0c78dc1ed197cbf81f028a7621396ac66d11457L82-R86))
*  Add the import of "errors" package to the factory package, to create an error if the cluster object is null in the New function ([link](https://github.com/labring/sealos/pull/3837/files?diff=unified&w=0#diff-a64a2ca3d3f264b05c5b417eebf264678a0b5cdcc11e7c9f4cc2a99054ba0738R18))

