### PR TITLE
feature(main): reset cluster not delete nodes

### DIFF
--- a/pkg/runtime/k3s/k3s.go
+++ b/pkg/runtime/k3s/k3s.go
@@ -94,13 +94,13 @@ func (k *K3s) ScaleUp(masters []string, nodes []string) error {
 func (k *K3s) ScaleDown(masters []string, nodes []string) error {
 	if len(masters) != 0 {
 		logger.Info("master %s will be deleted", masters)
-		if err := k.resetNodes(masters); err != nil {
+		if err := k.removeNodes(masters); err != nil {
 			return err
 		}
 	}
 	if len(nodes) != 0 {
 		logger.Info("worker %s will be deleted", nodes)
-		return k.resetNodes(nodes)
+		return k.removeNodes(nodes)
 	}
 	return nil
 }

--- a/pkg/runtime/k3s/lifecycle.go
+++ b/pkg/runtime/k3s/lifecycle.go
@@ -34,6 +34,17 @@ func (k *K3s) resetNodes(nodes []string) error {
 	for i := range nodes {
 		node := nodes[i]
 		eg.Go(func() error {
+			return k.resetNode(node)
+		})
+	}
+	return eg.Wait()
+}
+
+func (k *K3s) removeNodes(nodes []string) error {
+	eg, _ := errgroup.WithContext(context.Background())
+	for i := range nodes {
+		node := nodes[i]
+		eg.Go(func() error {
 			if err := k.deleteNode(node); err != nil {
 				return err
 			}

--- a/pkg/runtime/k3s/lifecycle.go
+++ b/pkg/runtime/k3s/lifecycle.go
@@ -50,7 +50,7 @@ func (k *K3s) resetNode(host string) error {
 	if removeKubeConfigErr != nil {
 		logger.Error("failed to clean node, exec command %s failed, %v", removeKubeConfig, removeKubeConfigErr)
 	}
-	if slices.Contains(k.cluster.GetNodeIPList(), host) {
+	if slices.Contains(k.cluster.GetNodeIPAndPortList(), host) {
 		vipAndPort := fmt.Sprintf("%s:%d", k.cluster.GetVIP(), k.config.APIServerPort)
 		ipvsclearErr := k.remoteUtil.IPVSClean(host, vipAndPort)
 		if ipvsclearErr != nil {
@@ -63,7 +63,10 @@ func (k *K3s) resetNode(host string) error {
 // TODO: remove from API
 func (k *K3s) deleteNode(node string) error {
 	//remove master
-	masterIPs := strings.RemoveFromSlice(k.cluster.GetMasterIPList(), node)
+	masterIPs := k.cluster.GetMasterIPList()
+	if slices.Contains(k.cluster.GetMasterIPAndPortList(), node) {
+		masterIPs = strings.RemoveFromSlice(k.cluster.GetMasterIPList(), node)
+	}
 	if len(masterIPs) > 0 {
 		// TODO: do we need draining first?
 		if err := k.removeNode(node); err != nil {

--- a/pkg/runtime/kubernetes/reset.go
+++ b/pkg/runtime/kubernetes/reset.go
@@ -81,7 +81,7 @@ func (k *KubeadmRuntime) resetNode(node string, cleanHook func()) error {
 	if removeKubeConfigErr != nil {
 		logger.Error("failed to clean node, exec command %s failed, %v", removeKubeConfig, removeKubeConfigErr)
 	}
-	if slices.Contains(k.cluster.GetNodeIPList(), node) {
+	if slices.Contains(k.cluster.GetNodeIPAndPortList(), node) {
 		ipvscleanErr := k.execIPVSClean(node)
 		if ipvscleanErr != nil {
 			logger.Error("failed to clean node route and ipvs failed, %v", ipvscleanErr)


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2692f57</samp>

### Summary
🐛🛠️🌱

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change.
2.  🛠️ - This emoji represents a tool or improvement, which is the broader goal of the pull request that the change belongs to.
3.  🌱 - This emoji represents a seed or growth, which could symbolize the enhancement of the k3s cluster functionality and stability.
-->
Fix a bug in `pkg/runtime/k3s/lifecycle.go` that could remove a non-master node from the masterIPs slice. Enhance the k3s lifecycle management.

> _`masterIPs` slice_
> _bug fixed with a condition_
> _autumn leaves cluster_

### Walkthrough
* Fix a bug where a non-master node could be removed from the masterIPs slice when deleting a node ([link](https://github.com/labring/sealos/pull/3991/files?diff=unified&w=0#diff-18b1fd2bd860036843fa344a0cd7d1ab962be73078b9afdad30e9835009da6afL66-R69) in `pkg/runtime/k3s/lifecycle.go`)


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
