### PR TITLE
fix: merge config order

### DIFF
--- a/pkg/apply/applydrivers/apply_drivers_default.go
+++ b/pkg/apply/applydrivers/apply_drivers_default.go
@@ -123,6 +123,11 @@ func (c *Applier) Apply() error {
 
 func (c *Applier) getWriteBackObjects() []interface{} {
 	obj := []interface{}{c.ClusterDesired}
+	if runtimeConfig := c.ClusterFile.GetRuntimeConfig(); runtimeConfig != nil {
+		if components := runtimeConfig.GetComponents(); len(components) > 0 {
+			obj = append(obj, components...)
+		}
+	}
 	if configs := c.ClusterFile.GetConfigs(); len(configs) > 0 {
 		for i := range configs {
 			obj = append(obj, configs[i])

--- a/pkg/apply/processor/install.go
+++ b/pkg/apply/processor/install.go
@@ -34,6 +34,7 @@ import (
 	"github.com/labring/sealos/pkg/utils/logger"
 	"github.com/labring/sealos/pkg/utils/maps"
 	"github.com/labring/sealos/pkg/utils/rand"
+	stringsutil "github.com/labring/sealos/pkg/utils/strings"
 )
 
 var ForceOverride bool
@@ -151,7 +152,7 @@ func (c *InstallProcessor) PreProcess(cluster *v2.Cluster) error {
 		} else {
 			ctrName = rand.Generator(8)
 		}
-		cluster.Spec.Image = merge(cluster.Spec.Image, img)
+		cluster.Spec.Image = stringsutil.Merge(cluster.Spec.Image, img)
 		bderInfo, err := c.Buildah.Create(ctrName, img)
 		if err != nil {
 			return err
@@ -195,17 +196,6 @@ func (c *InstallProcessor) UpgradeIfNeed(cluster *v2.Cluster) error {
 		cluster.ReplaceRootfsImage()
 	}
 	return nil
-}
-
-func merge(ss []string, s string) []string {
-	var ret []string
-	for i := range ss {
-		if ss[i] != s {
-			ret = append(ret, ss[i])
-		}
-	}
-	ret = append(ret, s)
-	return ret
 }
 
 func (c *InstallProcessor) PostProcess(*v2.Cluster) error {

--- a/pkg/runtime/interface.go
+++ b/pkg/runtime/interface.go
@@ -33,4 +33,6 @@ type CertManager interface {
 	UpdateCertSANs(certSANs []string) error
 }
 
-type Config any
+type Config interface {
+	GetComponents() []any
+}

--- a/pkg/runtime/k3s/bootstrap.go
+++ b/pkg/runtime/k3s/bootstrap.go
@@ -59,13 +59,12 @@ func (k *K3s) writeJoinConfigWithCallbacks(runMode string, callbacks ...callback
 	var defaultCallbacks []callback
 	switch runMode {
 	case serverMode:
-		defaultCallbacks = []callback{defaultingServerConfig}
+		defaultCallbacks = []callback{defaultingServerConfig, k.merge, k.overrideServerConfig}
 	case agentMode:
-		defaultCallbacks = []callback{defaultingAgentConfig}
+		defaultCallbacks = []callback{defaultingAgentConfig, k.overrideAgentConfig}
 	}
 
 	defaultCallbacks = append(defaultCallbacks,
-		k.overrideConfig,
 		func(c *Config) { c.ServerURL = fmt.Sprintf("https://%s:%d", master0, c.HTTPSPort) },
 		// TODO: set --image-service-endpoint flag in c.ExtraKubeletArgs options
 	)
@@ -169,7 +168,9 @@ func (k *K3s) getRawInitConfig(callbacks ...callback) ([]byte, error) {
 func (k *K3s) generateAndSendInitConfig() error {
 	src := filepath.Join(k.pathResolver.TmpPath(), defaultInitFilename)
 	if !file.IsExist(src) {
-		raw, err := k.getRawInitConfig(defaultingServerConfig, k.overrideConfig, setClusterInit)
+		raw, err := k.getRawInitConfig(defaultingServerConfig, k.merge, k.overrideServerConfig,
+			func(c *Config) { c.ClusterInit = true },
+		)
 		if err != nil {
 			return err
 		}

--- a/pkg/runtime/k3s/consts.go
+++ b/pkg/runtime/k3s/consts.go
@@ -19,6 +19,7 @@ const Distribution = "k3s"
 const (
 	defaultBinDir              = "/usr/local/bin"
 	defaultConfigPath          = "/etc/rancher/k3s/config.yaml"
+	defaultRootFsK3sFileName   = "k3s.yaml"
 	defaultInitFilename        = "k3s-init.yaml"
 	defaultJoinMastersFilename = "k3s-join-master.yaml"
 	defaultJoinNodesFilename   = "k3s-join-master.yaml"

--- a/pkg/runtime/k3s/k3s.go
+++ b/pkg/runtime/k3s/k3s.go
@@ -79,7 +79,7 @@ func (k *K3s) Upgrade(version string) error {
 }
 
 func (k *K3s) GetRawConfig() ([]byte, error) {
-	cfg, err := k.getInitConfig(defaultingServerConfig, k.overrideServerConfig, setClusterInit)
+	cfg, err := k.getInitConfig(defaultingConfig, k.overrideServerConfig, setClusterInit)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/runtime/k3s/k3s.go
+++ b/pkg/runtime/k3s/k3s.go
@@ -79,7 +79,7 @@ func (k *K3s) Upgrade(version string) error {
 }
 
 func (k *K3s) GetRawConfig() ([]byte, error) {
-	cfg, err := k.getInitConfig(defaultingServerConfig, k.overrideConfig, setClusterInit)
+	cfg, err := k.getInitConfig(defaultingServerConfig, k.overrideServerConfig, setClusterInit)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/runtime/k3s/types.go
+++ b/pkg/runtime/k3s/types.go
@@ -14,7 +14,9 @@
 
 package k3s
 
-import "time"
+import (
+	"time"
+)
 
 // from github.com/k3s-io/k3s/pkg/cli/cmds/server.go
 type Config struct {
@@ -129,4 +131,8 @@ type AgentConfig struct {
 	Taints                   []string `json:"node-taint,omitempty"`
 	ImageCredProvBinDir      string   `json:"image-credential-provider-bin-dir,omitempty"`
 	ImageCredProvConfig      string   `json:"image-credential-provider-config,omitempty"`
+}
+
+func (c *Config) GetComponents() []any {
+	return []any{c}
 }

--- a/pkg/runtime/k3s/types.go
+++ b/pkg/runtime/k3s/types.go
@@ -23,8 +23,6 @@ type Config struct {
 	ClusterCIDR          []string `json:"cluster-cidr,omitempty"`
 	AgentToken           string   `json:"agent-token,omitempty"`
 	AgentTokenFile       string   `json:"agent-token-file,omitempty"`
-	Token                string   `json:"token,omitempty"`
-	TokenFile            string   `json:"token-file,omitempty"`
 	ClusterSecret        string   `json:"-"`
 	ServiceCIDR          []string `json:"service-cidr,omitempty"`
 	ServiceNodePortRange string   `json:"service-node-port-range,omitempty"`
@@ -37,9 +35,7 @@ type Config struct {
 	// The port which kube-apiserver runs on
 	APIServerPort            int           `json:"-"`
 	APIServerBindAddress     string        `json:"-"`
-	DataDir                  string        `json:"data-dir,omitempty"`
 	DisableAgent             bool          `json:"disable-agent,omitempty"`
-	PreferBundledBin         bool          `json:"prefer-bundled-bin,omitempty"`
 	KubeConfigOutput         string        `json:"write-kubeconfig,omitempty"`
 	KubeConfigMode           string        `json:"write-kubeconfig-mode,omitempty"`
 	HelmJobImage             string        `json:"helm-job-image,omitempty"`
@@ -51,7 +47,6 @@ type Config struct {
 	ExtraSchedulerArgs       []string      `json:"kube-scheduler-arg,omitempty"`
 	ExtraControllerArgs      []string      `json:"kube-controller-manager-arg,omitempty"`
 	ExtraCloudControllerArgs []string      `json:"kube-cloud-controller-manager-arg,omitempty"`
-	Rootless                 bool          `json:"rootless,omitempty"`
 	DatastoreEndpoint        string        `json:"datastore-endpoint,omitempty"`
 	DatastoreCAFile          string        `json:"datastore-cafile,omitempty"`
 	DatastoreCertFile        string        `json:"datastore-certfile,omitempty"`
@@ -59,7 +54,6 @@ type Config struct {
 	AdvertiseIP              string        `json:"advertise-address,omitempty"`
 	AdvertisePort            int           `json:"advertise-port,omitempty"`
 	DisableScheduler         bool          `json:"disable-scheduler,omitempty"`
-	ServerURL                string        `json:"server,omitempty"`
 	MultiClusterCIDR         bool          `json:"multi-cluster-cidr,omitempty"`
 	FlannelBackend           string        `json:"flannel-backend,omitempty"`
 	FlannelIPv6Masq          bool          `json:"flannel-ipv6-masq,omitempty"`
@@ -105,6 +99,16 @@ type Config struct {
 }
 
 type AgentConfig struct {
+	Debug                    bool     `json:"debug,omitempty"`
+	VLevel                   int      `json:"v,omitempty"`
+	VModule                  string   `json:"vmodule,omitempty"`
+	LogFile                  string   `json:"log,omitempty"`
+	AlsoLogToStderr          bool     `json:"alsologtostderr,omitempty"`
+	Token                    string   `json:"token,omitempty"`
+	TokenFile                string   `json:"token-file,omitempty"`
+	ServerURL                string   `json:"server,omitempty"`
+	DataDir                  string   `json:"data-dir,omitempty"`
+	LBServerPort             int      `json:"lb-server-port,omitempty"`
 	ResolvConf               string   `json:"resolv-conf,omitempty"`
 	NodeIP                   []string `json:"node-ip,omitempty"`
 	NodeExternalIP           []string `json:"node-external-ip,omitempty"`
@@ -118,7 +122,6 @@ type AgentConfig struct {
 	FlannelCniConfFile       string   `json:"flannel-cni-conf,omitempty"`
 	VPNAuth                  string   `json:"vpn-auth,omitempty"`
 	VPNAuthFile              string   `json:"vpn-auth-file,omitempty"`
-	Debug                    bool     `json:"debug,omitempty"`
 	RootlessAlreadyUnshared  bool     `json:"-"`
 	WithNodeID               bool     `json:"with-node-id,omitempty"`
 	EnableSELinux            bool     `json:"selinux,omitempty"`
@@ -131,6 +134,8 @@ type AgentConfig struct {
 	Taints                   []string `json:"node-taint,omitempty"`
 	ImageCredProvBinDir      string   `json:"image-credential-provider-bin-dir,omitempty"`
 	ImageCredProvConfig      string   `json:"image-credential-provider-config,omitempty"`
+	Rootless                 bool     `json:"rootless,omitempty"`
+	PreferBundledBin         bool     `json:"prefer-bundled-bin,omitempty"`
 }
 
 func (c *Config) GetComponents() []any {

--- a/pkg/runtime/kubernetes/types/kubeadm_config.go
+++ b/pkg/runtime/kubernetes/types/kubeadm_config.go
@@ -49,6 +49,12 @@ func NewKubeadmConfig() *KubeadmConfig {
 	return &KubeadmConfig{}
 }
 
+func (k *KubeadmConfig) GetComponents() []any {
+	return []any{
+		k.InitConfiguration, k.ClusterConfiguration, k.JoinConfiguration, k.KubeProxyConfiguration, k.KubeletConfiguration,
+	}
+}
+
 var defaultMergeOpts = []func(*mergo.Config){
 	mergo.WithOverride,
 	mergo.WithAppendSlice,

--- a/pkg/utils/strings/strings.go
+++ b/pkg/utils/strings/strings.go
@@ -97,6 +97,17 @@ func RemoveFromSlice(ss []string, s string) (result []string) {
 	return
 }
 
+func Merge(ss []string, s string) []string {
+	var ret []string
+	for i := range ss {
+		if ss[i] != s {
+			ret = append(ret, ss[i])
+		}
+	}
+	ret = append(ret, s)
+	return ret
+}
+
 func FormatSize(size int64) (Size string) {
 	if size < 1024 {
 		Size = fmt.Sprintf("%.2fB", float64(size)/float64(1))


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8d90408</samp>

### Summary
🚀🔧📝

<!--
1.  🚀 - This emoji represents the new feature of customizing the runtime components for k3s clusters. It conveys the idea of launching or deploying something new and exciting.
2.  🔧 - This emoji represents the refactoring and improvement of the code for k3s config generation and merging. It conveys the idea of fixing or tweaking something to make it better or more efficient.
3.  📝 - This emoji represents the addition of constants, methods, and types to support the new feature and the refactoring. It conveys the idea of writing or documenting something.
-->
This pull request refactors and updates the code for managing k3s and kubernetes runtime configurations. It introduces a new feature of customizing the runtime components for k3s clusters using an in place config file. It also improves the defaulting and merging logic for k3s server and agent configs. It changes the `Config` type to an interface and adds a `GetComponents` method to it. It uses the `stringsutil.Merge` function to simplify the code for merging image names.

> _Sing, O Muse, of the skillful code review_
> _That brought new features to the k3s cluster_
> _How the wise developers, with crafty moves_
> _Improved the `Config` type and its master_

### Walkthrough
*  Refactor the code and use the `stringsutil.Merge` function to merge the image names for the cluster ([link](https://github.com/labring/sealos/pull/3847/files?diff=unified&w=0#diff-dc16722036c8f44c78015609d3ab3424d2f4d09543296a24d98e6ebea7a2dbb9R37),[link](https://github.com/labring/sealos/pull/3847/files?diff=unified&w=0#diff-dc16722036c8f44c78015609d3ab3424d2f4d09543296a24d98e6ebea7a2dbb9L154-R155),[link](https://github.com/labring/sealos/pull/3847/files?diff=unified&w=0#diff-dc16722036c8f44c78015609d3ab3424d2f4d09543296a24d98e6ebea7a2dbb9L200-L210))
*  Add the `GetComponents` method to the `Config` interface and the `KubeadmConfig` and `AgentConfig` types to return the runtime components as a slice of `any` ([link](https://github.com/labring/sealos/pull/3847/files?diff=unified&w=0#diff-b35891ca8ad92d93e6a216e844bf36106c34b47fff08b5b35ccc981a7126c0e0L36-R38),[link](https://github.com/labring/sealos/pull/3847/files?diff=unified&w=0#diff-ccf0d9cfa7c71109a2b4a5347149a867a9f899b11ee9694c5d3c146393249220L132-R143),[link](https://github.com/labring/sealos/pull/3847/files?diff=unified&w=0#diff-28bf679f318f0039d1cffc3ff8c01a3f40b12950d79d76d2ea774628776270ceR52-R57))
  - appending the components from the runtime config to the objects that will be written back to the cluster file in the `getWriteBackObjects` function in `apply_drivers_default.go` ([link](https://github.com/labring/sealos/pull/3847/files?diff=unified&w=0#diff-d1f1631a24e7fe7fb68c634146ce33bba145222a02effcb95e24d8e3cd6ce80bR126-R130))
  - merging the in place config file from the root file system with the provided config in the `merge` function in `config.go` ([link](https://github.com/labring/sealos/pull/3847/files?diff=unified&w=0#diff-1ac07404062b36cde73e55f9032f236034f050e04c56942d3038c96bc3db176cL74-R139))
  - using the `defaultingConfig`, `merge`, `overrideServerConfig`, `overrideAgentConfig`, `setClusterInit`, and `removeServerFlagsInAgentConfig` functions as callbacks for different run modes in the `writeJoinConfigWithCallbacks`, `joinNodes`, and `generateAndSendInitConfig` functions in `bootstrap.go` ([link](https://github.com/labring/sealos/pull/3847/files?diff=unified&w=0#diff-481ba56b502b479282760464d0c78dc1ed197cbf81f028a7621396ac66d11457L59-R71),[link](https://github.com/labring/sealos/pull/3847/files?diff=unified&w=0#diff-481ba56b502b479282760464d0c78dc1ed197cbf81f028a7621396ac66d11457L104-R106),[link](https://github.com/labring/sealos/pull/3847/files?diff=unified&w=0#diff-481ba56b502b479282760464d0c78dc1ed197cbf81f028a7621396ac66d11457L172-R175))
  - using the same callbacks for the init config in the `GetRawConfig` function in `k3s.go` ([link](https://github.com/labring/sealos/pull/3847/files?diff=unified&w=0#diff-bbd34650a9df8e53a19b8bfbfdcb2e05b494065152ed63e4ba63b4138f2f3b90L82-R82))
  - adding the fields for the debug, log, token, server URL, data dir, and load balancer server port options to the `Config` type in `types.go` ([link](https://github.com/labring/sealos/pull/3847/files?diff=unified&w=0#diff-ccf0d9cfa7c71109a2b4a5347149a867a9f899b11ee9694c5d3c146393249220R102-R111))
  - moving the `Token`, `TokenFile`, `Rootless`, `ServerURL`, and `PreferBundledBin` fields from the `Config` type to the `AgentConfig` type in `types.go` ([link](https://github.com/labring/sealos/pull/3847/files?diff=unified&w=0#diff-ccf0d9cfa7c71109a2b4a5347149a867a9f899b11ee9694c5d3c146393249220L24-L25),[link](https://github.com/labring/sealos/pull/3847/files?diff=unified&w=0#diff-ccf0d9cfa7c71109a2b4a5347149a867a9f899b11ee9694c5d3c146393249220L38-R38),[link](https://github.com/labring/sealos/pull/3847/files?diff=unified&w=0#diff-ccf0d9cfa7c71109a2b4a5347149a867a9f899b11ee9694c5d3c146393249220L52),[link](https://github.com/labring/sealos/pull/3847/files?diff=unified&w=0#diff-ccf0d9cfa7c71109a2b4a5347149a867a9f899b11ee9694c5d3c146393249220L60))
  - removing the `Debug` field from the `AgentConfig` type in `types.go` ([link](https://github.com/labring/sealos/pull/3847/files?diff=unified&w=0#diff-ccf0d9cfa7c71109a2b4a5347149a867a9f899b11ee9694c5d3c146393249220L119))
  - removing the `PreferBundledBin` field from the `defaultingServerConfig` function in `config.go` and adding a return statement ([link](https://github.com/labring/sealos/pull/3847/files?diff=unified&w=0#diff-1ac07404062b36cde73e55f9032f236034f050e04c56942d3038c96bc3db176cL49-R77))
*  Add the imports for the `os`, `netutils`, `fileutils`, and `logger` packages to the `config.go` file ([link](https://github.com/labring/sealos/pull/3847/files?diff=unified&w=0#diff-1ac07404062b36cde73e55f9032f236034f050e04c56942d3038c96bc3db176cL21-R42))
*  Add a constant for the default root file system k3s config file name to the `consts.go` file ([link](https://github.com/labring/sealos/pull/3847/files?diff=unified&w=0#diff-0c0010105ddbbdaf1bfa12f774875c2393b6f87f97016136b739eb8291843f41R22))
*  Add parentheses around the import statement for the `time` package in the `types.go` file ([link](https://github.com/labring/sealos/pull/3847/files?diff=unified&w=0#diff-ccf0d9cfa7c71109a2b4a5347149a867a9f899b11ee9694c5d3c146393249220L17-R19))


