### PR TITLE
add account webhook namespaceSelector matchExpressions with user ns label

### DIFF
--- a/controllers/account/api/v1/debt_webhook.go
+++ b/controllers/account/api/v1/debt_webhook.go
@@ -53,7 +53,7 @@ const (
 
 var logger = logf.Log.WithName("debt-resource")
 
-//+kubebuilder:webhook:path=/validate-v1-sealos-cloud,mutating=true,failurePolicy=ignore,groups="*",resources=*,verbs=create;update;delete,versions=v1,name=debt.sealos.io,admissionReviewVersions=v1,sideEffects=None
+//+kubebuilder:webhook:path=/validate-v1-sealos-cloud,mutating=false,failurePolicy=ignore,groups="*",resources=*,verbs=create;update;delete,versions=v1,name=debt.sealos.io,admissionReviewVersions=v1,sideEffects=None
 // +kubebuilder:object:generate=false
 
 type DebtValidate struct {

--- a/controllers/account/config/default/manager_auth_proxy_patch.yaml
+++ b/controllers/account/config/default/manager_auth_proxy_patch.yaml
@@ -40,6 +40,10 @@ spec:
           runAsNonRoot: true
           allowPrivilegeEscalation: false
         env:
+          - name: DOMAIN
+            value: '{{ .cloudDomain }}'
+          - name: PORT
+            value: '{{ .cloudPort }}'
           - name: ACCOUNT_NAMESPACE
             value: "sealos-system"
           - name: NAMESPACE_NAME

--- a/controllers/account/config/default/webhookcainjection_patch.yaml
+++ b/controllers/account/config/default/webhookcainjection_patch.yaml
@@ -1,9 +1,9 @@
 # This patch add annotation to admission webhook config and
 # the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
 apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
+kind: ValidatingWebhookConfiguration
 metadata:
-  name: mutating-webhook-configuration
+  name: validating-webhook-configuration
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 

--- a/controllers/account/config/manager/manager.yaml
+++ b/controllers/account/config/manager/manager.yaml
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-  replicas: 3
+  replicas: 1
   template:
     metadata:
       annotations:
@@ -53,9 +53,9 @@ spec:
         resources:
           limits:
             cpu: 1000m
-            memory: 1000Mi
+            memory: 1024Mi
           requests:
             cpu: 100m
-            memory: 640Mi
+            memory: 64Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/controllers/account/config/webhook/kustomizeconfig.yaml
+++ b/controllers/account/config/webhook/kustomizeconfig.yaml
@@ -4,18 +4,11 @@ nameReference:
 - kind: Service
   version: v1
   fieldSpecs:
-  - kind: MutatingWebhookConfiguration
-    group: admissionregistration.k8s.io
-    path: webhooks/clientConfig/service/name
   - kind: ValidatingWebhookConfiguration
     group: admissionregistration.k8s.io
     path: webhooks/clientConfig/service/name
 
 namespace:
-- kind: MutatingWebhookConfiguration
-  group: admissionregistration.k8s.io
-  path: webhooks/clientConfig/service/namespace
-  create: true
 - kind: ValidatingWebhookConfiguration
   group: admissionregistration.k8s.io
   path: webhooks/clientConfig/service/namespace

--- a/controllers/account/config/webhook/manifests.yaml
+++ b/controllers/account/config/webhook/manifests.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
+kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null
-  name: mutating-webhook-configuration
+  name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
   - v1

--- a/controllers/account/controllers/account_controller.go
+++ b/controllers/account/controllers/account_controller.go
@@ -117,7 +117,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, nil
 	}
 
-	account, err := r.syncAccount(ctx, owner, r.AccountSystemNamespace, payment.Namespace)
+	account, err := r.syncAccount(ctx, payment.Spec.UserID, r.AccountSystemNamespace, payment.Namespace)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("get account failed: %v", err)
 	}
