### PR TITLE
fix: get remote kubeconfig path with $HOME variable

### DIFF
--- a/pkg/runtime/kubernetes/runtime.go
+++ b/pkg/runtime/kubernetes/runtime.go
@@ -102,7 +102,7 @@ func (k *KubeadmRuntime) ScaleUp(newMasterIPList []string, newNodeIPList []strin
 		if err := k.joinNodes(newNodeIPList); err != nil {
 			return err
 		}
-		return k.copyKubeConfigFileToNodes(newNodeIPList)
+		return k.copyKubeConfigFileToNodes(newNodeIPList...)
 	}
 	return nil
 }

--- a/pkg/ssh/scp.go
+++ b/pkg/ssh/scp.go
@@ -108,6 +108,10 @@ func (c *Client) sftpConnect(host string) (sshClient *ssh.Client, sftpClient *sf
 // Copy is copy file or dir to remotePath, add md5 validate
 func (c *Client) Copy(host, localPath, remotePath string) error {
 	if c.isLocalAction(host) {
+		if !filepath.IsAbs(localPath) || !filepath.IsAbs(remotePath) {
+			logger.Warn(`either the local path or the remote path is not an absolute path, `+
+				`copy might not work as expected.`, localPath, remotePath)
+		}
 		logger.Debug("local %s copy files src %s to dst %s", host, localPath, remotePath)
 		return file.RecursionCopy(localPath, remotePath)
 	}

--- a/pkg/utils/file/file_v3.go
+++ b/pkg/utils/file/file_v3.go
@@ -210,6 +210,7 @@ func CopyDirV3(srcPath, destPath string, filters ...func(filePath string) bool) 
 
 // Copy copies file from source to target path.
 func Copy(src, dest string) error {
+	_ = os.Remove(dest)
 	// Gather file information to set back later.
 	si, err := os.Lstat(src)
 	if err != nil {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c678e8e</samp>

### Summary
🐛🚨♻️

<!--
1.  🐛 - This emoji represents a bug fix, which is the case for the change in the `CopyDirV3` function that removes the destination directory before copying the source directory.
2.  🚨 - This emoji represents a warning or an alert, which is the case for the change in the `Copy` function that adds a warning message if the paths are not absolute.
3.  ♻️ - This emoji represents a refactor or a code improvement, which is the case for the changes in the `k3s` package that use the `filepath` and `errgroup` packages, simplify the function signatures, and remove unused code.
-->
This pull request improves the file copying logic and cross-platform compatibility of the `k3s` and `kubernetes` packages. It also adds a warning message to the `scp` package and fixes a bug in the `file` package. The main files affected are `pkg/runtime/k3s/bootstrap.go`, `pkg/runtime/kubernetes/kubeconfig.go`, `pkg/runtime/kubernetes/runtime.go`, `pkg/ssh/scp.go`, and `pkg/utils/file/file_v3.go`.

> _To scale up the cluster with ease_
> _We copy the kube config to nodes with `...`_
> _We warn if the paths are not absolute_
> _And remove the dest dir to avoid dispute_
> _We also refactor the `k3s` code with `filepath` and `errgroup` keys_

### Walkthrough
*  Replace `copyKubeConfigFileToAllNodes` function with `copyKubeConfigFileToNodes` function in `k3s` and `kubernetes` packages ([link](https://github.com/labring/sealos/pull/3906/files?diff=unified&w=0#diff-481ba56b502b479282760464d0c78dc1ed197cbf81f028a7621396ac66d11457L41-R39),[link](https://github.com/labring/sealos/pull/3906/files?diff=unified&w=0#diff-481ba56b502b479282760464d0c78dc1ed197cbf81f028a7621396ac66d11457L100-R98),[link](https://github.com/labring/sealos/pull/3906/files?diff=unified&w=0#diff-481ba56b502b479282760464d0c78dc1ed197cbf81f028a7621396ac66d11457L123-R121),[link](https://github.com/labring/sealos/pull/3906/files?diff=unified&w=0#diff-481ba56b502b479282760464d0c78dc1ed197cbf81f028a7621396ac66d11457L196-R205),[link](https://github.com/labring/sealos/pull/3906/files?diff=unified&w=0#diff-1a58d81796123e7aedd8187d415bd0a728390559c4272712445ca3def343c7eaL19-R42),[link](https://github.com/labring/sealos/pull/3906/files?diff=unified&w=0#diff-e2c95ead191fa195332452118677e193cabcd0b8f6321096050fc69ba84a98feL105-R105))
* Add warning message to `Copy` function in `scp` package if local or remote path is not absolute ([link](https://github.com/labring/sealos/pull/3906/files?diff=unified&w=0#diff-b16c36d4f08b48cbf3c1ea3ba2e4cc74463e7581ea73b0827620e04841061051R111-R114))
* Fix bug in `CopyDirV3` function in `file` package by removing destination directory before copying source directory ([link](https://github.com/labring/sealos/pull/3906/files?diff=unified&w=0#diff-7796d87590d9d286299b72efe7f36682bfa234554c3749e2762efb386ccc6c20R213))
* Remove unused `path` package from `k3s` package ([link](https://github.com/labring/sealos/pull/3906/files?diff=unified&w=0#diff-481ba56b502b479282760464d0c78dc1ed197cbf81f028a7621396ac66d11457L20))
* Remove empty line from `k3s` package to improve code formatting and readability ([link](https://github.com/labring/sealos/pull/3906/files?diff=unified&w=0#diff-481ba56b502b479282760464d0c78dc1ed197cbf81f028a7621396ac66d11457L26))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
