### PR TITLE
fix(main): delete clean_unused_func

### DIFF
--- a/pkg/runtime/kubernetes/init.go
+++ b/pkg/runtime/kubernetes/init.go
@@ -68,10 +68,6 @@ func (k *KubeadmRuntime) GenerateCert() error {
 	)
 }
 
-func (k *KubeadmRuntime) SendNewCertAndKeyToMasters() error {
-	return k.sendNewCertAndKey(k.getMasterIPAndPortList())
-}
-
 func (k *KubeadmRuntime) CreateKubeConfigFiles() error {
 	logger.Info("start to create kubeconfig...")
 	hostName, err := k.execHostname(k.getMaster0IPAndPort())


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ce50eb8</samp>

### Summary
🗑️🔀🔐

<!--
1.  🗑️ - This emoji represents the deletion of the method, which is no longer needed.
2.  🔀 - This emoji represents the relocation of the functionality, which was moved to another command.
3.  🔐 - This emoji represents the certificate and key generation, which is the main purpose of the method.
-->
Removed `SendNewCertAndKeyToMasters` method from `KubeadmRuntime` struct. Simplified certificate distribution logic by using `sealos join` command.

> _`SendNewCertAndKey`_
> _Moved to `sealos join` command_
> _No more duplication_

### Walkthrough
*  Remove `SendNewCertAndKeyToMasters` method from `KubeadmRuntime` struct ([link](https://github.com/labring/sealos/pull/4017/files?diff=unified&w=0#diff-6163e31171d376412c35c8701bac0c34ef8a1ca248ba51c3a22b925e6e67f736L71-L74))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