@@ -219,7 +219,7 @@ func (r *AccountReconciler) syncAccount(ctx context.Context, owner, accountNames
 		}
 		return nil
 	}); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create account %v, err: %v", account, err)
 	}
 	if owner != getUsername(userNamespace) {
 		return &account, nil

--- a/controllers/account/controllers/debt_controller.go
+++ b/controllers/account/controllers/debt_controller.go
@@ -320,7 +320,7 @@ var NoticeTemplate = map[int]string{
 
 func (r *DebtReconciler) sendNotice(ctx context.Context, noticeType int, namespaces []string) error {
 	now := time.Now().UTC().Unix()
-	ntf := v1.Notification{
+	ntfTmp := &v1.Notification{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "debt-notice" + strconv.Itoa(noticeType),
 		},
@@ -333,8 +333,9 @@ func (r *DebtReconciler) sendNotice(ctx context.Context, noticeType int, namespa
 		},
 	}
 	for i := range namespaces {
+		ntf := ntfTmp.DeepCopy()
 		ntf.Namespace = namespaces[i]
-		if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, &ntf, func() error {
+		if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, ntf, func() error {
 			return nil
 		}); err != nil {
 			return err

--- a/controllers/account/deploy/manifests/deploy.yaml.tmpl
+++ b/controllers/account/deploy/manifests/deploy.yaml.tmpl
@@ -1259,15 +1259,15 @@ spec:
         - /manager
         env:
         - name: DOMAIN
-          value: {{ .cloudDomain }}
+          value: '{{ .cloudDomain }}'
         - name: PORT
-          value: "{{ .cloudPort }}"
+          value: '{{ .cloudPort }}'
         - name: ACCOUNT_NAMESPACE
           value: sealos-system
         - name: NAMESPACE_NAME
           value: user-system
         - name: NEW_ACCOUNT_AMOUNT
-          value: "ri79LzQiQrs6CVa1ctE308+AseBXbOua0RIMCXAH5hc3irs="
+          value: ri79LzQiQrs6CVa1ctE308+AseBXbOua0RIMCXAH5hc3irs=
         - name: WHITELIST
           value: notifications.Notification.notification.sealos.io/v1,payments.Payment.account.sealos.io/v1,billingrecordqueries.BillingRecordQuery.account.sealos.io/v1,billinginfoqueries.BillingInfoQuery.account.sealos.io/v1,pricequeries.PriceQuery.account.sealos.io/v1
         - name: ACCOUNT_SYSTEM_NAMESPACE
@@ -1380,11 +1380,11 @@ spec:
   selfSigned: {}
 ---
 apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
+kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: account-system/account-serving-cert
-  name: account-mutating-webhook-configuration
+  name: account-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
   - v1
@@ -1398,12 +1398,8 @@ webhooks:
   name: debt.sealos.io
   namespaceSelector:
     matchExpressions:
-      - key: metadata.name
-        operator: NotIn
-        values:
-          - account-system
-          - kube-system
-          - calico-system
+      - key: user.sealos.io/owner
+        operator: Exists
   rules:
   - apiGroups:
     - '*'


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a223f96</samp>

### Summary
🏷️🛡️🏘️

<!--
1.  🏷️ - This emoji represents the use of labels, which are key-value pairs that can be attached to any Kubernetes resource for identification and selection purposes. The change to the `namespaceSelector` involves using a label instead of a name to match namespaces.
2.  🛡️ - This emoji represents the use of validation, which is a process of checking the validity and conformity of Kubernetes resources before they are created or updated. The change to the `ValidatingWebhookConfiguration` involves using a webhook to perform validation on namespaces that have the label.
3.  🏘️ - This emoji represents the use of multi-tenancy, which is a feature that allows multiple users or groups to share a single Kubernetes cluster with isolation and resource allocation. The change to the `ValidatingWebhookConfiguration` is part of a feature to support multi-tenant clusters with sealos.
-->
Changed the namespace selector for the validating webhook to use a custom label. This enables sealos to support multi-tenant clusters.

> _`namespaceSelector`_
> _Changed to use custom label_
> _Webhook validates_

### Walkthrough
* Change the namespace selector for the validating webhook to use a custom label ([link](https://github.com/labring/sealos/pull/3996/files?diff=unified&w=0#diff-11c0253bf67d2025a97d6953bad0e237ce9ac7a60d0a35ae1e277e934ceaea0eL1401-R1402))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
