### PR TITLE
feat(costcenter): supported for network

### DIFF
--- a/frontend/providers/costcenter/public/locales/en/common.json
+++ b/frontend/providers/costcenter/public/locales/en/common.json
@@ -34,6 +34,7 @@
   "Type": "Type",
   "CPU": "CPU",
   "Memory": "Memory",
+  "Network": "Network",
   "Storage": "Storage",
   "Total Amount": "Total Amount",
   "Transfer Amount": "Transfer Amount",

--- a/frontend/providers/costcenter/public/locales/zh/common.json
+++ b/frontend/providers/costcenter/public/locales/zh/common.json
@@ -36,6 +36,7 @@
   "CPU": "CPU",
   "Memory": "内存",
   "Storage": "存储卷",
+  "Network": "网络",
   "Total Amount": "总金额",
   "Payment Result": "支付结果",
   "Payment Successful": "支付成功",

--- a/frontend/providers/costcenter/src/components/billing/billingTable.tsx
+++ b/frontend/providers/costcenter/src/components/billing/billingTable.tsx
@@ -31,9 +31,9 @@ export function BillingTable({ data }: { data: BillingItem[] }) {
               >
                 <Flex display={'flex'} alignItems={'center'}>
                   <Text mr="4px">{t(item)}</Text>
-                  {['CPU', 'Gpu', 'Memory', 'Storage', 'Total Amount'].includes(item) && (
-                    <CurrencySymbol type={currency} />
-                  )}
+                  {['CPU', 'Gpu', 'Memory', 'Storage', 'Network', 'Total Amount'].includes(
+                    item
+                  ) && <CurrencySymbol type={currency} />}
                 </Flex>
               </Th>
             ))}
