### PR TITLE
fix: auth image

### DIFF
--- a/service/auth/deploy/manifests/deploy.yaml
+++ b/service/auth/deploy/manifests/deploy.yaml
@@ -188,7 +188,7 @@ spec:
             capabilities:
               drop:
                 - "ALL"
-          image: labring/docker-casbin:main
+          image: labring4docker/casbin:main
           ports:
             - containerPort: 8080
               name: nginx


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b57cae5</samp>

### Summary
🐳🔄🧪

<!--
1.  🐳 - This emoji is often used to represent Docker or anything related to containers, so it could be used to indicate that the `image` field of the `casbin` container was changed to use a different Docker source.
2.  🔄 - This emoji is often used to represent updating, refreshing, or changing something, so it could be used to indicate that the `image` field of the `casbin` container was updated to use a different repository name.
3.  🧪 - This emoji is often used to represent testing, experimenting, or trying something new, so it could be used to indicate that the change was made to test the deployment of the `casbin` service using a different Docker image source.
-->
Updated the Docker image source for the `casbin` service in `service/auth/deploy/manifests/deploy.yaml`. This was done to test the deployment of the service using a different repository.

> _`casbin` image changed_
> _To test a different source_
> _Autumn of trials_

### Walkthrough
* Updated the `image` field of the `casbin` container to use a different repository name (`labring4docker`) for testing purposes ([link](https://github.com/labring/sealos/pull/3885/files?diff=unified&w=0#diff-fd2c9f86d940ff23d04ff9ab53d36959cfa4bf5d38379e4111be106f5c2b3ceaL191-R191))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
