### PR TITLE
feat(terminal):auto switch namespace and modify prompt

### DIFF
--- a/frontend/providers/costcenter/src/pages/billing/index.tsx
+++ b/frontend/providers/costcenter/src/pages/billing/index.tsx
@@ -90,13 +90,13 @@ function NamespaceMenu({
               key={v}
               {...(idx === namespaceIdx
                 ? {
-                  color: '#0884DD',
-                  bg: '#F4F6F8'
-                }
+                    color: '#0884DD',
+                    bg: '#F4F6F8'
+                  }
                 : {
-                  color: '#5A646E',
-                  bg: '#FDFDFE'
-                })}
+                    color: '#5A646E',
+                    bg: '#FDFDFE'
+                  })}
               h="30px"
               fontFamily="PingFang SC"
               fontSize="12px"
@@ -362,52 +362,53 @@ function InOutTabPanel({ namespace }: { namespace: string }) {
   );
   const { t } = useTranslation();
   const tableResult = data?.data?.status?.item || [];
-  return (<TabPanel p="0">
-    <Flex alignItems={'center'} flexWrap={'wrap'}>
-      <Flex align={'center'} mb={'24px'}>
-        <Text fontSize={'12px'} mr={'12px'} width={['60px', '60px', 'auto', 'auto']}>
-          {t('Transaction Time')}
-        </Text>
-        <SelectRange isDisabled={isFetching}></SelectRange>
-      </Flex>
-      <Flex align={'center'} mb={'24px'}>
-        <Text fontSize={'12px'} mr={'12px'} width={['60px', '60px', 'auto', 'auto']}>
-          {t('Type')}
-        </Text>
-        <TypeMenu
-          selectType={selectType}
-          setType={setType}
-          isDisabled={isFetching}
-          optional={[BillingType.ALL, BillingType.CONSUME, BillingType.RECHARGE]}
-        />
-      </Flex>
-      <SearchBox isDisabled={isFetching} setOrderID={setOrderID} />
-    </Flex>
-    {isSuccess && tableResult.length > 0 ? (
-      <>
-        <Box overflow={'auto'}>
-          <CommonBillingTable
-            data={tableResult.filter((x) =>
-              [BillingType.CONSUME, BillingType.RECHARGE].includes(x.type)
-            )}
-          />
-        </Box>
-        <Flex justifyContent={'flex-end'}>
-          <SwitchPage
-            totalPage={totalPage}
-            totalItem={totalItem}
-            pageSize={pageSize}
-            currentPage={currentPage}
-            setCurrentPage={setcurrentPage}
+  return (
+    <TabPanel p="0">
+      <Flex alignItems={'center'} flexWrap={'wrap'}>
+        <Flex align={'center'} mb={'24px'}>
+          <Text fontSize={'12px'} mr={'12px'} width={['60px', '60px', 'auto', 'auto']}>
+            {t('Transaction Time')}
+          </Text>
+          <SelectRange isDisabled={isFetching}></SelectRange>
+        </Flex>
+        <Flex align={'center'} mb={'24px'}>
+          <Text fontSize={'12px'} mr={'12px'} width={['60px', '60px', 'auto', 'auto']}>
+            {t('Type')}
+          </Text>
+          <TypeMenu
+            selectType={selectType}
+            setType={setType}
+            isDisabled={isFetching}
+            optional={[BillingType.ALL, BillingType.CONSUME, BillingType.RECHARGE]}
           />
         </Flex>
-      </>
-    ) : (
-      <Flex direction={'column'} w="full" align={'center'} flex={'1'} h={'0'} justify={'center'}>
-        <NotFound></NotFound>
+        <SearchBox isDisabled={isFetching} setOrderID={setOrderID} />
       </Flex>
-    )}
-  </TabPanel>
+      {isSuccess && tableResult.length > 0 ? (
+        <>
+          <Box overflow={'auto'}>
+            <CommonBillingTable
+              data={tableResult.filter((x) =>
+                [BillingType.CONSUME, BillingType.RECHARGE].includes(x.type)
+              )}
+            />
+          </Box>
+          <Flex justifyContent={'flex-end'}>
+            <SwitchPage
+              totalPage={totalPage}
+              totalItem={totalItem}
+              pageSize={pageSize}
+              currentPage={currentPage}
+              setCurrentPage={setcurrentPage}
+            />
+          </Flex>
+        </>
+      ) : (
+        <Flex direction={'column'} w="full" align={'center'} flex={'1'} h={'0'} justify={'center'}>
+          <NotFound></NotFound>
+        </Flex>
+      )}
+    </TabPanel>
   );
 }
 function TransferTabPanel({ namespace }: { namespace: string }) {

--- a/frontend/providers/terminal/src/components/terminal/index.tsx
+++ b/frontend/providers/terminal/src/components/terminal/index.tsx
@@ -18,6 +18,7 @@ function Terminal({ url, site }: { url: string; site: string }) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const { query } = router;
   const session = useSessionStore((s) => s.session);
+  const nsid = session.user.nsid;
   const [tabContents, setTabContents] = useState<Terminal[]>([
     {
       id: tabId,
@@ -37,14 +38,20 @@ function Terminal({ url, site }: { url: string; site: string }) {
           newTerminal(decodeURIComponent(e.data.command));
         }
         if (e.data?.ttyd === 'ready') {
-          const command = iframeRef.current?.getAttribute('data-command');
-          iframeRef?.current?.contentWindow?.postMessage({ command }, url);
           iframeRef.current?.contentWindow?.postMessage(
             {
-              command: `kubectl config set-context --current --namespace=${session.user.nsid}`
+              command: `kubectl config set-context --current --namespace=${nsid} && export PS1="\\u@(${nsid}) \\W\\$ " && clear`
             },
             url
           );
+          iframeRef.current?.contentWindow?.postMessage(
+            {
+              command: `echo -e "\\e[A\\e[K 👉  Switched to namespace \\e[1;4;32m${nsid}\\e[0m"`
+            },
+            url
+          );
+          const command = iframeRef.current?.getAttribute('data-command');
+          iframeRef?.current?.contentWindow?.postMessage({ command }, url);
         }
       } catch (error) {
         console.log(error, 'error');


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2063155</samp>

### Summary
🎨🛠️➕

<!--
1.  🎨 for improving the code style and readability of the `billing` page component.
2.  🛠️ for enhancing the terminal component to automatically switch to the user's namespace and display it on the prompt.
3.  ➕ for adding a `nsid` variable to store the namespace ID from the session.
-->
This pull request improves the frontend of the sealos application by making the code more readable and the terminal more user-friendly. It formats the `billing` page component and adds a feature to the `terminal` component to automatically switch to and show the user's namespace. It also introduces a new variable `nsid` to store the namespace ID.

> _The billing page got a makeover_
> _With object spread syntax all over_
> _The terminal too_
> _Has something new_
> _It shows the `nsid` and namespace of the user_

### Walkthrough
*  Add `nsid` variable to store user's namespace ID from session ([link](https://github.com/labring/sealos/pull/3961/files?diff=unified&w=0#diff-c1dd222fee93d5de2dd2a2b7301133528d315a8b108f13426bda3cc56234d21dR21))
*  Modify terminal command to switch and display user's namespace and echo feedback message ([link](https://github.com/labring/sealos/pull/3961/files?diff=unified&w=0#diff-c1dd222fee93d5de2dd2a2b7301133528d315a8b108f13426bda3cc56234d21dL44-R54))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
