### PR TITLE
feat: add owner check.

### DIFF
--- a/controllers/account/api/v1/debt_webhook.go
+++ b/controllers/account/api/v1/debt_webhook.go
@@ -172,7 +172,7 @@ func checkOption(ctx context.Context, logger logr.Logger, c client.Client, nsNam
 
 	for _, account := range accountList.Items {
 		if account.Status.Balance < account.Status.DeductionBalance {
-			return admission.ValidationResponse(false, fmt.Sprintf(code.MessageFormat, code.CodeInsufficientBalance, fmt.Sprintf("account balance less than 0,now account is %.2f¥. Please recharge the user %s.", GetAccountDebtBalance(account), user)))
+			return admission.ValidationResponse(false, fmt.Sprintf(code.MessageFormat, code.InsufficientBalance, fmt.Sprintf("account balance less than 0,now account is %.2f¥. Please recharge the user %s.", GetAccountDebtBalance(account), user)))
 		}
 	}
 	return admission.Allowed(fmt.Sprintf("pass user %s , namespace %s", user, ns.Name))

--- a/controllers/admission/api/v1/ingress_webhook.go
+++ b/controllers/admission/api/v1/ingress_webhook.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/labring/sealos/controllers/pkg/code"
 
@@ -132,6 +133,13 @@ func (v *IngressValidator) ValidateDelete(ctx context.Context, obj runtime.Objec
 }
 
 func (v *IngressValidator) validate(ctx context.Context, i *netv1.Ingress) error {
+	// count validate cost time
+
+	startTime := time.Now()
+	defer func() {
+		ilog.Info("finished validate", "ingress namespace", i.Namespace, "ingress name", i.Name, "cost", time.Since(startTime))
+	}()
+
 	request, _ := admission.RequestFromContext(ctx)
 	ilog.Info("validating", "ingress namespace", i.Namespace, "ingress name", i.Name, "user", request.UserInfo.Username, "userGroups", request.UserInfo.Groups)
 	if !isUserServiceAccount(request.UserInfo.Username) {

--- a/controllers/admission/api/v1/ingress_webhook.go
+++ b/controllers/admission/api/v1/ingress_webhook.go
@@ -73,7 +73,7 @@ func (v *IngressValidator) SetupWithManager(mgr ctrl.Manager) error {
 	iv := IngressValidator{Client: mgr.GetClient(), domain: os.Getenv("DOMAIN"), cache: mgr.GetCache()}
 
 	err := iv.cache.IndexField(
-		ctrl.SetupSignalHandler(),
+		context.Background(),
 		&netv1.Ingress{},
 		IngressHostIndex,
 		func(obj client.Object) []string {

--- a/controllers/admission/cmd/main.go
+++ b/controllers/admission/cmd/main.go
@@ -18,20 +18,19 @@ package main
 
 import (
 	"flag"
+
 	"os"
 
-	corev1 "k8s.io/api/core/v1"
-	netv1 "k8s.io/api/networking/v1"
-
 	v1 "github.com/labring/sealos/controllers/admission/api/v1"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	//+kubebuilder:scaffold:imports
@@ -90,13 +89,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = builder.WebhookManagedBy(mgr).
-		For(&netv1.Ingress{}).
-		WithValidator(&v1.IngressValidator{Client: mgr.GetClient(), Domain: os.Getenv("DOMAIN")}).
-		WithDefaulter(&v1.IngressMutator{Client: mgr.GetClient()}).
-		Complete()
-	if err != nil {
-		setupLog.Error(err, "unable to create ingress webhook")
+	if (&v1.IngressValidator{}).SetupWithManager(mgr) != nil {
+		setupLog.Error(err, "unable to create ingress validator webhook")
+		os.Exit(1)
+	}
+
+	if (&v1.IngressMutator{}).SetupWithManager(mgr) != nil {
+		setupLog.Error(err, "unable to create ingress mutator webhook")
 		os.Exit(1)
 	}
 

--- a/controllers/admission/config/webhook/manifests.yaml
+++ b/controllers/admission/config/webhook/manifests.yaml
@@ -13,6 +13,10 @@ webhooks:
       path: /mutate-networking-k8s-io-v1-ingress
   failurePolicy: Ignore
   name: mingress.sealos.io
+  namespaceSelector:
+    matchExpressions:
+      - key: user.sealos.io/owner
+        operator: Exists
   rules:
   - apiGroups:
     - networking.k8s.io
@@ -33,6 +37,10 @@ webhooks:
       path: /mutate--v1-namespace
   failurePolicy: Ignore
   name: mnamespace.sealos.io
+  namespaceSelector:
+    matchExpressions:
+      - key: user.sealos.io/owner
+        operator: Exists
   rules:
   - apiGroups:
     - ""
@@ -59,6 +67,10 @@ webhooks:
       path: /validate-networking-k8s-io-v1-ingress
   failurePolicy: Ignore
   name: vingress.sealos.io
+  namespaceSelector:
+    matchExpressions:
+      - key: user.sealos.io/owner
+        operator: Exists
   rules:
   - apiGroups:
     - networking.k8s.io
@@ -80,6 +92,10 @@ webhooks:
       path: /validate--v1-namespace
   failurePolicy: Ignore
   name: vnamespace.sealos.io
+  namespaceSelector:
+    matchExpressions:
+      - key: user.sealos.io/owner
+        operator: Exists
   rules:
   - apiGroups:
     - ""

--- a/controllers/admission/deploy/manifests/deploy.yaml.tmpl
+++ b/controllers/admission/deploy/manifests/deploy.yaml.tmpl
@@ -426,6 +426,10 @@ webhooks:
       path: /mutate-networking-k8s-io-v1-ingress
   failurePolicy: {{ .ingressWebhookFailurePolicy }}
   name: mingress.sealos.io
+  namespaceSelector:
+    matchExpressions:
+      - key: user.sealos.io/owner
+        operator: Exists
   rules:
   - apiGroups:
     - networking.k8s.io
@@ -448,6 +452,10 @@ webhooks:
       path: /mutate--v1-namespace
   failurePolicy: {{ .namespaceWebhookFailurePolicy }}
   name: mnamespace.sealos.io
+  namespaceSelector:
+    matchExpressions:
+      - key: user.sealos.io/owner
+        operator: Exists
   rules:
   - apiGroups:
     - ""
@@ -486,6 +494,10 @@ webhooks:
       path: /validate-networking-k8s-io-v1-ingress
   failurePolicy: {{ .ingressWebhookFailurePolicy }}
   name: vingress.sealos.io
+  namespaceSelector:
+    matchExpressions:
+      - key: user.sealos.io/owner
+        operator: Exists
   rules:
   - apiGroups:
     - networking.k8s.io
@@ -509,6 +521,10 @@ webhooks:
       path: /validate--v1-namespace
   failurePolicy: {{ .namespaceWebhookFailurePolicy }}
   name: vnamespace.sealos.io
+  namespaceSelector:
+    matchExpressions:
+      - key: user.sealos.io/owner
+        operator: Exists
   rules:
   - apiGroups:
     - ""

--- a/controllers/pkg/code/common.go
+++ b/controllers/pkg/code/common.go
@@ -24,4 +24,5 @@ const (
 	CodeInsufficientBalance = 40001
 	// CodeAdmissionForIngressFailedCnameCheck admission webhook for ingress
 	CodeAdmissionForIngressFailedCnameCheck = 40300
+	CodeAdmissionForIngressFailedOwnerCheck = 40301
 )

--- a/controllers/pkg/code/common.go
+++ b/controllers/pkg/code/common.go
@@ -20,9 +20,9 @@ const (
 
 // code
 const (
-	// CodeInsufficientBalance  debt webhook
-	CodeInsufficientBalance = 40001
-	// CodeAdmissionForIngressFailedCnameCheck admission webhook for ingress
-	CodeAdmissionForIngressFailedCnameCheck = 40300
-	CodeAdmissionForIngressFailedOwnerCheck = 40301
+	// InsufficientBalance  debt webhook
+	InsufficientBalance = 40001
+	// IngressFailedCnameCheck admission webhook for ingress
+	IngressFailedCnameCheck = 40300
+	IngressFailedOwnerCheck = 40301
 )


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8a13406</samp>

### Summary
:sparkles::recycle::fire:

<!--
1.  :sparkles: - This emoji is often used to indicate the addition of new features or enhancements, so it could be used to represent the addition of the new error code constant and the webhooks for ingresses in the `v1` package.
2.  :recycle: - This emoji is often used to indicate refactoring or improving existing code, so it could be used to represent the refactoring of the validation logic and the simplification of the webhooks creation in the admission controller.
3.  :fire: - This emoji is often used to indicate the removal of code or files, so it could be used to represent the removal of the unused import in `main.go`.
-->
This pull request adds webhooks for ingresses in the `v1` package of the admission controller, and improves the validation logic to check for host conflicts across namespaces. It also introduces a new error code for the owner check failure in the `code` package.

> _We are the masters of the ingress domain_
> _We validate and mutate with webhooks of pain_
> _No one can claim our hosts with a false name_
> _We use the `CodeAdmissionForIngressFailedOwnerCheck` to reign_

### Walkthrough
*  Add and register webhooks for mutating and validating ingresses ([link](https://github.com/labring/sealos/pull/3972/files?diff=unified&w=0#diff-85092151f8d0263b436e9a6e626fb989e64a3202deac7c687278fee8ffc3e44cL23-R32), [link](https://github.com/labring/sealos/pull/3972/files?diff=unified&w=0#diff-85092151f8d0263b436e9a6e626fb989e64a3202deac7c687278fee8ffc3e44cR50-R56), [link](https://github.com/labring/sealos/pull/3972/files?diff=unified&w=0#diff-85092151f8d0263b436e9a6e626fb989e64a3202deac7c687278fee8ffc3e44cL55-R97), [link](https://github.com/labring/sealos/pull/3972/files?diff=unified&w=0#diff-03f4cc75479be78b2e722a42a2fa0ae9392e5df7f0370a8ddd5f6209eab9aea6L93-R101))
* Refactor and improve the validation logic for ingresses ([link](https://github.com/labring/sealos/pull/3972/files?diff=unified&w=0#diff-85092151f8d0263b436e9a6e626fb989e64a3202deac7c687278fee8ffc3e44cL102-R189), [link](https://github.com/labring/sealos/pull/3972/files?diff=unified&w=0#diff-219a0592c75381f16de31b69d6044a0b2f8259709c5fca7d5d520ba164ed6b7eR27))
* Reorder the imports in `ingress_webhook.go` and `main.go` alphabetically and remove unused dependencies ([link](https://github.com/labring/sealos/pull/3972/files?diff=unified&w=0#diff-85092151f8d0263b436e9a6e626fb989e64a3202deac7c687278fee8ffc3e44cL23-R32), [link](https://github.com/labring/sealos/pull/3972/files?diff=unified&w=0#diff-03f4cc75479be78b2e722a42a2fa0ae9392e5df7f0370a8ddd5f6209eab9aea6L21-R33))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
