### PR TITLE
fix(main): delete .kube dir for all nodes

### DIFF
--- a/pkg/runtime/k3s/lifecycle.go
+++ b/pkg/runtime/k3s/lifecycle.go
@@ -41,6 +41,11 @@ func (k *K3s) resetNodes(nodes []string) error {
 
 func (k *K3s) resetNode(host string) error {
 	logger.Info("start to reset node: %s", host)
+	removeKubeConfig := "rm -rf $HOME/.kube"
+	removeKubeConfigErr := k.sshClient.CmdAsync(host, removeKubeConfig)
+	if removeKubeConfigErr != nil {
+		logger.Error("failed to clean node, exec command %s failed, %v", removeKubeConfig, removeKubeConfigErr)
+	}
 	if slices.Contains(k.cluster.GetNodeIPList(), host) {
 		vipAndPort := fmt.Sprintf("%s:%d", k.cluster.GetVIP(), k.config.APIServerPort)
 		ipvscleanErr := k.remoteUtil.IPVSClean(host, vipAndPort)

--- a/pkg/runtime/kubernetes/reset.go
+++ b/pkg/runtime/kubernetes/reset.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	removeKubeConfig        = "rm -rf .kube"
+	removeKubeConfig        = "rm -rf $HOME/.kube"
 	remoteCleanMasterOrNode = `if which kubeadm;then kubeadm reset -f %s;fi && \
 rm -rf /etc/kubernetes/ && \
 rm -rf /etc/cni && rm -rf /opt/cni && \
@@ -68,7 +68,7 @@ func (k *KubeadmRuntime) resetMasters(nodes []string) {
 func (k *KubeadmRuntime) resetNode(node string, cleanHook func()) error {
 	logger.Info("start to reset node: %s", node)
 	resetCmd := fmt.Sprintf(remoteCleanMasterOrNode, vlogToStr(k.klogLevel), k.getEtcdDataDir())
-	removeKubeConfigErr := k.sshCmdAsync(node, removeKubeConfig)
+
 	resetCmdErr := k.sshCmdAsync(node, resetCmd)
 	if cleanHook != nil {
 		cleanHook()
@@ -77,6 +77,7 @@ func (k *KubeadmRuntime) resetNode(node string, cleanHook func()) error {
 	if resetCmdErr != nil {
 		logger.Error("failed to clean node, exec command %s failed, %v", resetCmd, resetCmdErr)
 	}
+	removeKubeConfigErr := k.sshCmdAsync(node, removeKubeConfig)
 	if removeKubeConfigErr != nil {
 		logger.Error("failed to clean node, exec command %s failed, %v", removeKubeConfig, removeKubeConfigErr)
 	}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8972ff7</samp>

### Summary
🧹🔐🐮

<!--
1.  🧹 - This emoji represents cleaning or tidying up, which is what the new step does by removing the `.kube` directory.
2.  🔐 - This emoji represents security or privacy, which is related to the removal of the k3s credentials and configuration files that may be stored in the `.kube` directory.
3.  🐮 - This emoji represents k3s, which is the name of the lightweight Kubernetes distribution that is the subject of this change.
-->
This pull request improves the node reset functionality for both `kubernetes` and `k3s` packages, by ensuring that the `.kube` directory is properly removed from the nodes. This prevents potential conflicts or security issues with leftover configuration files and credentials.

> _We are the masters of the nodes_
> _We purge them of their secrets_
> _We wield the `sshClient` as our sword_
> _We execute the `rm -rf`_

### Walkthrough
*  Remove `.kube` directory from node's home directory after uninstalling k3s ([link](https://github.com/labring/sealos/pull/3911/files?diff=unified&w=0#diff-18b1fd2bd860036843fa344a0cd7d1ab962be73078b9afdad30e9835009da6afR44-R52), [link](https://github.com/labring/sealos/pull/3911/files?diff=unified&w=0#diff-7900a011ff8023dc4a89534df78af40b157162140492b82915924b265b7c5396L71-R71), [link](https://github.com/labring/sealos/pull/3911/files?diff=unified&w=0#diff-7900a011ff8023dc4a89534df78af40b157162140492b82915924b265b7c5396L80-R86))
* Update `removeKubeConfig` constant to take node's home directory as an argument ([link](https://github.com/labring/sealos/pull/3911/files?diff=unified&w=0#diff-7900a011ff8023dc4a89534df78af40b157162140492b82915924b265b7c5396L28-R28))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
