### PR TITLE
feat(applaunchpad, dbprovider, template):support multi ns

### DIFF
--- a/frontend/packages/client-sdk/src/master.ts
+++ b/frontend/packages/client-sdk/src/master.ts
@@ -55,8 +55,10 @@ class MasterSDK {
     return {
       user: {
         id: session.user.userId,
+        k8sUsername: session.user.k8s_username,
         name: session.user.name,
-        avatar: session.user.avatar
+        avatar: session.user.avatar,
+        nsid: session.user.nsid
       },
       kubeconfig: session.kubeconfig
     };

--- a/frontend/packages/client-sdk/src/types/user.d.ts
+++ b/frontend/packages/client-sdk/src/types/user.d.ts
@@ -30,11 +30,13 @@ export type UserQuotaItemType = {
   limit: number;
 };
 
-export type UserInfoV1 = {
-  readonly id: string;
-  readonly name: string;
-  readonly avatar: string;
-};
+export type UserInfoV1 = Readonly<{
+  id: string;
+  name: string;
+  avatar: string;
+  k8sUsername: string;
+  nsid: string;
+}>;
 
 export type SessionV1 = {
   token?: OAuthToken;

--- a/frontend/packages/client-sdk/src/utils/kubernetes.ts
+++ b/frontend/packages/client-sdk/src/utils/kubernetes.ts
@@ -266,7 +266,7 @@ export async function initK8s({ req }: { req: { headers: IncomingHttpHeaders } }
     return Promise.reject('User is null');
   }
 
-  const namespace = `ns-${kube_user.name}`;
+  const namespace = kc.contexts[0].namespace || `ns-${kube_user.name}`;
 
   return Promise.resolve({
     kc,

--- a/frontend/providers/applaunchpad/src/services/backend/kubernetes.ts
+++ b/frontend/providers/applaunchpad/src/services/backend/kubernetes.ts
@@ -195,7 +195,7 @@ export async function getK8s({ kubeconfig }: { kubeconfig: string }) {
     return Promise.reject('用户不存在');
   }
 
-  const namespace = `ns-${kube_user.name}`;
+  const namespace = kc.contexts[0].namespace || `ns-${kube_user.name}`;
 
   const applyYamlList = async (yamlList: string[], type: 'create' | 'replace') => {
     // insert namespace

--- a/frontend/providers/applaunchpad/src/utils/user.ts
+++ b/frontend/providers/applaunchpad/src/utils/user.ts
@@ -18,7 +18,7 @@ export const getUserNamespace = () => {
   const kubeConfig = getUserKubeConfig();
   const json: any = yaml.load(kubeConfig);
   try {
-    return `ns-${json.users[0].name}`;
+    return json?.contexts[0]?.context?.namespace || `ns-${json.users[0].name}`;
   } catch (err) {
     return 'nx-';
   }

--- a/frontend/providers/dbprovider/src/services/backend/kubernetes.ts
+++ b/frontend/providers/dbprovider/src/services/backend/kubernetes.ts
@@ -212,7 +212,7 @@ export async function getK8s({ kubeconfig }: { kubeconfig: string }) {
     return Promise.reject('用户不存在');
   }
 
-  const namespace = GetUserDefaultNameSpace(kube_user.name);
+  const namespace = kc.contexts[0].namespace || GetUserDefaultNameSpace(kube_user.name);
 
   const applyYamlList = async (yamlList: string[], type: 'create' | 'replace' | 'update') => {
     // insert namespace

--- a/frontend/providers/template/src/services/backend/kubernetes.ts
+++ b/frontend/providers/template/src/services/backend/kubernetes.ts
@@ -150,7 +150,7 @@ export async function getK8s({ kubeconfig }: { kubeconfig: string }) {
     return Promise.reject('用户不存在');
   }
 
-  const namespace = GetUserDefaultNameSpace(kube_user.name);
+  const namespace = kc.contexts[0].namespace || GetUserDefaultNameSpace(kube_user.name);
 
   const applyYamlList = async (yamlList: string[], type: 'create' | 'replace' | 'dryrun') => {
     // insert namespace


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a7efc79</samp>

### Summary
🆕🔄🛠️

<!--
1.  🆕 - This emoji represents the new feature of allowing users to switch between different namespaces in the UI, which is enabled by the addition of the `k8sUsername` and `nsid` properties to the `user` object in the `MasterSDK` class.
2.  🔄 - This emoji represents the change of using the `namespace` property from the current context in the `kubeconfig` object, if it exists, instead of always generating a namespace based on the user's name, which is applied to the `initK8s`, `getK8s`, and `getUserNamespace` functions in various modules. This change respects the user's preference of namespace and makes the code more consistent and flexible.
3.  🛠️ - This emoji represents the improvement of managing and applying YAML resources, database resources, and templates in the cluster, which is enabled by the change of using the `namespace` property from the current context in the `kubeconfig` object, if it exists, instead of always generating a namespace based on the user's name, which is applied to the `getK8s` functions in various modules. This improvement makes the code more robust and reliable.
-->
Use the `namespace` property from the `kubeconfig` object to determine the user's namespace in various frontend modules and services. This allows users to switch between different namespaces in the UI and respects their preference of namespace when interacting with the cluster.

> _`kubeconfig` holds_
> _user's namespace preference_
> _respect it in code_

### Walkthrough
*  Add `k8sUsername` and `nsid` properties to `user` object in `MasterSDK` class to identify user's Kubernetes username and namespace ID ([link](https://github.com/labring/sealos/pull/3927/files?diff=unified&w=0#diff-eb01c4844385592fca4616e5bf3e2ecb6366e3e22ff6d6acbf0cee9db225ea8eL58-R61))
  - `initK8s` in `frontend/packages/client-sdk/src/utils/kubernetes.ts` to initialize Kubernetes client ([link](https://github.com/labring/sealos/pull/3927/files?diff=unified&w=0#diff-8e20d24e75723767b71a4e1f752205b7d937f7b1dd774d7f594d0a341a33fe2aL269-R269))
  - `getK8s` in `frontend/providers/applaunchpad/src/services/backend/kubernetes.ts` to apply YAML resources to cluster ([link](https://github.com/labring/sealos/pull/3927/files?diff=unified&w=0#diff-ff7543b1021859d89fcd9d3967edd2f4c8e7236c6ecf9297bd894e1bfac784b1L198-R198))
  - `getUserNamespace` in `frontend/providers/applaunchpad/src/utils/user.ts` to display namespace in UI ([link](https://github.com/labring/sealos/pull/3927/files?diff=unified&w=0#diff-98d1c5f5525ac897ea07c09ea77075648c827e3e79bb9e1a3e95f7df1ffa441cL21-R21))
  - `getK8s` in `frontend/providers/dbprovider/src/services/backend/kubernetes.ts` to manage database resources in cluster ([link](https://github.com/labring/sealos/pull/3927/files?diff=unified&w=0#diff-aa3d00d79f59606c007f7e7837e61d057ca7a7284795173af17daa20a7dd9f23L215-R215))
  - `getK8s` in `frontend/providers/template/src/services/backend/kubernetes.ts` to create or update templates in cluster ([link](https://github.com/labring/sealos/pull/3927/files?diff=unified&w=0#diff-1399c05ed7b4639e736cef5c7c1fc256c5840a5370a280a37cfb38c2d3b62081L153-R153))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
