### PR TITLE
add default install of metrics-server

### DIFF
--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -43,6 +43,7 @@ sealos gen labring/kubernetes:v1.25.6\
     labring/cert-manager:v1.8.0\
     labring/openebs:v3.4.0\
     labring/kubernetes-reflector:v7.0.151\
+    labring/metrics-server:v0.6.4\
     labring/zot:v1.4.3\
     labring/kubeblocks:v0.5.3\
     --env policy=anonymousPolicy\

--- a/deploy/registry/install_base_server.md
+++ b/deploy/registry/install_base_server.md
@@ -27,7 +27,7 @@
 ### Init sealos cluster
 ```bash
 wget https://github.com/labring/sealos/releases/download/v4.1.3/sealos_4.1.3_linux_amd64.tar.gz && tar -zxvf sealos_4.1.3_linux_amd64.tar.gz sealos && chmod +x sealos && mv sealos /usr/bin
-sealos run labring/kubernetes:v1.24.0 labring/calico:v3.22.1 --masters xxx.xxx.xxx.xxx --nodes xxx.xxx.xxx.xxx --port 4238 -i ~/.ssh/id_ed25519
+sealos run labring/kubernetes:v1.24.0 labring/calico:v3.22.1 labring/metrics-server:v0.6.4 --masters xxx.xxx.xxx.xxx --nodes xxx.xxx.xxx.xxx --port 4238 -i ~/.ssh/id_ed25519
 ```
 
 ### Install base packages


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0382faa</samp>

### Summary
📊🚀🌱

<!--
1.  📊 - This emoji represents metrics, data, or charts, and can be used to indicate the addition of the metrics-server component.
2.  🚀 - This emoji represents deployment, launch, or speed, and can be used to indicate the modification of the sealos run command to include the metrics-server image.
3.  🌱 - This emoji represents growth, development, or improvement, and can be used to indicate the enhancement of the Kubernetes cluster functionality with the metrics-server.
-->
This pull request adds the `labring/metrics-server:v0.6.4` image to the sealos cluster deployment. This image enables resource metrics collection and horizontal pod autoscaling for Kubernetes.

> _`metrics-server` /_
> _Collects and exposes data /_
> _Autumn of scaling_

### Walkthrough
*  Add `labring/metrics-server:v0.6.4` image to Kubernetes setup and sealos cluster initialization ([link](https://github.com/labring/sealos/pull/3876/files?diff=unified&w=0#diff-e5a74fab87ec2353240365589f23b63386a45bbcdbf1512850a1fb07eee48742R46), [link](https://github.com/labring/sealos/pull/3876/files?diff=unified&w=0#diff-5dd88b176f4dc3b3195b387e9b877dc4e4a3c45ba35b12c9320daee47a6a059aL30-R30))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
