### PR TITLE
fix: disable scp checksum by default

### DIFF
--- a/pkg/system/env.go
+++ b/pkg/system/env.go
@@ -85,7 +85,7 @@ var configOptions = []ConfigOption{
 	{
 		Key:          ScpChecksumConfigKey,
 		Description:  "whether to check the md5sum value is consistent during the copy process.",
-		DefaultValue: "true",
+		DefaultValue: "false",
 	},
 	{
 		Key:         ContainerStorageConfEnvKey,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b7b0a4b</samp>

### Summary
🚀🛠️🔧

<!--
1.  🚀 - This emoji can be used to indicate a performance improvement or a speed boost, which is one of the goals of the pull request and the change to the default value of the configuration key.
2.  🛠️ - This emoji can be used to indicate a bug fix or a maintenance work, which is another goal of the pull request and the change to the reliability of the copy process.
3.  🔧 - This emoji can be used to indicate a configuration change or a tweak, which is the actual effect of the change to the default value of the configuration key.
-->
Changed the default behavior of the sealos tool to skip md5sum checks when copying files to remote nodes. This improves the performance and reliability of the installation and upgrade of Kubernetes clusters with `pkg/system/env.go`.

> _`ScpChecksumConfigKey`_
> _False by default, faster copy_
> _Autumn leaves fall gently_

### Walkthrough
* Change the default value of `ScpChecksumConfigKey` to `false` to improve the copy performance and reliability ([link](https://github.com/labring/sealos/pull/3913/files?diff=unified&w=0#diff-eaaf2377b1fb084a0d060b3f7191ba1fb3760d54285aec3aa4b0ace2486d3bf8L88-R88))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
