### PR TITLE
backup buildah image cr build logic to deprecate

### DIFF
--- a/deprecate/pkg/buildah/build.go
+++ b/deprecate/pkg/buildah/build.go
@@ -1,0 +1,199 @@
+// Copyright © 2022 buildah.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/containers/buildah/blob/main/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containers/buildah/define"
+	"github.com/containers/buildah/imagebuildah"
+	buildahcli "github.com/containers/buildah/pkg/cli"
+	"github.com/containers/buildah/util"
+	"github.com/spf13/cobra"
+
+	"github.com/labring/sealos/pkg/utils/logger"
+)
+
+func newBuildCommand() *cobra.Command {
+	buildDescription := fmt.Sprintf(`
+  Builds an OCI image using instructions in one or more Sealfiles/Kubefiles/Dockerfiles/Containerfiles.
+
+  If no arguments are specified, %s will use the current working directory
+  as the build context and look for a instructions file. The build fails if no any of
+  Sealfile/Kubefile/Dockerfile/Containerfile is present.`, rootCmd.Root().Name())
+
+	layerFlagsResults := buildahcli.LayerResults{}
+	buildFlagResults := buildahcli.BudResults{}
+	fromAndBudResults := buildahcli.FromAndBudResults{}
+	userNSResults := buildahcli.UserNSResults{}
+	namespaceResults := buildahcli.NameSpaceResults{}
+	sopts := saverOptions{}
+
+	buildCommand := &cobra.Command{
+		Use:     "build [CONTEXT]",
+		Aliases: []string{"build-using-dockerfile", "bud"},
+		Short:   "Build an image using instructions in a Containerfile or Kubefile",
+		Long:    buildDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			br := buildahcli.BuildOptions{
+				LayerResults:      &layerFlagsResults,
+				BudResults:        &buildFlagResults,
+				UserNSResults:     &userNSResults,
+				FromAndBudResults: &fromAndBudResults,
+				NameSpaceResults:  &namespaceResults,
+			}
+			return buildCmd(cmd, args, sopts, br)
+		},
+		Args: cobra.MaximumNArgs(1),
+		Example: fmt.Sprintf(`%[1]s build
+  %[1]s bud -f Kubefile.simple .
+  %[1]s bud -f Kubefile.simple -f Kubefile.notsosimple .`, rootCmd.CommandPath()),
+	}
+	buildCommand.SetUsageTemplate(UsageTemplate())
+
+	flags := buildCommand.Flags()
+	flags.SetInterspersed(false)
+
+	// build is a all common flags
+	buildFlags := buildahcli.GetBudFlags(&buildFlagResults)
+	buildFlags.StringVar(&buildFlagResults.Runtime, "runtime", util.Runtime(), "`path` to an alternate runtime. Use BUILDAH_RUNTIME environment variable to override.")
+
+	layerFlags := buildahcli.GetLayerFlags(&layerFlagsResults)
+	fromAndBudFlags, err := buildahcli.GetFromAndBudFlags(&fromAndBudResults, &userNSResults, &namespaceResults)
+	bailOnError(err, "failed to setup From and Build flags")
+
+	sopts.RegisterFlags(flags)
+	flags.AddFlagSet(&buildFlags)
+	flags.AddFlagSet(&layerFlags)
+	flags.AddFlagSet(&fromAndBudFlags)
+	flags.SetNormalizeFunc(buildahcli.AliasFlags)
+
+	bailOnError(markFlagsHidden(flags, "tls-verify"), "")
+	bailOnError(markFlagsHidden(flags, append(flagsInBuildCommandToBeHidden(), flagsAssociatedWithPlatform()...)...), "")
+	buildCommand.SetUsageTemplate(UsageTemplate())
+
+	return buildCommand
+}
+
+func buildCmd(c *cobra.Command, inputArgs []string, sopts saverOptions, iopts buildahcli.BuildOptions) error {
+	if flagChanged(c, "logfile") {
+		logfile, err := os.OpenFile(iopts.Logfile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
+		if err != nil {
+			return err
+		}
+		iopts.Logwriter = logfile
+		defer iopts.Logwriter.Close()
+	}
+
+	if len(iopts.File) == 0 {
+		ctxDir, err := getContextDir(inputArgs)
+		if err != nil {
+			return err
+		}
+		getFile := func(filename string) (string, error) {
+			file := filepath.Join(ctxDir, filename)
+			fileInfo, err := os.Stat(file)
+			if err != nil {
+				return "", fmt.Errorf("cannot find %s in context directory: %w", filename, err)
+			}
+			// The file exists, now verify the correct mode
+			if mode := fileInfo.Mode(); mode.IsRegular() {
+				return file, nil
+			}
+			return "", fmt.Errorf("assumed %s is a file but it's not", filename)
+		}
+
+		defaultFileNames := []string{"Sealfile", "Kubefile", "Dockerfile", "Containerfile"}
+		for _, name := range defaultFileNames {
+			if foundFile, err := getFile(name); err == nil && foundFile != "" {
+				iopts.File = append(iopts.File, foundFile)
+			}
+		}
+		if len(iopts.File) == 0 {
+			return fmt.Errorf("cannot find any of %v in context directory", strings.Join(defaultFileNames, ", "))
+		}
+	}
+	if err := setDefaultFlagsWithSetters(c, setDefaultTLSVerifyFlag); err != nil {
+		return err
+	}
+
+	options, containerfiles, removeAll, err := buildahcli.GenBuildOptions(c, inputArgs, iopts)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		for _, f := range removeAll {
+			os.RemoveAll(f)
+		}
+	}()
+
+	platforms, err := parsePlatforms(c)
+	if err != nil {
+		return err
+	}
+	if err = runSaveImages(options.ContextDirectory, platforms, options.SystemContext, &sopts); err != nil {
+		return err
+	}
+	if globalFlagResults.DefaultMountsFile != "" {
+		options.DefaultMountsFilePath = globalFlagResults.DefaultMountsFile
+	}
+
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+
+	id, ref, err := imagebuildah.BuildDockerfiles(getContext(), store, options, containerfiles...)
+	if err == nil && options.Manifest != "" {
+		logger.Debug("manifest list id = %q, ref = %q", id, ref.String())
+	}
+	return err
+}
+
+func getContextDir(inputArgs []string) (string, error) {
+	contextDir := ""
+	cliArgs := inputArgs
+	var err error
+	// Nothing provided, we assume the current working directory as build
+	// context
+	if len(cliArgs) == 0 {
+		contextDir, err = os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("unable to choose current working directory as build context: %w", err)
+		}
+	} else {
+		// The context directory could be a URL.  Try to handle that.
+		tempDir, subDir, err := define.TempDirForURL("", "buildah", cliArgs[0])
+		if err != nil {
+			return "", fmt.Errorf("prepping temporary context directory: %w", err)
+		}
+		if tempDir != "" {
+			// We had to download it to a temporary directory.
+			// Delete it later.
+			contextDir = filepath.Join(tempDir, subDir)
+		} else {
+			// Nope, it was local.  Use it as is.
+			absDir, err := filepath.Abs(cliArgs[0])
+			if err != nil {
+				return "", fmt.Errorf("determining path to directory: %w", err)
+			}
+			contextDir = absDir
+		}
+	}
+	return contextDir, err
+}

--- a/deprecate/pkg/buildah/buildah.go
+++ b/deprecate/pkg/buildah/buildah.go
@@ -1,0 +1,335 @@
+// Copyright © 2022 buildah.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/containers/buildah/blob/main/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"runtime/pprof"
+
+	"github.com/containers/common/pkg/config"
+	"github.com/containers/storage"
+	"github.com/containers/storage/pkg/unshare"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/labring/sealos/pkg/system"
+	"github.com/labring/sealos/pkg/utils/logger"
+)
+
+type globalFlags struct {
+	LogLevel                   string
+	Root                       string
+	RunRoot                    string
+	StorageDriver              string
+	RegistriesConf             string
+	RegistriesConfDir          string
+	DefaultMountsFile          string
+	StorageOpts                []string
+	UserNSUID                  []string
+	UserNSGID                  []string
+	CPUProfile                 string
+	cpuProfileFile             *os.File
+	MemoryProfile              string
+	UserShortNameAliasConfPath string
+	CgroupManager              string
+}
+
+func (opts *globalFlags) HiddenFlags() []string {
+	// hidden most of buildah flags
+	return []string{
+		"registries-conf",
+		"registries-conf-dir",
+		"short-name-alias-conf",
+		"cgroup-manager",
+		"userns-uid-map",
+		"userns-gid-map",
+		logLevel,
+		"cpu-profile",
+		"default-mounts-file",
+		"memory-profile",
+		"root", "runroot", "storage-driver", "storage-opt",
+	}
+}
+
+const logLevel = "log-level"
+
+func RegisterGlobalFlags(fs *pflag.FlagSet) error {
+	var (
+		defaultStoreDriverOptions []string
+	)
+	storageOptions, err := storage.DefaultStoreOptions(unshare.GetRootlessUID() > 0, unshare.GetRootlessUID())
+	if err != nil {
+		return err
+	}
+
+	if len(storageOptions.GraphDriverOptions) > 0 {
+		optionSlice := storageOptions.GraphDriverOptions[:]
+		defaultStoreDriverOptions = optionSlice
+	}
+
+	containerConfig, err := config.Default()
+	if err != nil {
+		return err
+	}
+	containerConfig.CheckCgroupsAndAdjustConfig()
+	// TODO Need to allow for environment variable
+	fs.StringVar(&globalFlagResults.RegistriesConf, "registries-conf", "", "path to registries.conf file (not usually used)")
+	fs.StringVar(&globalFlagResults.RegistriesConfDir, "registries-conf-dir", "", "path to registries.conf.d directory (not usually used)")
+	fs.StringVar(&globalFlagResults.UserShortNameAliasConfPath, "short-name-alias-conf", "", "path to short name alias cache file (not usually used)")
+	fs.StringVar(&globalFlagResults.Root, "root", storageOptions.GraphRoot, "storage root dir")
+	fs.StringVar(&globalFlagResults.RunRoot, "runroot", storageOptions.RunRoot, "storage state dir")
+	fs.StringVar(&globalFlagResults.CgroupManager, "cgroup-manager", containerConfig.Engine.CgroupManager, "cgroup manager")
+	fs.StringVar(&globalFlagResults.StorageDriver, "storage-driver", storageOptions.GraphDriverName, "storage-driver")
+	fs.StringSliceVar(&globalFlagResults.StorageOpts, "storage-opt", defaultStoreDriverOptions, "storage driver option")
+	fs.StringSliceVar(&globalFlagResults.UserNSUID, "userns-uid-map", []string{}, "default `ctrID:hostID:length` UID mapping to use")
+	fs.StringSliceVar(&globalFlagResults.UserNSGID, "userns-gid-map", []string{}, "default `ctrID:hostID:length` GID mapping to use")
+	fs.StringVar(&globalFlagResults.DefaultMountsFile, "default-mounts-file", "", "path to default mounts file")
+	fs.StringVar(&globalFlagResults.LogLevel, logLevel, "warn", `The log level to be used. Either "trace", "debug", "info", "warn", "error", "fatal", or "panic".`)
+	fs.StringVar(&globalFlagResults.CPUProfile, "cpu-profile", "", "`file` to write CPU profile")
+	fs.StringVar(&globalFlagResults.MemoryProfile, "memory-profile", "", "`file` to write memory profile")
+	return markFlagsHidden(fs, globalFlagResults.HiddenFlags()...)
+}
+
+var (
+	globalFlagResults globalFlags
+	rootCmd           *cobra.Command
+	postRunHooks      []func() error
+)
+
+func markFlagsHidden(fs *pflag.FlagSet, names ...string) error {
+	for _, name := range names {
+		if err := fs.MarkHidden(name); err != nil {
+			return fmt.Errorf("unable to mark %s flag as hidden: %v", name, err)
+		}
+	}
+	return nil
+}
+
+func AllImageSubCommands() []*cobra.Command {
+	cmds := []*cobra.Command{
+		newBuildCommand(),
+		newCreateCmd(),
+		newDiffCommand(),
+		newInspectCommand(),
+		newImagesCommand(),
+		newLoadCommand(),
+		newLoginCommand(),
+		newLogoutCommand(),
+		newManifestCommand(),
+		newMergeCommand(),
+		newPullCommand(),
+		newPushCommand(),
+		newRMICommand(),
+		newSaveCommand(),
+		newTagCommand(),
+	}
+	SetRequireBuildahAnnotation(cmds...)
+	return cmds
+}
+
+func AllContainerSubCommands() []*cobra.Command {
+	cmds := []*cobra.Command{
+		newContainersCommand(),
+		newFromCommand(),
+		newMountCommand(),
+		newRMCommand(),
+		newUmountCommand(),
+	}
+	SetRequireBuildahAnnotation(cmds...)
+	return cmds
+}
+
+func AllSubCommands() []*cobra.Command {
+	return append(AllContainerSubCommands(), append(AllImageSubCommands(), newUnshareCommand())...)
+}
+
+func RegisterRootCommand(cmd *cobra.Command) {
+	rootCmd = cmd
+	cmd.SilenceUsage = true
+	bailOnError(RegisterGlobalFlags(cmd.PersistentFlags()), "failed to register global flags")
+	wrapPrePersistentRun(cmd)
+	wrapPostPersistentRun(cmd)
+}
+
+func RegisterPostRun(fn func() error) {
+	if rootCmd == nil {
+		logger.Fatal("Must not register post run function before RegisterRootCommand")
+	}
+	postRunHooks = append(postRunHooks, fn)
+}
+
+const (
+	requireBuildahAnnotationKey = "buildah-required"
+	requireBuildahAnnotationVal = "true"
+)
+
+// SetRequireBuildahAnnotation explicit call this function on commands that
+// require buildah module dependency
+func SetRequireBuildahAnnotation(cmds ...*cobra.Command) {
+	for i := range cmds {
+		if cmds[i].Annotations == nil {
+			cmds[i].Annotations = map[string]string{}
+		}
+		cmds[i].Annotations[requireBuildahAnnotationKey] = requireBuildahAnnotationVal
+	}
+}
+
+func requirePreRun(cmd *cobra.Command) bool {
+	for {
+		if cmd == nil {
+			break
+		}
+		if cmd.Annotations != nil &&
+			cmd.Annotations[requireBuildahAnnotationKey] == requireBuildahAnnotationVal {
+			return true
+		}
+		cmd = cmd.Parent()
+	}
+	return false
+}
+
+func wrapPrePersistentRun(cmd *cobra.Command) {
+	switch {
+	case cmd.PersistentPreRun != nil:
+		run := cmd.PersistentPreRun
+		cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+			if requirePreRun(cmd) {
+				bailOnError(TrySetupWithDefaults(defaultSetters...), "unable to setup")
+			}
+			run(cmd, args)
+		}
+	case cmd.PersistentPreRunE != nil:
+		runE := cmd.PersistentPreRunE
+		cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+			if requirePreRun(cmd) {
+				bailOnError(TrySetupWithDefaults(defaultSetters...), "unable to setup")
+			}
+			return runE(cmd, args)
+		}
+	default:
+		cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+			if requirePreRun(cmd) {
+				bailOnError(TrySetupWithDefaults(defaultSetters...), "unable to setup")
+			}
+		}
+	}
+}
+
+func wrapPostPersistentRun(cmd *cobra.Command) {
+	// shutdown store if necessary
+	switch {
+	case cmd.PersistentPostRun != nil:
+		run := cmd.PersistentPostRun
+		cmd.PersistentPostRun = func(cmd *cobra.Command, args []string) {
+			bailOnError(after(cmd), "")
+			run(cmd, args)
+		}
+	case cmd.PersistentPostRunE != nil:
+		runE := cmd.PersistentPostRunE
+		cmd.PersistentPostRunE = func(cmd *cobra.Command, args []string) error {
+			bailOnError(after(cmd), "")
+			return runE(cmd, args)
+		}
+	default:
+		cmd.PersistentPostRun = func(cmd *cobra.Command, args []string) {
+			bailOnError(after(cmd), "")
+		}
+	}
+}
+
+func shutdownStore(cmd *cobra.Command) error {
+	if needToShutdownStore {
+		store, err := getStore(cmd)
+		if err != nil {
+			return err
+		}
+		logger.Debug("shutting down the store")
+		needToShutdownStore = false
+		if _, err = store.Shutdown(false); err != nil {
+			if errors.Is(err, storage.ErrLayerUsedByContainer) {
+				logger.Info("failed to shutdown storage: %q", err)
+			} else {
+				logger.Warn("failed to shutdown storage: %q", err)
+			}
+		}
+	}
+	return nil
+}
+
+func after(cmd *cobra.Command) error {
+	if err := shutdownStore(cmd); err != nil {
+		return err
+	}
+
+	if globalFlagResults.CPUProfile != "" {
+		pprof.StopCPUProfile()
+		globalFlagResults.cpuProfileFile.Close()
+	}
+	if globalFlagResults.MemoryProfile != "" {
+		memoryProfileFile, err := os.Create(globalFlagResults.MemoryProfile)
+		if err != nil {
+			logger.Fatal("could not create memory profile %s: %v", globalFlagResults.MemoryProfile, err)
+		}
+		defer memoryProfileFile.Close()
+		runtime.GC()
+		if err := pprof.Lookup("heap").WriteTo(memoryProfileFile, 1); err != nil {
+			logger.Fatal("could not write memory profile %s: %v", globalFlagResults.MemoryProfile, err)
+		}
+	}
+	for i := range postRunHooks {
+		if err := postRunHooks[i](); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func init() {
+	original := defaultSetters
+	defaultSetters = []Setter{maybeSetupLogrusLogger, maybeSetupProfiler}
+	defaultSetters = append(defaultSetters, original...)
+}
+
+func maybeSetupLogrusLogger() (err error) {
+	if logLevelVal, _ := system.Get(system.BuildahLogLevelConfigKey); logLevelVal != "" {
+		globalFlagResults.LogLevel = logLevelVal
+	}
+	logrusLvl, err := logrus.ParseLevel(globalFlagResults.LogLevel)
+	if err != nil {
+		return fmt.Errorf("unable to parse log level: %w", err)
+	}
+	if logrusLvl <= logrus.DebugLevel {
+		logrus.SetLevel(logrusLvl)
+	}
+	return nil
+}
+
+func maybeSetupProfiler() (err error) {
+	if globalFlagResults.CPUProfile != "" {
+		cpuProfileFile, err := os.Create(globalFlagResults.CPUProfile)
+		if err != nil {
+			return fmt.Errorf("could not create CPU profile %s: %v", globalFlagResults.CPUProfile, err)
+		}
+		globalFlagResults.cpuProfileFile = cpuProfileFile
+		if err = pprof.StartCPUProfile(globalFlagResults.cpuProfileFile); err != nil {
+			return fmt.Errorf("error starting CPU profiling: %v", err)
+		}
+	}
+	return nil
+}

--- a/deprecate/pkg/buildah/common.go
+++ b/deprecate/pkg/buildah/common.go
@@ -1,0 +1,334 @@
+// Copyright © 2022 buildah.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/containers/buildah/blob/main/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/containers/buildah"
+	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/common/pkg/umask"
+	is "github.com/containers/image/v5/storage"
+	"github.com/containers/image/v5/types"
+	"github.com/containers/storage"
+	"github.com/containers/storage/pkg/unshare"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/labring/sealos/pkg/system"
+	wrapunshare "github.com/labring/sealos/pkg/unshare"
+	"github.com/labring/sealos/pkg/utils/logger"
+)
+
+var (
+	// configuration, including customizations made in containers.conf
+	needToShutdownStore = false
+)
+
+var (
+	IsRootless = wrapunshare.IsRootless
+)
+
+func flagChanged(c *cobra.Command, name string) bool {
+	if fs := c.Flag(name); fs != nil && fs.Changed {
+		return true
+	}
+	return false
+}
+
+func setDefaultFlagsWithSetters(c *cobra.Command, setters ...func(*cobra.Command) error) error {
+	for i := range setters {
+		if err := setters[i](c); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getPlatformFlags() *pflag.FlagSet {
+	fs := &pflag.FlagSet{}
+	fs.String("arch", runtime.GOARCH, "set the ARCH of the image to the provided value instead of the architecture of the host")
+	fs.String("os", runtime.GOOS, "set the OS to the provided value instead of the current operating system of the host")
+	fs.StringSlice("platform", []string{parse.DefaultPlatform()}, "set the OS/ARCH/VARIANT of the image to the provided value instead of the current operating system and architecture of the host (for example `linux/arm`)")
+	fs.String("variant", "", "override the `variant` of the specified image")
+	return fs
+}
+
+func flagsAssociatedWithPlatform() []string {
+	return []string{
+		"arch", "os", "os-feature", "os-version", "variant",
+	}
+}
+
+func flagsInBuildCommandToBeHidden() []string {
+	return []string{
+		"add-host",
+		"cap-add",
+		"cap-drop",
+		"cgroup-parent",
+		"cgroupns",
+		"cpp-flag",
+		"cpu-period",
+		"cpu-quota",
+		"cpu-shares",
+		"cpuset-cpus",
+		"cpuset-mems",
+		"decryption-key",
+		"device",
+		"disable-content-trust",
+		"hooks-dir",
+		"identity-label",
+		"iidfile",
+		"ipc",
+		"logfile",
+		"logsplit",
+		"memory",
+		"memory-swap",
+		"network",
+		"no-hosts",
+		"pid",
+		"runtime",
+		"runtime-flag",
+		"secret",
+		"security-opt",
+		"ssh",
+		"stdin",
+		"ulimit",
+		"unsetenv",
+		"userns",
+		"userns-gid-map",
+		"userns-gid-map-group",
+		"userns-uid-map",
+		"userns-uid-map-user",
+		"uts",
+		"volume",
+	}
+}
+
+func setDefaultTLSVerifyFlag(c *cobra.Command) error {
+	return setDefaultFlagIfNotChanged(c, "tls-verify", "false")
+}
+
+func setDefaultSaveImageFlag(c *cobra.Command) error {
+	return setDefaultFlagIfNotChanged(c, "save-image", "false")
+}
+
+func getPlatformFromFlags(c *cobra.Command) []string {
+	platforms, err := c.Flags().GetStringSlice("platform")
+	if err != nil {
+		logger.Error("failed to get platform from flags: %v", err)
+		return []string{}
+	}
+	return platforms
+}
+
+func getTagsFromFlags(c *cobra.Command) []string {
+	tag, err := c.Flags().GetStringArray("tag")
+	if err != nil {
+		return []string{}
+	}
+	return tag
+}
+
+func setDefaultFlagIfNotChanged(c *cobra.Command, k, v string) error {
+	if fs := c.Flag(k); fs != nil && !fs.Changed {
+		if err := c.Flags().Set(k, v); err != nil {
+			return fmt.Errorf("failed to set --%s default to %s: %v", k, v, err)
+		}
+	}
+	return nil
+}
+
+// setDefaultSystemContext use only when tls-verify flag not present.
+func setDefaultSystemContext(sc *types.SystemContext) {
+	sc.DockerInsecureSkipTLSVerify = types.NewOptionalBool(true)
+	sc.OCIInsecureSkipTLSVerify = true
+	sc.DockerDaemonInsecureSkipTLSVerify = true
+}
+
+func bailOnError(err error, format string, a ...interface{}) { // nolint: golint,goprintffuncname
+	if err != nil {
+		if format != "" {
+			logger.Error("%s: %v", fmt.Sprintf(format, a...), err)
+		} else {
+			logger.Error("%v", err)
+		}
+		os.Exit(1)
+	}
+}
+
+func getStore(c *cobra.Command) (storage.Store, error) {
+	if err := setXDGRuntimeDir(); err != nil {
+		return nil, err
+	}
+	options, err := storage.DefaultStoreOptions(unshare.GetRootlessUID() > 0, unshare.GetRootlessUID())
+	if err != nil {
+		return nil, err
+	}
+	if flagChanged(c, "root") || flagChanged(c, "runroot") {
+		options.GraphRoot = globalFlagResults.Root
+		options.RunRoot = globalFlagResults.RunRoot
+	}
+	if flagChanged(c, "storage-driver") {
+		options.GraphDriverName = globalFlagResults.StorageDriver
+		// If any options setup in config, these should be dropped if user overrode the driver
+		options.GraphDriverOptions = []string{}
+	}
+	if flagChanged(c, "storage-opt") {
+		if len(globalFlagResults.StorageOpts) > 0 {
+			options.GraphDriverOptions = globalFlagResults.StorageOpts
+		}
+	}
+
+	// Do not allow to mount a graphdriver that is not vfs if we are creating the userns as part
+	// of the mount command.
+	// Differently, allow the mount if we are already in a userns, as the mount point will still
+	// be accessible once "buildah mount" exits.
+	if os.Geteuid() != 0 && options.GraphDriverName != "vfs" {
+		return nil, fmt.Errorf("cannot mount using driver %s in rootless mode. You need to run it in a `%s unshare` session", options.GraphDriverName, c.Root().Name())
+	}
+
+	if len(globalFlagResults.UserNSUID) > 0 {
+		uopts := globalFlagResults.UserNSUID
+		gopts := globalFlagResults.UserNSGID
+
+		if len(gopts) == 0 {
+			gopts = uopts
+		}
+
+		uidmap, gidmap, err := unshare.ParseIDMappings(uopts, gopts)
+		if err != nil {
+			return nil, err
+		}
+		options.UIDMap = uidmap
+		options.GIDMap = gidmap
+	} else {
+		if len(globalFlagResults.UserNSGID) > 0 {
+			return nil, errors.New("option --userns-gid-map can not be used without --userns-uid-map")
+		}
+	}
+
+	// If a subcommand has the flags, check if they are set; if so, override the global values
+	if flagChanged(c, "userns-uid-map") {
+		uopts, _ := c.Flags().GetStringSlice("userns-uid-map")
+		gopts, _ := c.Flags().GetStringSlice("userns-gid-map")
+		if len(gopts) == 0 {
+			gopts = uopts
+		}
+		uidmap, gidmap, err := unshare.ParseIDMappings(uopts, gopts)
+		if err != nil {
+			return nil, err
+		}
+		options.UIDMap = uidmap
+		options.GIDMap = gidmap
+	} else {
+		if flagChanged(c, "userns-gid-map") {
+			return nil, errors.New("option --userns-gid-map can not be used without --userns-uid-map")
+		}
+	}
+	umask.Check()
+
+	store, err := storage.GetStore(options)
+	if store != nil {
+		is.Transport.SetStore(store)
+	}
+	// Do we really need to shutdown store before exit?
+	// needToShutdownStore = true
+	return store, err
+}
+
+// setXDGRuntimeDir sets XDG_RUNTIME_DIR when if it is unset under rootless
+func setXDGRuntimeDir() error {
+	if IsRootless() && os.Getenv("XDG_RUNTIME_DIR") == "" {
+		runtimeDir, err := storage.GetRootlessRuntimeDir(unshare.GetRootlessUID())
+		if err != nil {
+			return err
+		}
+		if err := os.Setenv("XDG_RUNTIME_DIR", runtimeDir); err != nil {
+			return errors.New("could not set XDG_RUNTIME_DIR")
+		}
+	}
+	return nil
+}
+
+func openBuilder(ctx context.Context, store storage.Store, name string) (builder *buildah.Builder, err error) {
+	if name != "" {
+		builder, err = buildah.OpenBuilder(store, name)
+		if errors.Is(err, os.ErrNotExist) {
+			options := buildah.ImportOptions{
+				Container: name,
+			}
+			builder, err = buildah.ImportBuilder(ctx, store, options)
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	if builder == nil {
+		return nil, errors.New("finding build container")
+	}
+	return builder, nil
+}
+
+func openBuilders(store storage.Store) (builders []*buildah.Builder, err error) {
+	return buildah.OpenAllBuilders(store)
+}
+
+// getContext returns a context.TODO
+func getContext() context.Context {
+	return context.TODO()
+}
+
+func defaultFormat() string {
+	format, _ := system.Get(system.BuildahFormatConfigKey)
+	return format
+}
+
+// Tail returns a string slice after the first element unless there are
+// not enough elements, then it returns an empty slice.  This is to replace
+// the urfavecli Tail method for args
+func Tail(a []string) []string {
+	if len(a) >= 2 {
+		return a[1:]
+	}
+	return []string{}
+}
+
+// UsageTemplate returns the usage template for podman commands
+// This blocks the displaying of the global options. The main podman
+// command should not use this.
+func UsageTemplate() string {
+	return `Usage:{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+  {{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+
+Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+{{end}}
+`
+}

--- a/deprecate/pkg/buildah/constants.go
+++ b/deprecate/pkg/buildah/constants.go
@@ -1,0 +1,83 @@
+// Copyright © 2022 sealos.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/containers/buildah/define"
+	"github.com/containers/image/v5/directory"
+	"github.com/containers/image/v5/docker"
+	"github.com/containers/image/v5/docker/archive"
+	ociarchive "github.com/containers/image/v5/oci/archive"
+	"github.com/containers/image/v5/oci/layout"
+	"github.com/containers/image/v5/openshift"
+	"github.com/containers/image/v5/sif"
+	"github.com/containers/image/v5/storage"
+	"github.com/containers/image/v5/tarball"
+)
+
+const (
+	OCIArchive        string = "oci-archive"
+	OCIManifestDir    string = "oci-dir"
+	DockerArchive     string = "docker-archive"
+	DockerManifestDir string = "docker-dir"
+)
+
+var DefaultTransport = OCIArchive
+
+func ValidateTransport(s string) error {
+	switch s {
+	case OCIArchive, DockerArchive:
+	default:
+		return fmt.Errorf("unsupported transport %s, available options are %s", s, strings.Join([]string{OCIArchive, DockerArchive}, ", "))
+	}
+	return nil
+}
+
+const (
+	DisableAutoRootless = "DISABLE_AUTO_ROOTLESS"
+)
+
+const (
+	PullIfMissing = define.PullIfMissing
+	PullAlways    = define.PullAlways
+	PullIfNewer   = define.PullIfNewer
+	PullNever     = define.PullNever
+)
+
+var (
+	TransportDir               = directory.Transport.Name()
+	TransportDocker            = docker.Transport.Name()
+	TransportDockerArchive     = archive.Transport.Name()
+	TransportOCIArchive        = ociarchive.Transport.Name()
+	TransportOCI               = layout.Transport.Name()
+	TransportAtomic            = openshift.Transport.Name()
+	TransportSif               = sif.Transport.Name()
+	TransportTarball           = tarball.Transport.Name()
+	TransportContainersStorage = storage.Transport.Name()
+)
+
+func FormatReferenceWithTransportName(tr string, ref string) string {
+	switch tr {
+	case TransportAtomic, TransportContainersStorage, TransportDir, TransportDockerArchive, TransportOCI, TransportOCIArchive, TransportTarball, TransportSif:
+		return tr + ":" + ref
+	case TransportDocker:
+		return tr + "://" + ref
+	default:
+		panic(fmt.Errorf("unknown transport %s", tr))
+	}
+}

--- a/deprecate/pkg/buildah/containers.go
+++ b/deprecate/pkg/buildah/containers.go
@@ -1,0 +1,352 @@
+// Copyright © 2022 buildah.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/containers/buildah/blob/main/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/containers/buildah"
+	"github.com/containers/buildah/define"
+	"github.com/containers/buildah/pkg/formats"
+	"github.com/containers/buildah/util"
+	"github.com/containers/storage"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var containersHeader = map[string]string{
+	"ContainerName": "CONTAINER NAME",
+	"ContainerID":   "CONTAINER ID",
+	"Builder":       "BUILDER",
+	"ImageID":       "IMAGE ID",
+	"ImageName":     "IMAGE NAME",
+}
+
+type JSONContainer struct {
+	ID            string `json:"id"`
+	Builder       bool   `json:"builder"`
+	ImageID       string `json:"imageid"`
+	ImageName     string `json:"imagename"`
+	ContainerName string `json:"containername"`
+}
+
+type containerOutputParams struct {
+	ContainerID   string
+	Builder       string
+	ImageID       string
+	ImageName     string
+	ContainerName string
+}
+
+type containerOptions struct {
+	all        bool
+	format     string
+	json       bool
+	noHeading  bool
+	noTruncate bool
+	quiet      bool
+}
+
+type containerFilterParams struct {
+	id       string
+	name     string
+	ancestor string
+}
+
+type containersResults struct {
+	all        bool
+	filter     string
+	format     string
+	json       bool
+	noheading  bool
+	notruncate bool
+	quiet      bool
+}
+
+func newDefaultContainerResults() *containersResults {
+	return &containersResults{}
+}
+
+func (opts *containersResults) RegisterFlags(fs *pflag.FlagSet) {
+	fs.BoolVarP(&opts.all, "all", "a", opts.all, "also list non-buildah containers")
+	fs.StringVarP(&opts.filter, "filter", "f", opts.filter, "filter output based on conditions provided")
+	fs.StringVar(&opts.format, "format", opts.format, "pretty-print containers using a Go template")
+	fs.BoolVar(&opts.json, "json", opts.json, "output in JSON format")
+	fs.BoolVarP(&opts.noheading, "noheading", "n", opts.noheading, "do not print column headings")
+	fs.BoolVar(&opts.notruncate, "notruncate", opts.notruncate, "do not truncate output")
+	fs.BoolVarP(&opts.quiet, "quiet", "q", opts.quiet, "display only container IDs")
+}
+
+func newContainersCommand() *cobra.Command {
+	var (
+		containersDescription = "\n  Lists containers which appear to be " + define.Package + " working containers, their\n  names and IDs, and the names and IDs of the images from which they were\n  initialized."
+		opts                  = newDefaultContainerResults()
+	)
+	containersCommand := &cobra.Command{
+		Use:     "containers",
+		Hidden:  true,
+		Aliases: []string{"list", "ls", "ps"},
+		Short:   "List working containers and their base images",
+		Long:    containersDescription,
+		Args:    cobra.ExactArgs(0),
+		//Flags:                  sortFlags(containersFlags),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return containersCmd(cmd, args, opts)
+		},
+		Example: fmt.Sprintf(`%[1]s containers
+  %[1]s containers --format "{{.ContainerID}} {{.ContainerName}}"
+  %[1]s containers -q --noheading --notruncate`, rootCmd.CommandPath()),
+	}
+	containersCommand.SetUsageTemplate(UsageTemplate())
+
+	opts.RegisterFlags(containersCommand.Flags())
+	return containersCommand
+}
+
+func containersCmd(c *cobra.Command, args []string, iopts *containersResults) error {
+	if len(args) > 0 {
+		return fmt.Errorf("'%s' does not accept arguments", c.CommandPath())
+	}
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+
+	if flagChanged(c, "quiet") && flagChanged(c, "format") {
+		return errors.New("quiet and format are mutually exclusive")
+	}
+
+	opts := containerOptions{
+		all:        iopts.all,
+		format:     iopts.format,
+		json:       iopts.json,
+		noHeading:  iopts.noheading,
+		noTruncate: iopts.notruncate,
+		quiet:      iopts.quiet,
+	}
+
+	var params *containerFilterParams
+	if flagChanged(c, "filter") {
+		params, err = parseCtrFilter(iopts.filter)
+		if err != nil {
+			return fmt.Errorf("parsing filter: %w", err)
+		}
+	}
+
+	if !opts.noHeading && !opts.quiet && opts.format == "" && !opts.json {
+		containerOutputHeader(!opts.noTruncate)
+	}
+
+	return outputContainers(store, opts, params)
+}
+
+func readContainers(store storage.Store, opts containerOptions, params *containerFilterParams) ([]containerOutputParams, []JSONContainer, error) {
+	seenImages := make(map[string]string)
+	imageNameForID := func(id string) string {
+		if id == "" {
+			return buildah.BaseImageFakeName
+		}
+		imageName, ok := seenImages[id]
+		if ok {
+			return imageName
+		}
+		img, err2 := store.Image(id)
+		if err2 == nil && len(img.Names) > 0 {
+			seenImages[id] = img.Names[0]
+		}
+		return seenImages[id]
+	}
+
+	builders, err := openBuilders(store)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading build containers: %w", err)
+	}
+	var (
+		containerOutput []containerOutputParams
+		JSONContainers  []JSONContainer
+	)
+	if !opts.all {
+		// only output containers created by buildah
+		for _, builder := range builders {
+			image := imageNameForID(builder.FromImageID)
+			if !matchesCtrFilter(builder.ContainerID, builder.Container, builder.FromImageID, image, params) {
+				continue
+			}
+			if opts.json {
+				JSONContainers = append(JSONContainers, JSONContainer{ID: builder.ContainerID,
+					Builder:       true,
+					ImageID:       builder.FromImageID,
+					ImageName:     image,
+					ContainerName: builder.Container})
+				continue
+			}
+			output := containerOutputParams{
+				ContainerID:   builder.ContainerID,
+				Builder:       "   *",
+				ImageID:       builder.FromImageID,
+				ImageName:     image,
+				ContainerName: builder.Container,
+			}
+			containerOutput = append(containerOutput, output)
+		}
+	} else {
+		// output all containers currently in storage
+		builderMap := make(map[string]struct{})
+		for _, builder := range builders {
+			builderMap[builder.ContainerID] = struct{}{}
+		}
+		containers, err2 := store.Containers()
+		if err2 != nil {
+			return nil, nil, fmt.Errorf("reading list of all containers: %w", err2)
+		}
+		for _, container := range containers {
+			name := ""
+			if len(container.Names) > 0 {
+				name = container.Names[0]
+			}
+			_, ours := builderMap[container.ID]
+			builder := ""
+			if ours {
+				builder = "   *"
+			}
+			if !matchesCtrFilter(container.ID, name, container.ImageID, imageNameForID(container.ImageID), params) {
+				continue
+			}
+			if opts.json {
+				JSONContainers = append(JSONContainers, JSONContainer{ID: container.ID,
+					Builder:       ours,
+					ImageID:       container.ImageID,
+					ImageName:     imageNameForID(container.ImageID),
+					ContainerName: name})
+				continue
+			}
+			output := containerOutputParams{
+				ContainerID:   container.ID,
+				Builder:       builder,
+				ImageID:       container.ImageID,
+				ImageName:     imageNameForID(container.ImageID),
+				ContainerName: name,
+			}
+			containerOutput = append(containerOutput, output)
+		}
+	}
+	return containerOutput, JSONContainers, nil
+}
+
+func outputContainers(store storage.Store, opts containerOptions, params *containerFilterParams) error {
+	containerOutput, JSONContainers, err := readContainers(store, opts, params)
+	if err != nil {
+		return err
+	}
+	if opts.json {
+		data, err := json.MarshalIndent(JSONContainers, "", "    ")
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%s\n", data)
+		return nil
+	}
+
+	if opts.format != "" {
+		out := formats.StdoutTemplateArray{Output: containersToGeneric(containerOutput), Template: opts.format, Fields: containersHeader}
+		return formats.Writer(out).Out()
+	}
+
+	for _, ctr := range containerOutput {
+		if opts.quiet {
+			fmt.Printf("%-64s\n", ctr.ContainerID)
+			continue
+		}
+		containerOutputUsingFormatString(!opts.noTruncate, ctr)
+	}
+	return nil
+}
+
+func containersToGeneric(templParams []containerOutputParams) (genericParams []interface{}) {
+	if len(templParams) > 0 {
+		for _, v := range templParams {
+			genericParams = append(genericParams, interface{}(v))
+		}
+	}
+	return genericParams
+}
+
+func containerOutputUsingFormatString(truncate bool, params containerOutputParams) {
+	if truncate {
+		fmt.Printf("%-12.12s  %-8s %-12.12s %-32s %s\n", params.ContainerID, params.Builder, params.ImageID, util.TruncateString(params.ImageName, 32), params.ContainerName)
+	} else {
+		fmt.Printf("%-64s %-8s %-64s %-32s %s\n", params.ContainerID, params.Builder, params.ImageID, params.ImageName, params.ContainerName)
+	}
+}
+
+func containerOutputHeader(truncate bool) {
+	if truncate {
+		fmt.Printf("%-12s  %-8s %-12s %-32s %s\n", "CONTAINER ID", "BUILDER", "IMAGE ID", "IMAGE NAME", "CONTAINER NAME")
+	} else {
+		fmt.Printf("%-64s %-8s %-64s %-32s %s\n", "CONTAINER ID", "BUILDER", "IMAGE ID", "IMAGE NAME", "CONTAINER NAME")
+	}
+}
+
+func parseCtrFilter(filter string) (*containerFilterParams, error) {
+	params := new(containerFilterParams)
+	filters := strings.Split(filter, ",")
+	for _, param := range filters {
+		pair := strings.SplitN(param, "=", 2)
+		if len(pair) != 2 {
+			return nil, fmt.Errorf("incorrect filter value %q, should be of form filter=value", param)
+		}
+		switch strings.TrimSpace(pair[0]) {
+		case "id":
+			params.id = pair[1]
+		case "name":
+			params.name = pair[1]
+		case "ancestor":
+			params.ancestor = pair[1]
+		default:
+			return nil, fmt.Errorf("invalid filter %q", pair[0])
+		}
+	}
+	return params, nil
+}
+
+func matchesCtrName(ctrName, argName string) bool {
+	return strings.Contains(ctrName, argName)
+}
+
+func matchesAncestor(imgName, imgID, argName string) bool {
+	if matchesID(imgID, argName) {
+		return true
+	}
+	return matchesReference(imgName, argName)
+}
+
+func matchesCtrFilter(ctrID, ctrName, imgID, imgName string, params *containerFilterParams) bool {
+	if params == nil {
+		return true
+	}
+	if params.id != "" && !matchesID(ctrID, params.id) {
+		return false
+	}
+	if params.name != "" && !matchesCtrName(ctrName, params.name) {
+		return false
+	}
+	if params.ancestor != "" && !matchesAncestor(imgName, imgID, params.ancestor) {
+		return false
+	}
+	return true
+}

--- a/deprecate/pkg/buildah/create.go
+++ b/deprecate/pkg/buildah/create.go
@@ -1,0 +1,108 @@
+// Copyright © 2022 sealos.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/storage/pkg/unshare"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/labring/sealos/pkg/utils/logger"
+)
+
+type createOptions struct {
+	name     string
+	platform string
+	short    bool
+}
+
+func newDefaultCreateOptions() *createOptions {
+	return &createOptions{
+		name:     "default",
+		platform: parse.DefaultPlatform(),
+	}
+}
+
+func (opts *createOptions) RegisterFlags(fs *pflag.FlagSet) {
+	fs.StringVarP(&opts.name, "cluster", "c", opts.name, "name of cluster to be created but not actually run")
+	fs.StringVar(&opts.platform, "platform", opts.platform, "set the OS/ARCH/VARIANT of the image to the provided value instead of the current operating system and architecture of the host (for example `linux/arm`)")
+	fs.BoolVar(&opts.short, "short", false, "if true, print just the mount path.")
+}
+
+func newCreateCmd() *cobra.Command {
+	opts := newDefaultCreateOptions()
+	var createCmd = &cobra.Command{
+		Use:   "create",
+		Short: "Create a cluster without running the CMD, for inspecting image",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			bder, err := New("")
+			if err != nil {
+				return err
+			}
+			flagSetters := []FlagSetter{}
+			if flagChanged(c, "platform") {
+				oss, arch, variant, err := parse.Platform(opts.platform)
+				if err != nil {
+					return err
+				}
+				flagSetters = append(flagSetters, WithPlatformOption(v1.Platform{OS: oss, Architecture: arch, Variant: variant}))
+			}
+			info, err := bder.Create(opts.name, args[0], flagSetters...)
+			if err != nil {
+				return err
+			}
+			if !opts.short {
+				logger.Info("Mount point: %s", info.MountPoint)
+			} else {
+				fmt.Println(info.MountPoint)
+			}
+			if !unshare.IsRootless() {
+				return nil
+			}
+			args = args[1:]
+			if len(args) < 1 {
+				shell, shellSet := os.LookupEnv("SHELL")
+				if !shellSet {
+					logger.Error("no command specified and no `SHELL` env set")
+					os.Exit(1)
+				}
+				args = []string{shell}
+			}
+			// nosemgrep: go.lang.security.audit.dangerous-exec-command.dangerous-exec-command
+			cmd := exec.Command(args[0], args[1:]...)
+			cmd.Env = unshare.RootlessEnv()
+			cmd.Stdin = os.Stdin
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			mountEnvs, unmountMounts, err := unshareMount(bder.(*realImpl).store, []string{info.ContainerID})
+			if err != nil {
+				return err
+			}
+			cmd.Env = append(cmd.Env, mountEnvs...)
+			unshare.ExecRunnable(cmd, unmountMounts)
+			os.Exit(1)
+			return nil
+		},
+	}
+	opts.RegisterFlags(createCmd.Flags())
+	return createCmd
+}

