### PR TITLE
fix(desktop): When a team member is kicked out, there is inconsistenc…

### DIFF
--- a/frontend/desktop/src/components/account/index.tsx
+++ b/frontend/desktop/src/components/account/index.tsx
@@ -86,7 +86,7 @@ const NsMenu = () => {
           </Flex>
         </PopoverHeader>
         <PopoverBody px="0" pb="0" pt="4px">
-          <NsList selected_ns_uid={ns_uid} click={switchTeam} />
+          <NsList selected_ns_uid={ns_uid} click={switchTeam} nullNs={switchTeam} />
         </PopoverBody>
       </PopoverContent>
     </Popover>

--- a/frontend/desktop/src/components/team/NsList.tsx
+++ b/frontend/desktop/src/components/team/NsList.tsx
@@ -6,7 +6,7 @@ import Iconfont from '../iconfont';
 import { ApiResp } from '@/types';
 import InviteMember from './InviteMember';
 import { NSType, NamespaceDto, UserRole } from '@/types/team';
-import useSessionStore from '@/stores/session';
+// import useSessionStore from '@/stores/session';
 const NsList = ({
   click,
   // selected,
@@ -19,16 +19,17 @@ const NsList = ({
   nullNs?: (privateNamespace: NamespaceDto) => void;
   // selected: (ns: NamespaceDto) => boolean;
 } & Parameters<typeof Box>[0]) => {
-  const session = useSessionStore((s) => s.session);
-  const { userId, k8s_username, ns_uid } = session.user;
+  // const session = useSessionStore((s) => s.session);
+  // const { userId, k8s_username, ns_uid } = session.user;
+  const queryClient = useQueryClient();
   const { data } = useQuery({
     queryKey: [
       'teamList',
-      'teamGroup',
-      {
-        userId,
-        k8s_username
-      }
+      'teamGroup'
+      // {
+      //   userId,
+      //   k8s_username
+      // }
     ],
     queryFn: () =>
       request<any, ApiResp<{ namespaces: (NamespaceDto & { role: UserRole })[] }>>(
@@ -37,7 +38,7 @@ const NsList = ({
   });
   const { copyData } = useCopyData();
   const namespaces = data?.data?.namespaces || [];
-  const namespace = namespaces.find((x) => x.uid === ns_uid);
+  const namespace = namespaces.find((x) => x.uid === selected_ns_uid);
   const privateNamespace = namespaces.find((x) => x.nstype === NSType.Private);
   if (!namespace && namespaces.length > 0 && privateNamespace) {
     // 被删了
@@ -72,6 +73,8 @@ const NsList = ({
               cursor={'pointer'}
               onClick={(e) => {
                 e.preventDefault();
+                queryClient.invalidateQueries({ queryKey: ['teamList'] });
+
                 click && click(ns);
               }}
               width={'full'}

--- a/frontend/desktop/src/components/team/TeamCenter.tsx
+++ b/frontend/desktop/src/components/team/TeamCenter.tsx
@@ -126,78 +126,80 @@ export default function TeamCenter() {
                 />
               </Box>
             </Stack>
-            <Box width={'730px'} borderRadius={'8px'} bgColor={'white'} h="100%">
-              <Box px="16px" py="20px">
-                <Text fontSize={'16px'} fontWeight={'600'}>
-                  管理 team
-                </Text>
-                <Box mx="10px" mt="22px">
-                  <Flex align={'center'}>
-                    <Text fontSize={'24px'} fontWeight={'600'} mr="8px">
-                      {teamName}
-                    </Text>
-                    <Box bgColor={'#ABADC3'} h="8px" w="8px" borderRadius={'50%'} />
-                    {isTeam && curTeamUser?.role === UserRole.Owner && (
-                      <DissolveTeam
-                        ml="auto"
+            {curTeamUser && (
+              <Box width={'730px'} borderRadius={'8px'} bgColor={'white'} h="100%">
+                <Box px="16px" py="20px">
+                  <Text fontSize={'16px'} fontWeight={'600'}>
+                    管理 team
+                  </Text>
+                  <Box mx="10px" mt="22px">
+                    <Flex align={'center'}>
+                      <Text fontSize={'24px'} fontWeight={'600'} mr="8px">
+                        {teamName}
+                      </Text>
+                      <Box bgColor={'#ABADC3'} h="8px" w="8px" borderRadius={'50%'} />
+                      {isTeam && curTeamUser.role === UserRole.Owner && (
+                        <DissolveTeam
+                          ml="auto"
+                          nsid={nsid}
+                          ns_uid={ns_uid}
+                          onSuccess={(delete_ns_uid) => {
+                            setNs_uid(default_ns_uid);
+                            setNsid(default_nsid);
+                          }}
+                        />
+                      )}
+                    </Flex>
+                    <Flex align={'center'} color={'#5A646E'} mt={'7px'} fontSize={'12px'}>
+                      <Text>Team ID: {nsid}</Text>
+                      <Box onClick={() => copyData(nsid)} cursor={'pointer'} ml="5px">
+                        <Iconfont
+                          iconName="icon-copy2"
+                          width={14}
+                          height={14}
+                          color="rgb(123, 131, 139)"
+                        ></Iconfont>
+                      </Box>
+                      <Text ml="24px">Created: {createTime ? formatTime(createTime) : ''}</Text>
+                    </Flex>
+                  </Box>
+                </Box>
+                <Divider bg={'rgba(0, 0, 0, 0.10)'} h="1px" />
+                <Stack mt="15px" mx="29px" flex={1}>
+                  <Flex align={'center'} gap="6px" mb={'12px'}>
+                    <Image src={'/images/list.svg'} w="20px" h="20px" />
+                    <Text>成员列表</Text>
+                    <Flex
+                      py="0px"
+                      px="6px"
+                      fontSize={'10px'}
+                      fontWeight={'600'}
+                      gap="10px"
+                      justifyContent={'center'}
+                      align={'center'}
+                      borderRadius="30px"
+                      background="#EFF0F1"
+                      color={'#5A646E'}
+                      minW="23px"
+                    >
+                      {users.length}
+                    </Flex>
+                    {isTeam && [UserRole.Owner, UserRole.Manager].includes(curTeamUser!.role) && (
+                      <InviteMember
+                        ownRole={curTeamUser.role ?? UserRole.Developer}
                         nsid={nsid}
                         ns_uid={ns_uid}
-                        onSuccess={(delete_ns_uid) => {
-                          setNs_uid(default_ns_uid);
-                          setNsid(default_nsid);
-                        }}
+                        buttonType="button"
+                        ml="auto"
                       />
                     )}
                   </Flex>
-                  <Flex align={'center'} color={'#5A646E'} mt={'7px'} fontSize={'12px'}>
-                    <Text>Team ID: {nsid}</Text>
-                    <Box onClick={() => copyData(nsid)} cursor={'pointer'} ml="5px">
-                      <Iconfont
-                        iconName="icon-copy2"
-                        width={14}
-                        height={14}
-                        color="rgb(123, 131, 139)"
-                      ></Iconfont>
-                    </Box>
-                    <Text ml="24px">Created: {createTime ? formatTime(createTime) : ''}</Text>
-                  </Flex>
-                </Box>
+                  <Box h="250px" overflow={'scroll'}>
+                    <UserTable users={users} isTeam={isTeam} ns_uid={ns_uid} nsid={nsid} />
+                  </Box>
+                </Stack>
               </Box>
-              <Divider bg={'rgba(0, 0, 0, 0.10)'} h="1px" />
-              <Stack mt="15px" mx="29px" flex={1}>
-                <Flex align={'center'} gap="6px" mb={'12px'}>
-                  <Image src={'/images/list.svg'} w="20px" h="20px" />
-                  <Text>成员列表</Text>
-                  <Flex
-                    py="0px"
-                    px="6px"
-                    fontSize={'10px'}
-                    fontWeight={'600'}
-                    gap="10px"
-                    justifyContent={'center'}
-                    align={'center'}
-                    borderRadius="30px"
-                    background="#EFF0F1"
-                    color={'#5A646E'}
-                    minW="23px"
-                  >
-                    {users.length}
-                  </Flex>
-                  {isTeam && [UserRole.Owner, UserRole.Manager].includes(curTeamUser!.role) && (
-                    <InviteMember
-                      ownRole={curTeamUser?.role ?? UserRole.Developer}
-                      nsid={nsid}
-                      ns_uid={ns_uid}
-                      buttonType="button"
-                      ml="auto"
-                    />
-                  )}
-                </Flex>
-                <Box h="250px" overflow={'scroll'}>
-                  <UserTable users={users} isTeam={isTeam} ns_uid={ns_uid} nsid={nsid} />
-                </Box>
-              </Stack>
-            </Box>
+            )}
           </ModalBody>
         </ModalContent>
       </Modal>

--- a/frontend/desktop/src/services/backend/auth.ts
+++ b/frontend/desktop/src/services/backend/auth.ts
@@ -26,13 +26,6 @@ export const authSession = async (header: IncomingHttpHeaders) => {
     const username = kc.getCurrentUser()?.name;
     const user = payload.user;
     if (!username || user.k8s_username !== username) throw new Error('user is invaild');
-    // console.log('user',user)
-    const utn = await queryUTN({
-      userId: user.uid,
-      k8s_username: user.k8s_username,
-      namespaceId: user.ns_uid
-    });
-    if (!utn) return Promise.resolve(null);
     return Promise.resolve({ kc, user });
   } catch (err) {
     console.error(err);

--- a/frontend/providers/costcenter/src/components/billing/billingTable.tsx
+++ b/frontend/providers/costcenter/src/components/billing/billingTable.tsx
@@ -81,13 +81,13 @@ export function CommonBillingTable({ data }: { data: BillingItem[] }) {
                         minW={'max-content'}
                         {...(item.type === BillingType.RECHARGE
                           ? {
-                            bg: '#E6F6F6',
-                            color: '#00A9A6'
-                          }
+                              bg: '#E6F6F6',
+                              color: '#00A9A6'
+                            }
                           : {
-                            bg: '#EBF7FD',
-                            color: '#0884DD'
-                          })}
+                              bg: '#EBF7FD',
+                              color: '#0884DD'
+                            })}
                         borderRadius="24px"
                         align={'center'}
                         justify={'space-evenly'}

--- a/frontend/providers/costcenter/src/pages/billing/index.tsx
+++ b/frontend/providers/costcenter/src/pages/billing/index.tsx
@@ -90,13 +90,13 @@ function NamespaceMenu({
               key={v}
               {...(idx === namespaceIdx
                 ? {
-                  color: '#0884DD',
-                  bg: '#F4F6F8'
-                }
+                    color: '#0884DD',
+                    bg: '#F4F6F8'
+                  }
                 : {
-                  color: '#5A646E',
-                  bg: '#FDFDFE'
-                })}
+                    color: '#5A646E',
+                    bg: '#FDFDFE'
+                  })}
               h="30px"
               fontFamily="PingFang SC"
               fontSize="12px"
@@ -362,52 +362,53 @@ function InOutTabPanel({ namespace }: { namespace: string }) {
   );
   const { t } = useTranslation();
   const tableResult = data?.data?.status?.item || [];
-  return (<TabPanel p="0">
-    <Flex alignItems={'center'} flexWrap={'wrap'}>
-      <Flex align={'center'} mb={'24px'}>
-        <Text fontSize={'12px'} mr={'12px'} width={['60px', '60px', 'auto', 'auto']}>
-          {t('Transaction Time')}
-        </Text>
-        <SelectRange isDisabled={isFetching}></SelectRange>
-      </Flex>
-      <Flex align={'center'} mb={'24px'}>
-        <Text fontSize={'12px'} mr={'12px'} width={['60px', '60px', 'auto', 'auto']}>
-          {t('Type')}
-        </Text>
-        <TypeMenu
-          selectType={selectType}
-          setType={setType}
-          isDisabled={isFetching}
-          optional={[BillingType.ALL, BillingType.CONSUME, BillingType.RECHARGE]}
-        />
-      </Flex>
-      <SearchBox isDisabled={isFetching} setOrderID={setOrderID} />
-    </Flex>
-    {isSuccess && tableResult.length > 0 ? (
-      <>
-        <Box overflow={'auto'}>
-          <CommonBillingTable
-            data={tableResult.filter((x) =>
-              [BillingType.CONSUME, BillingType.RECHARGE].includes(x.type)
-            )}
-          />
-        </Box>
-        <Flex justifyContent={'flex-end'}>
-          <SwitchPage
-            totalPage={totalPage}
-            totalItem={totalItem}
-            pageSize={pageSize}
-            currentPage={currentPage}
-            setCurrentPage={setcurrentPage}
+  return (
+    <TabPanel p="0">
+      <Flex alignItems={'center'} flexWrap={'wrap'}>
+        <Flex align={'center'} mb={'24px'}>
+          <Text fontSize={'12px'} mr={'12px'} width={['60px', '60px', 'auto', 'auto']}>
+            {t('Transaction Time')}
+          </Text>
+          <SelectRange isDisabled={isFetching}></SelectRange>
+        </Flex>
+        <Flex align={'center'} mb={'24px'}>
+          <Text fontSize={'12px'} mr={'12px'} width={['60px', '60px', 'auto', 'auto']}>
+            {t('Type')}
+          </Text>
+          <TypeMenu
+            selectType={selectType}
+            setType={setType}
+            isDisabled={isFetching}
+            optional={[BillingType.ALL, BillingType.CONSUME, BillingType.RECHARGE]}
           />
         </Flex>
-      </>
-    ) : (
-      <Flex direction={'column'} w="full" align={'center'} flex={'1'} h={'0'} justify={'center'}>
-        <NotFound></NotFound>
+        <SearchBox isDisabled={isFetching} setOrderID={setOrderID} />
       </Flex>
-    )}
-  </TabPanel>
+      {isSuccess && tableResult.length > 0 ? (
+        <>
+          <Box overflow={'auto'}>
+            <CommonBillingTable
+              data={tableResult.filter((x) =>
+                [BillingType.CONSUME, BillingType.RECHARGE].includes(x.type)
+              )}
+            />
+          </Box>
+          <Flex justifyContent={'flex-end'}>
+            <SwitchPage
+              totalPage={totalPage}
+              totalItem={totalItem}
+              pageSize={pageSize}
+              currentPage={currentPage}
+              setCurrentPage={setcurrentPage}
+            />
+          </Flex>
+        </>
+      ) : (
+        <Flex direction={'column'} w="full" align={'center'} flex={'1'} h={'0'} justify={'center'}>
+          <NotFound></NotFound>
+        </Flex>
+      )}
+    </TabPanel>
   );
 }
 function TransferTabPanel({ namespace }: { namespace: string }) {

--- a/frontend/providers/cronjob/tsconfig.json
+++ b/frontend/providers/cronjob/tsconfig.json
@@ -1,21 +1,11 @@
 {
   "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "baseUrl": ".",
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     }
   },
-  "include": [
-    "next-env.d.ts",
-    "src/**/*.ts",
-    "src/**/*.tsx"
-  ],
+  "include": ["next-env.d.ts", "src/**/*.ts", "src/**/*.tsx"],
   "extends": "../../tsconfig.web.json"
 }

--- a/frontend/providers/license/next-i18next.config.js
+++ b/frontend/providers/license/next-i18next.config.js
@@ -9,4 +9,4 @@ module.exports = {
     locales: ['en', 'zh'],
     localeDetection: false
   }
-}
+};

--- a/frontend/providers/license/tsconfig.json
+++ b/frontend/providers/license/tsconfig.json
@@ -1,21 +1,11 @@
 {
   "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "baseUrl": ".",
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     }
   },
-  "include": [
-    "next-env.d.ts",
-    "src/**/*.ts",
-    "src/**/*.tsx"
-  ],
+  "include": ["next-env.d.ts", "src/**/*.ts", "src/**/*.tsx"],
   "extends": "../../tsconfig.web.json"
 }


### PR DESCRIPTION
…y between the front-end and back-end states.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c4874a4</samp>

### Summary
🆕🐛🚀

<!--
1.  🆕 for the new prop `nullNs` added to the `NsList` component.
2.  🐛 for the bug fix in the `TeamCenter` component to avoid rendering an empty team management box.
3.  🚀 for the performance improvement and refactoring in the `NsList` component and the `auth.ts` service.
-->
This pull request refactors the `NsList` component to use a more efficient data fetching hook, fixes indentation issues in the `costcenter` frontend provider, adds a new prop to handle null namespaces in the `NsMenu` component, prevents rendering an empty team management box in the `TeamCenter` component, and simplifies the user session authentication logic in the `auth.ts` service. These changes improve the performance, usability, and readability of the `sealos` frontend.

> _Oh we're the coders of the `costcenter` ship_
> _And we work hard to make it run_
> _We tweak the props and the queries and the hooks_
> _And we fix the bugs one by one_

### Walkthrough
* Remove unnecessary query for user token and obtain it from server response in `authSession` function ([link](https://github.com/labring/sealos/pull/3930/files?diff=unified&w=0#diff-af34e0df3a3d9dfbbb81a909e70c79b74a3ccfa553a9484b9917d77d2403f67cL29-L35))
* Invalidate team list query when switching or deleting teams in `NsList` component ([link](https://github.com/labring/sealos/pull/3930/files?diff=unified&w=0#diff-50deaba9efc4c75a52768ec6a78dd52044130f72eeced5bba0c2b788e1b9a22eL22-R32), [link](https://github.com/labring/sealos/pull/3930/files?diff=unified&w=0#diff-50deaba9efc4c75a52768ec6a78dd52044130f72eeced5bba0c2b788e1b9a22eR76-R77))
* Add `nullNs` prop to handle no namespace selected case in `NsList` component and pass it from `NsMenu` component ([link](https://github.com/labring/sealos/pull/3930/files?diff=unified&w=0#diff-f080c4cc5f58f00e0d58040ad4f90c0bdf6b500e0ea8d8711bacaa900803500bL89-R89), [link](https://github.com/labring/sealos/pull/3930/files?diff=unified&w=0#diff-50deaba9efc4c75a52768ec6a78dd52044130f72eeced5bba0c2b788e1b9a22eL40-R41))
* Add condition to render team management box only when team user data is available in `TeamCenter` component ([link](https://github.com/labring/sealos/pull/3930/files?diff=unified&w=0#diff-b53b7068e2fc1961703c702c867e6e3b9541703407d82445660e6756d9d7c409L129-R202))
* Adjust indentation of various expressions to match code style and improve readability in `BillingTable` component ([link](https://github.com/labring/sealos/pull/3930/files?diff=unified&w=0#diff-9b8e6d15a88b05c95c40bde8b06849bb4c0d723944381e623f89268102a7f7d4L35-R37), [link](https://github.com/labring/sealos/pull/3930/files?diff=unified&w=0#diff-9b8e6d15a88b05c95c40bde8b06849bb4c0d723944381e623f89268102a7f7d4L63-R69), [link](https://github.com/labring/sealos/pull/3930/files?diff=unified&w=0#diff-9b8e6d15a88b05c95c40bde8b06849bb4c0d723944381e623f89268102a7f7d4L83-R86))
* Rename `ns_uid` prop to `selected_ns_uid` to avoid confusion in `NsList` component ([link](https://github.com/labring/sealos/pull/3930/files?diff=unified&w=0#diff-50deaba9efc4c75a52768ec6a78dd52044130f72eeced5bba0c2b788e1b9a22eL40-R41))
* Remove unused import of `useSessionStore` hook in `NsList` component ([link](https://github.com/labring/sealos/pull/3930/files?diff=unified&w=0#diff-50deaba9efc4c75a52768ec6a78dd52044130f72eeced5bba0c2b788e1b9a22eL9-R9))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
