### PR TITLE
Fix doc deprecated "#gh-dark-mode-*" fragment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 <h2 align="center">
 
-![](/docs/4.0/img/sealos-left-dark.png#gh-dark-mode-only)
-![](/docs/4.0/img/sealos-left.png#gh-light-mode-only)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="./docs/4.0/img/sealos-left-dark.png">
+  <source media="(prefers-color-scheme: light)" srcset="./docs/4.0/img/sealos-left.png">
+  <img src="./docs/4.0/img/sealos-left.png">
+</picture>
 
 A Cloud Operating System designed for managing cloud-native applications
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,7 +1,10 @@
 <h2 align="center">
 
-![](/docs/4.0/img/sealos-left-dark.png#gh-dark-mode-only)
-![](/docs/4.0/img/sealos-left.png#gh-light-mode-only)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="./docs/4.0/img/sealos-left-dark.png">
+  <source media="(prefers-color-scheme: light)" srcset="./docs/4.0/img/sealos-left.png">
+  <img src="./docs/4.0/img/sealos-left.png">
+</picture>
 
 一款以 Kubernetes 为内核的云操作系统发行版
 

--- a/docs/4.0/docs/advanced-guide/Architecture/Architecture.md
+++ b/docs/4.0/docs/advanced-guide/Architecture/Architecture.md
@@ -6,7 +6,11 @@ All services are authenticated using `kubeconfig` as the application identity, e
 
 ## Overall Architecture
 
-![Architecture](./images/architecture_light.png#gh-light-mode-only)![Architecture](./images/architecture_dark.png#gh-dark-mode-only)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="./images/architecture_dark.png">
+  <source media="(prefers-color-scheme: light)" srcset="./images/architecture_light.png">
+  <img src="./images/architecture_light.png">
+</picture>
 
 ## Application Architecture
 
@@ -20,4 +24,8 @@ Applications can also call each other, for example, a database created by a user
 
 For more information, please refer to the [link](../../platform-components) documentation.
 
-![Application](./images/application_light.png#gh-light-mode-only)![Application](./images/application_dark.png#gh-dark-mode-only)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="./images/application_dark.png">
+  <source media="(prefers-color-scheme: light)" srcset="./images/application_light.png">
+  <img src="./images/application_light.png">
+</picture>

--- a/docs/4.0/i18n/zh-Hans/advanced-guide/Architecture/Architecture.md
+++ b/docs/4.0/i18n/zh-Hans/advanced-guide/Architecture/Architecture.md
@@ -5,8 +5,11 @@ Sealos 采用应用分离与应用互联的方式构建，不同应用可以独�
 
 ## 整体架构
 
-![Architecture](./images/architecture_light.png#gh-light-mode-only)![Architecture](./images/architecture_dark.png#gh-dark-mode-only)
-
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="./images/architecture_dark.png">
+  <source media="(prefers-color-scheme: light)" srcset="./images/architecture_light.png">
+  <img src="./images/architecture_light.png">
+</picture>
 
 ## 应用架构
 
@@ -20,4 +23,8 @@ Sealos 上的应用采用前后端分离的架构，同时前端能够提供 `SS
 
 详细信息可以点击 [链接](../../platform-components) 文档了解更多。
 
-![Application](./images/application_light.png#gh-light-mode-only)![Application](./images/application_dark.png#gh-dark-mode-only)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="./images/application_dark.png">
+  <source media="(prefers-color-scheme: light)" srcset="./images/application_light.png">
+  <img src="./images/application_light.png">
+</picture>


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1122c43</samp>

### Summary
🌐🌗📊

<!--
1.  🌐 - This emoji represents the change to the README_zh.md file, which is related to internationalization and localization of the documentation.
2. 🌗 - This emoji represents the change to the logo image in the README.md file, which is related to supporting dark and light mode for the website and the documentation.
3. 📊 - This emoji represents the change to the architecture and application diagrams, which are related to data visualization and presentation.
-->
Updated the documentation and logo images to support dark and light mode. This includes the English and Chinese versions of the `README.md` and `Architecture.md` files, as well as the corresponding diagrams.

> _We are the sealos, we command the cluster_
> _We don't need init, we have the power_
> _We shine in the dark, we adapt to the light_
> _We update our docs, we keep them in sight_

### Walkthrough
*  Use `<picture>` element with `<source>` tags for logo image in `README.md` and `README_zh.md` to support dark and light mode ([link](https://github.com/labring/sealos/pull/3981/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R7), [link](https://github.com/labring/sealos/pull/3981/files?diff=unified&w=0#diff-bc53aca037f8d406f619f15cf2c5c905a7a61f81f89cab98dd52f7ff65725f6eL3-R7))
*  Use `<picture>` element with `<source>` tags for architecture and application diagrams in `Architecture.md` and `Architecture/Architecture.md` (English and Chinese versions) to support dark and light mode ([link](https://github.com/labring/sealos/pull/3981/files?diff=unified&w=0#diff-c44d7a14ed0a9197b3af7353376caaa93df8284f2ed9d7e7ff365661cca4a84eL9-R13), [link](https://github.com/labring/sealos/pull/3981/files?diff=unified&w=0#diff-c44d7a14ed0a9197b3af7353376caaa93df8284f2ed9d7e7ff365661cca4a84eR27-R30), [link](https://github.com/labring/sealos/pull/3981/files?diff=unified&w=0#diff-0484b8de67ea4b55492b9d1a9c313fb15876b2cba3be7c2738806ac8c7836d80L8-R13), [link](https://github.com/labring/sealos/pull/3981/files?diff=unified&w=0#diff-0484b8de67ea4b55492b9d1a9c313fb15876b2cba3be7c2738806ac8c7836d80R26-R29))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