--- a/deprecate/pkg/buildah/diff.go
+++ b/deprecate/pkg/buildah/diff.go
@@ -1,0 +1,329 @@
+// Copyright © 2023 sealos.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/containers/common/libimage"
+	"github.com/containers/storage/pkg/archive"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/labring/sealos/pkg/utils/logger"
+)
+
+func parseDiffType(v string) (DiffType, error) {
+	switch v {
+	case "all":
+		return DiffAll, nil
+	case "container":
+		return DiffContainer, nil
+	case "image":
+		return DiffImage, nil
+	default:
+		return 0, fmt.Errorf("unknown diff type %s", v)
+	}
+}
+
+// extra type to use as enum
+type DiffType uint8
+
+const (
+	// only diff containers
+	DiffContainer DiffType = 1 << iota
+	// only diff images
+	DiffImage
+	// diff both containers and images
+	DiffAll DiffType = 0b11111111
+)
+
+func (d DiffType) String() string {
+	switch d {
+	case DiffAll:
+		return "all"
+	case DiffContainer:
+		return "container"
+	case DiffImage:
+		return "image"
+	default:
+		return "unknown"
+	}
+}
+
+type changesReportJSON struct {
+	Changed []string `json:"changed,omitempty"`
+	Added   []string `json:"added,omitempty"`
+	Deleted []string `json:"deleted,omitempty"`
+}
+
+func changesToJSON(out io.Writer, diffs []archive.Change) error {
+	body := changesReportJSON{}
+	for _, row := range diffs {
+		switch row.Kind {
+		case archive.ChangeAdd:
+			body.Added = append(body.Added, row.Path)
+		case archive.ChangeDelete:
+			body.Deleted = append(body.Deleted, row.Path)
+		case archive.ChangeModify:
+			body.Changed = append(body.Changed, row.Path)
+		default:
+			return fmt.Errorf("output kind %q not recognized", row.Kind)
+		}
+	}
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "     ")
+	return enc.Encode(body)
+}
+
+func changesToTable(out io.Writer, diffs []archive.Change) error {
+	for _, row := range diffs {
+		fmt.Fprintln(out, row.String())
+	}
+	return nil
+}
+
+type patchOption struct {
+	enabled bool
+	save    bool
+	tag     string
+}
+
+func (o *patchOption) RegisterFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&o.enabled, "patch", false, "if enabled then create a named archive file contains changes that we interested")
+	fs.StringVarP(&o.tag, "tag", "t", "", `tag name, diff will auto build a new image with the generated changes if flag specified and --patch=true`)
+	fs.BoolVar(&o.save, "save", false, `if enabled and --tag flag is specified, diff will save the built image into a oci-archive file with the name of --output`)
+}
+
+type diffOption struct {
+	patchOption
+	diffType string
+	output   string
+	filterFn func(archive.Change) bool
+}
+
+func newDiffCommand() *cobra.Command {
+	opts := &diffOption{
+		filterFn: excludeInitTrees,
+	}
+	cmd := &cobra.Command{
+		Use:   "diff",
+		Short: "Inspect changes to the object's file systems",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.ValidateAndSetDefaults(); err != nil {
+				return err
+			}
+			return runDiff(cmd, args, opts)
+		},
+		Example: fmt.Sprintf(`%[1]s diff labring/kubernetes:v1.25 labring/kubernetes:v1.26
+  %[1]s diff -o table oci-archive:/path/of/older.tar oci-archive:/path/of/newer.tar
+  %[1]s diff --patch --save --o patch.tar -t labring/kubernetes:patch-from-125-126 labring/kubernetes:v1.25 labring/kubernetes:v1.26`,
+			rootCmd.CommandPath()),
+	}
+	opts.RegisterFlags(cmd.Flags())
+	opts.patchOption.RegisterFlags(cmd.Flags())
+	cmd.Flags().AddFlagSet(getPlatformFlags())
+	cmd.SetUsageTemplate(UsageTemplate())
+
+	return cmd
+}
+
+func (o *diffOption) RegisterFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.diffType, "diff-type", DiffImage.String(), "type of object to diff, available options are [container, image, all]")
+	fs.StringVarP(&o.output, "output", "o", "json", "change the output format, available options are [json, table]")
+}
+
+func (o *diffOption) ValidateAndSetDefaults() error {
+	if o.patchOption.enabled {
+		tmpFn := o.filterFn
+		o.filterFn = func(c archive.Change) bool {
+			return tmpFn(c) && filterPatchFileRequired(c)
+		}
+	}
+	return nil
+}
+
+var initTrees = map[string]bool{
+	"/dev":               true,
+	"/etc/hostname":      true,
+	"/etc/hosts":         true,
+	"/etc/resolv.conf":   true,
+	"/proc":              true,
+	"/run":               true,
+	"/run/notify":        true,
+	"/run/.containerenv": true,
+	"/run/secrets":       true,
+	"/sys":               true,
+	"/etc/mtab":          true,
+}
+
+func excludeInitTrees(change archive.Change) bool {
+	return !initTrees[change.Path]
+}
+
+func filterPatchFileRequired(change archive.Change) bool {
+	switch change.Kind {
+	case archive.ChangeAdd:
+		return true
+	case archive.ChangeModify:
+		if !strings.HasPrefix(change.Path, "/registry") {
+			return true
+		}
+	}
+	return false
+}
+
+func runDiff(c *cobra.Command, args []string, opts *diffOption) error {
+	if len(args) != 2 {
+		return fmt.Errorf("%s requires exact 2 arguments", c.CommandPath())
+	}
+	diffType, err := parseDiffType(opts.diffType)
+	if err != nil {
+		return err
+	}
+	r, err := getRuntime(c)
+	if err != nil {
+		return err
+	}
+
+	ctx := getContext()
+	if diffType == DiffImage {
+		if args, err = r.PullOrLoadImages(ctx, args, libimage.CopyOptions{}); err != nil {
+			return err
+		}
+	}
+	from, to, err := r.getLayerIDs(args[0], args[1], diffType)
+	if err != nil {
+		return err
+	}
+	changes, err := r.Store.Changes(from, to)
+	if err != nil {
+		return err
+	}
+	var diffs []archive.Change
+	for _, c := range changes {
+		if opts.filterFn(c) {
+			diffs = append(diffs, c)
+		}
+	}
+	if !opts.patchOption.enabled {
+		switch opts.output {
+		case "json":
+			return changesToJSON(os.Stdout, diffs)
+		case "table":
+			return changesToTable(os.Stdout, diffs)
+		default:
+			return fmt.Errorf("unknown output format %s", opts.output)
+		}
+	}
+	img, err := r.Store.Image(args[1])
+	if err != nil {
+		return err
+	}
+	target, err := r.Store.DifferTarget(img.TopLayer)
+	if err != nil {
+		return fmt.Errorf("failed to get diff target: %v", err)
+	}
+	rc, err := archive.ExportChanges(target, diffs, nil, nil)
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+	// save into archive file only
+	if opts.patchOption.tag == "" {
+		compression := guessCompression(opts.output)
+		extension := "." + compression.Extension()
+		out := opts.output
+		if !strings.HasSuffix(out, extension) {
+			out = out + extension
+		}
+		file, err := os.Create(out)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		wc, err := archive.CompressStream(file, compression)
+		if err != nil {
+			return err
+		}
+		defer wc.Close()
+		_, err = io.Copy(wc, rc)
+		if err == nil {
+			logger.Info("file %s saved", out)
+		}
+		return err
+	}
+	// rebuild
+	tmpDir, err := os.MkdirTemp("", "diff-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+	if err = archive.Unpack(rc, tmpDir, &archive.TarOptions{}); err != nil {
+		return err
+	}
+	debug, _ := c.Flags().GetBool("debug")
+	if err = rerun("build",
+		fmt.Sprintf("--debug=%s", strconv.FormatBool(debug)),
+		fmt.Sprintf("-t=%s", opts.patchOption.tag),
+		"--save-image=false", tmpDir,
+	); err != nil {
+		return err
+	}
+	// save new image
+	if opts.patchOption.save {
+		if err = rerun("save",
+			fmt.Sprintf("--debug=%s", strconv.FormatBool(debug)),
+			fmt.Sprintf("--output=%s", opts.output), opts.patchOption.tag,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rerun(command string, args ...string) error {
+	cmd := exec.Command("/proc/self/exe", append([]string{command}, args...)...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	return cmd.Run()
+}
+
+const (
+	tarExt = "tar"
+)
+
+func guessCompression(v string) archive.Compression {
+	switch {
+	case strings.HasSuffix(v, tarExt+".bz2"):
+		return archive.Bzip2
+	case strings.HasSuffix(v, tarExt+".gz"):
+		return archive.Gzip
+	case strings.HasSuffix(v, tarExt+".xz"):
+		return archive.Xz
+	case strings.HasSuffix(v, tarExt+".zst"):
+		return archive.Zstd
+	default:
+		return archive.Uncompressed
+	}
+}

--- a/deprecate/pkg/buildah/doc.go
+++ b/deprecate/pkg/buildah/doc.go
@@ -1,0 +1,17 @@
+// Copyright © 2022 sealos.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+// Most of codes are COPIED from github.com/containers/buildah

--- a/deprecate/pkg/buildah/from.go
+++ b/deprecate/pkg/buildah/from.go
@@ -1,0 +1,401 @@
+// Copyright © 2022 buildah.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/containers/buildah/blob/main/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/containers/buildah"
+	"github.com/containers/buildah/define"
+	buildahcli "github.com/containers/buildah/pkg/cli"
+	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/common/pkg/auth"
+	"github.com/containers/common/pkg/config"
+	"github.com/containers/image/v5/types"
+	"github.com/containers/storage"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/labring/sealos/pkg/buildah/internal/util"
+	"github.com/labring/sealos/pkg/utils/logger"
+)
+
+type fromReply struct {
+	authfile        string
+	certDir         string
+	cidfile         string
+	creds           string
+	format          string
+	name            string
+	pull            string
+	pullAlways      bool
+	pullNever       bool
+	quiet           bool
+	signaturePolicy string
+	tlsVerify       bool
+	*buildahcli.FromAndBudResults
+	*buildahcli.UserNSResults
+	*buildahcli.NameSpaceResults
+}
+
+func newDefaultFromReply() *fromReply {
+	defaultContainerConfig, err := config.Default()
+	if err != nil {
+		logger.Fatal(err)
+	}
+	return &fromReply{
+		authfile:  auth.GetDefaultAuthFile(),
+		format:    defaultFormat(),
+		pull:      "true",
+		tlsVerify: false,
+		FromAndBudResults: &buildahcli.FromAndBudResults{
+			Devices:    defaultContainerConfig.Containers.Devices,
+			DNSSearch:  defaultContainerConfig.Containers.DNSSearches,
+			DNSServers: defaultContainerConfig.Containers.DNSServers,
+			DNSOptions: defaultContainerConfig.Containers.DNSOptions,
+			HTTPProxy:  true,
+			Isolation:  buildahcli.DefaultIsolation(),
+			Retry:      buildahcli.MaxPullPushRetries,
+			RetryDelay: buildahcli.PullPushRetryDelay.String(),
+			ShmSize:    defaultContainerConfig.Containers.ShmSize,
+			Ulimit:     defaultContainerConfig.Containers.DefaultUlimits,
+			Volumes:    defaultContainerConfig.Containers.Volumes,
+		},
+		UserNSResults:    &buildahcli.UserNSResults{},
+		NameSpaceResults: &buildahcli.NameSpaceResults{},
+	}
+}
+
+func (opts *fromReply) RegisterFlags(fs *pflag.FlagSet) {
+	fs.SetInterspersed(false)
+	fs.StringVar(&opts.authfile, "authfile", opts.authfile, "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
+	fs.StringVar(&opts.certDir, "cert-dir", opts.certDir, "use certificates at the specified path to access the registry")
+	fs.StringVar(&opts.cidfile, "cidfile", opts.cidfile, "write the container ID to the file")
+	fs.StringVar(&opts.creds, "creds", opts.creds, "use `[username[:password]]` for accessing the registry")
+	fs.StringVarP(&opts.format, "format", "f", opts.format, "`format` of the image manifest and metadata")
+	fs.StringVar(&opts.name, "name", opts.name, "`name` for the working container")
+	fs.StringVar(&opts.pull, "pull", opts.pull, "pull the image from the registry if newer or not present in store, if false, only pull the image if not present, if always, pull the image even if the named image is present in store, if never, only use the image present in store if available")
+	fs.Lookup("pull").NoOptDefVal = "true" //allow `--pull ` to be set to `true` as expected.
+
+	fs.BoolVar(&opts.pullAlways, "pull-always", opts.pullAlways, "pull the image even if the named image is present in store")
+	fs.BoolVar(&opts.pullNever, "pull-never", opts.pullNever, "do not pull the image, use the image present in store if available")
+	fs.BoolVarP(&opts.quiet, "quiet", "q", opts.quiet, "don't output progress information when pulling images")
+	fs.StringVar(&opts.signaturePolicy, "signature-policy", opts.signaturePolicy, "`pathname` of signature policy file (not usually used)")
+	fs.StringVar(&suffix, "suffix", "", "suffix to add to intermediate containers")
+	fs.BoolVar(&opts.tlsVerify, "tls-verify", opts.tlsVerify, "require HTTPS and verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
+	bailOnError(markFlagsHidden(fs, "pull-always", "pull-never", "suffix", "signature-policy", "tls-verify"), "")
+
+	// Add in the common flags
+	fromAndBudFlags, err := buildahcli.GetFromAndBudFlags(opts.FromAndBudResults, opts.UserNSResults, opts.NameSpaceResults)
+	bailOnError(err, "failed to setup From and Bud flags")
+
+	fs.AddFlagSet(&fromAndBudFlags)
+	fs.SetNormalizeFunc(buildahcli.AliasFlags)
+}
+
+var suffix string
+
+func newFromCommand() *cobra.Command {
+	var (
+		fromDescription = "\n  Creates a new working container, either from scratch or using a specified\n  image as a starting point."
+		opts            = newDefaultFromReply()
+	)
+
+	fromCommand := &cobra.Command{
+		Use:    "from",
+		Hidden: true,
+		Short:  "Create a working container based on an image",
+		Long:   fromDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fromCmd(cmd, args, opts)
+		},
+		Example: fmt.Sprintf(`%[1]s from --pull imagename
+  %[1]s from docker-daemon:imagename:imagetag
+  %[1]s from --name "myimagename" myregistry/myrepository/imagename:imagetag`, rootCmd.CommandPath()),
+	}
+	fromCommand.SetUsageTemplate(UsageTemplate())
+	opts.RegisterFlags(fromCommand.Flags())
+
+	return fromCommand
+}
+
+func onBuild(builder *buildah.Builder, quiet bool) error {
+	ctr := 0
+	for _, onBuildSpec := range builder.OnBuild() {
+		ctr = ctr + 1
+		commands := strings.Split(onBuildSpec, " ")
+		command := strings.ToUpper(commands[0])
+		args := commands[1:]
+		if !quiet {
+			fmt.Fprintf(os.Stderr, "STEP %d: %s\n", ctr, onBuildSpec)
+		}
+		switch command {
+		case "ADD":
+		case "COPY":
+			dest := ""
+			size := len(args)
+			if size > 1 {
+				dest = args[size-1]
+				args = args[:size-1]
+			}
+			if err := builder.Add(dest, command == "ADD", buildah.AddAndCopyOptions{}, args...); err != nil {
+				return err
+			}
+		case "ANNOTATION":
+			annotation := strings.SplitN(args[0], "=", 2)
+			if len(annotation) > 1 {
+				builder.SetAnnotation(annotation[0], annotation[1])
+			} else {
+				builder.UnsetAnnotation(annotation[0])
+			}
+		case "CMD":
+			builder.SetCmd(args)
+		case "ENV":
+			env := strings.SplitN(args[0], "=", 2)
+			if len(env) > 1 {
+				builder.SetEnv(env[0], env[1])
+			} else {
+				builder.UnsetEnv(env[0])
+			}
+		case "ENTRYPOINT":
+			builder.SetEntrypoint(args)
+		case "EXPOSE":
+			builder.SetPort(strings.Join(args, " "))
+		case "HOSTNAME":
+			builder.SetHostname(strings.Join(args, " "))
+		case "LABEL":
+			label := strings.SplitN(args[0], "=", 2)
+			if len(label) > 1 {
+				builder.SetLabel(label[0], label[1])
+			} else {
+				builder.UnsetLabel(label[0])
+			}
+		case "MAINTAINER":
+			builder.SetMaintainer(strings.Join(args, " "))
+		case "ONBUILD":
+			builder.SetOnBuild(strings.Join(args, " "))
+		case "RUN":
+			var stdout io.Writer
+			if quiet {
+				stdout = io.Discard
+			}
+			if err := builder.Run(args, buildah.RunOptions{Stdout: stdout}); err != nil {
+				return err
+			}
+		case "SHELL":
+			builder.SetShell(args)
+		case "STOPSIGNAL":
+			builder.SetStopSignal(strings.Join(args, " "))
+		case "USER":
+			builder.SetUser(strings.Join(args, " "))
+		case "VOLUME":
+			builder.AddVolume(strings.Join(args, " "))
+		case "WORKINGDIR":
+			builder.SetWorkDir(strings.Join(args, " "))
+		default:
+			logger.Error("unknown OnBuild command %q; ignored", onBuildSpec)
+		}
+	}
+	builder.ClearOnBuild()
+	return nil
+}
+
+func fromCmd(c *cobra.Command, args []string, iopts *fromReply) error {
+	if len(args) == 0 {
+		return errors.New("an image name (or \"scratch\") must be specified")
+	}
+	if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
+		return err
+	}
+	if len(args) > 1 {
+		return errors.New("too many arguments specified")
+	}
+	if err := setDefaultFlagsWithSetters(c, setDefaultTLSVerifyFlag); err != nil {
+		return err
+	}
+	if err := auth.CheckAuthFile(iopts.authfile); err != nil {
+		return err
+	}
+	systemContext, err := parse.SystemContextFromOptions(c)
+	if err != nil {
+		return fmt.Errorf("building system context: %w", err)
+	}
+	platforms, err := parse.PlatformsFromOptions(c)
+	if err != nil {
+		return err
+	}
+	if len(platforms) > 1 {
+		logger.Warn("ignoring platforms other than %+v: %+v", platforms[0], platforms[1:])
+	}
+
+	pullFlagsCount := 0
+	if c.Flag("pull").Changed {
+		pullFlagsCount++
+	}
+	if c.Flag("pull-always").Changed {
+		pullFlagsCount++
+	}
+	if c.Flag("pull-never").Changed {
+		pullFlagsCount++
+	}
+
+	if pullFlagsCount > 1 {
+		return errors.New("can only set one of 'pull' or 'pull-always' or 'pull-never'")
+	}
+
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+	builder, err := doFrom(c, args[0], iopts, store, systemContext)
+	if err != nil {
+		return err
+	}
+	if iopts.cidfile != "" {
+		filePath := iopts.cidfile
+		if err := os.WriteFile(filePath, []byte(builder.ContainerID), 0644); err != nil {
+			return fmt.Errorf("failed to write container ID file %q: %w", filePath, err)
+		}
+	}
+	fmt.Printf("%s\n", builder.Container)
+	return nil
+}
+
+func doFrom(c *cobra.Command, image string, iopts *fromReply,
+	store storage.Store,
+	systemContext *types.SystemContext,
+) (*buildah.Builder, error) {
+	defaultContainerConfig, err := config.Default()
+	if err != nil {
+		return nil, err
+	}
+	if systemContext == nil {
+		systemContext, err = parse.SystemContextFromOptions(c)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// Allow for --pull, --pull=true, --pull=false, --pull=never, --pull=always
+	// --pull-always and --pull-never.  The --pull-never and --pull-always options
+	// will not be documented.
+	pullPolicy := define.PullIfMissing
+	if strings.EqualFold(strings.TrimSpace(iopts.pull), "true") {
+		pullPolicy = define.PullIfNewer
+	}
+	if iopts.pullAlways || strings.EqualFold(strings.TrimSpace(iopts.pull), "always") {
+		pullPolicy = define.PullAlways
+	}
+	if iopts.pullNever || strings.EqualFold(strings.TrimSpace(iopts.pull), "never") {
+		pullPolicy = define.PullNever
+	}
+	logger.Debug("Pull Policy for pull [%v]", pullPolicy)
+
+	commonOpts, err := parse.CommonBuildOptions(c)
+	if err != nil {
+		return nil, err
+	}
+
+	isolation, err := parse.IsolationOption(iopts.Isolation)
+	if err != nil {
+		return nil, err
+	}
+
+	namespaceOptions, networkPolicy, err := parse.NamespaceOptions(c)
+	if err != nil {
+		return nil, fmt.Errorf("parsing namespace-related options: %w", err)
+	}
+	usernsOption, idmappingOptions, err := parse.IDMappingOptions(c, isolation)
+	if err != nil {
+		return nil, fmt.Errorf("parsing ID mapping options: %w", err)
+	}
+	namespaceOptions.AddOrReplace(usernsOption...)
+
+	format, err := util.GetFormat(iopts.format)
+	if err != nil {
+		return nil, err
+	}
+	devices := define.ContainerDevices{}
+	for _, device := range append(defaultContainerConfig.Containers.Devices, iopts.Devices...) {
+		dev, err := parse.DeviceFromPath(device)
+		if err != nil {
+			return nil, err
+		}
+		devices = append(devices, dev...)
+	}
+
+	capabilities, err := defaultContainerConfig.Capabilities("", iopts.CapAdd, iopts.CapDrop)
+	if err != nil {
+		return nil, err
+	}
+
+	commonOpts.Ulimit = append(defaultContainerConfig.Containers.DefaultUlimits, commonOpts.Ulimit...)
+
+	decConfig, err := util.DecryptConfig(iopts.DecryptionKeys)
+	if err != nil {
+		return nil, fmt.Errorf("unable to obtain decrypt config: %w", err)
+	}
+
+	var pullPushRetryDelay time.Duration
+	pullPushRetryDelay, err = time.ParseDuration(iopts.RetryDelay)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse value provided %q as --retry-delay: %w", iopts.RetryDelay, err)
+	}
+
+	options := buildah.BuilderOptions{
+		FromImage:             image,
+		Container:             iopts.name,
+		ContainerSuffix:       suffix,
+		PullPolicy:            pullPolicy,
+		SignaturePolicyPath:   iopts.signaturePolicy,
+		SystemContext:         systemContext,
+		DefaultMountsFilePath: globalFlagResults.DefaultMountsFile,
+		Isolation:             isolation,
+		NamespaceOptions:      namespaceOptions,
+		ConfigureNetwork:      networkPolicy,
+		CNIPluginPath:         iopts.CNIPlugInPath,
+		CNIConfigDir:          iopts.CNIConfigDir,
+		IDMappingOptions:      idmappingOptions,
+		Capabilities:          capabilities,
+		CommonBuildOpts:       commonOpts,
+		Format:                format,
+		BlobDirectory:         iopts.BlobCache,
+		Devices:               devices,
+		MaxPullRetries:        iopts.Retry,
+		PullRetryDelay:        pullPushRetryDelay,
+		OciDecryptConfig:      decConfig,
+	}
+
+	if !iopts.quiet {
+		options.ReportWriter = os.Stderr
+	}
+
+	builder, err := buildah.NewBuilder(getContext(), store, options)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := onBuild(builder, iopts.quiet); err != nil {
+		return nil, err
+	}
+	if err := builder.Save(); err != nil {
+		return nil, err
+	}
+	return builder, nil
+}

--- a/deprecate/pkg/buildah/imagecr.go
+++ b/deprecate/pkg/buildah/imagecr.go
@@ -1,0 +1,135 @@
+// Copyright © 2023 sealos.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/containers/image/v5/pkg/docker/config"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/util/homedir"
+
+	imagev1 "github.com/labring/sealos/controllers/imagehub/api/v1"
+	"github.com/labring/sealos/pkg/utils/file"
+	"github.com/labring/sealos/pkg/utils/logger"
+)
+
+// SpecificCroption is used to parse the cr-option `auto` to `yes` or `no`.
+func SpecificCroption(args []string) CrOpionEnum {
+	var dest, username string
+	switch len(args) {
+	case 1:
+		dest = args[0]
+	case 2:
+		dest = args[1]
+	}
+	registry, err := parseRawURL(dest)
+	if err != nil {
+		logger.Debug("parse image url failed, skip image cr build")
+		return CrOptionNo
+	}
+	creds, err := config.GetAllCredentials(nil)
+	if err != nil {
+		logger.Debug("get all credentials failed, skip image cr build")
+		return CrOptionNo
+	}
+	if _, ok := creds[registry]; ok {
+		username = creds[registry].Username
+	} else {
+		logger.Debug("no credentials for this registry, skip image cr build")
+		return CrOptionNo
+	}
+	if !file.IsExist(filepath.Join(homedir.HomeDir(), SealosRootPath, registry)) ||
+		!file.IsExist(filepath.Join(homedir.HomeDir(), SealosRootPath, registry, username)) {
+		logger.Debug("no kubeconfig file for this registry, skip image cr build")
+		return CrOptionNo
+	}
+	return CrOptionYes
+}
+
+func NewImageCRBuilderFromArgs(cmd *cobra.Command, args []string) (*ImageCRBuilder, error) {
+	var dest string
+	switch len(args) {
+	case 1:
+		dest = args[0]
+	case 2:
+		dest = args[1]
+	default:
+		return nil, errors.New("dest image name must be specified")
+	}
+	store, err := getStore(cmd)
+	if err != nil {
+		return nil, err
+	}
+	registr, err := parseRawURL(dest)
+	if err != nil {
+		return nil, err
+	}
+	icb := &ImageCRBuilder{
+		image:    dest,
+		store:    store,
+		registry: registr,
+		imageCR:  &imagev1.Image{},
+	}
+	return icb, nil
+}
+
+func NewAndRunImageCRBuilder(cmd *cobra.Command, args []string, iopts *pushOptions) error {
+	if iopts.crOption == CrOptionNo {
+		logger.Debug("skip image cr build by flag cr-option")
+		return nil
+	}
+	logger.Info("start image cr build and push")
+	icb, err := NewImageCRBuilderFromArgs(cmd, args)
+	if err != nil {
+		logger.Debug("new image cr builder failed, skip image cr build")
+		return err
+	}
+	// check if sealos registry, pahse registry info to ibc.
+	if !IsSealosRegistry(icb) {
+		logger.Debug("skip image cr build, not sealos registry")
+		return nil
+	}
+	if err := icb.Run(); err != nil {
+		logger.Error(err)
+		return err
+	}
+	logger.Info("image cr build and push success")
+	return nil
+}
+
+func IsSealosRegistry(icb *ImageCRBuilder) bool {
+	//Check Cri Login
+	creds, err := config.GetAllCredentials(nil)
+	if err != nil {
+		logger.Debug("get credentials err ,please login first ." + fmt.Sprintf("%v", err))
+		return false
+	}
+	if _, ok := creds[icb.registry]; ok {
+		icb.username = creds[icb.registry].Username
+		icb.userconfig = creds[icb.registry].Password
+	} else {
+		logger.Debug("get registry login info err, please login " + icb.registry + " first")
+		return false
+	}
+	if !file.IsExist(filepath.Join(homedir.HomeDir(), SealosRootPath, icb.registry)) ||
+		!file.IsExist(filepath.Join(homedir.HomeDir(), SealosRootPath, icb.registry, icb.username)) {
+		logger.Debug("no kubeconfig file for this registry, skip image cr build")
+		return false
+	}
+	return true
+}

--- a/deprecate/pkg/buildah/imagecrbuilder.go
+++ b/deprecate/pkg/buildah/imagecrbuilder.go
@@ -1,0 +1,250 @@
+// Copyright © 2022 sealos.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/containers/storage"
+	"github.com/openconfig/gnmi/errlist"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"k8s.io/client-go/util/homedir"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+
+	imagev1 "github.com/labring/sealos/controllers/imagehub/api/v1"
+	"github.com/labring/sealos/pkg/client-go/kubernetes"
+	"github.com/labring/sealos/pkg/utils/file"
+	"github.com/labring/sealos/pkg/utils/logger"
+	"github.com/labring/sealos/pkg/utils/rand"
+)
+
+type ImageCRBuilder struct {
+	image    string
+	registry string
+
+	username   string
+	userconfig string
+	imageCR    *imagev1.Image
+
+	containerID string
+	mountPoint  string
+	store       storage.Store
+}
+
+func (icb *ImageCRBuilder) Run() error {
+	var pipe []func() error
+	pipe = append(
+		pipe,
+		icb.CreateContainer,
+		icb.CreatImageCR,
+		icb.MutateImageCR,
+		icb.ApplyImageCR,
+		icb.DeleteContainer,
+	)
+	for _, f := range pipe {
+		err := f()
+		if err != nil {
+			logger.Error(err)
+			return err
+		}
+	}
+	return nil
+}
+
+// CreateContainer create a container, return mountpoint and containerID
+func (icb *ImageCRBuilder) CreateContainer() error {
+	logger.Debug("Executing CreateContainer in ImageCRBuilder")
+	// generate a random container name
+	containerID := fmt.Sprintf("%s-%s", icb.image, rand.Generator(8))
+	realImpl, err := New("")
+	if err != nil {
+		return err
+	}
+	builderInfo, err := realImpl.Create(containerID, icb.image)
+	if err != nil {
+		return err
+	}
+	if isExist := file.IsExist(builderInfo.MountPoint); !isExist {
+		return fmt.Errorf("mountPoint not Exist")
+	}
+	icb.containerID = containerID
+	icb.mountPoint = builderInfo.MountPoint
+	return nil
+}
+
+func (icb *ImageCRBuilder) CreatImageCR() error {
+	logger.Debug("Executing CreatImageCR in ImageCRBuilder")
+	if file.IsExist(filepath.Join(icb.mountPoint, ImageStdPath, ImageCRFile)) {
+		logger.Debug("image cr file exist, read it and parse it")
+		c, err := file.ReadAll(filepath.Join(icb.mountPoint, ImageStdPath, ImageCRFile))
+		if err != nil {
+			logger.Debug("read image cr file failed")
+			return err
+		}
+		err = icb.ParseImageCR(c)
+		if err != nil {
+			logger.Debug("parse image cr file failed")
+			return err
+		}
+	}
+	//if app base config not find
+	//image name which contains "/" and ":" couldn't be used in meta name
+	mateName := strings.Replace(icb.GetClearImagename(), ":", ".", -1)
+	mateName = strings.Replace(mateName, "/", ".", -1)
+	// replace image cr spec and matename by image
+	icb.imageCR.TypeMeta = metav1.TypeMeta{Kind: ImagehubKind, APIVersion: filepath.Join(ImagehubGroup, ImagehubVersion)}
+	icb.imageCR.ObjectMeta.Name = mateName
+	icb.imageCR.Spec.Name = imagev1.ImageName(icb.GetClearImagename())
+	logger.Debug("CreatImageCR in ImageCRBuilder done")
+	logger.Debug("ImageCRBuilder CreatImageCR result: ", icb.imageCR)
+	return nil
+}
+
+func (icb *ImageCRBuilder) MutateImageCR() error {
+	logger.Debug("Executing MutateImageCR in ImageCRBuilder")
+	var errl errlist.List
+	// Using a pipe helps with future file reading needs
+	fileReadPipeLine := []func() error{
+		//app config is the based file ,it should read first
+		icb.GetInspectInfo,
+		icb.GetReadmeDoc,
+	}
+	for _, f := range fileReadPipeLine {
+		if err := f(); err != nil {
+			errl.Add(err)
+		}
+	}
+	logger.Debug(errl.Err())
+	// Do not return error.
+	logger.Debug("MutateImageCR in ImageCRBuilder done")
+	logger.Debug("ImageCRBuilder MutateImageCR result: ", icb.imageCR)
+	return nil
+}
+
+func (icb *ImageCRBuilder) ApplyImageCR() error {
+	logger.Debug("Executing ApplyImageCR in ImageCRBuilder")
+	client, err := kubernetes.NewKubernetesClient(filepath.Join(homedir.HomeDir(), SealosRootPath, icb.registry, icb.username, KubeConfigPath), "")
+	if err != nil {
+		return err
+	}
+	resource := client.KubernetesDynamic().Resource(schema.GroupVersionResource{
+		Group:    ImagehubGroup,
+		Version:  ImagehubVersion,
+		Resource: ImagehubResource,
+	})
+	utd := unstructured.Unstructured{}
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(icb.imageCR)
+	if err != nil {
+		return err
+	}
+	utd.Object = obj
+	if _, err = resource.Create(context.TODO(), &utd, metav1.CreateOptions{}); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+		if utd.GetResourceVersion() == "" {
+			var objGet *unstructured.Unstructured
+			objGet, err = resource.Get(context.TODO(), utd.GetName(), metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			utd.SetResourceVersion(objGet.GetResourceVersion())
+		}
+		if _, err = resource.Update(context.TODO(), &utd, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (icb *ImageCRBuilder) DeleteContainer() error {
+	logger.Debug("Executing DeleteContainer in ImageCRBuilder")
+	realImpl, err := New("")
+	if err != nil {
+		return err
+	}
+	return realImpl.Delete(icb.containerID)
+}
+
+// ParseImageCR parse image cr yaml file ot an image cr obj
+func (icb *ImageCRBuilder) ParseImageCR(c []byte) error {
+	logger.Debug("Executing ParseImageCR in ImageCRBuilder")
+	cr := imagev1.Image{}
+	_, _, err := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme).Decode(c, nil, &cr)
+	if err != nil {
+		return fmt.Errorf("configParse err : %v", err)
+	}
+	cr.Spec.DetailInfo.Actions = make(map[string]imagev1.Action)
+	icb.imageCR = &cr
+	return nil
+}
+
+// GetReadmeDoc gen image cr detail info: readme
+func (icb *ImageCRBuilder) GetReadmeDoc() error {
+	logger.Debug("Executing GetReadmeDoc in ImageCRBuilder")
+	if file.IsExist(filepath.Join(icb.mountPoint, DocsPath)) {
+		c, err := file.ReadAll(filepath.Join(icb.mountPoint, DocsPath))
+		if err != nil {
+			return err
+		}
+		icb.imageCR.Spec.DetailInfo.Docs = string(c)
+	}
+	return nil
+}
+
+// GetInspectInfo gen image cr detail info: Id, Arch and Size
+func (icb *ImageCRBuilder) GetInspectInfo() error {
+	realImpl, err := New("")
+	if err != nil {
+		return err
+	}
+	containerInfo, err := realImpl.InspectContainer(icb.containerID)
+	if err != nil {
+		return err
+	}
+	var image v1.Image
+	if err = json.Unmarshal([]byte(containerInfo.Config), &image); err != nil {
+		return err
+	}
+	var manifest v1.Manifest
+	if err = json.Unmarshal([]byte(containerInfo.Manifest), &manifest); err != nil {
+		return err
+	}
+
+	sz, err := icb.store.ImageSize(containerInfo.FromImageID)
+	if err != nil {
+		return err
+	}
+	icb.imageCR.Spec.DetailInfo.ID = containerInfo.FromImageID
+	icb.imageCR.Spec.DetailInfo.Arch = image.Architecture
+	icb.imageCR.Spec.DetailInfo.Size = sz
+	icb.imageCR.Spec.DetailInfo.CreateTime = metav1.Time{Time: *image.Created}
+	return nil
+}
+
+// GetClearImagename replace 'hub.sealos.cn/org/repo:tag' to 'org/repo:tag'
+func (icb *ImageCRBuilder) GetClearImagename() string {
+	return strings.Replace(icb.image, icb.registry+"/", "", 1)
+}

--- a/deprecate/pkg/buildah/imagecrtypes.go
+++ b/deprecate/pkg/buildah/imagecrtypes.go
@@ -1,0 +1,63 @@
+// Copyright © 2023 sealos.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import "errors"
+
+const (
+	// DocsPath ImageStdPath  ImageCRFile are path to image cr and readme
+	DocsPath     = "README.md"
+	ImageStdPath = "metadata"
+	// ImageCRFile Todo how can we support both config.yml and config.yaml
+	ImageCRFile = "config.yaml"
+
+	// SealosRootPath and KubeConfigPath is path to user kubeconfig
+	SealosRootPath = ".sealos"
+	KubeConfigPath = "config"
+
+	// ImagehubGroup ImagehubVersion ImagehubKind are group version kind of image cr
+	ImagehubGroup    = "imagehub.sealos.io"
+	ImagehubVersion  = "v1"
+	ImagehubKind     = "Image"
+	ImagehubResource = "images"
+)
+
+type CrOpionEnum string
+
+const (
+	CrOptionNo   CrOpionEnum = "no"
+	CrOptionYes  CrOpionEnum = "yes"
+	CrOptionOnly CrOpionEnum = "only"
+	CrOptionAuto CrOpionEnum = "auto"
+)
+
+// String is used both by fmt.Print and by Cobra in help text
+func (e *CrOpionEnum) String() string {
+	return string(*e)
+}
+
+func (e *CrOpionEnum) Set(v string) error {
+	switch v {
+	case "only", "yes", "no", "auto":
+		*e = CrOpionEnum(v)
+		return nil
+	default:
+		return errors.New(`must be one of "only", "yes", "no", "auto"`)
+	}
+}
+
+func (e *CrOpionEnum) Type() string {
+	return "image cr opion enum"
+}

--- a/deprecate/pkg/buildah/images.go
+++ b/deprecate/pkg/buildah/images.go
@@ -1,0 +1,377 @@
+// Copyright © 2022 buildah.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/containers/buildah/blob/main/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	buildahcli "github.com/containers/buildah/pkg/cli"
+	"github.com/containers/buildah/pkg/formats"
+	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/common/libimage"
+	"github.com/containers/image/v5/types"
+	"github.com/containers/storage"
+	"github.com/docker/go-units"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+const none = "<none>"
+
+type jsonImage struct {
+	ID           string    `json:"id"`
+	Names        []string  `json:"names"`
+	Digest       string    `json:"digest"`
+	CreatedAt    string    `json:"createdat"`
+	Size         string    `json:"size"`
+	Created      int64     `json:"created"`
+	CreatedAtRaw time.Time `json:"createdatraw"`
+	ReadOnly     bool      `json:"readonly"`
+	History      []string  `json:"history"`
+}
+
+type imageOutputParams struct {
+	Tag          string
+	ID           string
+	Name         string
+	Digest       string
+	Created      int64
+	CreatedAt    string
+	Size         string
+	CreatedAtRaw time.Time
+	ReadOnly     bool
+	History      string
+}
+
+type imageOptions struct {
+	all       bool
+	digests   bool
+	format    string
+	json      bool
+	noHeading bool
+	truncate  bool
+	quiet     bool
+	readOnly  bool
+	history   bool
+}
+
+func newDefaultImageResults() *imageResults {
+	return &imageResults{
+		imageOptions: imageOptions{},
+	}
+}
+
+func (opts *imageResults) RegisterFlags(fs *pflag.FlagSet) {
+	fs.SetInterspersed(false)
+	fs.BoolVarP(&opts.all, "all", "a", opts.all, "show all images, including intermediate images from a build")
+	fs.BoolVar(&opts.digests, "digests", opts.digests, "show digests")
+	fs.StringSliceVarP(&opts.filter, "filter", "f", opts.filter, "filter output based on conditions provided")
+	fs.StringVar(&opts.format, "format", opts.format, "pretty-print images using a Go template")
+	fs.BoolVar(&opts.json, "json", opts.json, "output in JSON format")
+	fs.BoolVarP(&opts.noHeading, "noheading", "n", opts.noHeading, "do not print column headings")
+	// TODO needs alias here -- to `notruncate`
+	fs.BoolVar(&opts.truncate, "no-trunc", opts.truncate, "do not truncate output")
+	fs.BoolVarP(&opts.quiet, "quiet", "q", opts.quiet, "display only image IDs")
+	fs.BoolVarP(&opts.history, "history", "", opts.history, "display the image name history")
+}
+
+type imageResults struct {
+	imageOptions
+	filter []string
+}
+
+var imagesHeader = map[string]string{
+	"Name":      "REPOSITORY",
+	"Tag":       "TAG",
+	"ID":        "IMAGE ID",
+	"CreatedAt": "CREATED",
+	"Size":      "SIZE",
+	"ReadOnly":  "R/O",
+	"History":   "HISTORY",
+}
+
+func newImagesCommand() *cobra.Command {
+	var (
+		opts              = newDefaultImageResults()
+		imagesDescription = "\n  Lists locally stored images."
+	)
+	imagesCommand := &cobra.Command{
+		Use:   "images",
+		Short: "List images in local storage",
+		Long:  imagesDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return imagesCmd(cmd, args, opts)
+		},
+		Example: fmt.Sprintf(`%[1]s images --all
+  %[1]s images [imageName]
+  %[1]s images --format '{{.ID}} {{.Name}} {{.Size}} {{.CreatedAtRaw}}'`, rootCmd.CommandPath()),
+	}
+	imagesCommand.SetUsageTemplate(UsageTemplate())
+
+	opts.RegisterFlags(imagesCommand.Flags())
+	return imagesCommand
+}
+
+func imagesCmd(c *cobra.Command, args []string, iopts *imageResults) error {
+	if len(args) > 0 {
+		if iopts.all {
+			return errors.New("when using the --all switch, you may not pass any images names or IDs")
+		}
+
+		if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
+			return err
+		}
+		if len(args) > 1 {
+			return fmt.Errorf("'%s' requires at most 1 argument", c.CommandPath())
+		}
+	}
+	if iopts.quiet && iopts.format != "" {
+		return errors.New("quiet and format are mutually exclusive")
+	}
+
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+	systemContext, err := parse.SystemContextFromOptions(c)
+	if err != nil {
+		return fmt.Errorf("building system context: %w", err)
+	}
+
+	images, err := readImages(store, systemContext, args, iopts)
+	if err != nil {
+		return err
+	}
+
+	opts := imageOptions{
+		all:       iopts.all,
+		digests:   iopts.digests,
+		format:    iopts.format,
+		json:      iopts.json,
+		noHeading: iopts.noHeading,
+		truncate:  !iopts.truncate,
+		quiet:     iopts.quiet,
+		history:   iopts.history,
+	}
+
+	if opts.json {
+		return formatImagesJSON(images, opts)
+	}
+
+	return formatImages(images, opts)
+}
+
+func readImages(store storage.Store, systemContext *types.SystemContext, names []string, iopts *imageResults) ([]*libimage.Image, error) {
+	runtime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: systemContext})
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+
+	options := &libimage.ListImagesOptions{}
+	if len(iopts.filter) > 0 {
+		options.Filters = iopts.filter
+	}
+	if !iopts.all {
+		options.Filters = append(options.Filters, "intermediate=false")
+	}
+
+	return runtime.ListImages(ctx, names, options)
+}
+
+func outputHeader(opts imageOptions) string {
+	if opts.format != "" {
+		return strings.Replace(opts.format, `\t`, "\t", -1)
+	}
+	if opts.quiet {
+		return formats.IDString
+	}
+	format := "table {{.Name}}\t{{.Tag}}\t"
+	if opts.noHeading {
+		format = "{{.Name}}\t{{.Tag}}\t"
+	}
+
+	if opts.digests {
+		format += "{{.Digest}}\t"
+	}
+	format += "{{.ID}}\t{{.CreatedAt}}\t{{.Size}}"
+	if opts.readOnly {
+		format += "\t{{.ReadOnly}}"
+	}
+	if opts.history {
+		format += "\t{{.History}}"
+	}
+	return format
+}
+
+func formatImagesJSON(images []*libimage.Image, opts imageOptions) error {
+	jsonImages := []jsonImage{}
+	for _, image := range images {
+		// Copy the base data over to the output param.
+		size, err := image.Size()
+		if err != nil {
+			return err
+		}
+		created := image.Created()
+		jsonImages = append(jsonImages,
+			jsonImage{
+				CreatedAtRaw: created,
+				Created:      created.Unix(),
+				CreatedAt:    units.HumanDuration(time.Since(created)) + " ago",
+				Digest:       image.Digest().String(),
+				ID:           truncateID(image.ID(), opts.truncate),
+				Names:        image.Names(),
+				ReadOnly:     image.IsReadOnly(),
+				Size:         formattedSize(size),
+			})
+	}
+
+	data, err := json.MarshalIndent(jsonImages, "", "    ")
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s\n", data)
+	return nil
+}
+
+type imagesSorted []imageOutputParams
+
+func (a imagesSorted) Less(i, j int) bool {
+	return a[i].CreatedAtRaw.After(a[j].CreatedAtRaw)
+}
+
+func (a imagesSorted) Len() int {
+	return len(a)
+}
+
+func (a imagesSorted) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+func formatImages(images []*libimage.Image, opts imageOptions) error {
+	var outputData imagesSorted
+
+	for _, image := range images {
+		var outputParam imageOutputParams
+		size, err := image.Size()
+		if err != nil {
+			return err
+		}
+		created := image.Created()
+		outputParam.CreatedAtRaw = created
+		outputParam.Created = created.Unix()
+		outputParam.CreatedAt = units.HumanDuration(time.Since(created)) + " ago"
+		outputParam.Digest = image.Digest().String()
+		outputParam.ID = truncateID(image.ID(), opts.truncate)
+		outputParam.Size = formattedSize(size)
+		outputParam.ReadOnly = image.IsReadOnly()
+
+		repoTags, err := image.NamedRepoTags()
+		if err != nil {
+			return err
+		}
+
+		nameTagPairs, err := libimage.ToNameTagPairs(repoTags)
+		if err != nil {
+			return err
+		}
+
+		for _, pair := range nameTagPairs {
+			newParam := outputParam
+			newParam.Name = pair.Name
+			newParam.Tag = pair.Tag
+			newParam.History = formatHistory(image.NamesHistory(), pair.Name, pair.Tag)
+			outputData = append(outputData, newParam)
+			// `images -q` should a given ID only once.
+			if opts.quiet {
+				break
+			}
+		}
+	}
+
+	sort.Sort(outputData)
+	out := formats.StdoutTemplateArray{Output: imagesToGeneric(outputData), Template: outputHeader(opts), Fields: imagesHeader}
+	return formats.Writer(out).Out()
+}
+
+func formatHistory(history []string, name, tag string) string {
+	if len(history) == 0 {
+		return none
+	}
+	// Skip the first history entry if already existing as name
+	if fmt.Sprintf("%s:%s", name, tag) == history[0] {
+		if len(history) == 1 {
+			return none
+		}
+		return strings.Join(history[1:], ", ")
+	}
+	return strings.Join(history, ", ")
+}
+
+func truncateID(id string, truncate bool) string {
+	if !truncate {
+		return "sha256:" + id
+	}
+	idTruncLength := 12
+	if len(id) > idTruncLength {
+		return id[:idTruncLength]
+	}
+	return id
+}
+
+func imagesToGeneric(templParams []imageOutputParams) (genericParams []interface{}) {
+	if len(templParams) > 0 {
+		for _, v := range templParams {
+			genericParams = append(genericParams, interface{}(v))
+		}
+	}
+	return genericParams
+}
+
+func formattedSize(size int64) string {
+	suffixes := [5]string{"B", "KB", "MB", "GB", "TB"}
+
+	count := 0
+	formattedSize := float64(size)
+	for formattedSize >= 1000 && count < 4 {
+		formattedSize /= 1000
+		count++
+	}
+	return fmt.Sprintf("%.3g %s", formattedSize, suffixes[count])
+}
+
+func matchesID(imageID, argID string) bool {
+	return strings.HasPrefix(imageID, argID)
+}
+
+func matchesReference(name, argName string) bool {
+	if argName == "" {
+		return true
+	}
+	splitName := strings.Split(name, ":")
+	// If the arg contains a tag, we handle it differently than if it does not
+	if strings.Contains(argName, ":") {
+		splitArg := strings.Split(argName, ":")
+		return strings.HasSuffix(splitName[0], splitArg[0]) && (splitName[1] == splitArg[1])
+	}
+	return strings.HasSuffix(splitName[0], argName)
+}

