### PR TITLE
Fix/multi ns account

### DIFF
--- a/controllers/account/api/v1/debt_webhook.go
+++ b/controllers/account/api/v1/debt_webhook.go
@@ -84,32 +84,28 @@ func (d DebtValidate) Handle(ctx context.Context, req admission.Request) admissi
 		case kubeSystemGroup:
 			logger.V(1).Info("pass for kube-system")
 			return admission.ValidationResponse(true, "")
-		case fmt.Sprintf("%s:%s", saPrefix, req.Namespace):
-			if !isUserNamespace(req.Namespace) || isWhiteList(req) {
-				return admission.ValidationResponse(true, "")
-			}
-			logger.V(1).Info("check for user", "user", req.UserInfo.Username, "ns: ", req.Namespace, "name", req.Name, "Operation", req.Operation)
-			// Check if the request is for resourcequota resource
-			if req.Kind.Kind == "ResourceQuota" {
-				// Check if the operation is UPDATE or DELETE
-				switch req.Name {
-				case getDefaultQuotaName(req.Namespace), debtLimit0QuotaName:
-					return admission.Denied(fmt.Sprintf("ns %s request %s %s permission denied", req.Namespace, req.Kind.Kind, req.Operation))
-				}
-			}
-			if req.Kind.Kind == "Namespace" && req.Name == req.Namespace {
-				return admission.Denied(fmt.Sprintf("ns %s request %s %s permission denied", req.Namespace, req.Kind.Kind, req.Operation))
-			}
-			if req.Kind.Kind == "Payment" && req.Operation == admissionV1.Update {
-				return admission.Denied(fmt.Sprintf("ns %s request %s %s permission denied", req.Namespace, req.Kind.Kind, req.Operation))
-			}
-			return checkOption(ctx, logger, d.Client, req.Namespace)
-		default:
-			// continue to check other groups
+		}
+		// is user sa
+		if !strings.HasPrefix(g, saPrefix+":ns-") {
 			continue
 		}
+		if isWhiteList(req) {
+			return admission.ValidationResponse(true, "")
+		}
+		logger.V(1).Info("check for user", "user", req.UserInfo.Username, "ns: ", req.Namespace, "name", req.Name, "Operation", req.Operation)
+		// Check if the request is for resourcequota resource
+		if req.Kind.Kind == "ResourceQuota" && isDefaultQuotaName(req.Name) {
+			// Check if the operation is UPDATE or DELETE
+			return admission.Denied(fmt.Sprintf("ns %s request %s %s permission denied", req.Namespace, req.Kind.Kind, req.Operation))
+		}
+		if req.Kind.Kind == "Namespace" {
+			return admission.Denied(fmt.Sprintf("ns %s request %s %s permission denied", req.Namespace, req.Kind.Kind, req.Operation))
+		}
+		if req.Kind.Kind == "Payment" && req.Operation == admissionV1.Update {
+			return admission.Denied(fmt.Sprintf("ns %s request %s %s permission denied", req.Namespace, req.Kind.Kind, req.Operation))
+		}
+		return checkOption(ctx, logger, d.Client, req.Namespace)
 	}
-
 	logger.V(1).Info("pass ", "req.Namespace", req.Namespace)
 	return admission.ValidationResponse(true, "")
 }
@@ -140,17 +136,7 @@ func isWhiteList(req admission.Request) bool {
 	return false
 }
 
