### PR TITLE
feature(main): join nodes for k3s

### DIFF
--- a/pkg/runtime/k3s/bootstrap.go
+++ b/pkg/runtime/k3s/bootstrap.go
@@ -134,9 +134,10 @@ func (k *K3s) getAPIServerPort() int {
 }
 
 func (k *K3s) getMasterIPListAndHTTPSPort() []string {
+	apiPort := k.getAPIServerPort()
 	masters := make([]string, 0)
 	for _, master := range k.cluster.GetMasterIPList() {
-		masters = append(masters, fmt.Sprintf("%s:%d", master, k.getAPIServerPort()))
+		masters = append(masters, fmt.Sprintf("%s:%d", master, apiPort))
 	}
 	return masters
 }
@@ -234,7 +235,7 @@ func (k *K3s) copyKubeConfigFileToNodes(hosts ...string) error {
 	if err != nil {
 		return errors.WithMessage(err, "read admin.config file failed")
 	}
-	newData := strings.ReplaceAll(string(data), "https://0.0.0.0:6443", fmt.Sprintf("https://%s:%d", constants.DefaultAPIServerDomain, 6443))
+	newData := strings.ReplaceAll(string(data), "https://0.0.0.0", fmt.Sprintf("https://%s", constants.DefaultAPIServerDomain))
 	if err = file.WriteFile(src, []byte(newData)); err != nil {
 		return errors.WithMessage(err, "write admin.config file failed")
 	}

--- a/pkg/runtime/k3s/bootstrap.go
+++ b/pkg/runtime/k3s/bootstrap.go
@@ -18,6 +18,9 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
 
 	"golang.org/x/sync/errgroup"
 
@@ -227,14 +230,14 @@ func (k *K3s) pullKubeConfigFromMaster0() error {
 
 func (k *K3s) copyKubeConfigFileToNodes(hosts ...string) error {
 	src := k.pathResolver.AdminFile()
-	//data, err := file.ReadAll(src)
-	//if err != nil {
-	//	return errors.WithMessage(err, "read admin.config file failed")
-	//}
-	//newData := strings.ReplaceAll(string(data), "https://0.0.0.0:6443", fmt.Sprintf("https://%s:%d", constants.DefaultAPIServerDomain, 6443))
-	//if err = file.WriteFile(src, []byte(newData)); err != nil {
-	//	return errors.WithMessage(err, "write admin.config file failed")
-	//}
+	data, err := file.ReadAll(src)
+	if err != nil {
+		return errors.WithMessage(err, "read admin.config file failed")
+	}
+	newData := strings.ReplaceAll(string(data), "https://0.0.0.0:6443", fmt.Sprintf("https://%s:%d", constants.DefaultAPIServerDomain, 6443))
+	if err = file.WriteFile(src, []byte(newData)); err != nil {
+		return errors.WithMessage(err, "write admin.config file failed")
+	}
 	eg, _ := errgroup.WithContext(context.Background())
 	for _, node := range hosts {
 		node := node

--- a/pkg/runtime/k3s/bootstrap.go
+++ b/pkg/runtime/k3s/bootstrap.go
@@ -21,6 +21,8 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/labring/sealos/pkg/utils/iputils"
+
 	"github.com/labring/sealos/pkg/constants"
 	"github.com/labring/sealos/pkg/utils/file"
 	"github.com/labring/sealos/pkg/utils/logger"
@@ -36,6 +38,9 @@ func (k *K3s) initMaster0() error {
 		k.generateAndSendInitConfig,
 		func() error { return k.enableK3sService(master0) },
 		k.pullKubeConfigFromMaster0,
+		func() error {
+			return k.remoteUtil.HostsAdd(master0, iputils.GetHostIP(master0), constants.DefaultAPIServerDomain)
+		},
 		func() error { return k.copyKubeConfigFileToNodes(k.cluster.GetMaster0IPAndPort()) },
 	)
 }
@@ -95,6 +100,9 @@ func (k *K3s) joinMaster(master string) error {
 			return k.execer.Copy(master, filepath.Join(k.pathResolver.EtcPath(), defaultJoinMastersFilename), defaultK3sConfigPath)
 		},
 		func() error { return k.enableK3sService(master) },
+		func() error {
+			return k.remoteUtil.HostsAdd(master, iputils.GetHostIP(master), constants.DefaultAPIServerDomain)
+		},
 		func() error { return k.copyKubeConfigFileToNodes(master) },
 	)
 }
@@ -111,8 +119,34 @@ func (k *K3s) joinNodes(nodes []string) error {
 	return nil
 }
 
+func (k *K3s) getAPIServerPort() int {
+	src := filepath.Join(k.pathResolver.EtcPath(), defaultInitFilename)
+	if file.IsExist(src) {
+		cfg := &Config{}
+		if err := yaml.UnmarshalFile(src, cfg); err == nil {
+			return cfg.HTTPSPort
+		}
+	}
+	return constants.DefaultAPIServerPort
+}
+
+func (k *K3s) getMasterIPListAndHTTPSPort() []string {
+	masters := make([]string, 0)
+	for _, master := range k.cluster.GetMasterIPList() {
+		masters = append(masters, fmt.Sprintf("%s:%d", master, k.getAPIServerPort()))
+	}
+	return masters
+}
+
+func (k *K3s) getVipAndPort() string {
+	return fmt.Sprintf("%s:%d", k.cluster.GetVIP(), k.getAPIServerPort())
+}
+
 func (k *K3s) joinNode(node string) error {
 	return k.runPipelines(fmt.Sprintf("join node %s", node),
+		func() error {
+			return k.remoteUtil.IPVS(node, k.getVipAndPort(), k.getMasterIPListAndHTTPSPort())
+		},
 		func() error { return k.generateAndSendTokenFiles(node, "agent-token") },
 		func() error {
 			return k.execer.Copy(node, filepath.Join(k.pathResolver.EtcPath(), defaultJoinNodesFilename), defaultK3sConfigPath)
@@ -193,6 +227,14 @@ func (k *K3s) pullKubeConfigFromMaster0() error {
 
 func (k *K3s) copyKubeConfigFileToNodes(hosts ...string) error {
 	src := k.pathResolver.AdminFile()
+	//data, err := file.ReadAll(src)
+	//if err != nil {
+	//	return errors.WithMessage(err, "read admin.config file failed")
+	//}
+	//newData := strings.ReplaceAll(string(data), "https://0.0.0.0:6443", fmt.Sprintf("https://%s:%d", constants.DefaultAPIServerDomain, 6443))
+	//if err = file.WriteFile(src, []byte(newData)); err != nil {
+	//	return errors.WithMessage(err, "write admin.config file failed")
+	//}
 	eg, _ := errgroup.WithContext(context.Background())
 	for _, node := range hosts {
 		node := node

--- a/pkg/runtime/k3s/config.go
+++ b/pkg/runtime/k3s/config.go
@@ -37,9 +37,8 @@ var defaultMergeOpts = []func(*mergo.Config){
 }
 
 func defaultingConfig(c *Config) *Config {
-	//TODO update kube config
 	c.BindAddress = "0.0.0.0"
-	c.HTTPSPort = 6443
+	c.HTTPSPort = constants.DefaultAPIServerPort
 	c.ClusterCIDR = []string{"10.42.0.0/16"}
 	c.ServiceCIDR = []string{"10.96.0.0/16"}
 	c.ClusterDomain = constants.DefaultDNSDomain
@@ -171,16 +170,6 @@ func (k *K3s) getInitConfig(callbacks ...callback) (*Config, error) {
 		cfg = callbacks[i](cfg)
 	}
 	return cfg, nil
-}
-
-//lint:ignore U1000 Ignore unused function temporarily for debugging
-func (c *Config) getContainerRuntimeEndpoint() string {
-	if c.AgentConfig.Docker {
-		return "unix:///run/k3s/cri-dockerd/cri-dockerd.sock"
-	} else if len(c.AgentConfig.ContainerRuntimeEndpoint) == 0 {
-		return "unix:///run/k3s/containerd/containerd.sock"
-	}
-	return c.AgentConfig.ContainerRuntimeEndpoint
 }
 
 // ParseConfig return nil if data structure is not matched

--- a/pkg/runtime/k3s/consts.go
+++ b/pkg/runtime/k3s/consts.go
@@ -25,7 +25,7 @@ const (
 	defaultInitFilename        = "k3s-init.yaml"
 	defaultJoinMastersFilename = "k3s-join-master.yaml"
 	defaultJoinNodesFilename   = "k3s-join-node.yaml"
-	defaultPodManifestPath     = "pod-manifests"
+	k3sEtcStaticPod            = "/var/lib/rancher/k3s/agent/pod-manifests"
 )
 
 const (

--- a/pkg/runtime/k3s/k3s.go
+++ b/pkg/runtime/k3s/k3s.go
@@ -122,10 +122,11 @@ func (k *K3s) GetRawConfig() ([]byte, error) {
 }
 
 func (k *K3s) SyncNodeIPVS(mastersIPList, nodeIPList []string) error {
+	apiPort := k.getAPIServerPort()
 	mastersIPList = strings.RemoveDuplicate(mastersIPList)
 	masters := make([]string, 0)
 	for _, master := range mastersIPList {
-		masters = append(masters, fmt.Sprintf("%s:%d", iputils.GetHostIP(master), k.getAPIServerPort()))
+		masters = append(masters, fmt.Sprintf("%s:%d", iputils.GetHostIP(master), apiPort))
 	}
 	image := k.cluster.GetLvscareImage()
 	eg, _ := errgroup.WithContext(context.Background())
@@ -133,7 +134,7 @@ func (k *K3s) SyncNodeIPVS(mastersIPList, nodeIPList []string) error {
 		node := node
 		eg.Go(func() error {
 			logger.Info("start to sync lvscare static pod to node: %s master: %+v", node, masters)
-			err := k.remoteUtil.StaticPod(node, k.getVipAndPort(), constants.LvsCareStaticPodName, image, masters, k3sEtcStaticPod, []string{"--health-status", "401"})
+			err := k.remoteUtil.StaticPod(node, k.getVipAndPort(), constants.LvsCareStaticPodName, image, masters, k3sEtcStaticPod, "--health-status", "401")
 			if err != nil {
 				return fmt.Errorf("update lvscare static pod failed %s %v", node, err)
 			}

--- a/pkg/runtime/k3s/k3s.go
+++ b/pkg/runtime/k3s/k3s.go
@@ -15,7 +15,13 @@
 package k3s
 
 import (
+	"context"
 	"fmt"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/labring/sealos/pkg/utils/iputils"
+	"github.com/labring/sealos/pkg/utils/strings"
 
 	"github.com/labring/sealos/pkg/constants"
 	"github.com/labring/sealos/pkg/env"
@@ -115,9 +121,26 @@ func (k *K3s) GetRawConfig() ([]byte, error) {
 	return yaml.MarshalConfigs(cluster, cfg)
 }
 
-func (k *K3s) SyncNodeIPVS(_, _ []string) error {
-	logger.Error("not yet implemented, skip for testing")
-	return nil
+func (k *K3s) SyncNodeIPVS(mastersIPList, nodeIPList []string) error {
+	mastersIPList = strings.RemoveDuplicate(mastersIPList)
+	masters := make([]string, 0)
+	for _, master := range mastersIPList {
+		masters = append(masters, fmt.Sprintf("%s:%d", iputils.GetHostIP(master), k.getAPIServerPort()))
+	}
+	image := k.cluster.GetLvscareImage()
+	eg, _ := errgroup.WithContext(context.Background())
+	for _, node := range nodeIPList {
+		node := node
+		eg.Go(func() error {
+			logger.Info("start to sync lvscare static pod to node: %s master: %+v", node, masters)
+			err := k.remoteUtil.StaticPod(node, k.getVipAndPort(), constants.LvsCareStaticPodName, image, masters, k3sEtcStaticPod)
+			if err != nil {
+				return fmt.Errorf("update lvscare static pod failed %s %v", node, err)
+			}
+			return nil
+		})
+	}
+	return eg.Wait()
 }
 
 func (k *K3s) runPipelines(phase string, pipelines ...func() error) error {

--- a/pkg/runtime/k3s/k3s.go
+++ b/pkg/runtime/k3s/k3s.go
@@ -133,7 +133,7 @@ func (k *K3s) SyncNodeIPVS(mastersIPList, nodeIPList []string) error {
 		node := node
 		eg.Go(func() error {
 			logger.Info("start to sync lvscare static pod to node: %s master: %+v", node, masters)
-			err := k.remoteUtil.StaticPod(node, k.getVipAndPort(), constants.LvsCareStaticPodName, image, masters, k3sEtcStaticPod)
+			err := k.remoteUtil.StaticPod(node, k.getVipAndPort(), constants.LvsCareStaticPodName, image, masters, k3sEtcStaticPod, []string{"--health-status", "401"})
 			if err != nil {
 				return fmt.Errorf("update lvscare static pod failed %s %v", node, err)
 			}

--- a/pkg/runtime/k3s/lifecycle.go
+++ b/pkg/runtime/k3s/lifecycle.go
@@ -18,6 +18,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/labring/sealos/pkg/utils/iputils"
+
+	"github.com/labring/sealos/pkg/utils/strings"
+
 	"golang.org/x/exp/slices"
 
 	"github.com/labring/sealos/pkg/utils/logger"
@@ -48,15 +52,33 @@ func (k *K3s) resetNode(host string) error {
 	}
 	if slices.Contains(k.cluster.GetNodeIPList(), host) {
 		vipAndPort := fmt.Sprintf("%s:%d", k.cluster.GetVIP(), k.config.APIServerPort)
-		ipvscleanErr := k.remoteUtil.IPVSClean(host, vipAndPort)
-		if ipvscleanErr != nil {
-			logger.Error("failed to clean node route and ipvs failed, %v", ipvscleanErr)
+		ipvsclearErr := k.remoteUtil.IPVSClean(host, vipAndPort)
+		if ipvsclearErr != nil {
+			logger.Error("failed to clear node route and ipvs failed, %v", ipvsclearErr)
 		}
 	}
 	return nil
 }
 
 // TODO: remove from API
-func (k *K3s) deleteNode(_ string) error {
+func (k *K3s) deleteNode(node string) error {
+	//remove master
+	masterIPs := strings.RemoveFromSlice(k.cluster.GetMasterIPList(), node)
+	if len(masterIPs) > 0 {
+		// TODO: do we need draining first?
+		if err := k.removeNode(node); err != nil {
+			logger.Warn(fmt.Errorf("delete nodes %s failed %v", node, err))
+		}
+	}
 	return nil
+}
+
+func (k *K3s) removeNode(ip string) error {
+	logger.Info("start to remove node from k3s %s", ip)
+	nodeName, err := k.execer.CmdToString(k.cluster.GetMaster0IPAndPort(), fmt.Sprintf("kubectl get nodes -o wide | grep %s | awk '{print $1}'", iputils.GetHostIP(ip)), "")
+	if err != nil {
+		return fmt.Errorf("cannot get node with ip address %s: %v", ip, err)
+	}
+	logger.Debug("found node name is %s, we will delete it", nodeName)
+	return k.execer.CmdAsync(k.cluster.GetMaster0IPAndPort(), fmt.Sprintf("kubectl delete node %s --ignore-not-found=true", nodeName))
 }

--- a/pkg/runtime/k3s/lifecycle.go
+++ b/pkg/runtime/k3s/lifecycle.go
@@ -54,7 +54,7 @@ func (k *K3s) resetNode(host string) error {
 		vipAndPort := fmt.Sprintf("%s:%d", k.cluster.GetVIP(), k.config.APIServerPort)
 		ipvsclearErr := k.remoteUtil.IPVSClean(host, vipAndPort)
 		if ipvsclearErr != nil {
-			logger.Error("failed to clear node route and ipvs failed, %v", ipvsclearErr)
+			logger.Error("failed to clear ipvs rules for node %s: %v", host, ipvsclearErr)
 		}
 	}
 	return nil
@@ -75,7 +75,7 @@ func (k *K3s) deleteNode(node string) error {
 
 func (k *K3s) removeNode(ip string) error {
 	logger.Info("start to remove node from k3s %s", ip)
-	nodeName, err := k.execer.CmdToString(k.cluster.GetMaster0IPAndPort(), fmt.Sprintf("kubectl get nodes -o wide | grep %s | awk '{print $1}'", iputils.GetHostIP(ip)), "")
+	nodeName, err := k.execer.CmdToString(k.cluster.GetMaster0IPAndPort(), fmt.Sprintf("kubectl get nodes -o wide | awk '$6==\"%s\" {print $1}'", iputils.GetHostIP(ip)), "")
 	if err != nil {
 		return fmt.Errorf("cannot get node with ip address %s: %v", ip, err)
 	}

--- a/pkg/runtime/kubernetes/runtime_getter.go
+++ b/pkg/runtime/kubernetes/runtime_getter.go
@@ -112,7 +112,7 @@ func (k *KubeadmRuntime) syncNodeIPVSYaml(masterIPs, nodesIPs []string) error {
 
 func (k *KubeadmRuntime) execIPVSPod(ip string, masters []string) error {
 	image := k.cluster.GetLvscareImage()
-	return k.remoteUtil.StaticPod(ip, k.getVipAndPort(), constants.LvsCareStaticPodName, image, masters)
+	return k.remoteUtil.StaticPod(ip, k.getVipAndPort(), constants.LvsCareStaticPodName, image, masters, kubernetesEtcStaticPod)
 }
 
 func (k *KubeadmRuntime) execToken(ip, certificateKey string) (string, error) {

--- a/pkg/runtime/kubernetes/runtime_getter.go
+++ b/pkg/runtime/kubernetes/runtime_getter.go
@@ -112,7 +112,7 @@ func (k *KubeadmRuntime) syncNodeIPVSYaml(masterIPs, nodesIPs []string) error {
 
 func (k *KubeadmRuntime) execIPVSPod(ip string, masters []string) error {
 	image := k.cluster.GetLvscareImage()
-	return k.remoteUtil.StaticPod(ip, k.getVipAndPort(), constants.LvsCareStaticPodName, image, masters, kubernetesEtcStaticPod, []string{})
+	return k.remoteUtil.StaticPod(ip, k.getVipAndPort(), constants.LvsCareStaticPodName, image, masters, kubernetesEtcStaticPod)
 }
 
 func (k *KubeadmRuntime) execToken(ip, certificateKey string) (string, error) {

--- a/pkg/runtime/kubernetes/runtime_getter.go
+++ b/pkg/runtime/kubernetes/runtime_getter.go
@@ -112,7 +112,7 @@ func (k *KubeadmRuntime) syncNodeIPVSYaml(masterIPs, nodesIPs []string) error {
 
 func (k *KubeadmRuntime) execIPVSPod(ip string, masters []string) error {
 	image := k.cluster.GetLvscareImage()
-	return k.remoteUtil.StaticPod(ip, k.getVipAndPort(), constants.LvsCareStaticPodName, image, masters, kubernetesEtcStaticPod)
+	return k.remoteUtil.StaticPod(ip, k.getVipAndPort(), constants.LvsCareStaticPodName, image, masters, kubernetesEtcStaticPod, []string{})
 }
 
 func (k *KubeadmRuntime) execToken(ip, certificateKey string) (string, error) {

--- a/pkg/ssh/remote.go
+++ b/pkg/ssh/remote.go
@@ -86,13 +86,14 @@ func (s *Remote) IPVSClean(ip, vip string) error {
 	return s.executeRemoteUtilSubcommand(ip, out)
 }
 
-func (s *Remote) StaticPod(ip, vip, name, image string, masters []string) error {
-	staticPodIPVSTemplate := `static-pod lvscare --name {{.name}} --vip {{.vip}} --image {{.image}}  {{range $h := .masters}} --masters  {{$h}}{{end}}`
+func (s *Remote) StaticPod(ip, vip, name, image string, masters []string, path string) error {
+	staticPodIPVSTemplate := `static-pod lvscare --path {{.path}} --name {{.name}} --vip {{.vip}} --image {{.image}}  {{range $h := .masters}} --masters  {{$h}}{{end}}`
 	data := map[string]interface{}{
 		"vip":     vip,
 		"image":   image,
 		"masters": masters,
 		"name":    name,
+		"path":    path,
 	}
 	out, err := template.RenderTemplate("lvscare", staticPodIPVSTemplate, data)
 	if err != nil {

--- a/pkg/ssh/remote.go
+++ b/pkg/ssh/remote.go
@@ -86,7 +86,7 @@ func (s *Remote) IPVSClean(ip, vip string) error {
 	return s.executeRemoteUtilSubcommand(ip, out)
 }
 
-func (s *Remote) StaticPod(ip, vip, name, image string, masters []string, path string, options []string) error {
+func (s *Remote) StaticPod(ip, vip, name, image string, masters []string, path string, options ...string) error {
 	staticPodIPVSTemplate := `static-pod lvscare --path {{.path}} --name {{.name}} --vip {{.vip}} --image {{.image}}  {{range $h := .masters}} --masters  {{$h}} {{end}} {{range $o := .options}} --options  {{$o}} {{end}}`
 	data := map[string]interface{}{
 		"vip":     vip,

--- a/pkg/ssh/remote.go
+++ b/pkg/ssh/remote.go
@@ -86,14 +86,15 @@ func (s *Remote) IPVSClean(ip, vip string) error {
 	return s.executeRemoteUtilSubcommand(ip, out)
 }
 
-func (s *Remote) StaticPod(ip, vip, name, image string, masters []string, path string) error {
-	staticPodIPVSTemplate := `static-pod lvscare --path {{.path}} --name {{.name}} --vip {{.vip}} --image {{.image}}  {{range $h := .masters}} --masters  {{$h}}{{end}}`
+func (s *Remote) StaticPod(ip, vip, name, image string, masters []string, path string, options []string) error {
+	staticPodIPVSTemplate := `static-pod lvscare --path {{.path}} --name {{.name}} --vip {{.vip}} --image {{.image}}  {{range $h := .masters}} --masters  {{$h}} {{end}} {{range $o := .options}} --options  {{$o}} {{end}}`
 	data := map[string]interface{}{
 		"vip":     vip,
 		"image":   image,
 		"masters": masters,
 		"name":    name,
 		"path":    path,
+		"options": options,
 	}
 	out, err := template.RenderTemplate("lvscare", staticPodIPVSTemplate, data)
 	if err != nil {

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -15,32 +15,22 @@
 package template
 
 import (
-	"bytes"
-	"fmt"
 	"testing"
 )
 
 func TestTemplateSemverCompare(t *testing.T) {
-	v, b, e := TryParse(`
-version: {{if (semverCompare "^1.26.0" (default "" .ENV)) }}v1{{ else }}v1alpha2{{ end }}
-`)
-	if e != nil {
-		t.Errorf("parse err: %v", e)
+	staticPodIPVSTemplate := `static-pod lvscare --path {{.path}} --name {{.name}} --vip {{.vip}} --image {{.image}}  {{range $h := .masters}} --masters  {{$h}}  {{end}} {{range $o := .options}} --options  {{$o}} {{end}} `
+	data := map[string]interface{}{
+		"vip":     "127.0.0.1",
+		"image":   "test",
+		"masters": []string{"127.0.0.2"},
+		"name":    "lvscare",
+		"path":    "/etc/kubernetes",
+		"options": nil,
 	}
-	if !b {
-		t.Errorf("parse failed: %v", b)
+	out, err := RenderTemplate("lvscare", staticPodIPVSTemplate, data)
+	if err != nil {
+		t.Errorf("%+v", err)
 	}
-
-	out := bytes.NewBuffer(nil)
-	execErr := v.Execute(out, map[string]interface{}{
-		// comment out this to test true return
-		// "ENV": "v1.26.1",
-		// comment out this to test false return
-		"ENV": "v1.25.10",
-	})
-	if execErr != nil {
-		t.Errorf("template exec err: %v", execErr)
-	}
-
-	fmt.Println(out)
+	t.Log(out)
 }

--- a/test/e2e/k3s_basic_test.go
+++ b/test/e2e/k3s_basic_test.go
@@ -48,7 +48,7 @@ var _ = Describe("E2E_sealos_k3s_basic_test", func() {
 		BeforeEach(func() {
 			By("build rootfs")
 			dFile := config.RootfsDockerfile{
-				BaseImage: "labring/k3s:latest",
+				BaseImage: "labring/k3s:v1.25-latest",
 				Copys:     []string{"sealctl opt/"},
 			}
 			tmpdir, err := dFile.Write()


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 14e472d</samp>

### Summary
:sparkles::recycle::wrench:

<!--
1.  :sparkles: - This emoji represents the addition of a new feature or enhancement, such as the IPVS load balancing for the k3s runtime and the ability to sync the IPVS load balancer with the master IP list.
2.  :recycle: - This emoji represents the refactoring or improvement of existing code, such as the `Config` struct for k3s runtime and the `execIPVSPod` function for the kubeadm runtime.
3.  :wrench: - This emoji represents the addition of a new option or parameter, such as the static pod path for the IPVS load balancer.
-->
This pull request adds IPVS load balancing for the API server in the `k3s` runtime and makes some code quality improvements. It updates the `k3s` package to sync the IPVS load balancer with the master IP list and to use a constant for the static pod path. It also modifies the `kubeadm` package to use the same static pod path parameter for the IPVS load balancer. It affects the files `pkg/runtime/k3s/*` and `pkg/ssh/remote.go` and `pkg/runtime/kubernetes/runtime_getter.go`.

> _We're sailing on the k3s cluster, with IPVS on the nodes_
> _We'll sync the load balancer with the masters, as we go_
> _We'll heave away the static pods, to the path that we choose_
> _We'll sing a song of `kubeadm` and `remoteUtil`s_

### Walkthrough
*  Import `iputils` package to use its functions for IP address handling ([link](https://github.com/labring/sealos/pull/3944/files?diff=unified&w=0#diff-481ba56b502b479282760464d0c78dc1ed197cbf81f028a7621396ac66d11457R24-R25))
*  Update `/etc/hosts` file on master nodes with API server domain name and IP address using `remoteUtil.HostsAdd` and `iputils.GetHostIP` ([link](https://github.com/labring/sealos/pull/3944/files?diff=unified&w=0#diff-481ba56b502b479282760464d0c78dc1ed197cbf81f028a7621396ac66d11457R41-R43), [link](https://github.com/labring/sealos/pull/3944/files?diff=unified&w=0#diff-481ba56b502b479282760464d0c78dc1ed197cbf81f028a7621396ac66d11457R103-R105))
*  Add functions to `K3s` struct to get API server port, master IP list with port, and VIP with port from `k3s-init.yaml` file or `constants` package ([link](https://github.com/labring/sealos/pull/3944/files?diff=unified&w=0#diff-481ba56b502b479282760464d0c78dc1ed197cbf81f028a7621396ac66d11457L114-R149))
*  Create static pod for IPVS load balancer on nodes using `remoteUtil.IPVS` or `remoteUtil.StaticPod` with `lvscare` image and `k3sEtcStaticPod` path ([link](https://github.com/labring/sealos/pull/3944/files?diff=unified&w=0#diff-481ba56b502b479282760464d0c78dc1ed197cbf81f028a7621396ac66d11457L114-R149), [link](https://github.com/labring/sealos/pull/3944/files?diff=unified&w=0#diff-bbd34650a9df8e53a19b8bfbfdcb2e05b494065152ed63e4ba63b4138f2f3b90L118-R143), [link](https://github.com/labring/sealos/pull/3944/files?diff=unified&w=0#diff-4e5a3523c64be399ece9a2e68527f600e215e88a7f475d1b49bcb1bcb3a016a1L115-R115), [link](https://github.com/labring/sealos/pull/3944/files?diff=unified&w=0#diff-7b37f13f1a2f948d5e12c88b23195e7928670cfccc89bbbc893fda98e44978beL89-R90), [link](https://github.com/labring/sealos/pull/3944/files?diff=unified&w=0#diff-7b37f13f1a2f948d5e12c88b23195e7928670cfccc89bbbc893fda98e44978beR96))
*  Replace hard-coded value of `6443` with `constants.DefaultAPIServerPort` for `HTTPSPort` field of `Config` struct ([link](https://github.com/labring/sealos/pull/3944/files?diff=unified&w=0#diff-1ac07404062b36cde73e55f9032f236034f050e04c56942d3038c96bc3db176cL40-R41))
*  Remove unused function to get container runtime endpoint from `Config` struct ([link](https://github.com/labring/sealos/pull/3944/files?diff=unified&w=0#diff-1ac07404062b36cde73e55f9032f236034f050e04c56942d3038c96bc3db176cL176-L185))
*  Add constant value of `k3sEtcStaticPod` to `k3s` package ([link](https://github.com/labring/sealos/pull/3944/files?diff=unified&w=0#diff-0c0010105ddbbdaf1bfa12f774875c2393b6f87f97016136b739eb8291843f41L28-R28))
*  Comment out code to replace API server address in `admin.config` file as it is already set in `k3s-init.yaml` file and `/etc/hosts` file ([link](https://github.com/labring/sealos/pull/3944/files?diff=unified&w=0#diff-481ba56b502b479282760464d0c78dc1ed197cbf81f028a7621396ac66d11457R230-R237))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
