### PR TITLE
feature(main): support sealctl static_pod add options args

### DIFF
--- a/cmd/sealctl/cmd/static_pod.go
+++ b/cmd/sealctl/cmd/static_pod.go
@@ -47,11 +47,12 @@ func newStaticPodCmd() *cobra.Command {
 }
 
 type lvscarePod struct {
-	vip    string
-	master []string
-	image  string
-	name   string
-	print  bool
+	vip     string
+	master  []string
+	image   string
+	name    string
+	options []string
+	print   bool
 }
 
 func newLvscareCmd() *cobra.Command {
@@ -79,13 +80,14 @@ func newLvscareCmd() *cobra.Command {
 	lvscareCmd.Flags().StringVar(&obj.image, "image", v1beta1.DefaultLvsCareImage, "generator lvscare static pod image")
 	lvscareCmd.Flags().BoolVar(&setImage, "set-img", false, "update lvscare image to static pod")
 	lvscareCmd.Flags().StringSliceVar(&obj.master, "masters", []string{}, "generator masters addrs")
+	lvscareCmd.Flags().StringSliceVar(&obj.options, "options", []string{}, "lvscare args options")
 	lvscareCmd.Flags().BoolVar(&obj.print, "print", false, "is print yaml")
 	return lvscareCmd
 }
 
 func genNewPod(obj lvscarePod) error {
 	fileName := fmt.Sprintf("%s.%s", obj.name, constants.YamlFileSuffix)
-	yaml, err := ipvs.LvsStaticPodYaml(obj.vip, obj.master, obj.image, obj.name)
+	yaml, err := ipvs.LvsStaticPodYaml(obj.vip, obj.master, obj.image, obj.name, obj.options)
 	if err != nil {
 		return err
 	}

--- a/pkg/ipvs/lvscare.go
+++ b/pkg/ipvs/lvscare.go
@@ -32,7 +32,7 @@ const (
 	LvsCareCommand = "/usr/bin/lvscare"
 )
 
-func LvsStaticPodYaml(vip string, masters []string, image, name string) (string, error) {
+func LvsStaticPodYaml(vip string, masters []string, image, name string, options []string) (string, error) {
 	if vip == "" || len(masters) == 0 {
 		return "", fmt.Errorf("vip and mster not allow empty")
 	}
@@ -43,6 +43,9 @@ func LvsStaticPodYaml(vip string, masters []string, image, name string) (string,
 	for _, m := range masters {
 		args = append(args, "--rs")
 		args = append(args, m)
+	}
+	if len(options) > 0 {
+		args = append(args, options...)
 	}
 	flag := true
 	pod := componentPod(v1.Container{
@@ -108,9 +111,10 @@ func componentPod(container v1.Container) v1.Pod {
 			Namespace: metav1.NamespaceSystem,
 		},
 		Spec: v1.PodSpec{
-			Containers:  []v1.Container{container},
-			HostNetwork: true,
-			Volumes:     volumes,
+			Containers:        []v1.Container{container},
+			HostNetwork:       true,
+			Volumes:           volumes,
+			PriorityClassName: "system-node-critical",
 		},
 	}
 }

--- a/pkg/ipvs/lvscare_test.go
+++ b/pkg/ipvs/lvscare_test.go
@@ -25,9 +25,6 @@ var want = []string{
 kind: Pod
 metadata:
   creationTimestamp: null
-  labels:
-    component: kube-sealos-lvscare
-    tier: control-plane
   name: kube-sealos-lvscare
   namespace: kube-system
 spec:
@@ -35,7 +32,7 @@ spec:
   - args:
     - care
     - --vs
-    - 10.10.10.10:6443
+    - 10.10.10.10
     - --health-path
     - /healthz
     - --health-schem
@@ -46,6 +43,7 @@ spec:
     - 116.31.96.135:6443
     - --rs
     - 116.31.96.136:6443
+    - --aa
     command:
     - /usr/bin/lvscare
     image: fanux/lvscare:latest
@@ -59,7 +57,7 @@ spec:
       name: lib-modules
       readOnly: true
   hostNetwork: true
-  priorityClassName: system-cluster-critical
+  priorityClassName: system-node-critical
   volumes:
   - hostPath:
       path: /lib/modules
@@ -92,7 +90,7 @@ func TestLvsStaticPodYaml(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got, _ := LvsStaticPodYaml(tt.args.vip, tt.args.masters, tt.args.image, constants.LvsCareStaticPodName); got != tt.want {
+			if got, _ := LvsStaticPodYaml(tt.args.vip, tt.args.masters, tt.args.image, constants.LvsCareStaticPodName, []string{"--aa"}); got != tt.want {
 				t.Errorf("LvsStaticPodYaml() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0115433</samp>

### Summary
🚀🧪🛡️

<!--
1.  🚀 - This emoji represents the new feature of customizing the `lvscare` command arguments, which can improve the performance and reliability of the load balancing service.
2.  🧪 - This emoji represents the update to the test case, which ensures the correctness and quality of the code changes.
3.  🛡️ - This emoji represents the change to the priority class of the `lvscare` pod, which can protect it from being evicted by the kubelet and ensure its availability.
-->
The pull request adds a feature to customize the `lvscare` command arguments for the static pod creation in the `sealctl` tool. It also updates the test case and the priority class of the `lvscare` pod to match the new functionality.

> _To balance the load with `lvscare`_
> _We added a flag and a field there_
> _We can pass options_
> _To tweak its functions_
> _And set a priority class with care_

### Walkthrough
*  Add a new field `options` to the `lvscarePod` struct and a new flag `--options` to the `sealctl` command to allow the user to specify the arguments for the `lvscare` command ([link](https://github.com/labring/sealos/pull/3946/files?diff=unified&w=0#diff-6c1085f1556a1eb749a625f0dfd9b20ede763c1478174328b7e819760b923382L50-R55), [link](https://github.com/labring/sealos/pull/3946/files?diff=unified&w=0#diff-6c1085f1556a1eb749a625f0dfd9b20ede763c1478174328b7e819760b923382R83))
*  Pass the `options` field to the `LvsStaticPodYaml` function as a new parameter and append it to the `lvscare` container args in the static pod yaml ([link](https://github.com/labring/sealos/pull/3946/files?diff=unified&w=0#diff-6c1085f1556a1eb749a625f0dfd9b20ede763c1478174328b7e819760b923382L88-R90), [link](https://github.com/labring/sealos/pull/3946/files?diff=unified&w=0#diff-d26c131b3a7df2b0a973df40b7cd99ae13cba4f03bd55cf59617c40121814058L35-R35), [link](https://github.com/labring/sealos/pull/3946/files?diff=unified&w=0#diff-d26c131b3a7df2b0a973df40b7cd99ae13cba4f03bd55cf59617c40121814058R47-R49))
*  Change the `PriorityClassName` of the static pod spec from `system-cluster-critical` to `system-node-critical` to ensure the `lvscare` pod has a higher priority on the node ([link](https://github.com/labring/sealos/pull/3946/files?diff=unified&w=0#diff-d26c131b3a7df2b0a973df40b7cd99ae13cba4f03bd55cf59617c40121814058L111-R117), [link](https://github.com/labring/sealos/pull/3946/files?diff=unified&w=0#diff-3577d1ce4ae645e7356e6f3e8ae4a68dc6b1ef8c04a580bc0f66431f370fe99fL62-R60))
*  Update the test case in `lvscare_test.go` to reflect the changes in the `LvsStaticPodYaml` function and the `lvscare` command args ([link](https://github.com/labring/sealos/pull/3946/files?diff=unified&w=0#diff-3577d1ce4ae645e7356e6f3e8ae4a68dc6b1ef8c04a580bc0f66431f370fe99fL28-L30), [link](https://github.com/labring/sealos/pull/3946/files?diff=unified&w=0#diff-3577d1ce4ae645e7356e6f3e8ae4a68dc6b1ef8c04a580bc0f66431f370fe99fL38-R35), [link](https://github.com/labring/sealos/pull/3946/files?diff=unified&w=0#diff-3577d1ce4ae645e7356e6f3e8ae4a68dc6b1ef8c04a580bc0f66431f370fe99fR46), [link](https://github.com/labring/sealos/pull/3946/files?diff=unified&w=0#diff-3577d1ce4ae645e7356e6f3e8ae4a68dc6b1ef8c04a580bc0f66431f370fe99fL95-R93))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
