### PR TITLE
feat:license deploy

### DIFF
--- a/frontend/providers/license/deploy/Kubefile
+++ b/frontend/providers/license/deploy/Kubefile
@@ -6,6 +6,9 @@ COPY registry registry
 COPY manifests manifests
 
 ENV cloudDomain="127.0.0.1.nip.io"
+ENV licensePuchaseDomain="cloud.sealos.io"
 ENV certSecretName="wildcard-cert"
+ENV MONGODB_URI=""
+ENV PASSWORD_SALT=""
 
 CMD ["kubectl apply -f manifests"]

--- a/frontend/providers/license/deploy/manifests/appcr.yaml.tmpl
+++ b/frontend/providers/license/deploy/manifests/appcr.yaml.tmpl
@@ -11,7 +11,10 @@ spec:
   menuData:
     helpDropDown: false
     nameColor: text-black
-  name: license
+  i18n:
+    zh:
+      name: 许可证
+  name: License
   type: iframe
   displayType: normal
  

--- a/frontend/providers/license/deploy/manifests/deploy.yaml.tmpl
+++ b/frontend/providers/license/deploy/manifests/deploy.yaml.tmpl
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: license-frontend-config
-  namespace: sealos
+  namespace: license-frontend
 data:
   config.yaml: |-
     addr: :3000
@@ -11,7 +11,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: license-frontend
-  namespace: sealos
+  namespace: license-frontend
 spec:
   replicas: 1
   selector:
@@ -32,16 +32,18 @@ spec:
           env:
             - name: SEALOS_DOMAIN
               value: {{ .cloudDomain }}
+            - name: LICENSE_DOMAIN
+              value: {{ .licensePuchaseDomain }}
             - name: MONGODB_URI
               valueFrom:
                 secretKeyRef:
-                  key: mongodb_uri
                   name: license-frontend-secret
+                  key: mongodb_uri
             - name: PASSWORD_SALT
               valueFrom:
                 secretKeyRef:
-                  key: password_salt
                   name: license-frontend-secret
+                  key: password_salt
           securityContext:
             runAsNonRoot: true
             runAsUser: 1001
@@ -57,7 +59,7 @@ spec:
               cpu: 10m
               memory: 128Mi
           # do not modify this image, it is used for CI/CD
-          image: zhujingyang/sealos-license-frontend:1.0.1
+          image: ghcr.io/labring/sealos-license-frontend:latest
           imagePullPolicy: Always
           volumeMounts:
             - name: license-frontend-volume
@@ -74,7 +76,7 @@ metadata:
   labels:
     app: license-frontend
   name: license-frontend
-  namespace: sealos
+  namespace: license-frontend
 spec:
   ports:
     - name: http

--- a/frontend/providers/license/deploy/manifests/env.yaml.tmpl
+++ b/frontend/providers/license/deploy/manifests/env.yaml.tmpl
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: license-frontend-secret
+  namespace: license-frontend
+stringData:
+  mongodb_uri: {{ .MONGODB_URI }}
+  password_salt: {{ .PASSWORD_SALT }}

--- a/frontend/providers/license/deploy/manifests/ingress.yaml.tmpl
+++ b/frontend/providers/license/deploy/manifests/ingress.yaml.tmpl
@@ -14,7 +14,7 @@ metadata:
         add_header Cache-Control "public";
       }
   name: license-frontend
-  namespace: sealos
+  namespace: license-frontend
 spec:
   rules:
     - host: license.{{ .cloudDomain }}

--- a/frontend/providers/license/src/pages/api/platform/getEnv.ts
+++ b/frontend/providers/license/src/pages/api/platform/getEnv.ts
@@ -6,13 +6,15 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 export type Response = {
   domain?: string;
   hid: string; // PASSWORD_SALT
+  LICENSE_DOMAIN: string;
 };
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
   jsonRes<Response>(res, {
     data: {
       domain: process.env.SEALOS_DOMAIN || 'cloud.sealos.io',
-      hid: hashCrypto(process.env.PASSWORD_SALT || '')
+      hid: hashCrypto(process.env.PASSWORD_SALT || ''),
+      LICENSE_DOMAIN: process.env.LICENSE_DOMAIN || 'cloud.sealos.io'
     }
   });
 }