--- a/deprecate/pkg/buildah/imagesaver.go
+++ b/deprecate/pkg/buildah/imagesaver.go
@@ -1,0 +1,113 @@
+// Copyright © 2022 sealos.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/labring/sreg/pkg/registry/crane"
+	"github.com/labring/sreg/pkg/registry/save"
+
+	"github.com/containerd/containerd/platforms"
+	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/image/v5/types"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/labring/sreg/pkg/buildimage"
+
+	"github.com/labring/sealos/pkg/constants"
+	"github.com/labring/sealos/pkg/utils/logger"
+)
+
+type saverOptions struct {
+	maxPullProcs int
+	enabled      bool
+}
+
+func (opts *saverOptions) RegisterFlags(fs *pflag.FlagSet) {
+	fs.IntVar(&opts.maxPullProcs, "max-pull-procs", 5, "maximum number of goroutines for pulling")
+	fs.BoolVar(&opts.enabled, "save-image", true, "store images that parsed from the specific directories")
+}
+
+func runSaveImages(contextDir string, platforms []v1.Platform, sys *types.SystemContext, opts *saverOptions) error {
+	if !opts.enabled {
+		logger.Warn("save-image is disabled, skip pulling images")
+		return nil
+	}
+	registryDir := filepath.Join(contextDir, constants.RegistryDirName)
+	images, err := buildimage.List(contextDir)
+	if err != nil {
+		return err
+	}
+	if len(images) == 0 {
+		return nil
+	}
+	auths, err := crane.GetAuthInfo(sys)
+	if err != nil {
+		return err
+	}
+	is := save.NewImageSaver(getContext(), opts.maxPullProcs, auths)
+
+	for _, pf := range platforms {
+		images, err = is.SaveImages(images, registryDir, pf)
+		if err != nil {
+			return fmt.Errorf("failed to save images: %w", err)
+		}
+		logger.Info("saving images %s", strings.Join(images, ", "))
+	}
+	return nil
+}
+
+func parsePlatforms(c *cobra.Command) ([]v1.Platform, error) {
+	parsedPlatforms, err := parse.PlatformsFromOptions(c)
+	if err != nil {
+		return nil, err
+	}
+	// flags are not modified, use local platform
+	switch len(parsedPlatforms) {
+	case 0:
+		return []v1.Platform{platforms.DefaultSpec()}, nil
+	case 1:
+		var platform v1.Platform
+		idx0 := parsedPlatforms[0]
+		if idx0.OS != "" {
+			platform.OS = idx0.OS
+		} else {
+			platform.OS = runtime.GOOS
+		}
+		if idx0.Arch != "" {
+			platform.Architecture = idx0.Arch
+		} else {
+			platform.Architecture = runtime.GOARCH
+		}
+		if idx0.Variant != "" {
+			platform.Variant = idx0.Variant
+		} else {
+			platform.Variant = platforms.DefaultSpec().Variant
+		}
+		return []v1.Platform{platform}, nil
+	}
+
+	var ret []v1.Platform
+	for _, pf := range parsedPlatforms {
+		ret = append(ret, v1.Platform{Architecture: pf.Arch, OS: pf.OS, Variant: pf.Variant})
+	}
+	return ret, nil
+}

