### PR TITLE
Fix/billing

### DIFF
--- a/controllers/account/api/v1/debt_webhook.go
+++ b/controllers/account/api/v1/debt_webhook.go
@@ -69,9 +69,6 @@ func (d DebtValidate) Handle(ctx context.Context, req admission.Request) admissi
 	logger.V(1).Info("checking user", "userInfo", req.UserInfo, "req.Namespace", req.Namespace, "req.Name", req.Name, "req.gvrk", getGVRK(req), "req.Operation", req.Operation)
 	// skip delete request (删除quota资源除外)
 	if req.Operation == admissionV1.Delete && !strings.Contains(getGVRK(req), "quotas") {
-		if req.Kind.Kind == "Namespace" {
-			return admission.Denied(fmt.Sprintf("ns %s request %s %s permission denied", req.Namespace, req.Kind.Kind, req.Operation))
-		}
 		return admission.Allowed("")
 	}
 

--- a/controllers/account/controllers/account_controller.go
+++ b/controllers/account/controllers/account_controller.go
@@ -38,7 +38,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -97,6 +96,9 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if owner = user.Annotations[userv1.UserAnnotationOwnerKey]; owner == "" {
 			return ctrl.Result{}, fmt.Errorf("user owner is empty")
 		}
+		// This is only used to monitor and initialize user resource creation data,
+		// determine the resource quota created by the owner user and the resource quota initialized by the account user,
+		// and only the resource quota created by the team user
 		_, err = r.syncAccount(ctx, owner, r.AccountSystemNamespace, "ns-"+user.Name)
 		return ctrl.Result{}, err
 	} else if client.IgnoreNotFound(err) != nil {
@@ -117,7 +119,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, nil
 	}
 
-	account, err := r.syncAccount(ctx, payment.Spec.UserID, r.AccountSystemNamespace, payment.Namespace)
+	account, err := r.syncAccount(ctx, getUsername(payment.Spec.UserID), r.AccountSystemNamespace, payment.Namespace)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("get account failed: %v", err)
 	}