--- a/frontend/providers/license/src/pages/index.tsx
+++ b/frontend/providers/license/src/pages/index.tsx
@@ -39,7 +39,7 @@ export default function LicenseApp() {
 
   useQuery(['getPlatformEnv'], () => getPlatformEnv(), {
     onSuccess(data) {
-      const hid = data?.hid;
+      const hid = data.hid;
       if (!hid) {
         return toast({
           title: 'env hid error',
@@ -47,7 +47,7 @@ export default function LicenseApp() {
         });
       }
       const encodedHid = encodeURIComponent(hid);
-      const main = data?.domain ? data.domain : 'cloud.sealos.io';
+      const main = data.LICENSE_DOMAIN;
       const link = `https:/${main}/license?hid=${encodedHid}`;
       setPurchaseLink(link);
     }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ae3535e</samp>

### Summary
🌐🔐🛒

<!--
1.  🌐 - This emoji represents the i18n feature that was added to the license frontend service, which allows the service name to be displayed in different languages.
2.  🔐 - This emoji represents the security improvements that were made to the license frontend service, such as using a secret to store the sensitive environment variables and migrating the service to its own namespace.
3.  🛒 - This emoji represents the purchase link feature that was added to the license frontend service, which enables the user to buy the license from the specified domain.
-->
This pull request migrates the license frontend service to its own namespace `license-frontend` and updates the image source, environment variables, API response, and ingress configuration. These changes improve the security, performance, and user experience of the service.

> _`license-frontend`_
> _migrates to own namespace_
> _a spring cleaning_

### Walkthrough
*  Migrate the license frontend service to its own namespace `license-frontend` for better isolation and security ([link](https://github.com/labring/sealos/pull/4002/files?diff=unified&w=0#diff-0a58165e7a91e4aa1cced2e3211bb81faef30f0714e49482887d777c79953780L14-R17), [link](https://github.com/labring/sealos/pull/4002/files?diff=unified&w=0#diff-2d38284ad119b150da29e25cedd7b57db77b0ecfa2a3d72f328f8f35762a2d23L5-R5), [link](https://github.com/labring/sealos/pull/4002/files?diff=unified&w=0#diff-2d38284ad119b150da29e25cedd7b57db77b0ecfa2a3d72f328f8f35762a2d23L14-R14), [link](https://github.com/labring/sealos/pull/4002/files?diff=unified&w=0#diff-2d38284ad119b150da29e25cedd7b57db77b0ecfa2a3d72f328f8f35762a2d23L77-R79), [link](https://github.com/labring/sealos/pull/4002/files?diff=unified&w=0#diff-c044bb33c61e72df5a48f157dcadfc5e199c0b0b21b392ba5d1ef3fecd03a93aL17-R17))
* Add new environment variables `licensePuchaseDomain`, `MONGODB_URI`, and `PASSWORD_SALT` to the `Kubefile` to configure the license frontend service ([link](https://github.com/labring/sealos/pull/4002/files?diff=unified&w=0#diff-3417442bcdbb3a8c5e1ea56cc76ed25bf542cbed86c06b743c9b2a50c511f52dL9-R13))
* Create a secret for the license frontend service in the `license-frontend` namespace to store the `mongodb_uri` and `password_salt` values from the `Kubefile` ([link](https://github.com/labring/sealos/pull/4002/files?diff=unified&w=0#diff-abb0848ddef1e8e16d3a1f254c6a9be54e7c15f69fa21854efc289df31e2f605L1-R7))
* Change the image of the license frontend container to use the GitHub container registry for better access and security ([link](https://github.com/labring/sealos/pull/4002/files?diff=unified&w=0#diff-2d38284ad119b150da29e25cedd7b57db77b0ecfa2a3d72f328f8f35762a2d23L60-R62))
* Add a new environment variable `LICENSE_DOMAIN` to the license frontend container and the `Response` type in the `getEnv.ts` file to specify the domain for purchasing the license ([link](https://github.com/labring/sealos/pull/4002/files?diff=unified&w=0#diff-2d38284ad119b150da29e25cedd7b57db77b0ecfa2a3d72f328f8f35762a2d23L35-R46), [link](https://github.com/labring/sealos/pull/4002/files?diff=unified&w=0#diff-7167703ec1f6335a8522ab1955fd4eee9d1a99592b3323027fe32d0863b24588R9), [link](https://github.com/labring/sealos/pull/4002/files?diff=unified&w=0#diff-7167703ec1f6335a8522ab1955fd4eee9d1a99592b3323027fe32d0863b24588L15-R17))
* Use the `LICENSE_DOMAIN` value instead of the `domain` value to construct the purchase link for the user in the `index.tsx` file ([link](https://github.com/labring/sealos/pull/4002/files?diff=unified&w=0#diff-33ec3cc77e6f3d8a249e89149a66bbcef2df5f6f5838fa5c7561ad848128ffa2L50-R50))
* Remove the optional chaining operator from the `data.hid` expression in the `index.tsx` file to simplify the code ([link](https://github.com/labring/sealos/pull/4002/files?diff=unified&w=0#diff-33ec3cc77e6f3d8a249e89149a66bbcef2df5f6f5838fa5c7561ad848128ffa2L42-R42))
* Fix a typo in the indentation of the selector field of the license frontend service in the `deploy.yaml.tmpl` file ([link](https://github.com/labring/sealos/pull/4002/files?diff=unified&w=0#diff-2d38284ad119b150da29e25cedd7b57db77b0ecfa2a3d72f328f8f35762a2d23L85-L84))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