--- a/deprecate/pkg/buildah/inspect.go
+++ b/deprecate/pkg/buildah/inspect.go
@@ -1,0 +1,300 @@
+// Copyright © 2022 buildah.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/containers/buildah/blob/main/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+// nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"text/template"
+
+	"github.com/containers/buildah"
+	buildahcli "github.com/containers/buildah/pkg/cli"
+	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/buildah/util"
+	"github.com/containers/image/v5/image"
+	"github.com/containers/image/v5/manifest"
+	imagestorage "github.com/containers/image/v5/storage"
+	"github.com/containers/image/v5/types"
+	"github.com/containers/storage"
+	"github.com/opencontainers/go-digest"
+	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"golang.org/x/term"
+
+	"github.com/labring/sealos/pkg/utils/logger"
+)
+
+const (
+	inspectTypeApp       = "app"
+	inspectTypeContainer = "container"
+	inspectTypeImage     = "image"
+	inspectTypeManifest  = "manifest"
+)
+
+type inspectResults struct {
+	format      string
+	inspectType string
+}
+
+func newDefaultInspectResults() *inspectResults {
+	return &inspectResults{
+		inspectType: inspectTypeApp,
+	}
+}
+
+func (opts *inspectResults) RegisterFlags(fs *pflag.FlagSet) {
+	fs.SetInterspersed(false)
+	fs.StringVarP(&opts.format, "format", "f", opts.format, "use `format` as a Go template to format the output")
+	fs.StringVarP(&opts.inspectType, "type", "t", opts.inspectType, "look at the item of the specified `type` (container or image) and name")
+}
+
+func newInspectCommand() *cobra.Command {
+	var (
+		opts               = newDefaultInspectResults()
+		inspectDescription = "\n  Inspects a build container's or built image's configuration."
+	)
+
+	inspectCommand := &cobra.Command{
+		Use:   "inspect",
+		Short: "Inspect the configuration of a container or image",
+		Long:  inspectDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return inspectCmd(cmd, args, opts)
+		},
+		Example: fmt.Sprintf(`%[1]s inspect containerID
+  %[1]s inspect --type image imageWithTag
+  %[1]s inspect --type image @imageID # or just imageID, '@' is optional
+  %[1]s inspect --type image docker://alpine:latest
+  %[1]s inspect --type image oci-archive:/abs/path/of/oci/tarfile.tar
+  %[1]s inspect --type image docker-archive:/abs/path/of/docker/tarfile.tar
+  %[1]s inspect --format '{{.OCIv1.Config.Env}}' alpine`, rootCmd.CommandPath()),
+	}
+	inspectCommand.SetUsageTemplate(UsageTemplate())
+
+	fs := inspectCommand.Flags()
+	opts.RegisterFlags(fs)
+	// only useful for docker/container-storage transport
+	fs.AddFlagSet(getPlatformFlags())
+
+	return inspectCommand
+}
+
+func inspectCmd(c *cobra.Command, args []string, iopts *inspectResults) error {
+	var (
+		builder *buildah.Builder
+		output  *InspectOutput
+	)
+
+	if len(args) == 0 {
+		return errors.New("container or image name must be specified")
+	}
+	if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
+		return err
+	}
+	if len(args) > 1 {
+		return errors.New("too many arguments specified")
+	}
+
+	systemContext, err := parse.SystemContextFromOptions(c)
+	if err != nil {
+		return fmt.Errorf("building system context: %w", err)
+	}
+	setDefaultSystemContext(systemContext)
+
+	name := args[0]
+
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+
+	ctx := getContext()
+
+	switch iopts.inspectType {
+	case inspectTypeContainer, inspectTypeApp:
+		builder, err = openBuilder(ctx, store, name)
+		if err != nil {
+			if flagChanged(c, "type") {
+				return fmt.Errorf("reading build container: %w", err)
+			}
+			logger.Debug("failed to inspect container: %v, trying to inspect image", err)
+			output, err = openImage(ctx, systemContext, store, imagestorage.Transport, name)
+			if err != nil {
+				logger.Debug("failed to open image: %v, trying to inspect manifest", err)
+				if manifestErr := manifestInspect(ctx, store, systemContext, name); manifestErr == nil {
+					return nil
+				}
+				return err
+			}
+		}
+	case inspectTypeImage:
+		output, err = openImage(ctx, systemContext, store, imagestorage.Transport, name)
+		if err != nil {
+			return err
+		}
+	case inspectTypeManifest:
+		return manifestInspect(ctx, store, systemContext, name)
+	default:
+		return fmt.Errorf("available type options are %s", strings.Join(
+			[]string{inspectTypeContainer, inspectTypeApp, inspectTypeImage, inspectTypeManifest}, ", "))
+	}
+	var out interface{}
+	if builder != nil {
+		out = buildah.GetBuildInfo(builder)
+	} else if output != nil {
+		out = output
+	}
+	if iopts.format != "" {
+		format := iopts.format
+		if matched, err := regexp.MatchString("{{.*}}", format); err != nil {
+			return fmt.Errorf("validating format provided: %s: %w", format, err)
+		} else if !matched {
+			return fmt.Errorf("invalid format provided: %s", format)
+		}
+		t, err := template.New("format").Parse(format)
+		if err != nil {
+			return fmt.Errorf("template parsing error: %w", err)
+		}
+		if err = t.Execute(os.Stdout, out); err != nil {
+			return err
+		}
+		if term.IsTerminal(int(os.Stdout.Fd())) {
+			fmt.Println()
+		}
+		return nil
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "    ")
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		enc.SetEscapeHTML(false)
+	}
+	return enc.Encode(out)
+}
+
+type InspectOutput struct {
+	Name            string        `json:",omitempty"`
+	FromImageDigest digest.Digest `json:",omitempty"`
+	FromImageID     digest.Digest `json:",omitempty"`
+	OCIv1           *ociv1.Image  `json:"OCIv1,omitempty"`
+}
+
+func openImage(ctx context.Context, sc *types.SystemContext, store storage.Store, transport types.ImageTransport, imgRef string) (*InspectOutput, error) {
+	var (
+		rawManifest          []byte
+		config               *ociv1.Image
+		src                  types.ImageSource
+		imageDigest, imageID digest.Digest
+	)
+	// parse transport from image reference or use default
+	transport, imgName, err := parseTransportAndReference(transport, imgRef)
+	if err != nil {
+		return nil, err
+	}
+
+	foundID, img, src, err := inspectImage(ctx, sc, store, transport, imgName)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err = src.Close(); err != nil {
+			logger.Error("unexpected error while closing image: %v", err)
+		}
+	}()
+
+	// only set for transport container-storage
+	if _, ok := transport.(imagestorage.StoreTransport); ok && foundID != "" {
+		simg, err := store.Image(foundID)
+		if err != nil {
+			return nil, err
+		}
+		imageID = digest.Digest(simg.ID)
+		if strings.HasPrefix(simg.ID, imgName) && len(simg.Names) > 0 {
+			imgRef = simg.Names[0]
+		}
+	}
+
+	rawManifest, _, err = src.GetManifest(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving manifest for image: %w", err)
+	}
+
+	config, err = img.OCIConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error reading OCI-formatted configuration data: %w", err)
+	}
+
+	if imageDigest, err = manifest.Digest(rawManifest); err != nil {
+		return nil, fmt.Errorf("error computing manifest digest: %w", err)
+	}
+
+	return &InspectOutput{
+		Name:            imgRef,
+		FromImageDigest: imageDigest,
+		FromImageID:     imageID,
+		OCIv1:           config,
+	}, nil
+}
+
+func parseTransportAndReference(defaultTransport types.ImageTransport, ref string) (types.ImageTransport, string, error) {
+	transport, imgRef := finalizeReference(defaultTransport, ref)
+	parts := strings.SplitN(imgRef, ":", 2)
+	// should never happened
+	if len(parts) != 2 {
+		return nil, "", fmt.Errorf(`invalid image name "%s", expected colon-separated transport:reference`, imgRef)
+	}
+	return transport, parts[1], nil
+}
+
+// inspectImage return image id if found
+func inspectImage(ctx context.Context, sc *types.SystemContext, store storage.Store, transport types.ImageTransport, imgName string) (string, types.Image, types.ImageSource, error) {
+	parseSource := func(s string) (types.ImageSource, error) {
+		logger.Debug("parse reference %s with transport %s", s, transport.Name())
+		ref, err := transport.ParseReference(s)
+		if err != nil {
+			return nil, err
+		}
+		return ref.NewImageSource(ctx, sc)
+	}
+	var (
+		imageID string
+		src     types.ImageSource
+		err     error
+	)
+	switch transport.Name() {
+	case TransportContainersStorage:
+		_, img, tmpErr := util.FindImage(store, "", sc, imgName)
+		if tmpErr != nil {
+			return "", nil, nil, fmt.Errorf("importing settings: %w", tmpErr)
+		}
+		imageID = img.ID
+		src, err = parseSource(img.ID)
+	default:
+		src, err = parseSource(imgName)
+	}
+	if err != nil {
+		return imageID, nil, nil, fmt.Errorf("error parsing image name %q: %w", imgName, err)
+	}
+
+	img, err := image.FromUnparsedImage(ctx, sc, image.UnparsedInstance(src, nil))
+	return imageID, img, src, err
+}

