### PR TITLE
fix bugs of licenseissuer deploy

### DIFF
--- a/controllers/licenseissuer/deploy/manifests/customconfig.yaml.tmpl
+++ b/controllers/licenseissuer/deploy/manifests/customconfig.yaml.tmpl
@@ -19,7 +19,7 @@ data:
       "RegisterURL": "{{ .RegisterURL }}",
       "CloudSyncURL": "{{ .CloudSyncURL }}",
       "LicenseMonitorURL": "{{ .LicenseMonitorURL }}",
-      "NetworkProbeURL": "{{ .NetworkProbeURL }}",
+      "NetworkProbeURL": "{{ .NetworkProbeURL }}"
     }
 kind: ConfigMap
 metadata:

--- a/controllers/licenseissuer/preset/main.go
+++ b/controllers/licenseissuer/preset/main.go
@@ -43,7 +43,7 @@ func main() {
 		logger.Error(err, "Failed to preset root user")
 		return
 	}
-	logger.Error(err, "Failed to preset root user")
+	logger.Info("Preset root user successfully")
 }
 
 const (


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6e2d9ae</samp>

### Summary
🐛🚀📝

<!--
1.  🐛 - This emoji represents a bug fix, which is what the syntax fix for the JSON object is.
2.  🚀 - This emoji represents a performance improvement, which is what the logic fix for the log message is. By avoiding logging an error when there is none, the license issuer controller can perform better and avoid unnecessary noise in the logs.
3.  📝 - This emoji represents a documentation update, which is what the wording change for the log message is. By using more accurate and clear language, the license issuer controller can communicate its status better to the users and developers.
-->
Fix syntax and logic issues in the license issuer controller. Remove a trailing comma in `customconfig.yaml.tmpl` and change an erroneous log message in `main.go`.

> _`customconfig` fixed_
> _JSON syntax and logic_
> _Autumn of errors_

### Walkthrough
* Fix JSON syntax error in `customconfig.yaml.tmpl` by removing trailing comma ([link](https://github.com/labring/sealos/pull/3895/files?diff=unified&w=0#diff-7c1a18ed4f66152a3b9b5662b44117b6df2431c05a5f1c3242ef1586a6eb3524L22-R22))
* Change log level and message for root user preset success in `main.go` to avoid false error ([link](https://github.com/labring/sealos/pull/3895/files?diff=unified&w=0#diff-c903e68ded14407cea1f09e2b5518cb0ec596130c6e0bf6d74597a5006199938L46-R46))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
