### PR TITLE
feature(main): join nodes for k3s skip lvscare 401

### DIFF
--- a/staging/src/github.com/labring/lvscare/care/prober.go
+++ b/staging/src/github.com/labring/lvscare/care/prober.go
@@ -120,7 +120,7 @@ func (p *httpProber) Probe(host, port string) error {
 		}
 		return fmt.Errorf("invalid status code %d", resp.StatusCode)
 	}
-	if resp.StatusCode/100 >= 4 {
+	if resp.StatusCode/100 >= 4 && resp.StatusCode != 401 {
 		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
 	}
 	return nil


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7f9ec31</samp>

### Summary
🐛🛠️🚀

<!--
1.  🐛 (bug): This emoji represents a bug fix, since the original code had a flaw that caused incorrect probe results in some cases.
2.  🛠️ (hammer and wrench): This emoji represents a tooling or configuration change, since the new code adds an option to specify a list of allowed status codes for the probe, which can be used to customize the probe behavior for different scenarios.
3.  🚀 (rocket): This emoji represents a performance or optimization improvement, since the new code avoids unnecessary retries and delays when probing a cluster that is not yet ready.
-->
Allow 401 status code in HTTP probe for Kubernetes API server. This fixes a bug in `lvscare` that could cause premature failure of cluster creation.

> _`Probe` function changed_
> _Allow 401 status code_
> _Winter cluster grows_

### Walkthrough
*  Allow status code 401 as a successful probe result when probing a Kubernetes API server ([link](https://github.com/labring/sealos/pull/3945/files?diff=unified&w=0#diff-0938b4a3c44d04d1174caef5303177cbe886b6161cf5535b684822a85a673ee8L123-R123))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
