### PR TITLE
refactor: remove redundant nil check

### DIFF
--- a/pkg/types/v1beta1/utils.go
+++ b/pkg/types/v1beta1/utils.go
@@ -107,24 +107,18 @@ func (c *Cluster) GetAllIPS() []string {
 }
 
 func (c *Cluster) GetRootfsImage() *MountImage {
-	var image *MountImage
-	if c.Status.Mounts != nil {
-		for _, img := range c.Status.Mounts {
-			if img.IsRootFs() {
-				image = &img
-				break
-			}
+	for _, img := range c.Status.Mounts {
+		if img.IsRootFs() {
+			return &img
 		}
 	}
-	return image
+	return nil
 }
 
 func (c *Cluster) FindImage(name string) *MountImage {
-	if c.Status.Mounts != nil {
-		for _, img := range c.Status.Mounts {
-			if img.ImageName == name {
-				return &img
-			}
+	for _, img := range c.Status.Mounts {
+		if img.ImageName == name {
+			return &img
 		}
 	}
 	return nil


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d9dd052</samp>

### Summary
🧹🚀👁️

<!--
1.  🧹 - This emoji represents cleaning or simplifying code, which is what the removal of the nil checks and the `break` statement did.
2.  🚀 - This emoji represents improving performance or speed, which is what the simplifying of the code also achieved by reducing the number of iterations and comparisons.
3.  👁️ - This emoji represents improving readability or visibility, which is what the simplifying of the code also did by making the logic and the return values more clear and consistent.
-->
Simplify image finding functions in `pkg/types/v1beta1/utils.go`. Remove redundant code and improve code quality.

> _`GetRootfsImage`_
> _Simplified by removing_
> _Unneeded nil checks_

### Walkthrough
*  Simplify `GetRootfsImage` and `FindImage` functions by removing unnecessary nil checks and `break` statement ([link](https://github.com/labring/sealos/pull/3856/files?diff=unified&w=0#diff-24d4208e4143491e275db180879b141295e21323990c368f7530ba4124c00441L110-R121))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->

From the Go specification:

> "1. For a nil slice, the number of iterations is 0." https://go.dev/ref/spec#For_range

Therefore, an additional nil check for `(*Cluster).Status.Mounts` before the loop is unnecessary.