--- a/deprecate/pkg/buildah/interface.go
+++ b/deprecate/pkg/buildah/interface.go
@@ -1,0 +1,244 @@
+// Copyright © 2022 sealos.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/containers/buildah"
+	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/common/libimage"
+	"github.com/containers/image/v5/transports"
+	"github.com/containers/image/v5/types"
+	"github.com/containers/storage"
+	storagetypes "github.com/containers/storage/types"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/labring/sealos/pkg/utils/logger"
+)
+
+type Interface interface {
+	Pull(imageNames []string, opts ...FlagSetter) error
+	Load(input string, ociType string) (string, error)
+	InspectImage(name string, opts ...string) (*InspectOutput, error)
+	Create(name string, image string, opts ...FlagSetter) (buildah.BuilderInfo, error)
+	Delete(name string) error
+	InspectContainer(name string) (buildah.BuilderInfo, error)
+	ListContainers() ([]JSONContainer, error)
+	Runtime() *Runtime
+}
+
+func New(id string) (Interface, error) {
+	systemContext, err := parse.SystemContextFromOptions(rootCmd)
+	if err != nil {
+		return nil, fmt.Errorf("building system context: %w", err)
+	}
+	store, err := getStore(rootCmd)
+	if err != nil {
+		return nil, err
+	}
+	setDefaultSystemContext(systemContext)
+	r, err := getRuntimeWithStoreAndSystemContext(store, systemContext)
+	if err != nil {
+		return nil, err
+	}
+	return &realImpl{
+		id:            id,
+		store:         store,
+		systemContext: systemContext,
+		runtime:       r,
+	}, nil
+}
+
+type realImpl struct {
+	id            string // as identity prefix
+	store         storage.Store
+	systemContext *types.SystemContext
+	runtime       *Runtime
+}
+
+func (impl *realImpl) Runtime() *Runtime {
+	return impl.runtime
+}
+
+type FlagSetter func(*pflag.FlagSet) error
+
+func newFlagSetter(k string, v string) FlagSetter {
+	return func(fs *pflag.FlagSet) error {
+		if f := fs.Lookup(k); f != nil {
+			return fs.Set(k, v)
+		}
+		return nil
+	}
+}
+
+func WithPlatformOption(pf v1.Platform) FlagSetter {
+	return func(fs *pflag.FlagSet) error {
+		for _, fn := range []FlagSetter{
+			newFlagSetter("os", pf.OS),
+			newFlagSetter("arch", pf.Architecture),
+			newFlagSetter("variant", pf.Variant),
+		} {
+			if err := fn(fs); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func WithPullPolicyOption(policy string) FlagSetter {
+	return func(fs *pflag.FlagSet) error {
+		return newFlagSetter("policy", policy)(fs)
+	}
+}
+
+func (impl *realImpl) Pull(imageNames []string, opts ...FlagSetter) error {
+	cmd := impl.mockCmd()
+	iopt := newDefaultPullOptions()
+	_ = iopt.RegisterFlags(cmd.Flags())
+	for i := range opts {
+		if err := opts[i](cmd.Flags()); err != nil {
+			return err
+		}
+	}
+	if err := setDefaultFlagsWithSetters(cmd, setDefaultTLSVerifyFlag); err != nil {
+		return err
+	}
+	ids, err := doPull(cmd, impl.store, nil, imageNames, iopt)
+	if err != nil {
+		return err
+	}
+	logger.Debug("images %s are pulled", strings.Join(ids, ", "))
+	return nil
+}
+
+func finalizeReference(transport types.ImageTransport, imgName string) (types.ImageTransport, string) {
+	parts := strings.SplitN(imgName, ":", 2)
+	if len(parts) == 2 {
+		if transport := transports.Get(parts[0]); transport != nil {
+			return transport, imgName
+		}
+	}
+	return transport, FormatReferenceWithTransportName(transport.Name(), imgName)
+}
+
+func (impl *realImpl) InspectImage(name string, opts ...string) (*InspectOutput, error) {
+	transportName := TransportContainersStorage
+	if len(opts) > 0 {
+		transportName = opts[0]
+	}
+	transport := transports.Get(transportName)
+	if transport == nil {
+		return nil, fmt.Errorf(`unknown transport "%s"`, opts[0])
+	}
+	ctx := getContext()
+	return openImage(ctx, impl.systemContext, impl.store, transport, name)
+}
+
+func (impl *realImpl) Create(name string, image string, opts ...FlagSetter) (buildah.BuilderInfo, error) {
+	if err := impl.Delete(impl.finalizeName(name)); err != nil {
+		return buildah.BuilderInfo{}, fmt.Errorf("failed to delete: %v", err)
+	}
+	if _, err := impl.from(impl.finalizeName(name), image, opts...); err != nil {
+		return buildah.BuilderInfo{}, fmt.Errorf("failed to from: %v", err)
+	}
+	if _, err := impl.mount(impl.finalizeName(name)); err != nil {
+		return buildah.BuilderInfo{}, fmt.Errorf("failed to mount: %v", err)
+	}
+	return impl.InspectContainer(name)
+}
+
+func (impl *realImpl) Delete(name string) error {
+	builder, err := openBuilder(getContext(), impl.store, impl.finalizeName(name))
+	if err != nil {
+		if err == storagetypes.ErrContainerUnknown {
+			return nil
+		}
+		return err
+	}
+	return builder.Delete()
+}
+
+func (impl *realImpl) from(name, image string, opts ...FlagSetter) (*buildah.Builder, error) {
+	cmd := impl.mockCmd()
+	iopts := newDefaultFromReply()
+	iopts.name = impl.finalizeName(name)
+	iopts.pull = ""
+	iopts.RegisterFlags(cmd.Flags())
+	for i := range opts {
+		if err := opts[i](cmd.Flags()); err != nil {
+			return nil, err
+		}
+	}
+	if err := setDefaultFlagsWithSetters(cmd, setDefaultTLSVerifyFlag); err != nil {
+		return nil, err
+	}
+	return doFrom(cmd, image, iopts, impl.store, nil)
+}
+
+func (impl *realImpl) mount(name string) (jsonMount, error) {
+	jsonMounts, err := doMounts(impl.store, []string{name})
+	if err != nil {
+		return jsonMount{}, err
+	}
+	return jsonMounts[0], nil
+}
+
+func (impl *realImpl) mockCmd() *cobra.Command {
+	return &cobra.Command{
+		Use: "mock",
+	}
+}
+
+func (impl *realImpl) InspectContainer(name string) (buildah.BuilderInfo, error) {
+	builder, err := openBuilder(getContext(), impl.store, impl.finalizeName(name))
+	if err != nil {
+		return buildah.BuilderInfo{}, err
+	}
+	return buildah.GetBuildInfo(builder), nil
+}
+
+func (impl *realImpl) finalizeName(name string) string {
+	if strings.HasPrefix(name, impl.id) {
+		return name
+	}
+	return fmt.Sprintf("%s-%s", impl.id, name)
+}
+
+func (impl *realImpl) ListContainers() ([]JSONContainer, error) {
+	opts := containerOptions{
+		json:      true,
+		noHeading: true,
+	}
+	params, err := parseCtrFilter(fmt.Sprintf("name=%s", impl.id))
+	if err != nil {
+		return nil, fmt.Errorf("parsing filter: %w", err)
+	}
+	_, jsonContainers, err := readContainers(impl.store, opts, params)
+	return jsonContainers, err
+}
+
+func (impl *realImpl) Load(input string, transport string) (string, error) {
+	ref := FormatReferenceWithTransportName(transport, input)
+	names, err := impl.runtime.PullOrLoadImages(getContext(), []string{ref}, libimage.CopyOptions{})
+	if err != nil {
+		return "", err
+	}
+	return names[0], nil
+}

--- a/deprecate/pkg/buildah/interface_test.go
+++ b/deprecate/pkg/buildah/interface_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2023 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buildah
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func Test_realImpl_InspectImage(t *testing.T) {
+	type args struct {
+		name string
+		opts []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "local-0",
+			args: args{
+				name: "docker.io/labring/kubernetes:v1.25.3",
+				opts: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "local-1",
+			args: args{
+				name: "containers-storage:docker.io/labring/kubernetes:v1.25.3",
+				opts: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "local-2",
+			args: args{
+				name: "cd5271889c3b",
+				opts: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "remote-0",
+			args: args{
+				name: "docker://docker.io/labring/kubernetes:v1.25.3",
+				opts: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "remote-1",
+			args: args{
+				name: "docker.io/labring/kubernetes:v1.25.3",
+				opts: []string{"docker"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "remote-0-new",
+			args: args{
+				name: "docker://docker.io/labring/kubernetes:v1.25.4",
+				opts: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "remote-1-new",
+			args: args{
+				name: "docker.io/labring/kubernetes:v1.25.4",
+				opts: []string{"docker"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "tar-oci",
+			args: args{
+				name: "/home/cuisongliu/Downloads/hello-world-oci.tar",
+				opts: []string{"oci-archive"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "tar-docker",
+			args: args{
+				name: "/home/cuisongliu/Downloads/hello-world.tar",
+				opts: []string{"docker-archive"},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := &cobra.Command{
+				Use:   "test",
+				Short: "test",
+			}
+			//storage-driver
+			RegisterRootCommand(root)
+			impl, err := New("")
+			if err != nil {
+				t.Errorf("%+v", err)
+				return
+			}
+			got, err := impl.InspectImage(tt.args.name, tt.args.opts...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("InspectImage() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			t.Logf("%+v", got)
+		})
+	}
+}

--- a/deprecate/pkg/buildah/internal/util/util.go
+++ b/deprecate/pkg/buildah/internal/util/util.go
@@ -1,0 +1,68 @@
+// Copyright © 2022 buildah.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/containers/buildah/blob/main/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+
+	"github.com/containers/buildah/define"
+	encconfig "github.com/containers/ocicrypt/config"
+	enchelpers "github.com/containers/ocicrypt/helpers"
+)
+
+func DecryptConfig(decryptionKeys []string) (*encconfig.DecryptConfig, error) {
+	decConfig := &encconfig.DecryptConfig{}
+	if len(decryptionKeys) > 0 {
+		// decryption
+		dcc, err := enchelpers.CreateCryptoConfig([]string{}, decryptionKeys)
+		if err != nil {
+			return nil, fmt.Errorf("invalid decryption keys: %w", err)
+		}
+		cc := encconfig.CombineCryptoConfigs([]encconfig.CryptoConfig{dcc})
+		decConfig = cc.DecryptConfig
+	}
+
+	return decConfig, nil
+}
+
+// EncryptConfig translates encryptionKeys into a EncriptionsConfig structure
+func EncryptConfig(encryptionKeys []string, encryptLayers []int) (*encconfig.EncryptConfig, *[]int, error) {
+	var encLayers *[]int
+	var encConfig *encconfig.EncryptConfig
+
+	if len(encryptionKeys) > 0 {
+		// encryption
+		encLayers = &encryptLayers
+		ecc, err := enchelpers.CreateCryptoConfig(encryptionKeys, []string{})
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid encryption keys: %w", err)
+		}
+		cc := encconfig.CombineCryptoConfigs([]encconfig.CryptoConfig{ecc})
+		encConfig = cc.EncryptConfig
+	}
+	return encConfig, encLayers, nil
+}
+
+// GetFormat translates format string into either docker or OCI format constant
+func GetFormat(format string) (string, error) {
+	switch format {
+	case define.OCI:
+		return define.OCIv1ImageManifest, nil
+	case define.DOCKER:
+		return define.Dockerv2ImageManifest, nil
+	default:
+		return "", fmt.Errorf("unrecognized image type %q", format)
+	}
+}

--- a/deprecate/pkg/buildah/load.go
+++ b/deprecate/pkg/buildah/load.go
@@ -1,0 +1,115 @@
+// Copyright © 2022 buildah.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/containers/buildah/blob/main/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Mostly copy from github.com/containers/podman
+
+package buildah
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/containers/common/libimage"
+	"github.com/containers/common/pkg/config"
+	"github.com/containers/common/pkg/download"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"golang.org/x/term"
+)
+
+type loadOptions struct {
+	input string
+	quiet bool
+}
+
+func (o *loadOptions) RegisterFlags(fs *pflag.FlagSet) {
+	fs.StringVarP(&o.input, "input", "i", "", "load images from specified tar archive file, default(stdin)")
+	fs.BoolVarP(&o.quiet, "quiet", "q", false, "suppress the output")
+}
+
+func newLoadCommand() *cobra.Command {
+	var opts = &loadOptions{}
+
+	loadCommand := &cobra.Command{
+		Use:   "load",
+		Short: "Load image(s) from archive file",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return load(cmd, args, opts)
+		},
+		Example: fmt.Sprintf(`%[1]s load -i kubernetes.tar`, rootCmd.CommandPath()),
+	}
+	loadCommand.SetUsageTemplate(UsageTemplate())
+	opts.RegisterFlags(loadCommand.Flags())
+
+	return loadCommand
+}
+
+func load(cmd *cobra.Command, _ []string, loadOpts *loadOptions) error {
+	if len(loadOpts.input) > 0 {
+		// Download the input file if needed.
+		if strings.HasPrefix(loadOpts.input, "https://") || strings.HasPrefix(loadOpts.input, "http://") {
+			containerConfig, err := config.Default()
+			if err != nil {
+				return err
+			}
+			tmpdir, err := containerConfig.ImageCopyTmpDir()
+			if err != nil {
+				return err
+			}
+			tmpfile, err := download.FromURL(tmpdir, loadOpts.input)
+			if err != nil {
+				return err
+			}
+			defer os.Remove(tmpfile)
+			loadOpts.input = tmpfile
+		}
+
+		if _, err := os.Stat(loadOpts.input); err != nil {
+			return err
+		}
+	} else {
+		if term.IsTerminal(int(os.Stdin.Fd())) {
+			return errors.New("cannot read from terminal, use command-line redirection or the --input flag")
+		}
+		outFile, err := os.CreateTemp("", rootCmd.Name())
+		if err != nil {
+			return fmt.Errorf("creating file %v", err)
+		}
+		defer os.Remove(outFile.Name())
+		defer outFile.Close()
+
+		_, err = io.Copy(outFile, os.Stdin)
+		if err != nil {
+			return fmt.Errorf("copying file %v", err)
+		}
+		loadOpts.input = outFile.Name()
+	}
+	r, err := getRuntime(cmd)
+	if err != nil {
+		return err
+	}
+	loadOptions := &libimage.LoadOptions{}
+	if !loadOpts.quiet {
+		loadOptions.Writer = os.Stderr
+	}
+	loadedImages, err := r.Load(getContext(), loadOpts.input, loadOptions)
+	if err != nil {
+		return err
+	}
+	fmt.Println("Loaded image: " + strings.Join(loadedImages, "\nLoaded image: "))
+	return nil
+}

--- a/deprecate/pkg/buildah/login.go
+++ b/deprecate/pkg/buildah/login.go
@@ -1,0 +1,168 @@
+// Copyright © 2022 buildah.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/containers/buildah/blob/main/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+
+	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/common/pkg/auth"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/client-go/tools/clientcmd"
+
+	fileutil "github.com/labring/sealos/pkg/utils/file"
+)
+
+type loginReply struct {
+	loginOpts  auth.LoginOptions
+	getLogin   bool
+	tlsVerify  bool
+	kubeconfig string
+}
+
+func newDefaultLoginReply() loginReply {
+	return loginReply{
+		loginOpts: auth.LoginOptions{
+			Stdin:              os.Stdin,
+			Stdout:             os.Stdout,
+			AcceptRepositories: true,
+		},
+		getLogin:  true,
+		tlsVerify: false,
+	}
+}
+
+func (opts *loginReply) RegisterFlags(fs *pflag.FlagSet) {
+	fs.SetInterspersed(false)
+	fs.BoolVar(&opts.tlsVerify, "tls-verify", opts.tlsVerify, "require HTTPS and verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
+	fs.BoolVar(&opts.getLogin, "get-login", opts.getLogin, "return the current login user for the registry")
+	fs.AddFlagSet(auth.GetLoginFlags(&opts.loginOpts))
+	// e.g sealos login --kubeconfig /root/.kube/config hub.sealos.io
+	fs.StringVarP(&opts.kubeconfig, "kubeconfig", "k", opts.kubeconfig, "Login to sealos registry: hub.sealos.io by kubeconfig")
+	bailOnError(markFlagsHidden(fs, "tls-verify"), "")
+}
+
+func newLoginCommand() *cobra.Command {
+	var (
+		opts             = newDefaultLoginReply()
+		loginDescription = "Login to a container registry on a specified server."
+	)
+	loginCommand := &cobra.Command{
+		Use:   "login",
+		Short: "Login to a container registry",
+		Long:  loginDescription,
+
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if opts.kubeconfig == "" {
+				return nil
+			}
+			// username is current context kubeconfig user id
+			username, err := GetCurrentUserFromKubeConfig(opts.kubeconfig)
+			if err != nil {
+				return err
+			}
+			// set user/password
+			passwordb, err := fileutil.ReadAll(opts.kubeconfig)
+			if err != nil {
+				return err
+			}
+			opts.loginOpts.Username = username
+			opts.loginOpts.Password = string(passwordb)
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return loginCmd(cmd, args, &opts)
+		},
+		PostRunE: func(cmd *cobra.Command, args []string) error {
+			if opts.kubeconfig == "" {
+				return nil
+			}
+			// config will be copyed to $(HOME)/.sealos/$(args[0]).HOST/$(user)/config
+			registryHost, err := parseRawURL(args[0])
+			if err != nil {
+				return err
+			}
+			sealosKubeConfdir := fmt.Sprintf("%s/%s/%s/%s", os.Getenv("HOME"), ".sealos", registryHost, opts.loginOpts.Username)
+			if err := fileutil.MkDirs(sealosKubeConfdir); err != nil {
+				return err
+			}
+			sealosKubeconfPath := fmt.Sprintf("%s/%s", sealosKubeConfdir, "config")
+			// copy file, will overwrite the original file
+			return fileutil.Copy(opts.kubeconfig, sealosKubeconfPath)
+		},
+		Example: fmt.Sprintf(`%s login quay.io`, rootCmd.CommandPath()),
+	}
+	loginCommand.SetUsageTemplate(UsageTemplate())
+	opts.RegisterFlags(loginCommand.Flags())
+	// set user/password and kubeconfig mutually exclusive
+	loginCommand.MarkFlagsMutuallyExclusive("username", "kubeconfig")
+	return loginCommand
+}
+
+func loginCmd(c *cobra.Command, args []string, iopts *loginReply) error {
+	if len(args) > 1 {
+		return errors.New("too many arguments, login takes only 1 argument")
+	}
+	if len(args) == 0 {
+		return errors.New("please specify a registry to login to")
+	}
+	if err := setDefaultFlagsWithSetters(c, setDefaultTLSVerifyFlag); err != nil {
+		return err
+	}
+
+	if err := setXDGRuntimeDir(); err != nil {
+		return err
+	}
+
+	systemContext, err := parse.SystemContextFromOptions(c)
+	if err != nil {
+		return fmt.Errorf("building system context: %w", err)
+	}
+	ctx := getContext()
+	iopts.loginOpts.GetLoginSet = flagChanged(c, "get-login")
+	return auth.Login(ctx, systemContext, &iopts.loginOpts, args)
+}
+
+func GetCurrentUserFromKubeConfig(filename string) (userid string, err error) {
+	config, err := clientcmd.LoadFromFile(filename)
+	if err != nil {
+		return "", err
+	}
+	expectedCtx, exists := config.Contexts[config.CurrentContext]
+	if !exists {
+		return "", fmt.Errorf("failed to find current context %s", config.CurrentContext)
+	}
+	return expectedCtx.AuthInfo, nil
+}
+
+func parseRawURL(rawurl string) (domain string, err error) {
+	u, err := url.ParseRequestURI(rawurl)
+	if err != nil || u.Host == "" {
+		u, repErr := url.ParseRequestURI("https://" + rawurl)
+		if repErr != nil {
+			fmt.Printf("Could not parse raw url: %s, error: %v", rawurl, err)
+			return
+		}
+		domain = u.Host
+		err = nil
+		return
+	}
+	domain = u.Host
+	return
+}

--- a/deprecate/pkg/buildah/logout.go
+++ b/deprecate/pkg/buildah/logout.go
@@ -1,0 +1,69 @@
+// Copyright © 2022 buildah.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/containers/buildah/blob/main/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/common/pkg/auth"
+	"github.com/spf13/cobra"
+)
+
+func newLogoutCommand() *cobra.Command {
+	var (
+		opts = auth.LogoutOptions{
+			Stdout:             os.Stdout,
+			AcceptRepositories: true,
+		}
+		logoutDescription = "Remove the cached username and password for the registry."
+	)
+	logoutCommand := &cobra.Command{
+		Use:   "logout",
+		Short: "Logout of a container registry",
+		Long:  logoutDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return logoutCmd(cmd, args, &opts)
+		},
+		Example: fmt.Sprintf(`%s logout quay.io`, rootCmd.CommandPath()),
+	}
+	logoutCommand.SetUsageTemplate(UsageTemplate())
+
+	flags := auth.GetLogoutFlags(&opts)
+	flags.SetInterspersed(false)
+	logoutCommand.Flags().AddFlagSet(flags)
+	return logoutCommand
+}
+
+func logoutCmd(c *cobra.Command, args []string, iopts *auth.LogoutOptions) error {
+	if len(args) > 1 {
+		return errors.New("too many arguments, logout takes at most 1 argument")
+	}
+	if len(args) == 0 && !iopts.All {
+		return errors.New("registry must be given")
+	}
+
+	if err := setXDGRuntimeDir(); err != nil {
+		return err
+	}
+
+	systemContext, err := parse.SystemContextFromOptions(c)
+	if err != nil {
+		return fmt.Errorf("building system context: %w", err)
+	}
+	return auth.Logout(systemContext, iopts, args)
+}

--- a/deprecate/pkg/buildah/manifest.go
+++ b/deprecate/pkg/buildah/manifest.go
@@ -1,0 +1,946 @@
+// Copyright © 2022 buildah.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/containers/buildah/blob/main/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/containers/buildah/pkg/cli"
+	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/buildah/util"
+	"github.com/containers/common/libimage"
+	"github.com/containers/common/libimage/manifests"
+	"github.com/containers/common/pkg/auth"
+	cp "github.com/containers/image/v5/copy"
+	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/transports"
+	"github.com/containers/image/v5/transports/alltransports"
+	"github.com/containers/image/v5/types"
+	"github.com/containers/storage"
+	"github.com/hashicorp/go-multierror"
+	digest "github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/labring/sealos/pkg/utils/logger"
+)
+
+type manifestCreateOpts struct {
+	os, arch                        string
+	all, tlsVerify, insecure, amend bool
+}
+
+func (opts *manifestCreateOpts) RegisterFlags(fs *pflag.FlagSet) error {
+	fs.BoolVar(&opts.all, "all", false, "add all of the lists' images if the images to add are lists")
+	fs.BoolVar(&opts.amend, "amend", false, "modify an existing list if one with the desired name already exists")
+	fs.StringVar(&opts.os, "os", "", "if any of the specified images is a list, choose the one for `os`")
+	fs.StringVar(&opts.arch, "arch", "", "if any of the specified images is a list, choose the one for `arch`")
+	fs.BoolVar(&opts.insecure, "insecure", false, "neither require HTTPS nor verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
+	fs.BoolVar(&opts.tlsVerify, "tls-verify", false, "require HTTPS and verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
+	fs.SetNormalizeFunc(cli.AliasFlags)
+	return markFlagsHidden(fs, []string{"os", "arch", "insecure", "tls-verify"}...)
+}
+
+type manifestAddOpts struct {
+	authfile, certDir, creds, os, arch, variant, osVersion string
+	features, osFeatures, annotations                      []string
+	tlsVerify, insecure, all                               bool
+}
+
+func (opts *manifestAddOpts) RegisterFlags(fs *pflag.FlagSet) error {
+	fs.StringVar(&opts.authfile, "authfile", auth.GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
+	fs.StringVar(&opts.certDir, "cert-dir", "", "use certificates at the specified path to access the registry")
+	fs.StringVar(&opts.creds, "creds", "", "use `[username[:password]]` for accessing the registry")
+	fs.StringVar(&opts.os, "os", "", "override the `OS` of the specified image")
+	fs.StringVar(&opts.arch, "arch", "", "override the `architecture` of the specified image")
+	fs.StringVar(&opts.variant, "variant", "", "override the `variant` of the specified image")
+	fs.StringVar(&opts.osVersion, "os-version", "", "override the OS `version` of the specified image")
+	fs.StringSliceVar(&opts.features, "features", nil, "override the `features` of the specified image")
+	fs.StringSliceVar(&opts.osFeatures, "os-features", nil, "override the OS `features` of the specified image")
+	fs.StringSliceVar(&opts.annotations, "annotation", nil, "set an `annotation` for the specified image")
+	fs.BoolVar(&opts.insecure, "insecure", false, "neither require HTTPS nor verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
+	fs.BoolVar(&opts.tlsVerify, "tls-verify", false, "require HTTPS and verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
+	fs.BoolVar(&opts.all, "all", false, "add all of the list's images if the image is a list")
+	fs.SetNormalizeFunc(cli.AliasFlags)
+	return markFlagsHidden(fs, []string{"insecure", "tls-verify"}...)
+}
+
+type manifestRemoveOpts struct{}
+
+type manifestAnnotateOpts struct {
+	os, arch, variant, osVersion      string
+	features, osFeatures, annotations []string
+}
+
+func (opts *manifestAnnotateOpts) RegisterFlags(fs *pflag.FlagSet) error {
+	fs.StringVar(&opts.os, "os", "", "override the `OS` of the specified image")
+	fs.StringVar(&opts.arch, "arch", "", "override the `Architecture` of the specified image")
+	fs.StringVar(&opts.variant, "variant", "", "override the `Variant` of the specified image")
+	fs.StringVar(&opts.osVersion, "os-version", "", "override the os `version` of the specified image")
+	fs.StringSliceVar(&opts.features, "features", nil, "override the `features` of the specified image")
+	fs.StringSliceVar(&opts.osFeatures, "os-features", nil, "override the os `features` of the specified image")
+	fs.StringSliceVar(&opts.annotations, "annotation", nil, "set an `annotation` for the specified image")
+	return nil
+}
+
+type manifestInspectOpts struct{}
+
+func newManifestCommand() *cobra.Command {
+	var (
+		manifestDescription         = "\n  Creates, modifies, and pushes manifest lists and image indexes."
+		manifestCreateDescription   = "\n  Creates manifest lists and image indexes."
+		manifestAddDescription      = "\n  Adds an image to a manifest list or image index."
+		manifestRemoveDescription   = "\n  Removes an image from a manifest list or image index."
+		manifestAnnotateDescription = "\n  Adds or updates information about an entry in a manifest list or image index."
+		manifestInspectDescription  = "\n  Display the contents of a manifest list or image index."
+		manifestPushDescription     = "\n  Pushes manifest lists and image indexes to registries."
+		manifestRmDescription       = "\n  Remove one or more manifest lists from local storage."
+		manifestExistsDescription   = "\n  Check if a manifest list exists in local storage."
+		manifestCreateOpts          manifestCreateOpts
+		manifestAddOpts             manifestAddOpts
+		manifestRemoveOpts          manifestRemoveOpts
+		manifestAnnotateOpts        manifestAnnotateOpts
+		manifestInspectOpts         manifestInspectOpts
+		manifestPushOpts            pushOptions
+	)
+	manifestCommand := &cobra.Command{
+		Use:   "manifest",
+		Short: "Manipulate manifest lists and image indexes",
+		Long:  manifestDescription,
+		Example: fmt.Sprintf(`%[1]s manifest create localhost/list
+  %[1]s manifest add localhost/list localhost/image
+  %[1]s manifest annotate --annotation A=B localhost/list localhost/image
+  %[1]s manifest annotate --annotation A=B localhost/list sha256:entryManifestDigest
+  %[1]s manifest inspect localhost/list
+  %[1]s manifest push localhost/list transport:destination
+  %[1]s manifest remove localhost/list sha256:entryManifestDigest
+  %[1]s manifest rm localhost/list`, rootCmd.CommandPath()),
+	}
+	manifestCommand.SetUsageTemplate(UsageTemplate())
+
+	manifestCreateCommand := &cobra.Command{
+		Use:   "create",
+		Short: "Create manifest list or image index",
+		Long:  manifestCreateDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return manifestCreateCmd(cmd, args, manifestCreateOpts)
+		},
+		Example: fmt.Sprintf(`%[1]s manifest create mylist:v1.11
+  %[1]s manifest create mylist:v1.11 arch-specific-image-to-add
+  %[1]s manifest create --all mylist:v1.11 transport:tagged-image-to-add`, rootCmd.CommandPath()),
+		Args: cobra.MinimumNArgs(1),
+	}
+	manifestCreateCommand.SetUsageTemplate(UsageTemplate())
+	err := manifestCreateOpts.RegisterFlags(manifestCreateCommand.Flags())
+	bailOnError(err, "failed to register manifest create option flags")
+	manifestCommand.AddCommand(manifestCreateCommand)
+
+	manifestAddCommand := &cobra.Command{
+		Use:   "add",
+		Short: "Add images to a manifest list or image index",
+		Long:  manifestAddDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return manifestAddCmd(cmd, args, manifestAddOpts)
+		},
+		Example: fmt.Sprintf(`%[1]s manifest add mylist:v1.11 image:v1.11-amd64
+  %[1]s manifest add mylist:v1.11 transport:imageName`, rootCmd.CommandPath()),
+		Args: cobra.MinimumNArgs(2),
+	}
+	manifestAddCommand.SetUsageTemplate(UsageTemplate())
+	err = manifestAddOpts.RegisterFlags(manifestAddCommand.Flags())
+	bailOnError(err, "failed to register manifest add option flags")
+	manifestCommand.AddCommand(manifestAddCommand)
+
+	manifestRemoveCommand := &cobra.Command{
+		Use:   "remove",
+		Short: "Remove an entry from a manifest list or image index",
+		Long:  manifestRemoveDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return manifestRemoveCmd(cmd, args, manifestRemoveOpts)
+		},
+		Example: fmt.Sprintf(`%s manifest remove mylist:v1.11 sha256:15352d97781ffdf357bf3459c037be3efac4133dc9070c2dce7eca7c05c3e736`, rootCmd.CommandPath()),
+		Args:    cobra.MinimumNArgs(2),
+	}
+	manifestRemoveCommand.SetUsageTemplate(UsageTemplate())
+	manifestCommand.AddCommand(manifestRemoveCommand)
+
+	manifestExistsCommand := &cobra.Command{
+		Use:   "exists",
+		Short: "Check if a manifest list exists in local storage",
+		Long:  manifestExistsDescription,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return manifestExistsCmd(cmd, args)
+		},
+		Example: fmt.Sprintf(`%s manifest exists mylist`, rootCmd.CommandPath()),
+	}
+	manifestExistsCommand.SetUsageTemplate(UsageTemplate())
+	manifestCommand.AddCommand(manifestExistsCommand)
+
+	manifestAnnotateCommand := &cobra.Command{
+		Use:   "annotate",
+		Short: "Add or update information about an entry in a manifest list or image index",
+		Long:  manifestAnnotateDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return manifestAnnotateCmd(cmd, args, manifestAnnotateOpts)
+		},
+		Example: fmt.Sprintf(`%s manifest annotate --annotation left=right mylist:v1.11 image:v1.11-amd64`, rootCmd.CommandPath()),
+		Args:    cobra.MinimumNArgs(2),
+	}
+	manifestAnnotateCommand.SetUsageTemplate(UsageTemplate())
+	err = manifestAnnotateOpts.RegisterFlags(manifestAnnotateCommand.Flags())
+	bailOnError(err, "failed to register manifest annotate option flags")
+	manifestCommand.AddCommand(manifestAnnotateCommand)
+
+	manifestInspectCommand := &cobra.Command{
+		Use:   "inspect",
+		Short: "Display the contents of a manifest list or image index",
+		Long:  manifestInspectDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return manifestInspectCmd(cmd, args, manifestInspectOpts)
+		},
+		Example: fmt.Sprintf(`%s manifest inspect mylist:v1.11`, rootCmd.CommandPath()),
+		Args:    cobra.MinimumNArgs(1),
+	}
+	manifestInspectCommand.SetUsageTemplate(UsageTemplate())
+	manifestCommand.AddCommand(manifestInspectCommand)
+
+	manifestPushCommand := &cobra.Command{
+		Use:   "push",
+		Short: "Push a manifest list or image index to a registry",
+		Long:  manifestPushDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return manifestPushCmd(cmd, args, manifestPushOpts)
+		},
+		Example: fmt.Sprintf(`%s manifest push mylist:v1.11 transport:imageName`, rootCmd.CommandPath()),
+		Args:    cobra.MinimumNArgs(2),
+	}
+	manifestPushCommand.SetUsageTemplate(UsageTemplate())
+	fs := manifestPushCommand.Flags()
+	fs.BoolVar(&manifestPushOpts.rm, "rm", false, "remove the manifest list if push succeeds")
+	fs.BoolVar(&manifestPushOpts.all, "all", false, "also push the images in the list")
+	fs.StringVar(&manifestPushOpts.authfile, "authfile", auth.GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
+	fs.StringVar(&manifestPushOpts.certDir, "cert-dir", "", "use certificates at the specified path to access the registry")
+	fs.StringVar(&manifestPushOpts.creds, "creds", "", "use `[username[:password]]` for accessing the registry")
+	fs.StringVar(&manifestPushOpts.digestfile, "digestfile", "", "after copying the image, write the digest of the resulting digest to the file")
+	fs.StringVarP(&manifestPushOpts.format, "format", "f", "", "manifest type (oci or v2s2) to attempt to use when pushing the manifest list (default is manifest type of source)")
+	fs.BoolVarP(&manifestPushOpts.removeSignatures, "remove-signatures", "", false, "don't copy signatures when pushing images")
+	fs.StringVar(&manifestPushOpts.signBy, "sign-by", "", "sign the image using a GPG key with the specified `FINGERPRINT`")
+	fs.StringVar(&manifestPushOpts.signaturePolicy, "signature-policy", "", "`pathname` of signature policy file (not usually used)")
+	fs.BoolVar(&manifestPushOpts.insecure, "insecure", false, "neither require HTTPS nor verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
+	fs.BoolVar(&manifestPushOpts.tlsVerify, "tls-verify", false, "require HTTPS and verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
+	fs.BoolVarP(&manifestPushOpts.quiet, "quiet", "q", false, "don't output progress information when pushing lists")
+	fs.SetNormalizeFunc(cli.AliasFlags)
+	bailOnError(markFlagsHidden(fs, "signature-policy", "insecure", "tls-verify"), "")
+	manifestCommand.AddCommand(manifestPushCommand)
+
+	manifestRmCommand := &cobra.Command{
+		Use:   "rm",
+		Short: "Remove manifest list or image index",
+		Long:  manifestRmDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return manifestRmCmd(cmd, args)
+		},
+		Example: fmt.Sprintf(`%s manifest rm mylist:v1.11`, rootCmd.CommandPath()),
+		Args:    cobra.MinimumNArgs(1),
+	}
+	manifestRmCommand.SetUsageTemplate(UsageTemplate())
+	manifestCommand.AddCommand(manifestRmCommand)
+	return manifestCommand
+}
+
+func manifestExistsCmd(c *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return errors.New("at least a name must be specified for the list")
+	}
+	name := args[0]
+
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+
+	systemContext, err := parse.SystemContextFromOptions(c)
+	if err != nil {
+		return fmt.Errorf("building system context: %w", err)
+	}
+	runtime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: systemContext})
+	if err != nil {
+		return err
+	}
+
+	_, err = runtime.LookupManifestList(name)
+	if err != nil {
+		if errors.Is(err, storage.ErrImageUnknown) {
+			return err
+		}
+		return err
+	}
+	return nil
+}
+
+func manifestCreateCmd(c *cobra.Command, args []string, opts manifestCreateOpts) error {
+	if len(args) == 0 {
+		return errors.New("at least a name must be specified for the list")
+	}
+	listImageSpec := args[0]
+	imageSpecs := args[1:]
+
+	if err := setDefaultFlagsWithSetters(c, setDefaultTLSVerifyFlag); err != nil {
+		return err
+	}
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+	systemContext, err := parse.SystemContextFromOptions(c)
+	if err != nil {
+		return fmt.Errorf("building system context: %w", err)
+	}
+	runtime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: systemContext})
+	if err != nil {
+		return err
+	}
+
+	list := manifests.Create()
+	var manifestListID string
+
+	names, err := util.ExpandNames([]string{listImageSpec}, systemContext, store)
+	if err != nil {
+		return fmt.Errorf("encountered while expanding image name %q: %w", listImageSpec, err)
+	}
+	if manifestListID, err = list.SaveToImage(store, "", names, manifest.DockerV2ListMediaType); err != nil {
+		if errors.Is(err, storage.ErrDuplicateName) && opts.amend {
+			for _, name := range names {
+				manifestList, err := runtime.LookupManifestList(listImageSpec)
+				if err != nil {
+					logger.Debug("no list named %q found: %v", listImageSpec, err)
+					continue
+				}
+				if _, list, err = manifests.LoadFromImage(store, manifestList.ID()); err != nil {
+					logger.Debug("no list found in %q", name)
+					continue
+				}
+				manifestListID = manifestList.ID()
+				break
+			}
+			if list == nil {
+				return fmt.Errorf("--amend specified but no matching manifest list found with name %q", listImageSpec)
+			}
+		} else {
+			return err
+		}
+	}
+
+	for _, imageSpec := range imageSpecs {
+		ref, err := alltransports.ParseImageName(imageSpec)
+		if err != nil {
+			if ref, err = alltransports.ParseImageName(util.DefaultTransport + imageSpec); err != nil {
+				// check if the local image exists
+				if ref, _, err = util.FindImage(store, "", systemContext, imageSpec); err != nil {
+					return err
+				}
+			}
+		}
+		refLocal, _, err := util.FindImage(store, "", systemContext, imageSpec)
+		if err == nil {
+			// Found local image so use that.
+			ref = refLocal
+		}
+		_, err = list.Add(getContext(), systemContext, ref, opts.all)
+		if err != nil {
+			return err
+		}
+	}
+
+	imageID, err := list.SaveToImage(store, manifestListID, names, manifest.DockerV2ListMediaType)
+	if err == nil {
+		fmt.Printf("%s\n", imageID)
+	}
+	return err
+}
+
+func manifestAddCmd(c *cobra.Command, args []string, opts manifestAddOpts) error {
+	if err := auth.CheckAuthFile(opts.authfile); err != nil {
+		return err
+	}
+	if err := setDefaultFlagsWithSetters(c, setDefaultTLSVerifyFlag); err != nil {
+		return err
+	}
+
+	listImageSpec := ""
+	imageSpec := ""
+	switch len(args) {
+	case 0, 1:
+		return errors.New("at least a list image and an image to add must be specified")
+	case 2:
+		listImageSpec = args[0]
+		if listImageSpec == "" {
+			return fmt.Errorf(`invalid image name "%s"`, args[0])
+		}
+		imageSpec = args[1]
+		if imageSpec == "" {
+			return fmt.Errorf(`invalid image name "%s"`, args[1])
+		}
+	default:
+		return errors.New("at least two arguments are necessary: list and image to add to list")
+	}
+
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+
+	systemContext, err := parse.SystemContextFromOptions(c)
+	if err != nil {
+		return fmt.Errorf("building system context: %w", err)
+	}
+	runtime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: systemContext})
+	if err != nil {
+		return err
+	}
+
+	manifestList, err := runtime.LookupManifestList(listImageSpec)
+	if err != nil {
+		return err
+	}
+	_, list, err := manifests.LoadFromImage(store, manifestList.ID())
+	if err != nil {
+		return err
+	}
+
+	ref, err := alltransports.ParseImageName(imageSpec)
+	if err != nil {
+		if ref, err = alltransports.ParseImageName(util.DefaultTransport + imageSpec); err != nil {
+			// check if the local image exists
+			if ref, _, err = util.FindImage(store, "", systemContext, imageSpec); err != nil {
+				return err
+			}
+		}
+	}
+
+	digest, err := list.Add(getContext(), systemContext, ref, opts.all)
+	if err != nil {
+		var storeErr error
+		// Retry without a custom system context.  A user may want to add
+		// a custom platform (see #3511).
+		if ref, _, storeErr = util.FindImage(store, "", nil, imageSpec); storeErr != nil {
+			logger.Error("Error while trying to find image on local storage: %v", storeErr)
+			return err
+		}
+		digest, storeErr = list.Add(getContext(), systemContext, ref, opts.all)
+		if storeErr != nil {
+			logger.Error("Error while trying to add on manifest list: %v", storeErr)
+			return err
+		}
+	}
+
+	if opts.os != "" {
+		if err := list.SetOS(digest, opts.os); err != nil {
+			return err
+		}
+	}
+	if opts.osVersion != "" {
+		if err := list.SetOSVersion(digest, opts.osVersion); err != nil {
+			return err
+		}
+	}
+	if len(opts.osFeatures) != 0 {
+		if err := list.SetOSFeatures(digest, opts.osFeatures); err != nil {
+			return err
+		}
+	}
+	if opts.arch != "" {
+		if err := list.SetArchitecture(digest, opts.arch); err != nil {
+			return err
+		}
+	}
+	if opts.variant != "" {
+		if err := list.SetVariant(digest, opts.variant); err != nil {
+			return err
+		}
+	}
+	if len(opts.features) != 0 {
+		if err := list.SetFeatures(digest, opts.features); err != nil {
+			return err
+		}
+	}
+	if len(opts.annotations) != 0 {
+		annotations := make(map[string]string)
+		for _, annotationSpec := range opts.annotations {
+			spec := strings.SplitN(annotationSpec, "=", 2)
+			if len(spec) != 2 {
+				return fmt.Errorf("no value given for annotation %q", spec[0])
+			}
+			annotations[spec[0]] = spec[1]
+		}
+		if err := list.SetAnnotations(&digest, annotations); err != nil {
+			return err
+		}
+	}
+
+	updatedListID, err := list.SaveToImage(store, manifestList.ID(), nil, "")
+	if err == nil {
+		fmt.Printf("%s: %s\n", updatedListID, digest.String())
+	}
+
+	return err
+}
+
+func manifestRemoveCmd(c *cobra.Command, args []string, _ manifestRemoveOpts) error {
+	listImageSpec := ""
+	var instanceDigest digest.Digest
+	switch len(args) {
+	case 0, 1:
+		return errors.New("at least a list image and one or more instance digests must be specified")
+	case 2:
+		listImageSpec = args[0]
+		if listImageSpec == "" {
+			return fmt.Errorf(`invalid image name "%s"`, args[0])
+		}
+		instanceSpec := args[1]
+		if instanceSpec == "" {
+			return fmt.Errorf(`invalid instance "%s"`, args[1])
+		}
+		d, err := digest.Parse(instanceSpec)
+		if err != nil {
+			return fmt.Errorf(`invalid instance "%s": %v`, args[1], err)
+		}
+		instanceDigest = d
+	default:
+		return errors.New("at least two arguments are necessary: list and digest of instance to remove from list")
+	}
+
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+
+	systemContext, err := parse.SystemContextFromOptions(c)
+	if err != nil {
+		return fmt.Errorf("building system context: %w", err)
+	}
+
+	runtime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: systemContext})
+	if err != nil {
+		return err
+	}
+	manifestList, err := runtime.LookupManifestList(listImageSpec)
+	if err != nil {
+		return err
+	}
+
+	if err := manifestList.RemoveInstance(instanceDigest); err != nil {
+		return err
+	}
+
+	fmt.Printf("%s: %s\n", manifestList.ID(), instanceDigest.String())
+
+	return nil
+}
+
+func manifestRmCmd(c *cobra.Command, args []string) error {
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+
+	systemContext, err := parse.SystemContextFromOptions(c)
+	if err != nil {
+		return fmt.Errorf("building system context: %w", err)
+	}
+
+	runtime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: systemContext})
+	if err != nil {
+		return err
+	}
+
+	options := &libimage.RemoveImagesOptions{
+		Filters:        []string{"readonly=false"},
+		LookupManifest: true,
+	}
+	rmiReports, rmiErrors := runtime.RemoveImages(context.Background(), args, options)
+	for _, r := range rmiReports {
+		for _, u := range r.Untagged {
+			fmt.Printf("untagged: %s\n", u)
+		}
+	}
+	for _, r := range rmiReports {
+		if r.Removed {
+			fmt.Printf("%s\n", r.ID)
+		}
+	}
+
+	var multiE *multierror.Error
+	multiE = multierror.Append(multiE, rmiErrors...)
+	return multiE.ErrorOrNil()
+}
+
+func manifestAnnotateCmd(c *cobra.Command, args []string, opts manifestAnnotateOpts) error {
+	listImageSpec := ""
+	imageSpec := ""
+	switch len(args) {
+	case 0:
+		return errors.New("at least a list image must be specified")
+	case 1:
+		listImageSpec = args[0]
+		if listImageSpec == "" {
+			return fmt.Errorf(`invalid image name "%s"`, args[0])
+		}
+	case 2:
+		listImageSpec = args[0]
+		if listImageSpec == "" {
+			return fmt.Errorf(`invalid image name "%s"`, args[0])
+		}
+		imageSpec = args[1]
+		if imageSpec == "" {
+			return fmt.Errorf(`invalid image name "%s"`, args[1])
+		}
+	default:
+		return errors.New("at least two arguments are necessary: list and image to add to list")
+	}
+
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+
+	systemContext, err := parse.SystemContextFromOptions(c)
+	if err != nil {
+		return fmt.Errorf("building system context: %w", err)
+	}
+	runtime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: systemContext})
+	if err != nil {
+		return err
+	}
+
+	manifestList, err := runtime.LookupManifestList(listImageSpec)
+	if err != nil {
+		return err
+	}
+
+	_, list, err := manifests.LoadFromImage(store, manifestList.ID())
+	if err != nil {
+		return err
+	}
+
+	digest, err := digest.Parse(imageSpec)
+	if err != nil {
+		ctx := getContext()
+		ref, _, err := util.FindImage(store, "", systemContext, imageSpec)
+		if err != nil {
+			return err
+		}
+		img, err := ref.NewImageSource(ctx, systemContext)
+		if err != nil {
+			return err
+		}
+		defer img.Close()
+		manifestBytes, _, err := img.GetManifest(ctx, nil)
+		if err != nil {
+			return err
+		}
+		digest, err = manifest.Digest(manifestBytes)
+		if err != nil {
+			return err
+		}
+	}
+
+	if opts.os != "" {
+		if err := list.SetOS(digest, opts.os); err != nil {
+			return err
+		}
+	}
+	if opts.osVersion != "" {
+		if err := list.SetOSVersion(digest, opts.osVersion); err != nil {
+			return err
+		}
+	}
+	if len(opts.osFeatures) != 0 {
+		if err := list.SetOSFeatures(digest, opts.osFeatures); err != nil {
+			return err
+		}
+	}
+	if opts.arch != "" {
+		if err := list.SetArchitecture(digest, opts.arch); err != nil {
+			return err
+		}
+	}
+	if opts.variant != "" {
+		if err := list.SetVariant(digest, opts.variant); err != nil {
+			return err
+		}
+	}
+	if len(opts.features) != 0 {
+		if err := list.SetFeatures(digest, opts.features); err != nil {
+			return err
+		}
+	}
+	if len(opts.annotations) != 0 {
+		annotations := make(map[string]string)
+		for _, annotationSpec := range opts.annotations {
+			spec := strings.SplitN(annotationSpec, "=", 2)
+			if len(spec) != 2 {
+				return fmt.Errorf("no value given for annotation %q", spec[0])
+			}
+			annotations[spec[0]] = spec[1]
+		}
+		if err := list.SetAnnotations(&digest, annotations); err != nil {
+			return err
+		}
+	}
+
+	updatedListID, err := list.SaveToImage(store, manifestList.ID(), nil, "")
+	if err == nil {
+		fmt.Printf("%s: %s\n", updatedListID, digest.String())
+	}
+
+	return nil
+}
+
+func manifestInspectCmd(c *cobra.Command, args []string, _ manifestInspectOpts) error {
+	imageSpec := ""
+	switch len(args) {
+	case 0:
+		return errors.New("at least a source list ID must be specified")
+	case 1:
+		imageSpec = args[0]
+		if imageSpec == "" {
+			return fmt.Errorf(`invalid image name "%s"`, imageSpec)
+		}
+	default:
+		return errors.New("only one argument is necessary for inspect: an image name")
+	}
+
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+
+	systemContext, err := parse.SystemContextFromOptions(c)
+	if err != nil {
+		return fmt.Errorf("building system context: %w", err)
+	}
+	setDefaultSystemContext(systemContext)
+	return manifestInspect(getContext(), store, systemContext, imageSpec)
+}
+
+func manifestInspect(ctx context.Context, store storage.Store, systemContext *types.SystemContext, imageSpec string) error {
+	runtime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: systemContext})
+	if err != nil {
+		return err
+	}
+
+	printManifest := func(manifest []byte) error {
+		var b bytes.Buffer
+		err = json.Indent(&b, manifest, "", "    ")
+		if err != nil {
+			return fmt.Errorf("rendering manifest for display: %w", err)
+		}
+
+		fmt.Printf("%s\n", b.String())
+		return nil
+	}
+
+	// Before doing a remote lookup, attempt to resolve the manifest list
+	// locally.
+	manifestList, err := runtime.LookupManifestList(imageSpec)
+	if err == nil {
+		schema2List, err := manifestList.Inspect()
+		if err != nil {
+			return err
+		}
+
+		rawSchema2List, err := json.Marshal(schema2List)
+		if err != nil {
+			return err
+		}
+
+		return printManifest(rawSchema2List)
+	}
+	if !errors.Is(err, storage.ErrImageUnknown) && !errors.Is(err, libimage.ErrNotAManifestList) {
+		return err
+	}
+
+	// TODO: at some point `libimage` should support resolving manifests
+	// like that.  Similar to `libimage.Runtime.LookupImage` we could
+	// implement a `*.LookupImageIndex`.
+	refs, err := util.ResolveNameToReferences(store, systemContext, imageSpec)
+	if err != nil {
+		logger.Debug("error parsing reference to image %q: %v", imageSpec, err)
+	}
+
+	if ref, _, err := util.FindImage(store, "", systemContext, imageSpec); err == nil {
+		refs = append(refs, ref)
+	} else if ref, err := alltransports.ParseImageName(imageSpec); err == nil {
+		refs = append(refs, ref)
+	}
+	if len(refs) == 0 {
+		return fmt.Errorf("locating images with names %v", imageSpec)
+	}
+
+	var (
+		latestErr error
+		result    []byte
+	)
+
+	appendErr := func(e error) {
+		if latestErr == nil {
+			latestErr = e
+		} else {
+			latestErr = fmt.Errorf("tried %v: %w", e, latestErr)
+		}
+	}
+
+	for _, ref := range refs {
+		logger.Debug("Testing reference %q for possible manifest", transports.ImageName(ref))
+
+		src, err := ref.NewImageSource(ctx, systemContext)
+		if err != nil {
+			appendErr(fmt.Errorf("reading image %q: %w", transports.ImageName(ref), err))
+			continue
+		}
+		defer src.Close()
+
+		manifestBytes, manifestType, err := src.GetManifest(ctx, nil)
+		if err != nil {
+			appendErr(fmt.Errorf("loading manifest %q: %w", transports.ImageName(ref), err))
+			continue
+		}
+
+		if !manifest.MIMETypeIsMultiImage(manifestType) {
+			appendErr(fmt.Errorf("manifest is of type %s (not a list type)", manifestType))
+			continue
+		}
+		result = manifestBytes
+		break
+	}
+	if len(result) == 0 && latestErr != nil {
+		return latestErr
+	}
+
+	return printManifest(result)
+}
+
+func manifestPushCmd(c *cobra.Command, args []string, opts pushOptions) error {
+	if err := auth.CheckAuthFile(opts.authfile); err != nil {
+		return err
+	}
+	if err := setDefaultFlagsWithSetters(c, setDefaultTLSVerifyFlag); err != nil {
+		return err
+	}
+
+	listImageSpec := ""
+	destSpec := ""
+	switch len(args) {
+	case 0:
+		return errors.New("at least a source list ID must be specified")
+	case 1:
+		return errors.New("two arguments are necessary to push: source and destination")
+	case 2:
+		listImageSpec = args[0]
+		destSpec = args[1]
+		if listImageSpec == "" {
+			return fmt.Errorf(`invalid image name "%s"`, listImageSpec)
+		}
+		if destSpec == "" {
+			return fmt.Errorf(`invalid image name "%s"`, destSpec)
+		}
+	default:
+		return errors.New("only two arguments are necessary to push: source and destination")
+	}
+
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+	systemContext, err := parse.SystemContextFromOptions(c)
+	if err != nil {
+		return fmt.Errorf("building system context: %w", err)
+	}
+	setDefaultSystemContext(systemContext)
+	return manifestPush(systemContext, store, listImageSpec, destSpec, opts)
+}
+
+func manifestPush(systemContext *types.SystemContext, store storage.Store, listImageSpec, destSpec string, opts pushOptions) error {
+	runtime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: systemContext})
+	if err != nil {
+		return err
+	}
+
+	manifestList, err := runtime.LookupManifestList(listImageSpec)
+	if err != nil {
+		return err
+	}
+
+	_, list, err := manifests.LoadFromImage(store, manifestList.ID())
+	if err != nil {
+		return err
+	}
+
+	dest, err := alltransports.ParseImageName(destSpec)
+	if err != nil {
+		return err
+	}
+
+	var manifestType string
+	if opts.format != "" {
+		switch opts.format {
+		case "oci":
+			manifestType = imgspecv1.MediaTypeImageManifest
+		case "v2s2", "docker":
+			manifestType = manifest.DockerV2Schema2MediaType
+		default:
+			return fmt.Errorf("unknown format %q. Choose on of the supported formats: 'oci' or 'v2s2'", opts.format)
+		}
+	}
+
+	options := manifests.PushOptions{
+		Store:              store,
+		SystemContext:      systemContext,
+		ImageListSelection: cp.CopySpecificImages,
+		Instances:          nil,
+		RemoveSignatures:   opts.removeSignatures,
+		SignBy:             opts.signBy,
+		ManifestType:       manifestType,
+	}
+	if opts.all {
+		options.ImageListSelection = cp.CopyAllImages
+	}
+	if !opts.quiet {
+		options.ReportWriter = os.Stderr
+	}
+
+	_, digest, err := list.Push(getContext(), dest, options)
+
+	if err == nil && opts.rm {
+		_, err = store.DeleteImage(manifestList.ID(), true)
+	}
+
+	if opts.digestfile != "" {
+		if err = os.WriteFile(opts.digestfile, []byte(digest.String()), 0644); err != nil {
+			return util.GetFailureCause(err, fmt.Errorf("failed to write digest to file %q: %w", opts.digestfile, err))
+		}
+	}
+
+	return err
+}

