### PR TITLE
feature: kubefile CMD support ENV values with "${...}" and "$..." format

### DIFF
--- a/pkg/guest/guest_test.go
+++ b/pkg/guest/guest_test.go
@@ -135,3 +135,223 @@ func TestDefault_getGuestCmd(t *testing.T) {
 		})
 	}
 }
+
+func TestDefault_getGuestCmd_dollarBraceVariable(t *testing.T) {
+	shell := func(cName, containerName, cmd string) string {
+		return fmt.Sprintf(constants.CdAndExecCmd, constants.GetAppWorkDir(cName, containerName), cmd)
+	}
+	type fields struct {
+	}
+	type args struct {
+		envs    map[string]string
+		cluster *v2.Cluster
+		mounts  []v2.MountImage
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   []string
+	}{
+		{
+			name:   "default",
+			fields: fields{},
+			args: args{
+				envs:    map[string]string{},
+				cluster: &v2.Cluster{Spec: v2.ClusterSpec{Command: nil}},
+				mounts: []v2.MountImage{
+					{
+						Cmd:        []string{"IFACE=${IFACE} bash ovn-install.sh"},
+						Entrypoint: nil,
+						Env:        map[string]string{"IFACE": "cccc"},
+					},
+				},
+			},
+			want: []string{shell("", "", "IFACE=cccc bash ovn-install.sh")},
+		},
+
+		{
+			name:   "default-env",
+			fields: fields{},
+			args: args{
+				envs:    map[string]string{},
+				cluster: &v2.Cluster{Spec: v2.ClusterSpec{Command: nil}},
+				mounts: []v2.MountImage{
+					{
+						Cmd:        []string{"IFACE=\"${IFACE}\" bash ovn-install.sh"},
+						Entrypoint: nil,
+						Env:        map[string]string{"IFACE": "eth.*|en.*"},
+					},
+				},
+			},
+			want: []string{shell("", "", "IFACE=\"eth.*|en.*\" bash ovn-install.sh")},
+		},
+		{
+			name:   "default-env-override",
+			fields: fields{},
+			args: args{
+				envs:    map[string]string{"IFACE": "default"},
+				cluster: &v2.Cluster{Spec: v2.ClusterSpec{Command: nil}},
+				mounts: []v2.MountImage{
+					{
+						Cmd:        []string{"IFACE=\"${IFACE}\" bash ovn-install.sh"},
+						Entrypoint: nil,
+						Env:        map[string]string{"IFACE": "eth.*|en.*"},
+					},
+				},
+			},
+			want: []string{shell("", "", "IFACE=\"default\" bash ovn-install.sh")},
+		},
+		{
+			name:   "default-cmd-override",
+			fields: fields{},
+			args: args{
+				envs:    map[string]string{"IFACE": "default"},
+				cluster: &v2.Cluster{Spec: v2.ClusterSpec{Command: []string{"IFACE=\"${IFACE}\" sh ovn-install.sh"}}},
+				mounts: []v2.MountImage{
+					{
+						Cmd:        []string{"IFACE=\"${IFACE}\" bash ovn-install.sh"},
+						Entrypoint: nil,
+						Env:        map[string]string{"IFACE": "eth.*|en.*"},
+					},
+				},
+			},
+			want: []string{shell("", "", "IFACE=\"default\" sh ovn-install.sh")},
+		},
+		{
+			name:   "default-entrypoint-cmd-override",
+			fields: fields{},
+			args: args{
+				envs:    map[string]string{"IFACE": "default"},
+				cluster: &v2.Cluster{Spec: v2.ClusterSpec{Command: []string{"IFACE=\"${IFACE}\" sh ovn-install.sh"}}},
+				mounts: []v2.MountImage{
+					{
+						Cmd:        []string{"IFACE=\"${IFACE}\" bash ovn-install.sh"},
+						Entrypoint: []string{"AA=${IFACE}"},
+						Env:        map[string]string{"IFACE": "eth.*|en.*"},
+					},
+				},
+			},
+			want: []string{shell("", "", "AA=default"), shell("", "", "IFACE=\"default\" sh ovn-install.sh")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for i := range tt.args.mounts {
+				if got := formalizeImageCommands(tt.args.cluster, i, tt.args.mounts[i], tt.args.envs); !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("getGuestCmd() = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestDefault_getGuestCmd_dollarVariable(t *testing.T) {
+	shell := func(cName, containerName, cmd string) string {
+		return fmt.Sprintf(constants.CdAndExecCmd, constants.GetAppWorkDir(cName, containerName), cmd)
+	}
+	type fields struct {
+	}
+	type args struct {
+		envs    map[string]string
+		cluster *v2.Cluster
+		mounts  []v2.MountImage
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   []string
+	}{
+		{
+			name:   "default",
+			fields: fields{},
+			args: args{
+				envs:    map[string]string{},
+				cluster: &v2.Cluster{Spec: v2.ClusterSpec{Command: nil}},
+				mounts: []v2.MountImage{
+					{
+						Cmd:        []string{"IFACE=$IFACE bash ovn-install.sh"},
+						Entrypoint: nil,
+						Env:        map[string]string{"IFACE": "cccc"},
+					},
+				},
+			},
+			want: []string{shell("", "", "IFACE=cccc bash ovn-install.sh")},
+		},
+
+		{
+			name:   "default-env",
+			fields: fields{},
+			args: args{
+				envs:    map[string]string{},
+				cluster: &v2.Cluster{Spec: v2.ClusterSpec{Command: nil}},
+				mounts: []v2.MountImage{
+					{
+						Cmd:        []string{"IFACE=\"$IFACE\" bash ovn-install.sh"},
+						Entrypoint: nil,
+						Env:        map[string]string{"IFACE": "eth.*|en.*"},
+					},
+				},
+			},
+			want: []string{shell("", "", "IFACE=\"eth.*|en.*\" bash ovn-install.sh")},
+		},
+		{
+			name:   "default-env-override",
+			fields: fields{},
+			args: args{
+				envs:    map[string]string{"IFACE": "default"},
+				cluster: &v2.Cluster{Spec: v2.ClusterSpec{Command: nil}},
+				mounts: []v2.MountImage{
+					{
+						Cmd:        []string{"IFACE=\"$IFACE\" bash ovn-install.sh"},
+						Entrypoint: nil,
+						Env:        map[string]string{"IFACE": "eth.*|en.*"},
+					},
+				},
+			},
+			want: []string{shell("", "", "IFACE=\"default\" bash ovn-install.sh")},
+		},
+		{
+			name:   "default-cmd-override",
+			fields: fields{},
+			args: args{
+				envs:    map[string]string{"IFACE": "default"},
+				cluster: &v2.Cluster{Spec: v2.ClusterSpec{Command: []string{"IFACE=\"$IFACE\" sh ovn-install.sh"}}},
+				mounts: []v2.MountImage{
+					{
+						Cmd:        []string{"IFACE=\"$IFACE\" bash ovn-install.sh"},
+						Entrypoint: nil,
+						Env:        map[string]string{"IFACE": "eth.*|en.*"},
+					},
+				},
+			},
+			want: []string{shell("", "", "IFACE=\"default\" sh ovn-install.sh")},
+		},
+		{
+			name:   "default-entrypoint-cmd-override",
+			fields: fields{},
+			args: args{
+				envs:    map[string]string{"IFACE": "default"},
+				cluster: &v2.Cluster{Spec: v2.ClusterSpec{Command: []string{"IFACE=\"$IFACE\" sh ovn-install.sh"}}},
+				mounts: []v2.MountImage{
+					{
+						Cmd:        []string{"IFACE=\"$IFACE\" bash ovn-install.sh"},
+						Entrypoint: []string{"AA=$IFACE"},
+						Env:        map[string]string{"IFACE": "eth.*|en.*"},
+					},
+				},
+			},
+			want: []string{shell("", "", "AA=default"), shell("", "", "IFACE=\"default\" sh ovn-install.sh")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for i := range tt.args.mounts {
+				if got := formalizeImageCommands(tt.args.cluster, i, tt.args.mounts[i], tt.args.envs); !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("getGuestCmd() = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b065a77</samp>

### Summary
🆕🛠️✅

<!--
1.  🆕 for adding new test functions and supporting new syntaxes for variable expansion.
2.  🛠️ for modifying the `tryReadVariableName` function and renaming and adding some constants.
3.  ✅ for testing the behavior of the `getGuestCmd` function with different variable expressions.
-->
This pull request adds new syntax options for variable expansion in the `expansion` package and the `getGuestCmd` function. It also updates the `expand.go` file and adds tests to the `guest_test.go` file to reflect the changes. The new syntaxes allow more flexibility and convenience for users who want to use variables in their cluster commands or mount images.

> _`getGuestCmd` tests_
> _new syntax for variables_
> _autumn of expansion_

### Walkthrough
*  Rename constants and add new ones to support two variable expansion syntaxes: `$()` and `${}` ([link](https://github.com/labring/sealos/pull/3921/files?diff=unified&w=0#diff-2b511e54070c7b67724c80bcd45f95c6f2845996ba9a582828b407eb6220a15aL5-R18))
*  Modify `tryReadVariableName` to use the renamed constants and handle the new syntaxes ([link](https://github.com/labring/sealos/pull/3921/files?diff=unified&w=0#diff-2b511e54070c7b67724c80bcd45f95c6f2845996ba9a582828b407eb6220a15aL86-R92), [link](https://github.com/labring/sealos/pull/3921/files?diff=unified&w=0#diff-2b511e54070c7b67724c80bcd45f95c6f2845996ba9a582828b407eb6220a15aL95-R124))
*  Add test functions to check `getGuestCmd` with different variable expressions in `pkg/guest/guest_test.go` ([link](https://github.com/labring/sealos/pull/3921/files?diff=unified&w=0#diff-584ab11eb7d0a4111ffe9dcff2d10b88f5a2b0ced0d2ef9b8bd0fa9fff54a04aR138-R357))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->

refer to #3853 
