### PR TITLE
fix: sync cert failed on non default port

### DIFF
--- a/pkg/runtime/update_cert.go
+++ b/pkg/runtime/update_cert.go
@@ -141,7 +141,7 @@ func (k *KubeadmRuntime) initCert() error {
 }
 
 func (k *KubeadmRuntime) syncCert() error {
-	for _, master := range k.getMasterIPList()[1:] {
+	for _, master := range k.getMasterIPAndPortList()[1:] {
 		logger.Debug("start to generate cert for master %s", master)
 		err := k.execCert(master)
 		if err != nil {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a17c042</samp>

### Summary
🔧🔐🌐

<!--
1.  🔧 - This emoji represents a wrench, which can be used to indicate a configuration or setup change. In this case, the change involves using a different function to get the master node information with custom ports.
2.  🔐 - This emoji represents a lock, which can be used to indicate a security or encryption change. In this case, the change affects the certificate generation and distribution process, which is related to the cluster's authentication and communication security.
3.  🌐 - This emoji represents a globe, which can be used to indicate a network or internet change. In this case, the change involves the use of different ports for the API server and etcd endpoints, which are related to the cluster's network connectivity and data storage.
-->
Use master node ports for certificate generation and distribution. This allows customizing the API server and etcd ports for different cluster setups. The change affects the `syncCert` function in `pkg/runtime/update_cert.go`.

> _`getMasterIPAndPortList`_
> _Custom ports for nodes_
> _Autumn leaves fall, sync certs_

### Walkthrough
* Use custom ports for API server and etcd endpoints in certificate generation and distribution ([link](https://github.com/labring/sealos/pull/4034/files?diff=unified&w=0#diff-b9346ab0b059d899b51c5743163c8ab95bc73fb4dedc926e6bd683db2777f207L144-R144))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