--- a/deprecate/pkg/buildah/merge.go
+++ b/deprecate/pkg/buildah/merge.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2022 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buildah
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/labring/sealos/pkg/image"
+
+	"github.com/containers/buildah/pkg/parse"
+
+	"github.com/containers/buildah"
+	buildahcli "github.com/containers/buildah/pkg/cli"
+	"github.com/containers/buildah/util"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/spf13/cobra"
+
+	"github.com/labring/sealos/pkg/utils/logger"
+	"github.com/labring/sealos/pkg/utils/rand"
+)
+
+func newMergeCommand() *cobra.Command {
+	layerFlagsResults := buildahcli.LayerResults{}
+	buildFlagResults := buildahcli.BudResults{}
+	fromAndBudResults := buildahcli.FromAndBudResults{}
+	userNSResults := buildahcli.UserNSResults{}
+	namespaceResults := buildahcli.NameSpaceResults{}
+	buildahInfo := &buildah.BuilderInfo{}
+	sopts := saverOptions{}
+	mergeCommand := &cobra.Command{
+		Use:   "merge",
+		Short: "merge multiple images into one",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			br := buildahcli.BuildOptions{
+				LayerResults:      &layerFlagsResults,
+				BudResults:        &buildFlagResults,
+				UserNSResults:     &userNSResults,
+				FromAndBudResults: &fromAndBudResults,
+				NameSpaceResults:  &namespaceResults,
+			}
+			logger.Debug("save enable: %+v", sopts.enabled)
+			return buildCmd(cmd, []string{buildahInfo.MountPoint}, sopts, br)
+		},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			tag := getTagsFromFlags(cmd)
+			var err error
+			flagSetters := []FlagSetter{}
+			if flagChanged(cmd, "platform") {
+				platformFlags := getPlatformFromFlags(cmd)
+				if len(platformFlags) != 1 {
+					return fmt.Errorf("only one platform is allowed")
+				}
+				oss, arch, variant, err := parse.Platform(platformFlags[0])
+				if err != nil {
+					return err
+				}
+				logger.Debug("os: %s, arch: %s, variant: %s, tag: %+v", oss, arch, variant, tag)
+				platform := v1.Platform{
+					Architecture: arch,
+					OS:           oss,
+					Variant:      variant,
+				}
+				flagSetters = append(flagSetters, WithPlatformOption(platform))
+			}
+
+			buildahInfo, err = mergeImagesWithScratchContainer(tag[0], args, flagSetters)
+			if err != nil {
+				return err
+			}
+			return setDefaultFlagsWithSetters(cmd, setDefaultTLSVerifyFlag, setDefaultSaveImageFlag)
+		},
+		PostRunE: func(cmd *cobra.Command, args []string) error {
+			tag := getTagsFromFlags(cmd)
+			logger.Debug("images %s is merged to %+v", strings.Join(args, ","), tag)
+			if buildahInfo != nil {
+				b, err := New("")
+				if err != nil {
+					return err
+				}
+				if err = b.Delete(buildahInfo.Container); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Args: cobra.MinimumNArgs(2),
+		Example: fmt.Sprintf(`
+  %[1]s merge -t new:0.1.0 kubernetes:v1.19.9 mysql:5.7.0 redis:6.0.0`, rootCmd.CommandPath()),
+	}
+	mergeCommand.SetUsageTemplate(UsageTemplate())
+
+	flags := mergeCommand.Flags()
+	flags.SetInterspersed(false)
+
+	// build is a all common flags
+	buildFlags := buildahcli.GetBudFlags(&buildFlagResults)
+	buildFlags.StringVar(&buildFlagResults.Runtime, "runtime", util.Runtime(), "`path` to an alternate runtime. Use BUILDAH_RUNTIME environment variable to override.")
+	layerFlags := buildahcli.GetLayerFlags(&layerFlagsResults)
+	fromAndBudFlags, err := buildahcli.GetFromAndBudFlags(&fromAndBudResults, &userNSResults, &namespaceResults)
+	bailOnError(err, "failed to setup From and Build flags")
+
+	sopts.RegisterFlags(flags)
+	flags.AddFlagSet(&buildFlags)
+	flags.AddFlagSet(&layerFlags)
+	flags.AddFlagSet(&fromAndBudFlags)
+	flags.SetNormalizeFunc(buildahcli.AliasFlags)
+	bailOnError(markFlagsHidden(flags, "save-image"), "")
+	bailOnError(markFlagsHidden(flags, "tls-verify"), "")
+	bailOnError(markFlagsHidden(flags, append(flagsInBuildCommandToBeHidden(), flagsAssociatedWithPlatform()...)...), "")
+	return mergeCommand
+}
+
+func mergeImagesWithScratchContainer(newImageName string, images []string, setters []FlagSetter) (*buildah.BuilderInfo, error) {
+	b, err := New("")
+	if err != nil {
+		return nil, err
+	}
+	cName := fmt.Sprintf("%s-%s", newImageName, rand.Generator(8))
+	bInfo, err := b.Create(cName, "scratch", setters...)
+	if err != nil {
+		return nil, err
+	}
+	logger.Debug("mergeDir: %s", bInfo.MountPoint)
+	if err = b.Pull(images, append(setters, WithPullPolicyOption(PullIfMissing.String()))...); err != nil {
+		return nil, err
+	}
+
+	imageObjList := make([]map[string]v1.Image, 0)
+	for _, i := range images {
+		obj, err := b.InspectImage(i)
+		if err != nil {
+			logger.Error("InspectImage error: %+v", err)
+		}
+		if obj != nil {
+			imageObjList = append(imageObjList, map[string]v1.Image{i: *obj.OCIv1})
+		}
+	}
+
+	dockerfile, err := image.MergeDockerfileFromImages(imageObjList)
+	if err != nil {
+		return nil, err
+	}
+	mergeDir := bInfo.MountPoint
+	err = os.WriteFile(path.Join(mergeDir, "Sealfile"), []byte(dockerfile), 0755)
+	if err != nil {
+		return nil, err
+	}
+	logger.Debug("buildOptions file: %s", path.Join(mergeDir, "Sealfile"))
+	logger.Debug("buildOptions tag: %s", newImageName)
+	logger.Debug("buildOptions contextDir: %s", mergeDir)
+	return &bInfo, nil
+}

