### PR TITLE
fix: ignore stderr output of sealctl render command

### DIFF
--- a/pkg/filesystem/rootfs/rootfs_default.go
+++ b/pkg/filesystem/rootfs/rootfs_default.go
@@ -152,7 +152,7 @@ func (f *defaultRootfs) mountRootfs(cluster *v2.Cluster, ipList []string) error 
 
 func getRenderCommand(binary string, target string) string {
 	// skip if sealctl doesn't has subcommand render
-	return fmt.Sprintf("%s render --debug=%v %s || true", binary,
+	return fmt.Sprintf("%s render --debug=%v %s 2>/dev/null || true", binary,
 		logger.IsDebugMode(),
 		strings.Join([]string{
 			filepath.Join(target, constants.EtcDirName),


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a58d847</samp>

### Summary
🐛🔧🚧

<!--
1.  🐛 - This emoji represents a bug fix, since the previous behavior of printing errors when the `sealctl render` command was not supported was undesirable and potentially confusing for the users.
2.  🔧 - This emoji represents a tooling or configuration change, since the `getRenderCommand` function is part of the internal logic of the `sealos` tool and the change affects how it interacts with the `sealctl` binary.
3.  🚧 - This emoji represents a work in progress, since the change is part of a larger pull request that aims to improve the compatibility of the `sealos` tool with different versions of `sealctl`, and there may be other changes or improvements needed before the pull request is ready to be merged.
-->
Improved compatibility with different `sealctl` versions by suppressing error output from `sealctl render` in `pkg/filesystem/rootfs/rootfs_default.go`.

> _`sealos` adapts_
> _to different `sealctl` versions_
> _silence the errors_

### Walkthrough
*  Suppress standard error output of `sealctl render` command to prevent unwanted errors when the command is not supported by the `sealctl` binary ([link](https://github.com/labring/sealos/pull/3881/files?diff=unified&w=0#diff-61493411683095682b775e1da8c4c1cca669f6a7807f480f6d747d4fb153fbe8L155-R155))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
