### PR TITLE
fix: write ip without port to hosts file

### DIFF
--- a/pkg/bootstrap/applier.go
+++ b/pkg/bootstrap/applier.go
@@ -20,6 +20,12 @@ type Applier interface {
 	Undo(Context, string) error
 }
 
+type common struct{}
+
+func (c *common) Filter(Context, string) bool { return true }
+func (c *common) Apply(Context, string) error { return nil }
+func (c *common) Undo(Context, string) error  { return nil }
+
 var (
 	defaultPreflights   []Applier
 	defaultInitializers []Applier

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -127,14 +127,10 @@ func runParallel(hosts []string, fn func(string) error) error {
 	return eg.Wait()
 }
 
-type defaultChecker struct {
-}
+type defaultChecker struct{ common }
 
 func (c *defaultChecker) String() string {
 	return "default_checker"
-}
-func (c *defaultChecker) Filter(_ Context, _ string) bool {
-	return true
 }
 
 func (c *defaultChecker) Apply(ctx Context, host string) error {
@@ -142,17 +138,9 @@ func (c *defaultChecker) Apply(ctx Context, host string) error {
 	return ctx.GetExecer().CmdAsync(host, cmds...)
 }
 
-func (c *defaultChecker) Undo(_ Context, _ string) error {
-	return nil
-}
-
-type defaultInitializer struct{}
+type defaultInitializer struct{ common }
 
 func (*defaultInitializer) String() string { return "initializer" }
-
-func (initializer *defaultInitializer) Filter(_ Context, _ string) bool {
-	return true
-}
 
 func (initializer *defaultInitializer) Apply(ctx Context, host string) error {
 	cmds := []string{ctx.GetBash().InitBash(host)}

--- a/pkg/bootstrap/cri.go
+++ b/pkg/bootstrap/cri.go
@@ -18,13 +18,9 @@ package bootstrap
 
 import "github.com/labring/sealos/pkg/utils/logger"
 
-type defaultCRIInitializer struct{}
+type defaultCRIInitializer struct{ common }
 
 func (*defaultCRIInitializer) String() string { return "cri_initializer" }
-
-func (initializer *defaultCRIInitializer) Filter(_ Context, _ string) bool {
-	return true
-}
 
 func (initializer *defaultCRIInitializer) Apply(ctx Context, host string) error {
 	initCRI := ctx.GetBash().InitCRIBash(host)

--- a/pkg/bootstrap/hosts.go
+++ b/pkg/bootstrap/hosts.go
@@ -22,15 +22,12 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/labring/sealos/pkg/constants"
+	"github.com/labring/sealos/pkg/utils/iputils"
 )
 
-type apiServerHostApplier struct {
-}
+type apiServerHostApplier struct{ common }
 
 func (*apiServerHostApplier) String() string { return "apiserver_host_applier" }
-func (*apiServerHostApplier) Filter(_ Context, _ string) bool {
-	return true
-}
 
 func (*apiServerHostApplier) Undo(ctx Context, host string) error {
 	return ctx.GetRemoter().HostsDelete(host, constants.DefaultAPIServerDomain)
@@ -50,10 +47,10 @@ func (a *apiServerHostApplier) Apply(ctx Context, host string) error {
 	return nil
 }
 
-type lvscareHostApplier struct {
-}
+type lvscareHostApplier struct{}
 
 func (*lvscareHostApplier) String() string { return "lvscare_host_applier" }
+
 func (*lvscareHostApplier) Filter(ctx Context, host string) bool {
 	return slices.Contains(ctx.GetCluster().GetNodeIPAndPortList(), host)
 }
@@ -63,9 +60,8 @@ func (*lvscareHostApplier) Undo(ctx Context, host string) error {
 }
 
 func (a *lvscareHostApplier) Apply(ctx Context, host string) error {
-	if err := ctx.GetRemoter().HostsAdd(host, host, constants.DefaultLvscareDomain); err != nil {
+	if err := ctx.GetRemoter().HostsAdd(host, iputils.GetHostIP(host), constants.DefaultLvscareDomain); err != nil {
 		return fmt.Errorf("failed to add hosts: %v", err)
 	}
-
 	return nil
 }

--- a/pkg/bootstrap/registry.go
+++ b/pkg/bootstrap/registry.go
@@ -57,13 +57,9 @@ func (*registryApplier) Undo(ctx Context, host string) error {
 	return ctx.GetExecer().CmdAsync(host, ctx.GetBash().CleanRegistryBash(host))
 }
 
-type registryHostApplier struct {
-}
+type registryHostApplier struct{ common }
 
 func (*registryHostApplier) String() string { return "registry_host_applier" }
-func (*registryHostApplier) Filter(_ Context, _ string) bool {
-	return true
-}
 
 func (*registryHostApplier) Undo(ctx Context, host string) error {
 	rc := helpers.GetRegistryInfo(ctx.GetExecer(), ctx.GetPathResolver().RootFSPath(), ctx.GetCluster().GetRegistryIPAndPort())


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 14445f2</samp>

### Summary
🚚🧹🐛

<!--
1.  🚚 - This emoji can be used to represent the moving of the type definitions from one file to another, as well as the refactoring of the code organization.
2.  🧹 - This emoji can be used to represent the cleaning up of the code duplication and the inheritance of the common methods from the `common` type.
3.  🐛 - This emoji can be used to represent the bug fix in the lvscare host applier.
-->
Refactor the `Applier` interface implementation and fix a bug in the lvscare host applier. Move the common methods of the `Applier` interface to a `common` type and embed it in other types that implement the interface. Move the type definitions to `applier.go` for better code organization.

> _Sing, O Muse, of the cunning refactorer_
> _Who moved and merged the types of `Applier`_
> _And gave them `common` as a benefactor_
> _To share the methods of the code supplier._

### Walkthrough
*  Refactor the types that implement the `Applier` interface to reduce code duplication and group them in `applier.go` ([link](https://github.com/labring/sealos/pull/3892/files?diff=unified&w=0#diff-de3f26f1624eee8c44e5b03991adef119123ff04ca1687ac72ce41d621588a22R23-R28), [link](https://github.com/labring/sealos/pull/3892/files?diff=unified&w=0#diff-ba5ce63d433715b7982a090186e3222e3a36d0d7a23a8976225c794b6a0b4c96L130-R134), [link](https://github.com/labring/sealos/pull/3892/files?diff=unified&w=0#diff-ba5ce63d433715b7982a090186e3222e3a36d0d7a23a8976225c794b6a0b4c96L145-R144), [link](https://github.com/labring/sealos/pull/3892/files?diff=unified&w=0#diff-2cf6377a14226cab5d78d1d3eafb360477aa4c36a8a56871ed6380543193fb50L21-R24), [link](https://github.com/labring/sealos/pull/3892/files?diff=unified&w=0#diff-caa721aa93cd55783ffe267cb9b8c0356fb179d4e21c49b0cef6bfdd5291dee8L25-R30), [link](https://github.com/labring/sealos/pull/3892/files?diff=unified&w=0#diff-337930c144a821682f59a69de1fff15c27eb379c4f61d9a5f3e3be34002f9c28L60-R62))
*  Fix a bug in the `Apply` method of the `lvscareHostApplier` type to use the correct IP address of the host in the hosts file ([link](https://github.com/labring/sealos/pull/3892/files?diff=unified&w=0#diff-caa721aa93cd55783ffe267cb9b8c0356fb179d4e21c49b0cef6bfdd5291dee8L66-R65))
*  Move the definition of the `lvscareHostApplier` type to `applier.go` and override the `Filter` method with a different logic ([link](https://github.com/labring/sealos/pull/3892/files?diff=unified&w=0#diff-caa721aa93cd55783ffe267cb9b8c0356fb179d4e21c49b0cef6bfdd5291dee8L53-R53))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
