### PR TITLE
add memory record for license 

### DIFF
--- a/controllers/licenseissuer/cmd/main.go
+++ b/controllers/licenseissuer/cmd/main.go
@@ -107,9 +107,10 @@ func main() {
 	}()
 
 	if err = (&controller.LicenseReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		DBCol:  dbCol,
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		DBCol:    dbCol,
+		Recorder: util.GetHashMap(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "License")
 		os.Exit(1)

--- a/controllers/licenseissuer/internal/controller/util/collect.go
+++ b/controllers/licenseissuer/internal/controller/util/collect.go
@@ -30,7 +30,6 @@ import (
 )
 
 const dateFormat = "2006-01-02"
-const Memory = "memory"
 
 type TypeInfo string
 type Date string

--- a/controllers/licenseissuer/internal/controller/util/const.go
+++ b/controllers/licenseissuer/internal/controller/util/const.go
@@ -82,5 +82,6 @@ const (
 	Notice        task = "Notice"
 	NoticeCleanup task = "NoticeCleanup"
 	NetWorkConfig task = "NetWorkConfig"
+	MemoryCleanup task = "MemoryCleanup"
 	// Add more tasks here
 )

--- a/controllers/licenseissuer/internal/controller/util/options.go
+++ b/controllers/licenseissuer/internal/controller/util/options.go
@@ -149,6 +149,9 @@ func (o *OperatorOptions) initOptions() {
 
 	o.RunnableOptions.Policy[Register] = OnceWithProbePolicy
 	o.RunnableOptions.Period[Register] = 5 * time.Minute
+
+	o.RunnableOptions.Policy[MemoryCleanup] = PeriodicPolicy
+	o.RunnableOptions.Period[MemoryCleanup] = 5 * time.Minute
 	// Add more tasks Policy and Period here
 }
 

--- a/controllers/licenseissuer/internal/controller/util/runnable.go
+++ b/controllers/licenseissuer/internal/controller/util/runnable.go
@@ -198,6 +198,8 @@ func (ti *TaskInstance) Run() error {
 		return NewNetworkConfig().probe(ti)
 	case Register:
 		return NewRegister().register(ti)
+	case MemoryCleanup:
+		return NewMemoryCleaner().cleanWork(ti)
 	default:
 		return fmt.Errorf("the task is not supported")
 		// allow developers to add their own runnable task


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e97b2fe</samp>

### Summary
🗃️🚀🧹

<!--
1.  🗃️ - This emoji represents the use of a hash map as a data structure for storing license tokens and their timestamps. It suggests the idea of organizing and indexing data in a container.
2.  🚀 - This emoji represents the improvement of performance and flexibility of the license reconciliation logic by using a hash map as an in-memory cache. It suggests the idea of speeding up and enhancing the functionality of the code.
3.  🧹 - This emoji represents the memory cleanup task that removes expired license tokens from the hash map. It suggests the idea of tidying up and freeing up resources.
-->
The pull request introduces a new `Recorder` hash map that caches license tokens and their timestamps in memory, and a memory cleanup task that removes expired tokens periodically. The `Recorder` hash map improves the license reconciliation performance and flexibility, and replaces the previous memory storage mechanism. The pull request modifies the `LicenseReconciler` struct, the `util` package, and the `Run` function to implement and use the new hash map and the cleanup task.

> _`Recorder` cache_
> _speeds up license checks - but_
> _needs memory cleanup_

### Walkthrough
*  Add a `Recorder` field to the `LicenseReconciler` struct to store license tokens and their timestamps in a hash map ([link](https://github.com/labring/sealos/pull/3860/files?diff=unified&w=0#diff-36f1d89cfaf08738adf3f892e93010308e4f392c18c944891cd80a6925432ee6L110-R113), [link](https://github.com/labring/sealos/pull/3860/files?diff=unified&w=0#diff-252532f462fce5f86a27a9c8d6327465943d4e1dc49c5323bf2ecc139fbf9adeL44-R48), [link](https://github.com/labring/sealos/pull/3860/files?diff=unified&w=0#diff-252532f462fce5f86a27a9c8d6327465943d4e1dc49c5323bf2ecc139fbf9adeR155-R167))
*  Use the `Recorder` hash map to check, authorize, and cache license tokens in the `Reconcile` and `CheckLicense` functions ([link](https://github.com/labring/sealos/pull/3860/files?diff=unified&w=0#diff-252532f462fce5f86a27a9c8d6327465943d4e1dc49c5323bf2ecc139fbf9adeL89-R90), [link](https://github.com/labring/sealos/pull/3860/files?diff=unified&w=0#diff-252532f462fce5f86a27a9c8d6327465943d4e1dc49c5323bf2ecc139fbf9adeL116-R120), [link](https://github.com/labring/sealos/pull/3860/files?diff=unified&w=0#diff-252532f462fce5f86a27a9c8d6327465943d4e1dc49c5323bf2ecc139fbf9adeL139-R131), [link](https://github.com/labring/sealos/pull/3860/files?diff=unified&w=0#diff-252532f462fce5f86a27a9c8d6327465943d4e1dc49c5323bf2ecc139fbf9adeR195))
*  Implement the `Map`, `HashMap`, `Memory`, and `MemoryClean` types and functions in the `util` package to provide the interface, logic, and singleton pattern for the `Recorder` hash map ([link](https://github.com/labring/sealos/pull/3860/files?diff=unified&w=0#diff-22ea5a191a491de77538188b7b4a5b4e6933052189a52da73d5464db26f4f553R22), [link](https://github.com/labring/sealos/pull/3860/files?diff=unified&w=0#diff-22ea5a191a491de77538188b7b4a5b4e6933052189a52da73d5464db26f4f553R131), [link](https://github.com/labring/sealos/pull/3860/files?diff=unified&w=0#diff-22ea5a191a491de77538188b7b4a5b4e6933052189a52da73d5464db26f4f553R271-R344))
*  Remove the `Memory` constant from the `util` package as it is no longer needed ([link](https://github.com/labring/sealos/pull/3860/files?diff=unified&w=0#diff-4e4281360e20f08c6cebb284a31b35fa26bc4b1d4d92fc160780aa46fbe75cb2L33))
*  Add the `MemoryCleanup` constant, task type, and policy to the `util` package to configure and run a periodic memory cleanup task that removes expired license tokens from the `Recorder` hash map ([link](https://github.com/labring/sealos/pull/3860/files?diff=unified&w=0#diff-d6694648159f56721eba95e37dec6193b7d553ff6099442d0c7d203dbbe5ca30R85), [link](https://github.com/labring/sealos/pull/3860/files?diff=unified&w=0#diff-22fb1820466f572d76033ba032440419ded2b28888ed2e6aad53d3101440e751R152-R154), [link](https://github.com/labring/sealos/pull/3860/files?diff=unified&w=0#diff-4d944b0cd144b572240100d4e0aee9b16e6cec6db7b771516917580e58267595R201-R202))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