@@ -89,6 +89,7 @@ export function BillingTable({ data }: { data: BillingItem[] }) {
                   <Td>{!item.type ? <span>{formatMoney(item.costs?.cpu || 0)}</span> : '-'}</Td>
                   <Td>{!item.type ? <span>{formatMoney(item.costs?.memory || 0)}</span> : '-'}</Td>
                   <Td>{!item.type ? <span>{formatMoney(item.costs?.storage || 0)}</span> : '-'}</Td>
+                  <Td>{!item.type ? <span>{formatMoney(item.costs?.network || 0)}</span> : '-'}</Td>
                   {gpuEnabled && (
                     <Td>{!item.type ? <span>{formatMoney(item.costs?.gpu || 0)}</span> : '-'}</Td>
                   )}

--- a/frontend/providers/costcenter/src/components/cost_overview/components/lineChart.tsx
+++ b/frontend/providers/costcenter/src/components/cost_overview/components/lineChart.tsx
@@ -16,7 +16,6 @@ import { BillingItem } from '@/types/billing';
 import { parseISO, format, isSameDay, startOfDay } from 'date-fns';
 import { formatMoney } from '@/utils/format';
 import { useTranslation } from 'next-i18next';
-import useBillingStore from '@/stores/billing';
 import useOverviewStore from '@/stores/overview';
 
 echarts.use([
@@ -37,15 +36,16 @@ export default function Trend({ data }: { data: BillingItem[] }) {
   const sourceValue =
     data
       .filter((v) => v.type === 0)
-      .map<[Date, number, number, number, number]>((item) => [
+      .map<[Date, number, number, number, number, number]>((item) => [
         parseISO(item.time),
         item.costs?.cpu || 0,
         item.costs?.memory || 0,
         item.costs?.storage || 0,
+        item.costs?.network || 0,
         item.amount
       ])
       // 归并为当天的开始
-      .reduce<[Date, number, number, number, number][]>((pre, cur) => {
+      .reduce<[Date, number, number, number, number, number][]>((pre, cur) => {
         if (pre.length !== 0) {
           const precost = pre[pre.length - 1];
           if (isSameDay(precost[0], cur[0])) {

--- a/frontend/providers/costcenter/src/components/cost_overview/components/pieChart.tsx
+++ b/frontend/providers/costcenter/src/components/cost_overview/components/pieChart.tsx
@@ -22,7 +22,7 @@ echarts.use([
 
 export default function CostChart({ data }: { data: BillingData['status']['deductionAmount'] }) {
   const { t } = useTranslation();
-  const { cpu = 0, memory = 0, storage = 0, gpu = 0 } = data;
+  const { cpu = 0, memory = 0, storage = 0, gpu = 0, network = 0 } = data;
   const gpuEnabled = useEnvStore((state) => state.gpuEnabled);
   const radius = useBreakpointValue({
     xl: ['45%', '70%'],
@@ -42,6 +42,7 @@ export default function CostChart({ data }: { data: BillingData['status']['deduc
       ['cpu', formatMoney(cpu).toFixed(2)],
       ['memory', formatMoney(memory).toFixed(2)],
       ['storage', formatMoney(storage).toFixed(2)],
+      ['network', formatMoney(network).toFixed(2)],
       ...(gpuEnabled ? [['gpu', formatMoney(gpu).toFixed(2)]] : [])
     ],
     [cpu, memory, storage, gpu, gpuEnabled]

--- a/frontend/providers/costcenter/src/components/cost_overview/cost.tsx
+++ b/frontend/providers/costcenter/src/components/cost_overview/cost.tsx
@@ -15,6 +15,7 @@ export const Cost = memo(function Cost() {
     cpu: _deduction?.cpu || 0,
     memory: _deduction?.memory || 0,
     storage: _deduction?.storage || 0,
+    network: _deduction?.network || 0,
     gpu: _deduction?.gpu || 0
   };
   return (

--- a/frontend/providers/costcenter/src/components/valuation/predictCard.tsx
+++ b/frontend/providers/costcenter/src/components/valuation/predictCard.tsx
@@ -15,7 +15,8 @@ export default function PredictCard() {
     const origin = [
       { name: 'CPU', cost: state.cpu },
       { name: 'Memory', cost: state.memory },
-      { name: 'Storage', cost: state.storage }
+      { name: 'Storage', cost: state.storage },
+      { name: 'Network', cost: state.network }
     ];
     if (!gpuEnabled) {
       origin.push({ name: total, cost: state.cpu + state.memory + state.storage });

--- a/frontend/providers/costcenter/src/constants/billing.ts
+++ b/frontend/providers/costcenter/src/constants/billing.ts
@@ -4,7 +4,8 @@ export const TableHeaders = [
   'Type',
   'CPU',
   'Memory',
-  'Storage'
+  'Storage',
+  'Network'
   // 'GPU',
   // 'Total Amount'
 ] as const;

--- a/frontend/providers/costcenter/src/constants/payment.ts
+++ b/frontend/providers/costcenter/src/constants/payment.ts
@@ -91,6 +91,6 @@ export const valuationMap = new Map([
   ['cpu', { unit: 'Core', scale: 1000, bg: '#33BABB', idx: 0 }],
   ['memory', { unit: 'GB', scale: 1024, bg: '#36ADEF', idx: 1 }],
   ['storage', { unit: 'GB', scale: 1024, bg: '#8172D8', idx: 2 }],
-  ['gpu', { unit: 'GPU', scale: 1000, bg: '#89CD11', idx: 3 }]
-  // ['network', { unit: 'M', scale: 1, bg: '#89CD11', idx: 4 }]
+  ['gpu', { unit: 'GPU', scale: 1000, bg: '#89CD11', idx: 3 }],
+  ['network', { unit: 'M', scale: 1, bg: '#89CD11', idx: 4 }]
 ]);

--- a/frontend/providers/costcenter/src/pages/api/billing/index.ts
+++ b/frontend/providers/costcenter/src/pages/api/billing/index.ts
@@ -13,6 +13,7 @@ const convertGpu = (_deduction?: RawCosts) =>
           if (cur[0] === 'cpu') pre.cpu = cur[1];
           else if (cur[0] === 'memory') pre.memory = cur[1];
           else if (cur[0] === 'storage') pre.storage = cur[1];
+          else if (cur[0] === 'network') pre.network = cur[1];
           else if (cur[0].startsWith('gpu-')) {
             typeof pre.gpu === 'number' && (pre.gpu += cur[1]);
           }
@@ -22,13 +23,15 @@ const convertGpu = (_deduction?: RawCosts) =>
           cpu: 0,
           memory: 0,
           storage: 0,
-          gpu: 0
+          gpu: 0,
+          network: 0
         }
       )
     : {
         cpu: 0,
         memory: 0,
         storage: 0,
+        network: 0,
         gpu: 0
       };
 export default async function handler(req: NextApiRequest, resp: NextApiResponse) {

--- a/frontend/providers/costcenter/src/pages/cost_overview/index.tsx
+++ b/frontend/providers/costcenter/src/pages/cost_overview/index.tsx
@@ -26,6 +26,7 @@ function CostOverview() {
   const updateCPU = useBillingStore((state) => state.updateCpu);
   const updateMemory = useBillingStore((state) => state.updateMemory);
   const updateStorage = useBillingStore((state) => state.updateStorage);
+  const updateNetwork = useBillingStore((state) => state.updateNetwork);
   const updateGpu = useBillingStore((state) => state.updateGpu);
   const cookie = getCookie('NEXT_LOCALE');
   useEffect(() => {
@@ -75,6 +76,7 @@ function CostOverview() {
     updateCPU(item?.cpu || 0);
     updateMemory(item?.memory || 0);
     updateStorage(item?.storage || 0);
+    updateNetwork(item?.network || 0);
     updateGpu(item?.gpu || 0);
   }, [costBillingItems, updateCPU, updateMemory, updateStorage]);
   const rechargeRef = useRef<any>();

--- a/frontend/providers/costcenter/src/stores/billing.ts
+++ b/frontend/providers/costcenter/src/stores/billing.ts
@@ -4,10 +4,12 @@ type BillingState = {
   cpu: number;
   memory: number;
   storage: number;
+  network: number;
   gpu: number;
   updateCpu: (cpu: number) => void;
   updateMemory: (memory: number) => void;
   updateStorage: (storage: number) => void;
+  updateNetwork: (network: number) => void;
   updateGpu: (gpu: number) => void;
 };
 const useBillingStore = create<BillingState>((set) => ({
@@ -15,9 +17,11 @@ const useBillingStore = create<BillingState>((set) => ({
   memory: 0,
   storage: 0,
   gpu: 0,
+  network: 0,
   updateCpu: (cpu: number) => set({ cpu: formatMoney(cpu) }),
   updateMemory: (memory: number) => set({ memory: formatMoney(memory) }),
   updateStorage: (storage: number) => set({ storage: formatMoney(storage) }),
+  updateNetwork: (network: number) => set({ network: formatMoney(network) }),
   updateGpu: (gpu: number) => set({ gpu: formatMoney(gpu) })
 }));
 

--- a/frontend/providers/costcenter/src/types/billing.ts
+++ b/frontend/providers/costcenter/src/types/billing.ts
@@ -10,11 +10,12 @@ export type BillingSpec =
   | {
       orderID: string; //如果给定orderId，则查找该id的值，该值为唯一值，因此当orderId给定时忽略其他查找限定值
     };
-export type RawCosts = Record<'cpu' | 'memory' | 'storage' | `gpu-${string}`, number>;
+export type RawCosts = Record<'network' | 'cpu' | 'memory' | 'storage' | `gpu-${string}`, number>;
 export type Costs = {
   cpu: number;
   memory: number;
   storage: number;
+  network: number;
   gpu?: number;
 };
 export type BillingItem<T = Costs> = {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e85708e</samp>

### Summary
🌐💰📊

<!--
1.  🌐 - This emoji represents the network concept and the addition of translations for the term "Network" in different locales. It also conveys the idea of connectivity and data transfer, which are related to network costs.
2. 💰 - This emoji represents the cost aspect of the changes, which involve adding network cost information to various components, charts, tables, and hooks. It also conveys the idea of money and billing, which are relevant to the application domain.
3. 📊 - This emoji represents the chart and table components that are modified to display network cost data. It also conveys the idea of data visualization and analysis, which are important features of the application.
-->
This pull request adds network cost information to the cost center billing and valuation features. It updates the components, API, store, types, constants, and locales to handle and display the network cost data. It also fixes some minor issues with type annotations and unused hooks.

> _Sing, O Muse, of the valiant developers who toiled_
> _To add network cost to the billing table, where the data is coiled_
> _Like the serpent Python, guarding the sacred oracle of Delphi_
> _They faced many challenges, but with skill and cunning, they did not flee_

### Walkthrough
*  Add network cost to billing data types and functions ([link](https://github.com/labring/sealos/pull/3870/files?diff=unified&w=0#diff-9c1ccfe07a79f6002af1d0584f08a85063ac0dc396ecc45f953cf71c013e74d2R16), [link](https://github.com/labring/sealos/pull/3870/files?diff=unified&w=0#diff-9c1ccfe07a79f6002af1d0584f08a85063ac0dc396ecc45f953cf71c013e74d2L25-R27), [link](https://github.com/labring/sealos/pull/3870/files?diff=unified&w=0#diff-9c1ccfe07a79f6002af1d0584f08a85063ac0dc396ecc45f953cf71c013e74d2R34), [link](https://github.com/labring/sealos/pull/3870/files?diff=unified&w=0#diff-8ec9c0a57d3228895fabd0b6a3bb38fa7c674f47a8413734617a76b2fa59277cL13-R18))
*  Add network cost to billing store and update function ([link](https://github.com/labring/sealos/pull/3870/files?diff=unified&w=0#diff-36a805891b5bcb0c5110641bec0309c8225373958e39fb3dcffd4b4d984c32b7L7-R12), [link](https://github.com/labring/sealos/pull/3870/files?diff=unified&w=0#diff-36a805891b5bcb0c5110641bec0309c8225373958e39fb3dcffd4b4d984c32b7L18-R24))
*  Add network cost to `common.json` files for English and Chinese locales ([link](https://github.com/labring/sealos/pull/3870/files?diff=unified&w=0#diff-22a0af9ffd00ea2fcfdc0db3fb38d437eb615c51f91a38ba0c3c100b20a09ddbR37), [link](https://github.com/labring/sealos/pull/3870/files?diff=unified&w=0#diff-54169e3c66c9921e2d46d2574fd77362a7f5e405e054acb1938dcf5c275e6c83R39))
*  Add network cost to billing table headers and cells ([link](https://github.com/labring/sealos/pull/3870/files?diff=unified&w=0#diff-a26098c548b0031c344e5eae6687f683110f4dc12ae9e734b20fc332094babd5L7-R8), [link](https://github.com/labring/sealos/pull/3870/files?diff=unified&w=0#diff-9b8e6d15a88b05c95c40bde8b06849bb4c0d723944381e623f89268102a7f7d4L34-R36), [link](https://github.com/labring/sealos/pull/3870/files?diff=unified&w=0#diff-9b8e6d15a88b05c95c40bde8b06849bb4c0d723944381e623f89268102a7f7d4R92))
*  Add network cost to cost overview charts and components ([link](https://github.com/labring/sealos/pull/3870/files?diff=unified&w=0#diff-53371acc4296e16ff3c822d22f0247a3a7b3e35ad45f0fbe9c661cdcd19da752L19), [link](https://github.com/labring/sealos/pull/3870/files?diff=unified&w=0#diff-53371acc4296e16ff3c822d22f0247a3a7b3e35ad45f0fbe9c661cdcd19da752L40-R48), [link](https://github.com/labring/sealos/pull/3870/files?diff=unified&w=0#diff-3edc2f283ac56945b8e6559991f6803e9ada830957ef0ded2b2cdfc237f436eeL25-R25), [link](https://github.com/labring/sealos/pull/3870/files?diff=unified&w=0#diff-3edc2f283ac56945b8e6559991f6803e9ada830957ef0ded2b2cdfc237f436eeR45), [link](https://github.com/labring/sealos/pull/3870/files?diff=unified&w=0#diff-73b1652d483b2849bfc5cd28bd7b202ae7420951efff9e44f8fb71970a5b58f0R18), [link](https://github.com/labring/sealos/pull/3870/files?diff=unified&w=0#diff-57364af364348a80bceab3fdbd760682f2b9cd86a3363e3c37009dd386aee678R29), [link](https://github.com/labring/sealos/pull/3870/files?diff=unified&w=0#diff-57364af364348a80bceab3fdbd760682f2b9cd86a3363e3c37009dd386aee678R79))
*  Add network cost to valuation map and predict card ([link](https://github.com/labring/sealos/pull/3870/files?diff=unified&w=0#diff-0e13a3f7cbc82a4b65fa3628942ac1faed7984d412bdfbf661c5e323b91bba4fL94-R95), [link](https://github.com/labring/sealos/pull/3870/files?diff=unified&w=0#diff-aacdb95056ff4f53c9e60f4d80210372a3c92d01f1041fd3b3070c432b017af0L18-R19))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