--- a/deprecate/pkg/buildah/mount.go
+++ b/deprecate/pkg/buildah/mount.go
@@ -1,0 +1,134 @@
+// Copyright © 2022 buildah.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/containers/buildah/blob/main/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	buildahcli "github.com/containers/buildah/pkg/cli"
+	"github.com/containers/storage"
+	"github.com/spf13/cobra"
+)
+
+type jsonMount struct {
+	Container  string `json:"container,omitempty"`
+	MountPoint string `json:"mountPoint"`
+}
+
+type mountOptions struct {
+	json bool
+}
+
+func newMountCommand() *cobra.Command {
+	var (
+		mountDescription = fmt.Sprintf(`%[1]s mount
+  mounts a working container's root filesystem for manipulation.
+`, rootCmd.CommandPath())
+		opts       mountOptions
+		noTruncate bool
+	)
+	mountCommand := &cobra.Command{
+		Use:    "mount",
+		Hidden: true,
+		Short:  "Mount a working container's root filesystem",
+		Long:   mountDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return mountCmd(cmd, args, opts)
+		},
+		Example: fmt.Sprintf(`%[1]s mount
+  %[1]s mount containerID
+  %[1]s mount containerID1 containerID2
+`, rootCmd.CommandPath()),
+	}
+	mountCommand.SetUsageTemplate(UsageTemplate())
+
+	fs := mountCommand.Flags()
+	fs.SetInterspersed(false)
+	fs.BoolVar(&opts.json, "json", false, "output in JSON format")
+	fs.BoolVar(&noTruncate, "notruncate", false, "do not truncate output")
+	err := markFlagsHidden(fs, "notruncate")
+	bailOnError(err, "")
+	return mountCommand
+}
+
+func mountCmd(c *cobra.Command, args []string, opts mountOptions) error {
+	if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
+		return err
+	}
+
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+	jsonMounts, err := doMounts(store, args)
+	if err != nil {
+		return err
+	}
+	if opts.json {
+		data, err := json.MarshalIndent(jsonMounts, "", "    ")
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%s\n", data)
+	} else {
+		for i := range jsonMounts {
+			fmt.Printf("%s %s\n", jsonMounts[i].Container, jsonMounts[i].MountPoint)
+		}
+	}
+	return nil
+}
+
+func doMounts(store storage.Store, args []string) ([]jsonMount, error) {
+	var jsonMounts []jsonMount
+	if len(args) > 0 {
+		// Do not allow to mount a graphdriver that is not vfs if we are creating the userns as part
+		// of the mount command.
+		// Differently, allow the mount if we are already in a userns, as the mount point will still
+		// be accessible once "buildah mount" exits.
+		if os.Geteuid() != 0 && store.GraphDriverName() != "vfs" {
+			return nil, fmt.Errorf("cannot mount using driver %s in rootless mode. You need to run it in a `buildah unshare` session", store.GraphDriverName())
+		}
+
+		for _, name := range args {
+			builder, err := openBuilder(getContext(), store, name)
+			if err != nil {
+				return nil, fmt.Errorf("reading build container %q: %w", name, err)
+			}
+			mountPoint, err := builder.Mount(builder.MountLabel)
+			if err != nil {
+				return nil, fmt.Errorf("mounting %q container %q: %w", name, builder.Container, err)
+			}
+			jsonMounts = append(jsonMounts, jsonMount{Container: name, MountPoint: mountPoint})
+		}
+	} else {
+		builders, err := openBuilders(store)
+		if err != nil {
+			return nil, fmt.Errorf("reading build containers: %w", err)
+		}
+
+		for _, builder := range builders {
+			mounted, err := builder.Mounted()
+			if err != nil {
+				return nil, err
+			}
+			if mounted {
+				jsonMounts = append(jsonMounts, jsonMount{Container: builder.Container, MountPoint: builder.MountPoint})
+			}
+		}
+	}
+	return jsonMounts, nil
+}

--- a/deprecate/pkg/buildah/pull.go
+++ b/deprecate/pkg/buildah/pull.go
@@ -1,0 +1,207 @@
+// Copyright © 2022 buildah.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/containers/buildah/blob/main/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/containers/buildah"
+	"github.com/containers/buildah/define"
+	buildahcli "github.com/containers/buildah/pkg/cli"
+	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/common/pkg/auth"
+	"github.com/containers/image/v5/types"
+	"github.com/containers/storage"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/labring/sealos/pkg/buildah/internal/util"
+	"github.com/labring/sealos/pkg/utils/logger"
+)
+
+type pullOptions struct {
+	allTags           bool
+	authfile          string
+	blobCache         string
+	certDir           string
+	creds             string
+	signaturePolicy   string
+	quiet             bool
+	removeSignatures  bool
+	tlsVerify         bool
+	decryptionKeys    []string
+	pullPolicy        string
+	os, arch, variant string
+	platform          []string
+	retry             int
+	retryDelay        time.Duration
+}
+
+func (opts *pullOptions) HiddenFlags() []string {
+	return []string{
+		"signature-policy", "blob-cache", "tls-verify", "arch", "os", "variant",
+	}
+}
+
+func newDefaultPullOptions() *pullOptions {
+	return &pullOptions{
+		authfile:   auth.GetDefaultAuthFile(),
+		pullPolicy: "missing",
+		tlsVerify:  false,
+		os:         runtime.GOOS,
+		arch:       runtime.GOARCH,
+		platform:   []string{parse.DefaultPlatform()},
+		retry:      buildahcli.MaxPullPushRetries,
+		retryDelay: buildahcli.PullPushRetryDelay,
+	}
+}
+
+func (opts *pullOptions) RegisterFlags(fs *pflag.FlagSet) error {
+	fs.SetInterspersed(false)
+	fs.BoolVarP(&opts.allTags, "all-tags", "a", opts.allTags, "download all tagged images in the repository")
+	fs.StringVar(&opts.authfile, "authfile", opts.authfile, "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
+	fs.StringVar(&opts.blobCache, "blob-cache", opts.blobCache, "store copies of pulled image blobs in the specified directory")
+	fs.StringVar(&opts.certDir, "cert-dir", opts.certDir, "use certificates at the specified path to access the registry")
+	fs.StringVar(&opts.creds, "creds", opts.creds, "use `[username[:password]]` for accessing the registry")
+	fs.StringVar(&opts.pullPolicy, "policy", opts.pullPolicy, "missing, always, or never.")
+	fs.BoolVar(&opts.removeSignatures, "remove-signatures", opts.removeSignatures, "don't copy signatures when pulling image")
+	fs.StringVar(&opts.signaturePolicy, "signature-policy", opts.signaturePolicy, "`pathname` of signature policy file (not usually used)")
+	fs.StringSliceVar(&opts.decryptionKeys, "decryption-key", opts.decryptionKeys, "key needed to decrypt the image")
+	fs.BoolVarP(&opts.quiet, "quiet", "q", opts.quiet, "don't output progress information when pulling images")
+	fs.StringVar(&opts.os, "os", opts.os, "prefer `OS` instead of the running OS for choosing images")
+	fs.StringVar(&opts.arch, "arch", opts.arch, "prefer `ARCH` instead of the architecture of the machine for choosing images")
+	fs.StringSliceVar(&opts.platform, "platform", opts.platform, "prefer OS/ARCH instead of the current operating system and architecture for choosing images")
+	fs.StringVar(&opts.variant, "variant", opts.variant, "override the `variant` of the specified image")
+	fs.BoolVar(&opts.tlsVerify, "tls-verify", opts.tlsVerify, "require HTTPS and verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
+	fs.IntVar(&opts.retry, "retry", opts.retry, "number of times to retry in case of failure when performing pull")
+	fs.DurationVar(&opts.retryDelay, "retry-delay", opts.retryDelay, "delay between retries in case of pull failures")
+	return markFlagsHidden(fs, opts.HiddenFlags()...)
+}
+
+func newPullCommand() *cobra.Command {
+	var (
+		opts = newDefaultPullOptions()
+
+		pullDescription = `  Pull images from a registry and stores it locally.
+  Images can be pulled using its tag or digest. If a tag is not
+  specified, the image with the 'latest' tag (if it exists) is pulled.`
+	)
+
+	pullCommand := &cobra.Command{
+		Use:   "pull",
+		Short: "Pull images from the specified location",
+		Long:  pullDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return pullCmd(cmd, args, opts)
+		},
+		Example: fmt.Sprintf(`%[1]s pull imagename
+  %[1]s pull docker-daemon:imagename:imagetag
+  %[1]s pull myregistry/myrepository/imagename:imagetag
+  %[1]s pull imageID1 imageID2 imageID3`, rootCmd.CommandPath()),
+	}
+	pullCommand.SetUsageTemplate(UsageTemplate())
+
+	err := opts.RegisterFlags(pullCommand.Flags())
+	bailOnError(err, "failed to register pull option flags")
+	return pullCommand
+}
+
+func pullCmd(c *cobra.Command, args []string, iopts *pullOptions) error {
+	if len(args) == 0 {
+		return errors.New("an image name must be specified")
+	}
+	if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
+		return err
+	}
+	if err := setDefaultFlagsWithSetters(c, setDefaultTLSVerifyFlag); err != nil {
+		return err
+	}
+	systemContext, err := parse.SystemContextFromOptions(c)
+	if err != nil {
+		return fmt.Errorf("building system context: %w", err)
+	}
+	platforms, err := parse.PlatformsFromOptions(c)
+	if err != nil {
+		return err
+	}
+	if len(platforms) > 1 {
+		logger.Warn("ignoring platforms other than %+v: %+v", platforms[0], platforms[1:])
+	}
+
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+	ids, err := doPull(c, store, systemContext, args, iopts)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s\n", strings.Join(ids, ","))
+	return nil
+}
+
+func doPull(c *cobra.Command, store storage.Store, systemContext *types.SystemContext, imageNames []string, iopts *pullOptions) ([]string, error) {
+	var err error
+	if systemContext == nil {
+		systemContext, err = parse.SystemContextFromOptions(c)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if err = auth.CheckAuthFile(iopts.authfile); err != nil {
+		return nil, err
+	}
+
+	decConfig, err := util.DecryptConfig(iopts.decryptionKeys)
+	if err != nil {
+		return nil, fmt.Errorf("unable to obtain decryption config: %w", err)
+	}
+
+	policy, ok := define.PolicyMap[iopts.pullPolicy]
+	if !ok {
+		return nil, fmt.Errorf("unsupported pull policy %q", iopts.pullPolicy)
+	}
+	options := buildah.PullOptions{
+		SignaturePolicyPath: iopts.signaturePolicy,
+		Store:               store,
+		SystemContext:       systemContext,
+		BlobDirectory:       iopts.blobCache,
+		AllTags:             iopts.allTags,
+		ReportWriter:        os.Stderr,
+		RemoveSignatures:    iopts.removeSignatures,
+		MaxRetries:          iopts.retry,
+		RetryDelay:          iopts.retryDelay,
+		OciDecryptConfig:    decConfig,
+		PullPolicy:          policy,
+	}
+
+	if iopts.quiet {
+		options.ReportWriter = nil // Turns off logging output
+	}
+	var ids []string
+	for _, imageName := range imageNames {
+		id, err := buildah.Pull(getContext(), imageName, options)
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}

--- a/deprecate/pkg/buildah/push.go
+++ b/deprecate/pkg/buildah/push.go
@@ -1,0 +1,296 @@
+// Copyright © 2022 buildah.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/containers/buildah/blob/main/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/containers/buildah"
+	"github.com/containers/buildah/define"
+	buildahcli "github.com/containers/buildah/pkg/cli"
+	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/buildah/util"
+	"github.com/containers/common/pkg/auth"
+	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/pkg/compression"
+	"github.com/containers/image/v5/transports"
+	"github.com/containers/image/v5/transports/alltransports"
+	"github.com/containers/storage"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	iutil "github.com/labring/sealos/pkg/buildah/internal/util"
+	"github.com/labring/sealos/pkg/utils/logger"
+)
+
+type pushOptions struct {
+	all                bool
+	authfile           string
+	blobCache          string
+	certDir            string
+	creds              string
+	digestfile         string
+	disableCompression bool
+	format             string
+	compressionFormat  string
+	compressionLevel   int
+	retry              int
+	retryDelay         time.Duration
+	rm                 bool
+	quiet              bool
+	removeSignatures   bool
+	signaturePolicy    string
+	signBy             string
+	tlsVerify          bool
+	encryptionKeys     []string
+	encryptLayers      []int
+	insecure           bool
+
+	// TODO: remove this flag once we have a better way to handle image cr pushing to the dest registry
+	crOption CrOpionEnum
+}
+
+func newDefaultPushOptions() *pushOptions {
+	return &pushOptions{
+		authfile:   auth.GetDefaultAuthFile(),
+		retry:      buildahcli.MaxPullPushRetries,
+		retryDelay: buildahcli.PullPushRetryDelay,
+		crOption:   CrOptionAuto,
+	}
+}
+
+func (opts *pushOptions) RegisterFlags(fs *pflag.FlagSet) error {
+	fs.SetInterspersed(false)
+	fs.BoolVar(&opts.all, "all", opts.all, "push all of the images referenced by the manifest list")
+	fs.StringVar(&opts.authfile, "authfile", opts.authfile, "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
+	fs.StringVar(&opts.blobCache, "blob-cache", opts.blobCache, "assume image blobs in the specified directory will be available for pushing")
+	fs.StringVar(&opts.certDir, "cert-dir", opts.certDir, "use certificates at the specified path to access the registry")
+	fs.StringVar(&opts.creds, "creds", opts.creds, "use `[username[:password]]` for accessing the registry")
+	fs.StringVar(&opts.digestfile, "digestfile", opts.digestfile, "after copying the image, write the digest of the resulting image to the file")
+	fs.BoolVarP(&opts.disableCompression, "disable-compression", "D", false, "don't compress layers")
+	fs.StringVarP(&opts.format, "format", "f", opts.format, "manifest type (oci, v2s1, or v2s2) to use in the destination (default is manifest type of source, with fallbacks)")
+	fs.StringVar(&opts.compressionFormat, "compression-format", opts.compressionFormat, "compression format to use")
+	fs.IntVar(&opts.compressionLevel, "compression-level", opts.compressionLevel, "compression level to use")
+	fs.BoolVarP(&opts.quiet, "quiet", "q", opts.quiet, "don't output progress information when pushing images")
+	fs.IntVar(&opts.retry, "retry", opts.retry, "number of times to retry in case of failure when performing push/pull")
+	fs.DurationVar(&opts.retryDelay, "retry-delay", opts.retryDelay, "delay between retries in case of push/pull failures")
+	fs.BoolVar(&opts.rm, "rm", opts.rm, "remove the manifest list if push succeeds")
+	fs.BoolVarP(&opts.removeSignatures, "remove-signatures", "", opts.removeSignatures, "don't copy signatures when pushing image")
+	fs.StringVar(&opts.signBy, "sign-by", opts.signBy, "sign the image using a GPG key with the specified `FINGERPRINT`")
+	fs.StringVar(&opts.signaturePolicy, "signature-policy", opts.signaturePolicy, "`pathname` of signature policy file (not usually used)")
+	fs.StringSliceVar(&opts.encryptionKeys, "encryption-key", opts.encryptionKeys, "key with the encryption protocol to use needed to encrypt the image (e.g. jwe:/path/to/key.pem)")
+	fs.IntSliceVar(&opts.encryptLayers, "encrypt-layer", opts.encryptLayers, "layers to encrypt, 0-indexed layer indices with support for negative indexing (e.g. 0 is the first layer, -1 is the last layer). If not defined, will encrypt all layers if encryption-key flag is specified")
+	fs.BoolVar(&opts.tlsVerify, "tls-verify", opts.tlsVerify, "require HTTPS and verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
+
+	// TODO: remove this flag once we have a better way to handle image cr pushing to the dest registry
+	fs.Var(&opts.crOption, "cr-option", `push image cr to the dest registry, allow values: "yes", "no", "only", "auto"`)
+	return markFlagsHidden(fs, []string{"signature-policy", "blob-cache", "tls-verify"}...)
+}
+
+func newPushCommand() *cobra.Command {
+	var (
+		opts            = newDefaultPushOptions()
+		pushDescription = fmt.Sprintf(`
+  Pushes an image to a specified location.
+
+  The Image "DESTINATION" uses a "transport":"details" format. If not specified, will reuse source IMAGE as DESTINATION.
+
+  Supported transports:
+  %s
+`, getListOfTransports())
+	)
+
+	pushCommand := &cobra.Command{
+		Use:   "push",
+		Short: "Push an image to a specified destination",
+		Long:  pushDescription,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			// specific croption is only valid when crOption is auto, and switch to a specific croption `yes` / `no`
+			if opts.crOption == CrOptionAuto {
+				opts.crOption = SpecificCroption(args)
+			}
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return pushCmd(cmd, args, opts)
+		},
+		PostRunE: func(cmd *cobra.Command, args []string) error {
+			return NewAndRunImageCRBuilder(cmd, args, opts)
+		},
+		Example: fmt.Sprintf(`%[1]s push imageID docker://registry.example.com/repository:tag
+  %[1]s push imageID docker-daemon:image:tagi
+  %[1]s push imageID oci:/path/to/layout:image:tag`, rootCmd.CommandPath()),
+	}
+	pushCommand.SetUsageTemplate(UsageTemplate())
+	err := opts.RegisterFlags(pushCommand.Flags())
+	bailOnError(err, "failed to register push option flags")
+	return pushCommand
+}
+
+func pushCmd(c *cobra.Command, args []string, iopts *pushOptions) error {
+	var src, destSpec string
+
+	if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
+		return err
+	}
+	if err := auth.CheckAuthFile(iopts.authfile); err != nil {
+		return err
+	}
+
+	switch len(args) {
+	case 0:
+		return errors.New("at least a source image ID must be specified")
+	case 1:
+		src = args[0]
+		destSpec = src
+		logger.Debug("Destination argument not specified, assuming the same as the source: %s", destSpec)
+	case 2:
+		src = args[0]
+		destSpec = args[1]
+		if src == "" {
+			return fmt.Errorf(`invalid image name "%s"`, args[0])
+		}
+	default:
+		return errors.New("only two arguments are necessary to push: source and destination")
+	}
+
+	compress := define.Gzip
+	if iopts.disableCompression {
+		compress = define.Uncompressed
+	}
+
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+
+	dest, err := alltransports.ParseImageName(destSpec)
+	// add the docker:// transport to see if they neglected it.
+	if err != nil {
+		destTransport := strings.Split(destSpec, ":")[0]
+		if t := transports.Get(destTransport); t != nil {
+			return err
+		}
+
+		if strings.Contains(destSpec, "://") {
+			return err
+		}
+
+		destSpec = "docker://" + destSpec
+		dest2, err2 := alltransports.ParseImageName(destSpec)
+		if err2 != nil {
+			return err
+		}
+		dest = dest2
+		logger.Debug("Assuming docker:// as the transport method for DESTINATION: %s", destSpec)
+	}
+	if err := setDefaultFlagsWithSetters(c, setDefaultTLSVerifyFlag); err != nil {
+		return err
+	}
+	systemContext, err := parse.SystemContextFromOptions(c)
+	if err != nil {
+		return fmt.Errorf("building system context: %w", err)
+	}
+
+	var manifestType string
+	if iopts.format != "" {
+		switch iopts.format {
+		case "oci":
+			manifestType = imgspecv1.MediaTypeImageManifest
+		case "v2s1":
+			manifestType = manifest.DockerV2Schema1SignedMediaType
+		case "v2s2", "docker":
+			manifestType = manifest.DockerV2Schema2MediaType
+		default:
+			return fmt.Errorf("unknown format %q. Choose on of the supported formats: 'oci', 'v2s1', or 'v2s2'", iopts.format)
+		}
+	}
+
+	encConfig, encLayers, err := iutil.EncryptConfig(iopts.encryptionKeys, iopts.encryptLayers)
+	if err != nil {
+		return fmt.Errorf("unable to obtain encryption config: %w", err)
+	}
+
+	options := buildah.PushOptions{
+		Compression:         compress,
+		ManifestType:        manifestType,
+		SignaturePolicyPath: iopts.signaturePolicy,
+		Store:               store,
+		SystemContext:       systemContext,
+		BlobDirectory:       iopts.blobCache,
+		RemoveSignatures:    iopts.removeSignatures,
+		SignBy:              iopts.signBy,
+		MaxRetries:          iopts.retry,
+		RetryDelay:          iopts.retryDelay,
+		OciEncryptConfig:    encConfig,
+		OciEncryptLayers:    encLayers,
+	}
+	if !iopts.quiet {
+		options.ReportWriter = os.Stderr
+	}
+	if iopts.compressionFormat != "" {
+		algo, err := compression.AlgorithmByName(iopts.compressionFormat)
+		if err != nil {
+			return err
+		}
+		options.CompressionFormat = &algo
+	}
+	if flagChanged(c, "compression-level") {
+		options.CompressionLevel = &iopts.compressionLevel
+	}
+
+	// check if the cr option is set to only and return before push.
+	if iopts.crOption == CrOptionOnly {
+		logger.Info("Only push image cr to the dest registry")
+		return nil
+	}
+
+	ref, digest, err := buildah.Push(getContext(), src, dest, options)
+	if err != nil {
+		if !errors.Is(err, storage.ErrImageUnknown) {
+			// Image might be a manifest so attempt a manifest push
+			if manifestsErr := manifestPush(systemContext, store, src, destSpec, *iopts); manifestsErr == nil {
+				return nil
+			}
+		}
+		return util.GetFailureCause(err, fmt.Errorf("pushing image %q to %q: %w", src, destSpec, err))
+	}
+	if ref != nil {
+		logger.Debug("pushed image %q with digest %s", ref, digest.String())
+	} else {
+		logger.Debug("pushed image with digest %s", digest.String())
+	}
+
+	logger.Debug("Successfully pushed %s with digest %s", transports.ImageName(dest), digest.String())
+
+	if iopts.digestfile != "" {
+		if err = os.WriteFile(iopts.digestfile, []byte(digest.String()), 0644); err != nil {
+			return util.GetFailureCause(err, fmt.Errorf("failed to write digest to file %q: %w", iopts.digestfile, err))
+		}
+	}
+
+	return nil
+}
+
+// getListOfTransports gets the transports supported from the image library
+// and strips of the "tarball" transport from the string of transports returned
+func getListOfTransports() string {
+	allTransports := strings.Join(transports.ListNames(), ",")
+	return strings.Replace(allTransports, ",tarball", "", 1)
+}

--- a/deprecate/pkg/buildah/rm.go
+++ b/deprecate/pkg/buildah/rm.go
@@ -1,0 +1,105 @@
+// Copyright © 2022 buildah.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/containers/buildah/blob/main/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	buildahcli "github.com/containers/buildah/pkg/cli"
+	"github.com/containers/buildah/util"
+	"github.com/spf13/cobra"
+)
+
+type rmResults struct {
+	all bool
+}
+
+func newRMCommand() *cobra.Command {
+	var (
+		rmDescription = "\n  Removes one or more working containers, unmounting them if necessary."
+		opts          rmResults
+	)
+	rmCommand := &cobra.Command{
+		Use:    "rm",
+		Hidden: true,
+		Short:  "Remove one or more working containers",
+		Long:   rmDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return rmCmd(cmd, args, opts)
+		},
+		Example: fmt.Sprintf(`%[1]s rm containerID
+  %[1]s rm containerID1 containerID2 containerID3
+  %[1]s rm --all`, rootCmd.CommandPath()),
+	}
+	rmCommand.SetUsageTemplate(UsageTemplate())
+
+	flags := rmCommand.Flags()
+	flags.SetInterspersed(false)
+	flags.BoolVarP(&opts.all, "all", "a", false, "remove all containers")
+	return rmCommand
+}
+
+func rmCmd(c *cobra.Command, args []string, iopts rmResults) error {
+	delContainerErrStr := "removing container"
+	if len(args) == 0 && !iopts.all {
+		return errors.New("container ID must be specified")
+	}
+	if len(args) > 0 && iopts.all {
+		return errors.New("when using the --all switch, you may not pass any containers names or IDs")
+	}
+
+	if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
+		return err
+	}
+
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+
+	var lastError error
+	if iopts.all {
+		builders, err := openBuilders(store)
+		if err != nil {
+			return fmt.Errorf("reading build containers: %w", err)
+		}
+
+		for _, builder := range builders {
+			id := builder.ContainerID
+			if err = builder.Delete(); err != nil {
+				lastError = util.WriteError(os.Stderr, fmt.Errorf("%s %q: %w", delContainerErrStr, builder.Container, err), lastError)
+				continue
+			}
+			fmt.Printf("%s\n", id)
+		}
+	} else {
+		for _, name := range args {
+			builder, err := openBuilder(getContext(), store, name)
+			if err != nil {
+				lastError = util.WriteError(os.Stderr, fmt.Errorf("%s %q: %w", delContainerErrStr, name, err), lastError)
+				continue
+			}
+			id := builder.ContainerID
+			if err = builder.Delete(); err != nil {
+				lastError = util.WriteError(os.Stderr, fmt.Errorf("%s %q: %w", delContainerErrStr, name, err), lastError)
+				continue
+			}
+			fmt.Printf("%s\n", id)
+		}
+	}
+	return lastError
+}

--- a/deprecate/pkg/buildah/rmi.go
+++ b/deprecate/pkg/buildah/rmi.go
@@ -1,0 +1,120 @@
+// Copyright © 2022 buildah.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/containers/buildah/blob/main/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	buildahcli "github.com/containers/buildah/pkg/cli"
+	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/common/libimage"
+	"github.com/hashicorp/go-multierror"
+	"github.com/spf13/cobra"
+)
+
+type rmiOptions struct {
+	all   bool
+	prune bool
+	force bool
+}
+
+func newRMICommand() *cobra.Command {
+	var (
+		rmiDescription = "\n  Removes one or more locally stored images."
+		opts           rmiOptions
+	)
+	rmiCommand := &cobra.Command{
+		Use:     "rmi",
+		Aliases: []string{"prune"},
+		Short:   "Remove one or more images from local storage",
+		Long:    rmiDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return rmiCmd(cmd, args, opts)
+		},
+		Example: fmt.Sprintf(`%[1]s rmi imageID
+  %[1]s rmi --all --force
+  %[1]s rmi imageID1 imageID2 imageID3`, rootCmd.CommandPath()),
+	}
+	rmiCommand.SetUsageTemplate(UsageTemplate())
+
+	flags := rmiCommand.Flags()
+	flags.SetInterspersed(false)
+	flags.BoolVarP(&opts.all, "all", "a", false, "remove all images")
+	flags.BoolVarP(&opts.prune, "prune", "p", false, "prune dangling images")
+	flags.BoolVarP(&opts.force, "force", "f", false, "force removal of the image and any containers using the image")
+
+	return rmiCommand
+}
+
+func rmiCmd(c *cobra.Command, args []string, iopts rmiOptions) error {
+	if len(args) == 0 && !iopts.all && !iopts.prune {
+		return errors.New("image name or ID must be specified")
+	}
+	if len(args) > 0 && iopts.all {
+		return errors.New("when using the --all switch, you may not pass any images names or IDs")
+	}
+	if iopts.all && iopts.prune {
+		return errors.New("when using the --all switch, you may not use --prune switch")
+	}
+	if len(args) > 0 && iopts.prune {
+		return errors.New("when using the --prune switch, you may not pass any images names or IDs")
+	}
+
+	if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
+		return err
+	}
+
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+
+	systemContext, err := parse.SystemContextFromOptions(c)
+	if err != nil {
+		return err
+	}
+	runtime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: systemContext})
+	if err != nil {
+		return err
+	}
+
+	options := &libimage.RemoveImagesOptions{
+		Filters: []string{"readonly=false"},
+	}
+	if iopts.prune {
+		options.Filters = append(options.Filters, "dangling=true")
+	} else if !iopts.all {
+		options.Filters = append(options.Filters, "intermediate=false")
+	}
+	options.Force = iopts.force
+
+	rmiReports, rmiErrors := runtime.RemoveImages(context.Background(), args, options)
+	for _, r := range rmiReports {
+		for _, u := range r.Untagged {
+			fmt.Printf("untagged: %s\n", u)
+		}
+	}
+	for _, r := range rmiReports {
+		if r.Removed {
+			fmt.Printf("%s\n", r.ID)
+		}
+	}
+
+	var multiE *multierror.Error
+	multiE = multierror.Append(multiE, rmiErrors...)
+	return multiE.ErrorOrNil()
+}

