### PR TITLE
fix: service targetport update

### DIFF
--- a/frontend/providers/applaunchpad/src/utils/deployYaml2Json.ts
+++ b/frontend/providers/applaunchpad/src/utils/deployYaml2Json.ts
@@ -220,6 +220,7 @@ export const json2Service = (data: AppEditType) => {
     spec: {
       ports: data.networks.map((item, i) => ({
         port: str2Num(item.port),
+        targetPort: str2Num(item.port),
         name: item.portName
       })),
       selector: {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a9f8dac</samp>

### Summary
🎯🚢🌉

<!--
1.  🎯 - This emoji represents the `targetPort` property, which is used to direct traffic to the right port on the pod. It also suggests the idea of hitting a target or goal, which could be related to the purpose of the service object.
2.  🚢 - This emoji represents the pod, which is the basic unit of deployment in Kubernetes and often runs a single container. It also suggests the idea of shipping or delivering something, which could be related to the function of the service object.
3.  🌉 - This emoji represents the service object, which is used to expose a set of pods to other pods or external clients. It also suggests the idea of bridging or connecting something, which could be related to the role of the service object.
-->
Add `targetPort` to service object in `deployYaml2Json.ts`. This fixes a bug where the service could not forward traffic to the correct port on the pod.

> _`targetPort` added_
> _service forwards to pod port_
> _k8s spec in spring_

### Walkthrough
*  Add `targetPort` property to service object in `deployYaml2Json.ts` to support different container and service ports ([link](https://github.com/labring/sealos/pull/4011/files?diff=unified&w=0#diff-9ab86159facb4b23aba0fce56898aa5ad9d4b2347685afe9ac476f763b8e1a63R223))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
