### PR TITLE
fix: skip same path

### DIFF
--- a/pkg/utils/file/file_v2.go
+++ b/pkg/utils/file/file_v2.go
@@ -157,6 +157,9 @@ func WriteFile(fileName string, content []byte) error {
 
 // RecursionCopy equals to `cp -r`
 func RecursionCopy(src, dst string) error {
+	if src == dst {
+		return nil
+	}
 	if IsDir(src) {
 		return CopyDirV3(src, dst)
 	}


### PR DESCRIPTION
skip cp when the target file is the same