@@ -200,12 +202,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 func (r *AccountReconciler) syncAccount(ctx context.Context, owner, accountNamespace string, userNamespace string) (*accountv1.Account, error) {
 	if err := r.syncResourceQuotaAndLimitRange(ctx, userNamespace); err != nil {
-		//return nil, fmt.Errorf("sync resource resourceQuota and limitRange failed: %v", err)
 		r.Logger.Error(err, "sync resource resourceQuota and limitRange failed")
-	}
-	//TODO delete after nodeport count quota already in resource-quota
-	if err := r.adaptNodePortCountQuota(ctx, userNamespace); err != nil {
-		r.Logger.Error(err, "adapt nodeport count quota failed")
 	}
 	account := accountv1.Account{
 		ObjectMeta: metav1.ObjectMeta{
@@ -221,6 +218,7 @@ func (r *AccountReconciler) syncAccount(ctx context.Context, owner, accountNames
 	}); err != nil {
 		return nil, fmt.Errorf("failed to create account %v, err: %v", account, err)
 	}
+	// If the user is not the owner, the user represents the team and does not perform subsequent account initialization operations
 	if owner != getUsername(userNamespace) {
 		return &account, nil
 	}
@@ -290,18 +288,18 @@ func (r *AccountReconciler) syncResourceQuotaAndLimitRange(ctx context.Context, 
 	return nil
 }
 
-func (r *AccountReconciler) adaptNodePortCountQuota(ctx context.Context, nsName string) error {
-	quota := resources.GetDefaultResourceQuota(nsName, ResourceQuotaPrefix+nsName)
-	return retry.Retry(10, 1*time.Second, func() error {
-		_, err := controllerutil.CreateOrUpdate(ctx, r.Client, quota, func() error {
-			if _, ok := quota.Spec.Hard[corev1.ResourceServicesNodePorts]; !ok {
-				quota.Spec.Hard[corev1.ResourceServicesNodePorts] = resource.MustParse(env.GetEnvWithDefault(resources.QuotaLimitsNodePorts, resources.DefaultQuotaLimitsNodePorts))
-			}
-			return nil
-		})
-		return err
-	})
-}
+//func (r *AccountReconciler) adaptNodePortCountQuota(ctx context.Context, nsName string) error {
+//	quota := resources.GetDefaultResourceQuota(nsName, ResourceQuotaPrefix+nsName)
+//	return retry.Retry(10, 1*time.Second, func() error {
+//		_, err := controllerutil.CreateOrUpdate(ctx, r.Client, quota, func() error {
+//			if _, ok := quota.Spec.Hard[corev1.ResourceServicesNodePorts]; !ok {
+//				quota.Spec.Hard[corev1.ResourceServicesNodePorts] = resource.MustParse(env.GetEnvWithDefault(resources.QuotaLimitsNodePorts, resources.DefaultQuotaLimitsNodePorts))
+//			}
+//			return nil
+//		})
+//		return err
+//	})
+//}
 
 func (r *AccountReconciler) syncRoleAndRoleBinding(ctx context.Context, name, namespace string) error {
 	role := rbacv1.Role{
@@ -430,11 +428,7 @@ func (r *AccountReconciler) SetupWithManager(mgr ctrl.Manager, rateOpts controll
 	r.Logger = ctrl.Log.WithName("account_controller")
 	r.AccountSystemNamespace = env.GetEnvWithDefault(ACCOUNTNAMESPACEENV, DEFAULTACCOUNTNAMESPACE)
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&userv1.User{}, builder.WithPredicates(predicate.And(OnlyCreatePredicate{}, predicate.Funcs{
-			CreateFunc: func(createEvent event.CreateEvent) bool {
-				return createEvent.Object.GetAnnotations()[userv1.UserAnnotationOwnerKey] == createEvent.Object.GetName()
-			},
-		}))).
+		For(&userv1.User{}, builder.WithPredicates(predicate.And(OnlyCreatePredicate{}))).
 		Watches(&source.Kind{Type: &accountv1.Payment{}}, &handler.EnqueueRequestForObject{}).
 		WithOptions(rateOpts).
 		Complete(r)

--- a/controllers/account/controllers/account_controller.go
+++ b/controllers/account/controllers/account_controller.go
@@ -226,7 +226,7 @@ func (r *AccountReconciler) syncAccount(ctx context.Context, owner, accountNames
 	if err := r.syncRoleAndRoleBinding(ctx, owner, userNamespace); err != nil {
 		return nil, fmt.Errorf("sync role and rolebinding failed: %v", err)
 	}
-	err := r.initBalance(&account)
+	err := initBalance(&account)
 	if err != nil {
 		return nil, fmt.Errorf("sync init balance failed: %v", err)
 	}
@@ -256,7 +256,7 @@ func (r *AccountReconciler) syncAccount(ctx context.Context, owner, accountNames
 	}); err != nil {
 		return nil, err
 	}
-	err = r.initBalance(&account)
+	err = initBalance(&account)
 	if err != nil {
 		return nil, fmt.Errorf("sync init balance failed: %v", err)
 	}
@@ -405,7 +405,7 @@ func SyncAccountStatus(ctx context.Context, client client.Client, account *accou
 	return client.Status().Update(ctx, account)
 }
 
-func (r *AccountReconciler) initBalance(account *accountv1.Account) (err error) {
+func initBalance(account *accountv1.Account) (err error) {
 	if account.Status.EncryptBalance == nil {
 		encryptBalance, err := crypto.EncryptInt64(account.Status.Balance)
 		if err != nil {

--- a/controllers/account/controllers/billing_controller.go
+++ b/controllers/account/controllers/billing_controller.go
@@ -141,6 +141,12 @@ func (r *BillingReconciler) rechargeBalance(owner string, amount int64) (err err
 	if err = r.Get(context.Background(), types.NamespacedName{Name: owner, Namespace: r.AccountSystemNamespace}, account); err != nil {
 		return fmt.Errorf("get account cr failed: %w", err)
 	}
+	if account.Status.EncryptDeductionBalance == nil {
+		account.Status.EncryptDeductionBalance, err = crypto.EncryptInt64(0)
+		if err != nil {
+			return fmt.Errorf("encrypt balance failed: %w", err)
+		}
+	}
 	if err = crypto.RechargeBalance(account.Status.EncryptDeductionBalance, amount); err != nil {
 		return fmt.Errorf("recharge balance failed: %w", err)
 	}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 39d829f</samp>

### Summary
🗑️📝🐛

<!--
1.  🗑️ for removing unnecessary or redundant code
2.  📝 for adding comments and improving clarity
3.  🐛 for fixing errors and avoiding unnecessary calls
-->
This pull request refactors and simplifies the account controller and the billing logic for accounts, removing unused or redundant code and adding comments and checks. It also removes an unnecessary condition from the debt webhook. The changes affect the files `controllers/account/controllers/account_controller.go`, `controllers/account/controllers/billing_controller.go`, `controllers/account/controllers/billingrecordquery_controller.go`, and `controllers/account/api/v1/debt_webhook.go`.

> _Webhook, controller_
> _Refactored and simplified_
> _Autumn of dead code_

### Walkthrough
*  Remove the code that denies the admission request for Namespace kind in the debt webhook ([link](https://github.com/labring/sealos/pull/4006/files?diff=unified&w=0#diff-e240069d1b78e1e32ee1fc0d1387fbe54aea40bbaa70873d6d6ec80ee5062717L72-L74))
*  Remove the unused import of "k8s.io/apimachinery/pkg/api/resource" from the account controller ([link](https://github.com/labring/sealos/pull/4006/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L41))
*  Add comments to explain the code blocks for monitoring and initializing user resource creation data and determining the resource quota for the owner and account users ([link](https://github.com/labring/sealos/pull/4006/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4R99-R101), [link](https://github.com/labring/sealos/pull/4006/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4R221))
*  Modify the call to syncAccount to use getUsername instead of directly passing the payment.Spec.UserID ([link](https://github.com/labring/sealos/pull/4006/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L120-R122))
*  Remove the code that calls adaptNodePortCountQuota, which is no longer needed as the nodeport count quota is already included in the resource quota ([link](https://github.com/labring/sealos/pull/4006/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L203-R206), [link](https://github.com/labring/sealos/pull/4006/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L293-R302))
*  Modify the call and definition of initBalance to remove the receiver r, as the function is changed to be a standalone function instead of a method of AccountReconciler ([link](https://github.com/labring/sealos/pull/4006/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L231-R229), [link](https://github.com/labring/sealos/pull/4006/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L261-R259), [link](https://github.com/labring/sealos/pull/4006/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L410-R408))
*  Modify the predicate for the controller to watch the User resource, to remove the condition that the user annotation owner key matches the user name, which is not relevant for the account controller ([link](https://github.com/labring/sealos/pull/4006/files?diff=unified&w=0#diff-f91e0859463583de85b899a42951c93a8525a321a022031a725ffc6a7b1235e4L433-R431))
*  Add a condition to check if the consumAmount is positive before calling rechargeBalance in the billing controller, to avoid unnecessary calls and errors when the amount is zero or negative ([link](https://github.com/labring/sealos/pull/4006/files?diff=unified&w=0#diff-2cae722bbe8482079dc4646e6a3f15ef57b710f8144877a5c387cc58da4c85eeL125-R133))
*  Add a call to initBalance before updating the account status in the billing controller, to ensure that the encrypt balance is initialized if it is nil ([link](https://github.com/labring/sealos/pull/4006/files?diff=unified&w=0#diff-2cae722bbe8482079dc4646e6a3f15ef57b710f8144877a5c387cc58da4c85eeR146-R148))
*  Remove the unused import of "github.com/labring/sealos/controllers/pkg/gpu" from the billing record query controller ([link](https://github.com/labring/sealos/pull/4006/files?diff=unified&w=0#diff-86d8d3e3c5437a16535b518a2119bb44ab128dff71b975031641b945d850eb11L29))
*  Modify the call and definition of ReconcilePriceQuery to remove the dbClient parameter, as the function is changed to use the default property type list instead of querying the database for prices ([link](https://github.com/labring/sealos/pull/4006/files?diff=unified&w=0#diff-86d8d3e3c5437a16535b518a2119bb44ab128dff71b975031641b945d850eb11L89-R88), [link](https://github.com/labring/sealos/pull/4006/files?diff=unified&w=0#diff-86d8d3e3c5437a16535b518a2119bb44ab128dff71b975031641b945d850eb11L151-R150))
*  Modify the logic of ReconcilePriceQuery to use the default property type list instead of querying the database for prices, and to use the alias field of the property type to display the GPU resource name if it exists ([link](https://github.com/labring/sealos/pull/4006/files?diff=unified&w=0#diff-86d8d3e3c5437a16535b518a2119bb44ab128dff71b975031641b945d850eb11L157-R171))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