--- a/deprecate/pkg/buildah/runtime.go
+++ b/deprecate/pkg/buildah/runtime.go
@@ -1,0 +1,150 @@
+// Copyright © 2023 sealos.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/common/libimage"
+	"github.com/containers/common/pkg/config"
+	imagestorage "github.com/containers/image/v5/storage"
+	"github.com/containers/image/v5/types"
+	"github.com/containers/storage"
+	"github.com/spf13/cobra"
+)
+
+type Runtime struct {
+	storage.Store
+	*libimage.Runtime
+}
+
+func getRuntimeWithStoreAndSystemContext(store storage.Store, sc *types.SystemContext) (*Runtime, error) {
+	libimageRuntime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: sc})
+	if err != nil {
+		return nil, err
+	}
+	return &Runtime{
+		Store:   store,
+		Runtime: libimageRuntime,
+	}, nil
+}
+
+func getRuntime(c *cobra.Command) (*Runtime, error) {
+	if c == nil {
+		c = rootCmd
+	}
+	store, err := getStore(c)
+	if err != nil {
+		return nil, err
+	}
+	sc, err := parse.SystemContextFromOptions(c)
+	if err != nil {
+		return nil, fmt.Errorf("building system context: %w", err)
+	}
+	return getRuntimeWithStoreAndSystemContext(store, sc)
+}
+
+func (r *Runtime) getLayerID(id string, diffType DiffType) (string, error) {
+	var lastErr error
+	if diffType&DiffImage == DiffImage {
+		toImage, _, err := r.Runtime.LookupImage(id, nil)
+		if err == nil {
+			return toImage.TopLayer(), nil
+		}
+		lastErr = err
+	}
+
+	if diffType&DiffContainer == DiffContainer {
+		toCtr, err := r.Store.Container(id)
+		if err == nil {
+			return toCtr.LayerID, nil
+		}
+		lastErr = err
+	}
+
+	if diffType == DiffAll {
+		toLayer, err := r.Store.Layer(id)
+		if err == nil {
+			return toLayer.ID, nil
+		}
+		lastErr = err
+	}
+	return "", fmt.Errorf("%s not found: %w", id, lastErr)
+}
+
+func (r *Runtime) PullOrLoadImages(ctx context.Context, args []string, options libimage.CopyOptions) ([]string, error) {
+	copyOpts := options
+	if copyOpts.Writer == nil {
+		copyOpts.Writer = os.Stderr
+	}
+	var result []string
+	for i := range args {
+		name := args[i]
+		tr, ref, err := parseTransportAndReference(imagestorage.Transport, name)
+		if err != nil {
+			return nil, err
+		}
+		switch tr.Name() {
+		case TransportDocker, TransportContainersStorage:
+			if tr.Name() == TransportDocker {
+				ref = strings.TrimPrefix(ref, "//")
+			}
+			pullImages, err := r.Runtime.Pull(ctx, ref, config.PullPolicyMissing, &libimage.PullOptions{
+				CopyOptions: copyOpts,
+			})
+			if err != nil {
+				return nil, err
+			}
+			name = pullImages[0].ID()
+			if names := pullImages[0].Names(); len(names) > 0 {
+				name = names[0]
+			}
+		default:
+			if !filepath.IsAbs(ref) {
+				cwd, err := os.Getwd()
+				if err != nil {
+					return nil, err
+				}
+				ref = filepath.Join(cwd, ref)
+			}
+			images, err := r.Runtime.Load(ctx, ref, &libimage.LoadOptions{
+				CopyOptions: copyOpts,
+			})
+			if err != nil {
+				return nil, err
+			}
+			name = images[0]
+		}
+		result = append(result, name)
+	}
+	return result, nil
+}
+
+func (r *Runtime) getLayerIDs(from, to string, diffType DiffType) (string, string, error) {
+	fromLayer, err := r.getLayerID(from, diffType)
+	if err != nil {
+		return "", "", err
+	}
+	toLayer, err := r.getLayerID(to, diffType)
+	if err != nil {
+		return "", "", err
+	}
+	return fromLayer, toLayer, nil
+}

--- a/deprecate/pkg/buildah/save.go
+++ b/deprecate/pkg/buildah/save.go
@@ -1,0 +1,109 @@
+// Copyright © 2022 buildah.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/containers/buildah/blob/main/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Mostly copy from github.com/containers/podman
+
+package buildah
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/containers/common/libimage"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type saveOptions struct {
+	compress                    bool
+	quiet                       bool
+	multiImageArchive           bool
+	ociAcceptUncompressedLayers bool
+	format                      string
+	output                      string
+}
+
+func (o *saveOptions) RegisterFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&o.compress, "compress", false, "compress tarball image layers when saving to a directory using the 'dir' transport. (default is same compression type as source)")
+	fs.BoolVarP(&o.quiet, "quiet", "q", false, "suppress the output")
+	fs.BoolVarP(&o.multiImageArchive, "multi-image-archive", "m", false, "interpret additional arguments as images not tags and create a multi-image-archive (only for docker-archive)")
+	fs.BoolVar(&o.ociAcceptUncompressedLayers, "uncompressed", false, "Accept uncompressed layers when copying OCI images")
+	fs.StringVar(&o.format, "format", OCIArchive, "save image to oci-archive, oci-dir (directory with oci manifest type), "+
+		"docker-archive, docker-dir (directory with v2s2 manifest type)")
+	fs.StringVarP(&o.output, "output", "o", "", "write to a specified file (default: stdout, which must be redirected)")
+}
+
+func (o *saveOptions) Validate() error {
+	if strings.Contains(o.output, ":") {
+		return fmt.Errorf("invalid filename (should not contain ':') %q", o.output)
+	}
+	return nil
+}
+
+func newSaveCommand() *cobra.Command {
+	var opts = &saveOptions{}
+
+	saveCommand := &cobra.Command{
+		Use:   "save",
+		Short: "Save image into archive file",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSave(cmd, args, opts)
+		},
+		Example: fmt.Sprintf(`%[1]s save -o kubernetes.tar labring/kubernetes:latest`, rootCmd.CommandPath()),
+	}
+	saveCommand.SetUsageTemplate(UsageTemplate())
+	opts.RegisterFlags(saveCommand.Flags())
+	_ = saveCommand.MarkFlagRequired("output")
+
+	return saveCommand
+}
+
+func runSave(cmd *cobra.Command, args []string, saveOpts *saveOptions) error {
+	var (
+		tags []string
+	)
+	if flagChanged(cmd, "compress") && saveOpts.format != DockerManifestDir {
+		return errors.New("--compress can only be set when --format is 'docker-dir'")
+	}
+
+	if err := saveOpts.Validate(); err != nil {
+		return err
+	}
+	if len(args) > 1 {
+		tags = args[1:]
+	}
+
+	r, err := getRuntime(cmd)
+	if err != nil {
+		return err
+	}
+	saveOptions := &libimage.SaveOptions{}
+	saveOptions.DirForceCompress = saveOpts.compress
+	saveOptions.OciAcceptUncompressedLayers = saveOpts.ociAcceptUncompressedLayers
+
+	if !saveOpts.quiet {
+		saveOptions.Writer = os.Stderr
+	}
+
+	names := []string{args[0]}
+	if saveOpts.multiImageArchive {
+		names = append(names, tags...)
+	} else {
+		saveOptions.AdditionalTags = tags
+	}
+	return r.Save(getContext(), names, saveOpts.format, saveOpts.output, saveOptions)
+}

--- a/deprecate/pkg/buildah/setup.go
+++ b/deprecate/pkg/buildah/setup.go
@@ -1,0 +1,214 @@
+// Copyright © 2022 sealos.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/labring/sealos/pkg/system"
+
+	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/common/pkg/config"
+	"github.com/containers/storage/pkg/homedir"
+	"github.com/containers/storage/pkg/unshare"
+	"github.com/containers/storage/types"
+
+	"github.com/labring/sealos/pkg/utils/file"
+	"github.com/labring/sealos/pkg/utils/logger"
+)
+
+var (
+	// use the defaultOverrideConfigFile var as default
+	defaultOverrideConfigFile          = "/etc/containers/storage.conf"
+	DefaultConfigFile                  string
+	DefaultSignaturePolicyPath         = config.DefaultSignaturePolicyPath
+	DefaultRootlessSignaturePolicyPath = "containers/policy.json"
+	DefaultGraphRoot                   = "/var/lib/containers/storage"
+	DefaultRegistriesFilePath          = "/etc/containers/registries.conf"
+	DefaultRootlessRegistriesFilePath  = "containers/registries.conf"
+)
+
+func init() {
+	_ = os.Setenv("TMPDIR", parse.GetTempDir())
+
+	// storage config path
+	if path, ok := os.LookupEnv(system.ContainerStorageConfEnvKey); ok {
+		DefaultConfigFile = path
+	} else if !unshare.IsRootless() {
+		DefaultConfigFile = defaultOverrideConfigFile
+	} else {
+		var err error
+		DefaultConfigFile, err = types.DefaultConfigFile(true)
+		bailOnError(err, "")
+	}
+	// config path
+	if unshare.IsRootless() {
+		configHome, err := homedir.GetConfigHome()
+		bailOnError(err, "")
+		DefaultSignaturePolicyPath = filepath.Join(configHome, DefaultRootlessSignaturePolicyPath)
+		DefaultRegistriesFilePath = filepath.Join(configHome, DefaultRootlessRegistriesFilePath)
+	}
+
+	// setters
+	if unshare.IsRootless() {
+		defaultSetters = append(defaultSetters,
+			determineIfRootlessPackagePresent,
+		)
+	} else if isRunningInContainer() {
+		defaultSetters = append(defaultSetters, func() error {
+			deps := map[string][]string{"fuse-overlayfs": {"fuse-overlayfs"}}
+			return determineIfPackagePresent(deps)
+		})
+	}
+
+	defaultSetters = append(defaultSetters, maybeReexecUsingUserNamespace)
+	defaultSetters = append(defaultSetters, configSetters...)
+}
+
+const defaultPolicy = `
+{
+    "default": [
+        {
+            "type": "insecureAcceptAnything"
+        }
+    ],
+    "transports":
+        {
+            "docker-daemon":
+                {
+                    "": [{"type":"insecureAcceptAnything"}]
+                }
+        }
+}
+`
+
+const defaultRegistries = `unqualified-search-registries = ["docker.io"]
+
+[[registry]]
+prefix = "docker.io/labring"
+location = "docker.io/labring"
+`
+
+const (
+	defaultRootStorageConf = `[storage]
+driver = "overlay"
+runroot = "/run/containers/storage"
+graphroot = "/var/lib/containers/storage"`
+	defaultRootlessStorageConf = `[storage]
+driver = "overlay"
+runroot = "%s"`
+	storageOptionsOverlaySnippet = `
+[storage.options.overlay]
+mount_program = "/bin/fuse-overlayfs"
+mountopt = "nodev,fsync=0"`
+)
+
+// todo: what if running by containerd?
+func isRunningInContainer() bool {
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+	return false
+}
+
+func setupContainerPolicy() error {
+	return writeFileIfNotExists(DefaultSignaturePolicyPath, []byte(defaultPolicy))
+}
+
+func setupRegistriesFile() error {
+	return writeFileIfNotExists(DefaultRegistriesFilePath, []byte(defaultRegistries))
+}
+
+func setupStorageConfigFile() error {
+	logger.Debug("using file %s as container storage config", DefaultConfigFile)
+	var content string
+	if unshare.IsRootless() {
+		runRoot := fmt.Sprintf("/run/user/%d", unshare.GetRootlessUID())
+		if err := os.MkdirAll(runRoot, 0755); err != nil && errors.Is(err, os.ErrPermission) {
+			// has not permission, then use cache home
+			cacheHome, err := homedir.GetCacheHome()
+			if err != nil {
+				return err
+			}
+			runRoot = cacheHome
+		}
+		content = fmt.Sprintf(defaultRootlessStorageConf, runRoot)
+	} else {
+		content = defaultRootStorageConf
+	}
+	if unshare.IsRootless() || isRunningInContainer() {
+		content += storageOptionsOverlaySnippet
+	}
+	return writeFileIfNotExists(DefaultConfigFile, []byte(content))
+}
+
+func writeFileIfNotExists(filename string, data []byte) error {
+	_, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		logger.Debug("create new buildah config %s cause it's not exist", filename)
+		err = file.WriteFile(filename, data)
+	}
+	return err
+}
+
+func determineIfRootlessPackagePresent() error {
+	deps := map[string][]string{"uidmap": {"newuidmap", "newgidmap"}, "fuse-overlayfs": {"fuse-overlayfs"}}
+	if err := determineIfPackagePresent(deps); err != nil {
+		return fmt.Errorf("%s or consider running in root mode", err.Error())
+	}
+	return nil
+}
+
+func determineIfPackagePresent(deps map[string][]string) error {
+	for pkg, executables := range deps {
+		for i := range executables {
+			if _, err := exec.LookPath(executables[i]); err != nil {
+				return fmt.Errorf("executable file '%s' not found in $PATH, install package '%s' first", executables[i], pkg)
+			}
+		}
+	}
+	return nil
+}
+
+func maybeReexecUsingUserNamespace() error {
+	unshare.MaybeReexecUsingUserNamespace(false)
+	return nil
+}
+
+type Setter func() error
+
+var configSetters = []Setter{
+	setupContainerPolicy,
+	setupRegistriesFile,
+	setupStorageConfigFile,
+}
+
+var defaultSetters = []Setter{}
+
+func TrySetupWithDefaults(setters ...Setter) error {
+	if len(setters) == 0 {
+		setters = defaultSetters
+	}
+	for i := range setters {
+		if err := setters[i](); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/deprecate/pkg/buildah/tag.go
+++ b/deprecate/pkg/buildah/tag.go
@@ -1,0 +1,70 @@
+// Copyright © 2022 buildah.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/containers/buildah/blob/main/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"fmt"
+
+	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/common/libimage"
+	"github.com/spf13/cobra"
+)
+
+func newTagCommand() *cobra.Command {
+	var (
+		tagDescription = "\n  Adds one or more additional names to locally-stored image."
+	)
+	tagCommand := &cobra.Command{
+		Use:   "tag",
+		Short: "Add an additional name to a local image",
+		Long:  tagDescription,
+		RunE:  tagCmd,
+
+		Example: fmt.Sprintf(`%[1]s tag imageName firstNewName
+  %[1]s tag imageName firstNewName SecondNewName`, rootCmd.CommandPath()),
+		Args: cobra.MinimumNArgs(2),
+	}
+	tagCommand.SetUsageTemplate(UsageTemplate())
+	return tagCommand
+}
+
+func tagCmd(c *cobra.Command, args []string) error {
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+	systemContext, err := parse.SystemContextFromOptions(c)
+	if err != nil {
+		return fmt.Errorf("building system context: %w", err)
+	}
+	runtime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: systemContext})
+	if err != nil {
+		return err
+	}
+
+	// Allow tagging manifest list instead of resolving instances from manifest
+	lookupOptions := &libimage.LookupImageOptions{ManifestList: true}
+	image, _, err := runtime.LookupImage(args[0], lookupOptions)
+	if err != nil {
+		return err
+	}
+
+	for _, tag := range args[1:] {
+		if err := image.Tag(tag); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/deprecate/pkg/buildah/umount.go
+++ b/deprecate/pkg/buildah/umount.go
@@ -1,0 +1,107 @@
+// Copyright © 2022 buildah.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/containers/buildah/blob/main/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	buildahcli "github.com/containers/buildah/pkg/cli"
+	"github.com/containers/storage"
+	"github.com/spf13/cobra"
+)
+
+func newUmountCommand() *cobra.Command {
+	umountCommand := &cobra.Command{
+		Use:     "umount",
+		Aliases: []string{"unmount"},
+		Hidden:  true,
+		Short:   "Unmount the root file system of the specified working containers",
+		Long:    "Unmounts the root file system of the specified working containers.",
+		RunE:    umountCmd,
+		Example: fmt.Sprintf(`%[1]s umount containerID
+  %[1]s umount containerID1 containerID2 containerID3
+  %[1]s umount --all`, rootCmd.CommandPath()),
+	}
+	umountCommand.SetUsageTemplate(UsageTemplate())
+
+	flags := umountCommand.Flags()
+	flags.SetInterspersed(false)
+	flags.BoolP("all", "a", false, "umount all of the currently mounted containers")
+	return umountCommand
+}
+
+func umountCmd(c *cobra.Command, args []string) error {
+	umountAll := false
+	if flagChanged(c, "all") {
+		umountAll = true
+	}
+	if len(args) == 0 && !umountAll {
+		return errors.New("at least one container ID must be specified")
+	}
+	if len(args) > 0 && umountAll {
+		return errors.New("when using the --all switch, you may not pass any container IDs")
+	}
+	if err := buildahcli.VerifyFlagsArgsOrder(args); err != nil {
+		return err
+	}
+
+	store, err := getStore(c)
+	if err != nil {
+		return err
+	}
+	_, err = doUMounts(store, args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
+	return err
+}
+
+func doUMounts(store storage.Store, args []string) ([]string, error) {
+	umountContainerErrStr := "error unmounting container"
+	var ids []string
+	if len(args) > 0 {
+		for _, name := range args {
+			builder, err := openBuilder(getContext(), store, name)
+			if err != nil {
+				return nil, fmt.Errorf("%s %s: %w", umountContainerErrStr, name, err)
+			}
+			if builder.MountPoint == "" {
+				continue
+			}
+
+			if err = builder.Unmount(); err != nil {
+				return nil, fmt.Errorf("%s %q: %w", umountContainerErrStr, builder.Container, err)
+			}
+			ids = append(ids, builder.ContainerID)
+		}
+	} else {
+		builders, err := openBuilders(store)
+		if err != nil {
+			return nil, fmt.Errorf("reading build Containers: %w", err)
+		}
+		for _, builder := range builders {
+			if builder.MountPoint == "" {
+				continue
+			}
+			if err = builder.Unmount(); err != nil {
+				return nil, fmt.Errorf("%s %q: %w", umountContainerErrStr, builder.Container, err)
+			}
+			ids = append(ids, builder.ContainerID)
+		}
+	}
+	return ids, nil
+}

--- a/deprecate/pkg/buildah/unshare.go
+++ b/deprecate/pkg/buildah/unshare.go
@@ -1,0 +1,143 @@
+// Copyright © 2022 buildah.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/containers/buildah/blob/main/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package buildah
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/containers/storage"
+	"github.com/containers/storage/pkg/unshare"
+	"github.com/spf13/cobra"
+
+	"github.com/labring/sealos/pkg/utils/logger"
+)
+
+func newUnshareCommand() *cobra.Command {
+	var (
+		unshareDescription = "\n  Manually enter unshare mode, runs a command in a modified user namespace."
+		unshareCommand     = &cobra.Command{
+			Use:    "unshare",
+			Hidden: true,
+			Short:  "Run a command in a modified user namespace",
+			Long:   unshareDescription,
+			RunE:   unshareCmd,
+			Example: fmt.Sprintf(`%[1]s unshare id
+  %[1]s unshare cat /proc/self/uid_map
+  %[1]s unshare buildah-script.sh`, rootCmd.CommandPath()),
+		}
+		unshareMounts []string
+	)
+	unshareCommand.SetUsageTemplate(UsageTemplate())
+	flags := unshareCommand.Flags()
+	flags.SetInterspersed(false)
+	flags.StringSliceVarP(&unshareMounts, "mount", "m", []string{}, "mount the specified containers (default [])")
+	return unshareCommand
+}
+
+func unshareMount(store storage.Store, mounts []string) ([]string, func(), error) {
+	if len(mounts) == 0 {
+		return nil, nil, nil
+	}
+	var mountedContainers, env []string
+	unmount := func() {
+		for _, mounted := range mountedContainers {
+			builder, err := openBuilder(getContext(), store, mounted)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, fmt.Errorf("loading information about build container %q: %w", mounted, err))
+				continue
+			}
+			err = builder.Unmount()
+			if err != nil {
+				fmt.Fprintln(os.Stderr, fmt.Errorf("unmounting build container %q: %w", mounted, err))
+				continue
+			}
+		}
+	}
+	for _, mountSpec := range mounts {
+		mount := strings.SplitN(mountSpec, "=", 2)
+		container := mountSpec
+		envVar := container
+		if len(mount) == 2 {
+			envVar = mount[0]
+			container = mount[1]
+		}
+		builder, err := openBuilder(getContext(), store, container)
+		if err != nil {
+			unmount()
+			return nil, nil, fmt.Errorf("loading information about build container %q: %w", container, err)
+		}
+		mountPoint, err := builder.Mount(builder.MountLabel)
+		if err != nil {
+			unmount()
+			return nil, nil, fmt.Errorf("mounting build container %q: %w", container, err)
+		}
+		logger.Debug("mounted container %q at %q", container, mountPoint)
+		mountedContainers = append(mountedContainers, container)
+		if envVar != "" {
+			envSpec := fmt.Sprintf("%s=%s", envVar, mountPoint)
+			logger.Debug("adding %q to environment", envSpec)
+			env = append(env, envSpec)
+		}
+	}
+	return env, unmount, nil
+}
+
+// unshareCmd execs whatever using the ID mappings that we want to use for ourselves
+func unshareCmd(c *cobra.Command, args []string) error {
+	// Set the default isolation type to use the "rootless" method.
+	if _, present := os.LookupEnv("BUILDAH_ISOLATION"); !present {
+		if err := os.Setenv("BUILDAH_ISOLATION", "rootless"); err != nil {
+			logger.Error("error setting BUILDAH_ISOLATION=rootless in environment: %v", err)
+			os.Exit(1)
+		}
+	}
+
+	// force reexec using the configured ID mappings
+	unshare.MaybeReexecUsingUserNamespace(true)
+	// exec the specified command, if there is one
+	if len(args) < 1 {
+		// try to exec the shell, if one's set
+		shell, shellSet := os.LookupEnv("SHELL")
+		if !shellSet {
+			logger.Error("no command specified")
+			os.Exit(1)
+		}
+		args = []string{shell}
+	}
+	unshareMounts, _ := c.Flags().GetStringSlice("mount")
+	store, err := getStore(c)
+	bailOnError(err, "cannot get store")
+	// Temporary ignore it...
+	// nosemgrep: go.lang.security.audit.dangerous-exec-command.dangerous-exec-command
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Env = unshare.RootlessEnv()
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	mountEnvs, unmountMounts, err := unshareMount(store, unshareMounts)
+	if err != nil {
+		return err
+	}
+	cmd.Env = append(cmd.Env, mountEnvs...)
+	unshare.ExecRunnable(cmd, unmountMounts)
+	os.Exit(1)
+	return nil
+}

--- a/deprecate/pkg/buildah/util.go
+++ b/deprecate/pkg/buildah/util.go
@@ -1,0 +1,42 @@
+// Copyright © 2023 sealos.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildah
+
+import (
+	"github.com/containers/common/libimage"
+
+	"github.com/labring/sealos/pkg/utils/file"
+)
+
+func PreloadIfTarFile(images []string, transport string) ([]string, error) {
+	r, err := getRuntime(nil)
+	if err != nil {
+		return nil, err
+	}
+	var ret []string
+	for i := range images {
+		if file.IsTarFile(images[i]) {
+			ref := FormatReferenceWithTransportName(transport, images[i])
+			names, err := r.PullOrLoadImages(getContext(), []string{ref}, libimage.CopyOptions{})
+			if err != nil {
+				return nil, err
+			}
+			ret = append(ret, names...)
+		} else {
+			ret = append(ret, images[i])
+		}
+	}
+	return ret, nil
+}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 15d6103</samp>

### Summary
📝🆕🧪

<!--
1.  📝 - This emoji represents the addition of license headers and package declarations to the existing files, which is a documentation and code organization change.
2.  🆕 - This emoji represents the addition of new files that implement new commands, types, and functions for the sealos CLI and the buildah package, which is a feature and enhancement change.
3.  🧪 - This emoji represents the addition of unit tests for the `realImpl` type, which is a testing and quality assurance change.
-->
This pull request adds the `buildah` package to the `deprecate` directory, which provides a sealos interface and commands for building and managing container images using buildah. The pull request also adds license headers and package declarations to the existing files in the `deprecate/pkg/buildah` directory, and adds unit tests for the `realImpl` type.

> _`sealos` adds `buildah`_
> _license and package headers_
> _autumn of deprecation_

### Walkthrough
*  Add license headers and package declarations to all files in the `buildah` package ([link](https://github.com/labring/sealos/pull/3955/files?diff=unified&w=0#diff-1b329d12c624581bed79dccd3eb747c454c056e67076b4cf9daa330463f533a0R1-R199), [link](https://github.com/labring/sealos/pull/3955/files?diff=unified&w=0#diff-da1028590ca91dfd4c174202fdd32da0e8212e6c8175e808f1e1b19a1b713101R1-R335), [link](https://github.com/labring/sealos/pull/3955/files?diff=unified&w=0#diff-628cb4d366d379d9664d7db7fc6674af9e4228b6235b93acdb648793f6fc6b78R1-R334), [link](https://github.com/labring/sealos/pull/3955/files?diff=unified&w=0#diff-aada0961f057dfbef5c6c73a0ac39e2e60b68874733804bf94d561ed51551d86R1-R83), [link](https://github.com/labring/sealos/pull/3955/files?diff=unified&w=0#diff-4db8b79f689f7a44a9e6f102619ab536ad577761c2b870f319bce8461998e5c5R1-R352), [link](https://github.com/labring/sealos/pull/3955/files?diff=unified&w=0#diff-2f746d328c07234a9807186b85578a3226b44b866413181e4179723cef0642d5R1-R108), [link](https://github.com/labring/sealos/pull/3955/files?diff=unified&w=0#diff-078476a6ad5e4c3849f8ea9c64d2236be3d44e9d49c9a9e9a0a750877ca8f423R1-R329), [link](https://github.com/labring/sealos/pull/3955/files?diff=unified&w=0#diff-f0336db09adec81b7afb43f482d89b96aaa7638e38110191857681531bc3d0dcR1-R17), [link](https://github.com/labring/sealos/pull/3955/files?diff=unified&w=0#diff-205cc275b784cb42754fc29272ad0e8b8b2d768a29af4159e9f715fc55461479R1-R135), [link](https://github.com/labring/sealos/pull/3955/files?diff=unified&w=0#diff-dc0534b16a8dcdf75c27e92557677942a8614a1dcd32c16fbe9dcfd048911657R1-R250), [link](https://github.com/labring/sealos/pull/3955/files?diff=unified&w=0#diff-4a56652b45fd593afcf0d47ceb017f9a5383a5a5754aca736cd9b03d2f5b16e9R1-R63), [link](https://github.com/labring/sealos/pull/3955/files?diff=unified&w=0#diff-e2829458d36ea457e18aaca9d8a9cfaa3b132cf82b6577f24ca87472c9e2d865R1-R377), [link](https://github.com/labring/sealos/pull/3955/files?diff=unified&w=0#diff-7a22d07d5855c08a1ae65e208144e795b28b6a189e90b22812d9272548dff4a5R1-R113), [link](https://github.com/labring/sealos/pull/3955/files?diff=unified&w=0#diff-812c7360586ee16831a8a00508f508478236abdab0966a6efdd1b358a90524a4R1-R300)) to comply with the Apache License 2.0 and to define the package scope and name.


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
