### PR TITLE
feat: support rendering template files on target host with sealctl

### DIFF
--- a/cmd/sealctl/cmd/initsystem.go
+++ b/cmd/sealctl/cmd/initsystem.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -31,124 +32,54 @@ var (
 func newInitSystemCmd() *cobra.Command {
 	var initsystemCmd = &cobra.Command{
 		Use:   "initsystem",
-		Short: "init system",
+		Short: "init system management",
 	}
-	initsystemCmd.AddCommand(newInitSystemEnableCmd())
-	initsystemCmd.AddCommand(newInitSystemStartCmd())
-	initsystemCmd.AddCommand(newInitSystemStopCmd())
-	initsystemCmd.AddCommand(newInitSystemRestartCmd())
-	initsystemCmd.AddCommand(newInitSystemIsExistsCmd())
-	initsystemCmd.AddCommand(newInitSystemIsEnabledCmd())
-	initsystemCmd.AddCommand(newInitSystemIsActiveCmd())
+	initsystemCmd.AddCommand(createInitSystemSubCommand("enable", func(s string) error {
+		return initsystemInterface.ServiceEnable(s)
+	}))
+	initsystemCmd.AddCommand(createInitSystemSubCommand("start", func(s string) error {
+		return initsystemInterface.ServiceStart(s)
+	}))
+	initsystemCmd.AddCommand(createInitSystemSubCommand("stop", func(s string) error {
+		return initsystemInterface.ServiceStop(s)
+	}))
+	initsystemCmd.AddCommand(createInitSystemSubCommand("restart", func(s string) error {
+		return initsystemInterface.ServiceRestart(s)
+	}))
+	initsystemCmd.AddCommand(createInitSystemSubCommand("is-exists", func(s string) error {
+		fmt.Println(initsystemInterface.ServiceExists(s))
+		return nil
+	}))
+	initsystemCmd.AddCommand(createInitSystemSubCommand("is-enabled", func(s string) error {
+		fmt.Println(initsystemInterface.ServiceIsEnabled(s))
+		return nil
+	}))
+	initsystemCmd.AddCommand(createInitSystemSubCommand("is-active", func(s string) error {
+		fmt.Println(initsystemInterface.ServiceIsActive(s))
+		return nil
+	}))
+
 	return initsystemCmd
 }
 
-func newInitSystemStartCmd() *cobra.Command {
-	var initsystemCmd = &cobra.Command{
-		Use:   "start",
-		Short: "start initsystem service",
+func createInitSystemSubCommand(verb string, runE func(string) error) *cobra.Command {
+	var short string
+	if strings.HasPrefix(verb, "is-") {
+		short = fmt.Sprintf("check if the initsystem service is %s", strings.TrimPrefix(verb, "is-"))
+	} else {
+		short = fmt.Sprintf("%s the initsystem service", verb)
+	}
+	return &cobra.Command{
+		Use:   verb,
+		Short: short,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return initsystemInterface.ServiceStart(args[0])
+			return runE(args[0])
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return initsystemInit()
 		},
 	}
-	return initsystemCmd
-}
-
-func newInitSystemEnableCmd() *cobra.Command {
-	var initsystemCmd = &cobra.Command{
-		Use:   "enable",
-		Short: "enable initsystem service",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return initsystemInterface.ServiceEnable(args[0])
-		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return initsystemInit()
-		},
-	}
-	return initsystemCmd
-}
-
-func newInitSystemStopCmd() *cobra.Command {
-	var initsystemCmd = &cobra.Command{
-		Use:   "stop",
-		Short: "stop initsystem service",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return initsystemInterface.ServiceStop(args[0])
-		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return initsystemInit()
-		},
-	}
-	return initsystemCmd
-}
-
-func newInitSystemRestartCmd() *cobra.Command {
-	var initsystemCmd = &cobra.Command{
-		Use:   "restart",
-		Short: "restart initsystem service",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return initsystemInterface.ServiceRestart(args[0])
-		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return initsystemInit()
-		},
-	}
-	return initsystemCmd
-}
-
-func newInitSystemIsExistsCmd() *cobra.Command {
-	var initsystemCmd = &cobra.Command{
-		Use:   "is-exists",
-		Short: "is exists initsystem service",
-		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			out := initsystemInterface.ServiceExists(args[0])
-			fmt.Println(out)
-		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return initsystemInit()
-		},
-	}
-	return initsystemCmd
-}
-
-func newInitSystemIsEnabledCmd() *cobra.Command {
-	var initsystemCmd = &cobra.Command{
-		Use:   "is-enabled",
-		Short: "is enabled initsystem service",
-		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			out := initsystemInterface.ServiceIsEnabled(args[0])
-			fmt.Println(out)
-		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return initsystemInit()
-		},
-	}
-	return initsystemCmd
-}
-
-func newInitSystemIsActiveCmd() *cobra.Command {
-	var initsystemCmd = &cobra.Command{
-		Use:   "is-active",
-		Short: "is active initsystem service",
-		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			out := initsystemInterface.ServiceIsActive(args[0])
-			fmt.Println(out)
-		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return initsystemInit()
-		},
-	}
-	return initsystemCmd
 }
 
 func initsystemInit() error {

--- a/cmd/sealctl/cmd/render.go
+++ b/cmd/sealctl/cmd/render.go
@@ -1,0 +1,125 @@
+// Copyright © 2023 sealos.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"helm.sh/helm/v3/pkg/cli/values"
+	"helm.sh/helm/v3/pkg/getter"
+
+	"github.com/labring/sealos/pkg/template"
+	fileutils "github.com/labring/sealos/pkg/utils/file"
+	"github.com/labring/sealos/pkg/utils/logger"
+	"github.com/labring/sealos/pkg/utils/maps"
+)
+
+func newRenderCommand() *cobra.Command {
+	var (
+		valueFiles []string
+		sets       []string
+	)
+	cmd := &cobra.Command{
+		Use:   "render",
+		Short: "render template files with values and envs",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRender(valueFiles, sets, args)
+		},
+	}
+	cmd.Flags().StringSliceVarP(&valueFiles, "values", "f", []string{}, "values files for context")
+	cmd.Flags().StringSliceVar(&sets, "set", []string{}, "k/v sets for context")
+	return cmd
+}
+
+func loadValues(valueFiles, sets []string) (map[string]interface{}, error) {
+	valueOpt := &values.Options{
+		ValueFiles: valueFiles,
+		Values:     sets,
+	}
+	return valueOpt.MergeValues([]getter.Provider{{
+		Schemes: []string{"http", "https"},
+		New:     getter.NewHTTPGetter,
+	}})
+}
+
+func findTemplateFiles(paths ...string) ([]string, error) {
+	var ret []string
+	for i := range paths {
+		files, err := fileutils.FindFilesMatchExtension(paths[i], ".tpl", ".tmpl")
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, files...)
+	}
+	return ret, nil
+}
+
+func runRender(valueFiles, sets []string, args []string) error {
+	mergedValues, err := loadValues(valueFiles, sets)
+	if err != nil {
+		return err
+	}
+	envs := maps.FromSlice(os.Environ())
+	data := make(map[string]interface{})
+	// For compatibility with older templates
+	for k, v := range envs {
+		data[k] = v
+	}
+
+	data["Values"] = mergedValues
+	data["Env"] = envs
+
+	filepaths, err := findTemplateFiles(args...)
+	if err != nil {
+		return err
+	}
+	for i := range filepaths {
+		if err := func(fp string) error {
+			logger.Debug("found template file %s, trying to rendering", fp)
+			trimed := strings.TrimSuffix(fp, filepath.Ext(fp))
+			if fileutils.IsExist(trimed) {
+				logger.Debug("found existing file %s, override it", trimed)
+			}
+			file, err := os.OpenFile(trimed, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
+			if err != nil {
+				return err
+			}
+			defer file.Close()
+			b, err := fileutils.ReadAll(fp)
+			if err != nil {
+				return err
+			}
+			t, err := template.Parse(string(b))
+			if err != nil {
+				return err
+			}
+			if err = t.Execute(file, data); err != nil {
+				return err
+			}
+			logger.Info("render %s from %s completed", trimed, fp)
+			return nil
+		}(filepaths[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(newRenderCommand())
+}

--- a/pkg/filesystem/rootfs/rootfs_default.go
+++ b/pkg/filesystem/rootfs/rootfs_default.go
@@ -20,7 +20,8 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"path"
+	"path/filepath"
+	"strings"
 
 	"golang.org/x/sync/errgroup"
 
@@ -46,19 +47,17 @@ func (f *defaultRootfs) UnMountRootfs(cluster *v2.Cluster, hosts []string) error
 	return f.unmountRootfs(cluster, hosts)
 }
 
-func (f *defaultRootfs) getClusterName(cluster *v2.Cluster) string {
-	return cluster.Name
-}
-
 func (f *defaultRootfs) getSSH(cluster *v2.Cluster) ssh.Interface {
 	return ssh.NewCacheClientFromCluster(cluster, true)
 }
 
 func (f *defaultRootfs) mountRootfs(cluster *v2.Cluster, ipList []string) error {
-	target := constants.NewPathResolver(f.getClusterName(cluster)).RootFSPath()
+	pathResolver := constants.NewPathResolver(cluster.Name)
+	target := pathResolver.RootFSPath()
 	ctx := context.Background()
 	eg, _ := errgroup.WithContext(ctx)
 	envProcessor := env.NewEnvProcessor(cluster)
+	// TODO: remove this when rendering on client side is GA
 	for _, mount := range f.mounts {
 		src := mount
 		eg.Go(func() error {
@@ -114,7 +113,8 @@ func (f *defaultRootfs) mountRootfs(cluster *v2.Cluster, ipList []string) error 
 					}
 				}
 			}
-			return nil
+			renderCommand := getRenderCommand(pathResolver.RootFSSealctlPath(), target)
+			return sshClient.CmdAsync(ip, envProcessor.WrapShell(ip, renderCommand))
 		})
 	}
 	if err := eg.Wait(); err != nil {
@@ -127,7 +127,12 @@ func (f *defaultRootfs) mountRootfs(cluster *v2.Cluster, ipList []string) error 
 		mountInfo := f.mounts[idx]
 		eg.Go(func() error {
 			if mountInfo.IsApplication() {
-				return copyFn(mountInfo, master0, constants.GetAppWorkDir(cluster.Name, mountInfo.Name))
+				targetDir := constants.GetAppWorkDir(cluster.Name, mountInfo.Name)
+				if err := copyFn(mountInfo, master0, targetDir); err != nil {
+					return err
+				}
+				renderCommand := getRenderCommand(pathResolver.RootFSSealctlPath(), targetDir)
+				return sshClient.CmdAsync(master0, envProcessor.WrapShell(master0, renderCommand))
 			}
 			return nil
 		})
@@ -135,8 +140,19 @@ func (f *defaultRootfs) mountRootfs(cluster *v2.Cluster, ipList []string) error 
 	return eg.Wait()
 }
 
+func getRenderCommand(binary string, target string) string {
+	// skip if sealctl doesn't has subcommand render
+	return fmt.Sprintf("%s render --debug=%v %s || true", binary,
+		logger.IsDebugMode(),
+		strings.Join([]string{
+			filepath.Join(target, constants.EtcDirName),
+			filepath.Join(target, constants.ScriptsDirName),
+			filepath.Join(target, constants.ManifestsDirName),
+		}, " "))
+}
+
 func (f *defaultRootfs) unmountRootfs(cluster *v2.Cluster, ipList []string) error {
-	clusterRootfsDir := constants.NewPathResolver(f.getClusterName(cluster)).Root()
+	clusterRootfsDir := constants.NewPathResolver(cluster.Name).Root()
 	rmRootfs := fmt.Sprintf("rm -rf %s", clusterRootfsDir)
 	deleteHomeDirCmd := fmt.Sprintf("rm -rf %s", constants.ClusterDir(cluster.Name))
 	eg, _ := errgroup.WithContext(context.Background())
@@ -153,9 +169,9 @@ func (f *defaultRootfs) unmountRootfs(cluster *v2.Cluster, ipList []string) erro
 
 func renderTemplatesWithEnv(mountDir string, ipList []string, p env.Interface, envs map[string]string) error {
 	var (
-		renderEtc       = path.Join(mountDir, constants.EtcDirName)
-		renderScripts   = path.Join(mountDir, constants.ScriptsDirName)
-		renderManifests = path.Join(mountDir, constants.ManifestsDirName)
+		renderEtc       = filepath.Join(mountDir, constants.EtcDirName)
+		renderScripts   = filepath.Join(mountDir, constants.ScriptsDirName)
+		renderManifests = filepath.Join(mountDir, constants.ManifestsDirName)
 	)
 
 	// currently only render once

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -39,10 +39,6 @@ func TryParse(text string) (*template.Template, bool, error) {
 	return tmp, !isFailed, err
 }
 
-func ParseFiles(filenames ...string) (*template.Template, error) {
-	return defaultTpl.ParseFiles(filenames...)
-}
-
 func Must(t *template.Template, err error) *template.Template {
 	return template.Must(t, err)
 }

--- a/pkg/utils/yaml/yaml.go
+++ b/pkg/utils/yaml/yaml.go
@@ -49,7 +49,7 @@ func unmarshalStrict(r io.Reader, obj interface{}) (err error) {
 			break
 		}
 		if rerr != nil {
-			return err
+			return rerr
 		}
 		if len(bytes.TrimSpace(buf)) == 0 {
 			continue


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7dff684</samp>

### Summary
🎨🐛📁

<!--
1.  🎨 for adding a new feature (render command) and improving the code structure and style.
2. 🐛 for fixing a bug in the yaml package.
3. 📁 for working with files and paths.
-->
This pull request improves the code quality and functionality of the sealos project. It simplifies the creation of init system subcommands, updates the rootfs package to use the `filepath` package and the `sealctl render` command, adds a new file matching function to the `file` package, implements a new render command for sealctl, removes an unused function from the template package, and fixes a bug in the yaml package.

> _`sealctl render` command_
> _adds template power to cmd_
> _autumn leaves fall fast_

### Walkthrough
*  Add a new render command for sealctl that renders template files with values and envs ([link](https://github.com/labring/sealos/pull/3872/files?diff=unified&w=0#diff-0d66e7d0a4f6f5e6ff0bccad74d41b3c45e03064ede5e8e8ddfb0ccb7ebab8f3R1-R125))
*  Refactor the init system commands to use a helper function that reduces code duplication and improves readability ([link](https://github.com/labring/sealos/pull/3872/files?diff=unified&w=0#diff-00c9ae9eb2d5e4b7bc481693c60c9d973c01cd2f06b8b292e1879ed81a1d40a2R21), [link](https://github.com/labring/sealos/pull/3872/files?diff=unified&w=0#diff-00c9ae9eb2d5e4b7bc481693c60c9d973c01cd2f06b8b292e1879ed81a1d40a2L34-R77), [link](https://github.com/labring/sealos/pull/3872/files?diff=unified&w=0#diff-00c9ae9eb2d5e4b7bc481693c60c9d973c01cd2f06b8b292e1879ed81a1d40a2L88-R84))
*  Execute the sealctl render command on the remote nodes after copying the files to the target directories in the rootfs package ([link](https://github.com/labring/sealos/pull/3872/files?diff=unified&w=0#diff-61493411683095682b775e1da8c4c1cca669f6a7807f480f6d747d4fb153fbe8L117-R117), [link](https://github.com/labring/sealos/pull/3872/files?diff=unified&w=0#diff-61493411683095682b775e1da8c4c1cca669f6a7807f480f6d747d4fb153fbe8L130-R135), [link](https://github.com/labring/sealos/pull/3872/files?diff=unified&w=0#diff-61493411683095682b775e1da8c4c1cca669f6a7807f480f6d747d4fb153fbe8L138-R155))
*  Remove the unused and redundant ParseFiles function from the template package ([link](https://github.com/labring/sealos/pull/3872/files?diff=unified&w=0#diff-4c6785786c3eaa4a21b69e4a2a47830bb533b95d63b5b6c5bf69bc7e2d76625cL42-L45))
*  Fix a bug in the unmarshalStrict function in the yaml package that returns the wrong error variable ([link](https://github.com/labring/sealos/pull/3872/files?diff=unified&w=0#diff-b8cb9511da408726e1d39ee9420fc9d8f485123ec17336d5148ad5990aedbf28L52-R52))
*  Replace the path package with the filepath package in the rootfs and file packages, which is more appropriate for manipulating file paths across different operating systems ([link](https://github.com/labring/sealos/pull/3872/files?diff=unified&w=0#diff-61493411683095682b775e1da8c4c1cca669f6a7807f480f6d747d4fb153fbe8L23-R24), [link](https://github.com/labring/sealos/pull/3872/files?diff=unified&w=0#diff-61493411683095682b775e1da8c4c1cca669f6a7807f480f6d747d4fb153fbe8L156-R174), [link](https://github.com/labring/sealos/pull/3872/files?diff=unified&w=0#diff-e85fc91bfb9efc098db62bbb76f08a44395448bc329ab4515dc672e38bc69797R24-R25))
*  Remove the unnecessary getClusterName function from the defaultRootfs struct ([link](https://github.com/labring/sealos/pull/3872/files?diff=unified&w=0#diff-61493411683095682b775e1da8c4c1cca669f6a7807f480f6d747d4fb153fbe8L49-L52))
*  Rename the variable clusterName to pathResolver in the rootfs package, which is more descriptive of its role as a path resolver for the cluster ([link](https://github.com/labring/sealos/pull/3872/files?diff=unified&w=0#diff-61493411683095682b775e1da8c4c1cca669f6a7807f480f6d747d4fb153fbe8L58-R60))
*  Add a TODO comment to remove the loop over the mounts when rendering on the client side is GA in the rootfs package, which indicates a future improvement plan ([link](https://github.com/labring/sealos/pull/3872/files?diff=unified&w=0#diff-61493411683095682b775e1da8c4c1cca669f6a7807f480f6d747d4fb153fbe8L58-R60))
*  Add the FindFilesMatchExtension function to the file package, which returns a slice of file paths that match the extensions ([link](https://github.com/labring/sealos/pull/3872/files?diff=unified&w=0#diff-e85fc91bfb9efc098db62bbb76f08a44395448bc329ab4515dc672e38bc69797R133-R166))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
