### PR TITLE
fix: set runmode env for each host before rendering templates

### DIFF
--- a/pkg/types/v1beta1/cluster.go
+++ b/pkg/types/v1beta1/cluster.go
@@ -61,7 +61,7 @@ const (
 
 	ImageKubeVersionEnvSysKey   = "SEALOS_SYS_KUBE_VERSION"
 	ImageSealosVersionEnvSysKey = "SEALOS_SYS_SEALOS_VERSION"
-	ImageK3sModeEnvSysKey       = "SEALOS_SYS_K3S_MODE"
+	ImageRunModeEnvSysKey       = "SEALOS_SYS_RUN_MODE"
 )
 
 const (

--- a/pkg/types/v1beta1/utils.go
+++ b/pkg/types/v1beta1/utils.go
@@ -189,13 +189,12 @@ func (c *Cluster) GetAllLabels() map[string]string {
 }
 
 func (c *Cluster) GetRolesByIP(ip string) []string {
-	var routes []string
 	for _, host := range c.Spec.Hosts {
 		if slices.Contains(host.IPS, ip) {
 			return host.Roles
 		}
 	}
-	return routes
+	return nil
 }
 
 func (c *Cluster) GetDistribution() string {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 72c44c1</samp>

### Summary
🔧🐛🗑️

<!--
1.  🔧 for refactoring the code
2.  🐛 for fixing the error handling
3.  🗑️ for removing the unnecessary variable
-->
Refactored and improved the code for setting the run mode and environment variables for the rootfs image of cluster nodes. Fixed some minor issues in the utility functions for node labels and roles.

> _We are the cluster nodes, we have different roles_
> _We set our run modes with `ImageRunModeEnvSysKey`_
> _We don't need redundant code, we fix what we return_
> _We handle the nil rootfs, or else we crash and burn_

### Walkthrough
* Replace the `ImageK3sModeEnvSysKey` constant with the `ImageRunModeEnvSysKey` constant to support different run modes for the cluster nodes ([link](https://github.com/labring/sealos/pull/3886/files?diff=unified&w=0#diff-35334f6468e96f899bc4bf46cf748223d1df25bab6f89e5ee932f9776089f789L64-R64), [link](https://github.com/labring/sealos/pull/3886/files?diff=unified&w=0#diff-61493411683095682b775e1da8c4c1cca669f6a7807f480f6d747d4fb153fbe8L73), [link](https://github.com/labring/sealos/pull/3886/files?diff=unified&w=0#diff-61493411683095682b775e1da8c4c1cca669f6a7807f480f6d747d4fb153fbe8L119-R130))
* Declare and check the `rootfs` and `rootfsEnvs` variables to store the rootfs image and the merged environment variables from the `pkg/filesystem/rootfs/rootfs_default.go` file ([link](https://github.com/labring/sealos/pull/3886/files?diff=unified&w=0#diff-61493411683095682b775e1da8c4c1cca669f6a7807f480f6d747d4fb153fbe8R108-R115), [link](https://github.com/labring/sealos/pull/3886/files?diff=unified&w=0#diff-61493411683095682b775e1da8c4c1cca669f6a7807f480f6d747d4fb153fbe8L119-R130))
* Return an error if the rootfs image is nil in the `pkg/filesystem/rootfs/rootfs_default.go` file ([link](https://github.com/labring/sealos/pull/3886/files?diff=unified&w=0#diff-61493411683095682b775e1da8c4c1cca669f6a7807f480f6d747d4fb153fbe8R21), [link](https://github.com/labring/sealos/pull/3886/files?diff=unified&w=0#diff-61493411683095682b775e1da8c4c1cca669f6a7807f480f6d747d4fb153fbe8R108-R115))
* Remove the unused and redundant `routes` variable from the `GetAllLabels` and `GetRolesByIP` functions in the `pkg/types/v1beta1/utils.go` file ([link](https://github.com/labring/sealos/pull/3886/files?diff=unified&w=0#diff-24d4208e4143491e275db180879b141295e21323990c368f7530ba4124c00441L192), [link](https://github.com/labring/sealos/pull/3886/files?diff=unified&w=0#diff-24d4208e4143491e275db180879b141295e21323990c368f7530ba4124c00441L198-R197))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