-func isUserNamespace(namespace string) bool {
-	return strings.HasPrefix(namespace, "ns-")
-}
-
 func checkOption(ctx context.Context, logger logr.Logger, c client.Client, nsName string) admission.Response {
-	//nsList := &corev1.NamespaceList{}
-	//if err := c.List(ctx, nsList, client.MatchingFields{"name": nsName}); err != nil {
-	//	logger.Error(err, "list ns error", "naName", nsName, "nsList", nsList)
-	//	return admission.ValidationResponse(true, nsName)
-	//}
-	// skip check if nsName is empty or equal to user system namespace
 	if nsName == "" {
 		return admission.Allowed("")
 	}
@@ -161,7 +147,7 @@ func checkOption(ctx context.Context, logger logr.Logger, c client.Client, nsNam
 	// Check if it is a user namespace
 	user, ok := ns.Labels[userV1.UserLabelOwnerKey]
 	if !ok {
-		return admission.ValidationResponse(true, fmt.Sprintf("this namespace is not user namespace %s,or have not create", ns.Name))
+		return admission.ValidationResponse(false, fmt.Sprintf("this namespace is not user namespace %s,or have not create", ns.Name))
 	}
 	logger.V(1).Info("check user namespace", "ns", ns.Name, "user", user)
 	accountList := AccountList{}
@@ -178,8 +164,8 @@ func checkOption(ctx context.Context, logger logr.Logger, c client.Client, nsNam
 	return admission.Allowed(fmt.Sprintf("pass user %s , namespace %s", user, ns.Name))
 }
 
-func getDefaultQuotaName(namespace string) string {
-	return fmt.Sprintf("quota-%s", namespace)
+func isDefaultQuotaName(name string) bool {
+	return strings.HasPrefix(name, "quota-") || name == debtLimit0QuotaName
 }
 
 func GetAccountDebtBalance(account Account) float64 {

--- a/controllers/account/config/default/manager_auth_proxy_patch.yaml
+++ b/controllers/account/config/default/manager_auth_proxy_patch.yaml
@@ -47,7 +47,7 @@ spec:
           - name: NEW_ACCOUNT_AMOUNT
             value: "ri79LzQiQrs6CVa1ctE308+AseBXbOua0RIMCXAH5hc3irs="
           - name: WHITELIST
-            value: "notifications.Notification.notification.sealos.io/v1,payments.Payment.account.sealos.io/v1,billingrecordqueries.BillingRecordQuery.account.sealos.io/v1,pricequeries.PriceQuery.account.sealos.io/v1"
+            value: "notifications.Notification.notification.sealos.io/v1,payments.Payment.account.sealos.io/v1,billingrecordqueries.BillingRecordQuery.account.sealos.io/v1,billinginfoqueries.BillingInfoQuery.account.sealos.io/v1,pricequeries.PriceQuery.account.sealos.io/v1"
           - name: ACCOUNT_SYSTEM_NAMESPACE
             valueFrom:
               fieldRef:

--- a/controllers/account/deploy/manifests/deploy.yaml.tmpl
+++ b/controllers/account/deploy/manifests/deploy.yaml.tmpl
@@ -1269,7 +1269,7 @@ spec:
         - name: NEW_ACCOUNT_AMOUNT
           value: "ri79LzQiQrs6CVa1ctE308+AseBXbOua0RIMCXAH5hc3irs="
         - name: WHITELIST
-          value: notifications.Notification.notification.sealos.io/v1,payments.Payment.account.sealos.io/v1,billingrecordqueries.BillingRecordQuery.account.sealos.io/v1,pricequeries.PriceQuery.account.sealos.io/v1
+          value: notifications.Notification.notification.sealos.io/v1,payments.Payment.account.sealos.io/v1,billingrecordqueries.BillingRecordQuery.account.sealos.io/v1,billinginfoqueries.BillingInfoQuery.account.sealos.io/v1,pricequeries.PriceQuery.account.sealos.io/v1
         - name: ACCOUNT_SYSTEM_NAMESPACE
           valueFrom:
             fieldRef:


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0b3ddd6</samp>

### Summary
:moneybag::repeat::hammer_and_wrench:

<!--
1.  :moneybag: - This emoji represents the addition of the new resource type related to billing information queries, which is relevant for the financial aspect of the service.
2.  :repeat: - This emoji represents the repetition of the same change from another file, which is not very significant or interesting.
3.  :hammer_and_wrench: - This emoji represents the refactoring and improvement of the admission webhook handler and the account controller, which are important for the functionality and quality of the service.
-->
This pull request refactors and improves the account controller and the debt webhook handler in the `account` module. It uses the owner annotation to sync account resources, simplifies the service account and namespace checks, and rejects invalid or default requests. It also adds a new resource type, `billinginfoqueries.BillingInfoQuery`, to the webhook whitelist.

> _We're the webhook crew and we know what to do_
> _We whitelist the `BillingInfoQuery` and deny the quota too_
> _We check the account status and the debt limit before we let it through_
> _Heave away, heave away, heave away on the count of three_

### Walkthrough
*  Simplify service account group and namespace check in admission webhook handler ([link](https://github.com/labring/sealos/pull/3978/files?diff=unified&w=0#diff-e240069d1b78e1e32ee1fc0d1387fbe54aea40bbaa70873d6d6ec80ee5062717L87-R108))
*  Reject admission requests for non-user namespaces or uncreated namespaces ([link](https://github.com/labring/sealos/pull/3978/files?diff=unified&w=0#diff-e240069d1b78e1e32ee1fc0d1387fbe54aea40bbaa70873d6d6ec80ee5062717L164-R150))
*  Check owner annotation instead of user name for account resource name ([link](https://github.com/labring/sealos/pull/3978/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L95-R100), [link](https://github.com/labring/sealos/pull/3978/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L116-R120))
*  Sync resource quota and limit range before getting or creating account resource ([link](https://github.com/labring/sealos/pull/3978/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L197-R212), [link](https://github.com/labring/sealos/pull/3978/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L220-L229))
*  Skip role and rolebinding sync for shared namespaces ([link](https://github.com/labring/sealos/pull/3978/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L212-R228))
*  Check default quota name prefix instead of suffix in admission webhook handler ([link](https://github.com/labring/sealos/pull/3978/files?diff=unified&w=0#diff-e240069d1b78e1e32ee1fc0d1387fbe54aea40bbaa70873d6d6ec80ee5062717L181-R168))
*  Add new resource type to whitelist environment variable in `manager_auth_proxy_patch.yaml` and `deploy.yaml.tmpl` ([link](https://github.com/labring/sealos/pull/3978/files?diff=unified&w=0#diff-afec2944b73c1e73393bfd1cec2dd27add46df610da031de5679d216ffc2512dL50-R50), [link](https://github.com/labring/sealos/pull/3978/files?diff=unified&w=0#diff-11c0253bf67d2025a97d6953bad0e237ce9ac7a60d0a35ae1e277e934ceaea0eL1272-R1272))
*  Remove unused function `isUserNamespace` from `debt_webhook.go` ([link](https://github.com/labring/sealos/pull/3978/files?diff=unified&w=0#diff-e240069d1b78e1e32ee1fc0d1387fbe54aea40bbaa70873d6d6ec80ee5062717L143-R139))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
