### PR TITLE
fix: default config for server/agent

### DIFF
--- a/pkg/runtime/k3s/k3s.go
+++ b/pkg/runtime/k3s/k3s.go
@@ -79,7 +79,7 @@ func (k *K3s) Upgrade(version string) error {
 }
 
 func (k *K3s) GetRawConfig() ([]byte, error) {
-	cfg, err := k.getInitConfig(k.overrideConfig, setClusterInit)
+	cfg, err := k.getInitConfig(defaultingServerConfig, k.overrideConfig, setClusterInit)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4e3d03e</samp>

### Summary
🛠️📄🐳

<!--
1.  🛠️ - This emoji represents the refactoring and improvement of the default config handling, as well as the addition of the `defaultingServerConfig` callback. It suggests that the changes are related to fixing or enhancing the code quality and functionality.
2.  📄 - This emoji represents the change to the `GetRawConfig` function, which returns the raw YAML config for the server. It suggests that the changes are related to documentation or configuration files.
3.  🐳 - This emoji represents the new function to get the container runtime endpoint from the agent config. It suggests that the changes are related to containers or Docker.
-->
Refactor the `k3s` package to improve config handling and consistency. Use different default callbacks for server and agent modes, and apply defaulting to server config generation. Add a function to get the container runtime endpoint from the agent config.

> _Sing, O Muse, of the cunning k3s developers_
> _Who reforged their code with skill and care_
> _To make their `config` more consistent and clear_
> _And handle the defaults of `server` and `agent` better_

### Walkthrough
*  Refactor `writeJoinConfigWithCallbacks` to use different default callbacks for server and agent modes ([link](https://github.com/labring/sealos/pull/3842/files?diff=unified&w=0#diff-481ba56b502b479282760464d0c78dc1ed197cbf81f028a7621396ac66d11457L58-R71))
*  Add `defaultingServerConfig` callback to `generateAndSendInitConfig` and `GetRawConfig` to set default values for server config ([link](https://github.com/labring/sealos/pull/3842/files?diff=unified&w=0#diff-481ba56b502b479282760464d0c78dc1ed197cbf81f028a7621396ac66d11457L163-R172), [link](https://github.com/labring/sealos/pull/3842/files?diff=unified&w=0#diff-bbd34650a9df8e53a19b8bfbfdcb2e05b494065152ed63e4ba63b4138f2f3b90L82-R82))
*  Replace `defaultConfig` variable with `defaultingServerConfig` and `defaultingAgentConfig` functions to avoid mutating global variable and allow more flexibility ([link](https://github.com/labring/sealos/pull/3842/files?diff=unified&w=0#diff-1ac07404062b36cde73e55f9032f236034f050e04c56942d3038c96bc3db176cL31-R64))
*  Use empty `Config` struct instead of copying `defaultConfig` in `getInitConfig` to avoid conflicts with default values ([link](https://github.com/labring/sealos/pull/3842/files?diff=unified&w=0#diff-1ac07404062b36cde73e55f9032f236034f050e04c56942d3038c96bc3db176cL70-R85))
*  Add `getContainerRuntimeEndpoint` function to return container runtime endpoint based on agent config ([link](https://github.com/labring/sealos/pull/3842/files?diff=unified&w=0#diff-1ac07404062b36cde73e55f9032f236034f050e04c56942d3038c96bc3db176cL87-R127))
*  Update `overrideConfig` to check if `AgentConfig` is nil before accessing it ([link](https://github.com/labring/sealos/pull/3842/files?diff=unified&w=0#diff-1ac07404062b36cde73e55f9032f236034f050e04c56942d3038c96bc3db176cL70-R85))
*  Update `ParseConfig` to use YAML reader instead of simple unmarshal to handle multiple documents in a single file ([link](https://github.com/labring/sealos/pull/3842/files?diff=unified&w=0#diff-1ac07404062b36cde73e55f9032f236034f050e04c56942d3038c96bc3db176cL87-R127))
*  Add missing imports to `k3s` package ([link](https://github.com/labring/sealos/pull/3842/files?diff=unified&w=0#diff-1ac07404062b36cde73e55f9032f236034f050e04c56942d3038c96bc3db176cL18-R24))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
