### PR TITLE
feat:modify the format of the exported file

### DIFF
--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/Header.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/Header.tsx
@@ -27,15 +27,12 @@ const Header = ({
   const { lastRoute } = useGlobalStore();
 
   const handleExportYaml = useCallback(async () => {
-    const zip = new JSZip();
-    yamlList.forEach((item) => {
-      zip.file(item.filename, item.value);
-    });
-    const res = await zip.generateAsync({ type: 'blob' });
+    const exportYamlString = yamlList.map((i) => i.value).join('---\n');
+    if (!exportYamlString) return;
     downLoadBold(
-      res,
-      'application/zip',
-      appName ? `${appName}.zip` : `yaml${dayjs().format('YYYYMMDDHHmmss')}.zip`
+      exportYamlString,
+      'application/yaml',
+      appName ? `${appName}.yaml` : `yaml${dayjs().format('YYYYMMDDHHmmss')}.yaml`
     );
   }, [appName, yamlList]);
 

--- a/frontend/providers/cronjob/src/utils/user.ts
+++ b/frontend/providers/cronjob/src/utils/user.ts
@@ -41,5 +41,5 @@ export const getUserNamespace = () => {
 export const getUserServiceAccount = () => {
   const kubeConfig = getUserKubeConfig();
   const json = yaml.load(kubeConfig) as KC;
-  return json?.contexts[0]?.context?.namespace?.replace('ns-', '') || `${json?.users[0]?.name}`;
+  return json?.contexts[0]?.context?.user || json?.users[0]?.name;
 };

--- a/frontend/providers/template/src/pages/deploy/components/Header.tsx
+++ b/frontend/providers/template/src/pages/deploy/components/Header.tsx
@@ -26,15 +26,12 @@ const Header = ({
   const { t } = useTranslation();
 
   const handleExportYaml = useCallback(async () => {
-    const zip = new JSZip();
-    yamlList.forEach((item) => {
-      zip.file(item.filename, item.value);
-    });
-    const res = await zip.generateAsync({ type: 'blob' });
+    const exportYamlString = yamlList.map((i) => i.value).join('---\n');
+    if (!exportYamlString) return;
     downLoadBold(
-      res,
-      'application/zip',
-      appName ? `${appName}.zip` : `yaml${dayjs().format('YYYYMMDDHHmmss')}.zip`
+      exportYamlString,
+      'application/yaml',
+      appName ? `${appName}.yaml` : `yaml${dayjs().format('YYYYMMDDHHmmss')}.yaml`
     );
   }, [appName, yamlList]);
 
@@ -49,8 +46,7 @@ const Header = ({
       w={'100%'}
       h={'80px'}
       alignItems={'center'}
-      backgroundColor={'rgba(255, 255, 255, 0.90)'}
-    >
+      backgroundColor={'rgba(255, 255, 255, 0.90)'}>
       <Flex
         boxShadow={'0px 1px 2px 0.5px rgba(84, 96, 107, 0.20)'}
         flexShrink={0}
@@ -60,8 +56,7 @@ const Header = ({
         h={'80px'}
         borderRadius={'8px'}
         backgroundColor={'#FBFBFC'}
-        border={' 1px solid rgba(255, 255, 255, 0.50)'}
-      >
+        border={' 1px solid rgba(255, 255, 255, 0.50)'}>
         <Image src={templateDetail?.spec?.icon} alt="" width={'60px'} height={'60px'} />
       </Flex>
       <Flex ml={'24px'} w="520px" flexDirection={'column'}>
@@ -83,8 +78,7 @@ const Header = ({
           mt={'8px'}
           fontSize={'12px'}
           color={'5A646E'}
-          fontWeight={400}
-        >
+          fontWeight={400}>
           {templateDetail?.spec?.description}
         </Text>
       </Flex>
@@ -98,8 +92,7 @@ const Header = ({
         bg={'myWhite.600'}
         borderColor={'myGray.200'}
         variant={'base'}
-        onClick={handleExportYaml}
-      >
+        onClick={handleExportYaml}>
         {t('Export')} Yaml
       </Button>
       <Button px={4} minW={'140px'} h={'40px'} variant={'primary'} onClick={applyCb}>

--- a/frontend/providers/template/src/pages/deploy/index.tsx
+++ b/frontend/providers/template/src/pages/deploy/index.tsx
@@ -252,8 +252,7 @@ export default function EditApp({ appName, tabType }: { appName?: string; tabTyp
       overflow={'auto'}
       position={'relative'}
       borderRadius={'12px'}
-      background={'linear-gradient(180deg, #FFF 0%, rgba(255, 255, 255, 0.70) 100%)'}
-    >
+      background={'linear-gradient(180deg, #FFF 0%, rgba(255, 255, 255, 0.70) 100%)'}>
       <Flex
         zIndex={99}
         position={'sticky'}
@@ -265,15 +264,13 @@ export default function EditApp({ appName, tabType }: { appName?: string; tabTyp
         justifyContent={'start'}
         alignItems={'center'}
         backgroundColor={'rgba(255, 255, 255)'}
-        backdropBlur={'100px'}
-      >
+        backdropBlur={'100px'}>
         <Flex
           alignItems={'center'}
           fontWeight={500}
           fontSize={16}
           color={'#7B838B'}
-          cursor={'pointer'}
-        >
+          cursor={'pointer'}>
           <Flex
             alignItems={'center'}
             css={{
@@ -284,16 +281,14 @@ export default function EditApp({ appName, tabType }: { appName?: string; tabTyp
                   fill: '#219BF4'
                 }
               }
-            }}
-          >
+            }}>
             <Icon
               ml={'19px'}
               viewBox="0 0 15 15"
               fill={'#24282C'}
               w={'15px'}
               h="15px"
-              onClick={() => router.push('/')}
-            >
+              onClick={() => router.push('/')}>
               <path d="M9.1875 13.1875L3.92187 7.9375C3.85937 7.875 3.81521 7.80729 3.78937 7.73438C3.76312 7.66146 3.75 7.58333 3.75 7.5C3.75 7.41667 3.76312 7.33854 3.78937 7.26562C3.81521 7.19271 3.85937 7.125 3.92187 7.0625L9.1875 1.79687C9.33333 1.65104 9.51562 1.57812 9.73438 1.57812C9.95312 1.57812 10.1406 1.65625 10.2969 1.8125C10.4531 1.96875 10.5312 2.15104 10.5312 2.35938C10.5312 2.56771 10.4531 2.75 10.2969 2.90625L5.70312 7.5L10.2969 12.0938C10.4427 12.2396 10.5156 12.4192 10.5156 12.6325C10.5156 12.8463 10.4375 13.0312 10.2812 13.1875C10.125 13.3438 9.94271 13.4219 9.73438 13.4219C9.52604 13.4219 9.34375 13.3438 9.1875 13.1875Z" />
             </Icon>
             <Text ml="4px" onClick={() => router.push('/')}>
@@ -303,8 +298,7 @@ export default function EditApp({ appName, tabType }: { appName?: string; tabTyp
           <Text px="6px">/</Text>
           <Text
             _hover={{ fill: '#219BF4', color: '#219BF4' }}
-            color={router.pathname === '/deploy' ? '#262A32' : '#7B838B'}
-          >
+            color={router.pathname === '/deploy' ? '#262A32' : '#7B838B'}>
             {data?.templateYaml?.metadata?.name}
           </Text>
         </Flex>
@@ -315,8 +309,7 @@ export default function EditApp({ appName, tabType }: { appName?: string; tabTyp
           flexDirection={'column'}
           width={'100%'}
           flexGrow={1}
-          backgroundColor={'rgba(255, 255, 255, 0.90)'}
-        >
+          backgroundColor={'rgba(255, 255, 255, 0.90)'}>
           <Header
             templateDetail={data?.templateYaml!}
             appName={''}

--- a/frontend/providers/template/src/pages/develop/index.tsx
+++ b/frontend/providers/template/src/pages/develop/index.tsx
@@ -85,8 +85,9 @@ export default function Develop() {
   const parseTemplate = (str: string) => {
     try {
       const result = getYamlSource(str);
+      const defaultInputes = getTemplateDefaultValues(result);
       setYamlSource(result);
-      const correctYaml = generateCorrectYaml(result);
+      const correctYaml = generateCorrectYaml(result, defaultInputes);
       setYamlList(developGenerateYamlList(correctYaml, detailName));
     } catch (error: any) {
       toast({
@@ -167,12 +168,13 @@ export default function Develop() {
   };
 
   const handleExportYaml = useCallback(async () => {
-    const zip = new JSZip();
-    yamlList.forEach((item) => {
-      zip.file(item.filename, item.value);
-    });
-    const res = await zip.generateAsync({ type: 'blob' });
-    downLoadBold(res, 'application/zip', `yaml${dayjs().format('YYYYMMDDHHmmss')}.zip`);
+    const exportYamlString = yamlList.map((i) => i.value).join('---\n');
+    if (!exportYamlString) return;
+    downLoadBold(
+      exportYamlString,
+      'application/yaml',
+      `yaml${dayjs().format('YYYYMMDDHHmmss')}.yaml`
+    );
   }, [yamlList]);
 
   return (
@@ -183,8 +185,7 @@ export default function Develop() {
         borderRadius={'8px'}
         overflowY={'hidden'}
         overflowX={'scroll'}
-        flex={1}
-      >
+        flex={1}>
         {/* left */}
         <Flex flexDirection={'column'} w="50%" borderRight={'1px solid #EFF0F1'}>
           <Flex
@@ -194,8 +195,7 @@ export default function Develop() {
             alignItems={'center'}
             backgroundColor={'#F8FAFB'}
             px="36px"
-            borderRadius={'8px 8px 0px 0px '}
-          >
+            borderRadius={'8px 8px 0px 0px '}>
             <MyIcon name="dev" color={'#24282C'} w={'24px'} h={'24px'}></MyIcon>
             <Text fontWeight={'500'} fontSize={'16px'} color={'#24282C'} ml="8px">
               {t('develop.Development')}
@@ -223,8 +223,7 @@ export default function Develop() {
             alignItems={'center'}
             backgroundColor={'#F8FAFB'}
             pl="42px"
-            borderRadius={'8px 8px 0px 0px '}
-          >
+            borderRadius={'8px 8px 0px 0px '}>
             <MyIcon name="eyeShow" color={'#24282C'} w={'24px'} h={'24px'}></MyIcon>
             <Text fontWeight={'500'} fontSize={'16px'} color={'#24282C'} ml="8px">
               {t('develop.Preview')}
@@ -236,8 +235,7 @@ export default function Develop() {
               pt="26px"
               pr={{ sm: '20px', md: '60px' }}
               borderBottom={'1px solid #EFF0F1'}
-              flexDirection={'column'}
-            >
+              flexDirection={'column'}>
               <Text fontWeight={'500'} fontSize={'18px'} color={'#24282C'}>
                 {t('develop.Configure Form')}
               </Text>
@@ -253,8 +251,7 @@ export default function Develop() {
                   minW={'100px'}
                   h={'34px'}
                   variant={'link'}
-                  onClick={handleExportYaml}
-                >
+                  onClick={handleExportYaml}>
                   {t('Export')} Yaml
                 </Button>
               </Flex>

--- a/frontend/providers/template/src/types/app.ts
+++ b/frontend/providers/template/src/types/app.ts
@@ -7,6 +7,7 @@ export type TemplateType = {
   spec: {
     gitRepo: string; // new
     templateType: 'inline'; // new
+    template_type?: string;
     author: string;
     title: string;
     url: string;

--- a/frontend/providers/template/src/utils/json-yaml.ts
+++ b/frontend/providers/template/src/utils/json-yaml.ts
@@ -150,7 +150,7 @@ export const handleTemplateToInstanceYaml = (
   instanceName: string
 ): TemplateInstanceType => {
   const {
-    spec: { gitRepo, templateType, ...resetSpec }
+    spec: { gitRepo, templateType, template_type, ...resetSpec }
   } = template;
 
   return {
@@ -161,7 +161,7 @@ export const handleTemplateToInstanceYaml = (
     },
     spec: {
       gitRepo: gitRepo,
-      templateType: templateType,
+      templateType: templateType || template_type,
       ...resetSpec
     }
   };


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3b2b8c2</samp>

### Summary
📄🐛🆕

<!--
1.  📄 - This emoji represents the change from exporting a ZIP file to exporting a single YAML file, which is a document format.
2. 🐛 - This emoji represents the bug fix in the `getUserServiceAccount` function, which was returning the wrong value for the service account name.
3. 🆕 - This emoji represents the addition of the `template_type` field to the `TemplateType` type definition and the `handleTemplateToInstanceYaml` function, which is a new feature that supports the backend.
-->
This pull request modifies the frontend code of several providers to export a single YAML file instead of a ZIP file when exporting templates or applications. This simplifies the export process and removes the dependency on JSZip. It also adds support for the new template type attribute in the backend and fixes a bug in the cronjob provider.

> _We're sailing on the code sea, me hearties_
> _We're exporting YAML files with ease_
> _We've fixed some bugs and added some features_
> _We're pulling and pushing on the count of three_

### Walkthrough
*  Simplified the export process of YAML files by removing the dependency on JSZip and exporting a single YAML file instead of a ZIP file containing multiple YAML files ([link](https://github.com/labring/sealos/pull/4040/files?diff=unified&w=0#diff-2f3845d19612259d3e58faffb9977cee54c5f65b51eed7276fe55ba93854055cL30-R35), [link](https://github.com/labring/sealos/pull/4040/files?diff=unified&w=0#diff-74e48c410474b0d87712e4aafe0ec2d97f103fce4db5023b487d2b7eeaa3566eL29-R34), [link](https://github.com/labring/sealos/pull/4040/files?diff=unified&w=0#diff-073ebdbc11446d7181ee4c02c0ea8ac50587ffb816c91ab532043fbaed052557L170-R177))
* Fixed a bug in the `getUserServiceAccount` function in the `user.ts` file by returning the user field from the context object instead of the namespace field ([link](https://github.com/labring/sealos/pull/4040/files?diff=unified&w=0#diff-e79d08843fb00e3a50c8be1e68442a61d5c631ce14afcf31a73aa48efb63f54bL44-R44))
* Added the `template_type` field to the `TemplateType` type definition in the `app.ts` file and the `handleTemplateToInstanceYaml` function in the `json-yaml.ts` file to support the new template type attribute that was introduced in the backend ([link](https://github.com/labring/sealos/pull/4040/files?diff=unified&w=0#diff-5022674d335f1796167a700b53c0d01fcb3da92b147e8820842fa511db8fab13R10), [link](https://github.com/labring/sealos/pull/4040/files?diff=unified&w=0#diff-84d51e848aedd9529ced2c91ab00024c3cc957d43afd780865ec66f81ce91ff4L153-R153), [link](https://github.com/labring/sealos/pull/4040/files?diff=unified&w=0#diff-84d51e848aedd9529ced2c91ab00024c3cc957d43afd780865ec66f81ce91ff4L164-R164))
* Improved the user experience by providing sensible defaults for the template inputs using the `defaultInputes` variable and the `generateCorrectYaml` function in the `index.tsx` file ([link](https://github.com/labring/sealos/pull/4040/files?diff=unified&w=0#diff-073ebdbc11446d7181ee4c02c0ea8ac50587ffb816c91ab532043fbaed052557L88-R90))
* Moved the `>` character to the previous line in several files to follow the code style convention of the project ([link](https://github.com/labring/sealos/pull/4040/files?diff=unified&w=0#diff-74e48c410474b0d87712e4aafe0ec2d97f103fce4db5023b487d2b7eeaa3566eL52-R49), [link](https://github.com/labring/sealos/pull/4040/files?diff=unified&w=0#diff-74e48c410474b0d87712e4aafe0ec2d97f103fce4db5023b487d2b7eeaa3566eL63-R59), [link](https://github.com/labring/sealos/pull/4040/files?diff=unified&w=0#diff-74e48c410474b0d87712e4aafe0ec2d97f103fce4db5023b487d2b7eeaa3566eL86-R81), [link](https://github.com/labring/sealos/pull/4040/files?diff=unified&w=0#diff-74e48c410474b0d87712e4aafe0ec2d97f103fce4db5023b487d2b7eeaa3566eL101-R95), [link](https://github.com/labring/sealos/pull/4040/files?diff=unified&w=0#diff-888bad66256fa519d098cf0f7ddf7eefbbc28b132220094e3ec079c2fae4125aL255-R255), [link](https://github.com/labring/sealos/pull/4040/files?diff=unified&w=0#diff-888bad66256fa519d098cf0f7ddf7eefbbc28b132220094e3ec079c2fae4125aL268-R267), [link](https://github.com/labring/sealos/pull/4040/files?diff=unified&w=0#diff-888bad66256fa519d098cf0f7ddf7eefbbc28b132220094e3ec079c2fae4125aL275-R273), [link](https://github.com/labring/sealos/pull/4040/files?diff=unified&w=0#diff-888bad66256fa519d098cf0f7ddf7eefbbc28b132220094e3ec079c2fae4125aL287-R284), [link](https://github.com/labring/sealos/pull/4040/files?diff=unified&w=0#diff-888bad66256fa519d098cf0f7ddf7eefbbc28b132220094e3ec079c2fae4125aL295-R291), [link](https://github.com/labring/sealos/pull/4040/files?diff=unified&w=0#diff-888bad66256fa519d098cf0f7ddf7eefbbc28b132220094e3ec079c2fae4125aL306-R301), [link](https://github.com/labring/sealos/pull/4040/files?diff=unified&w=0#diff-888bad66256fa519d098cf0f7ddf7eefbbc28b132220094e3ec079c2fae4125aL318-R312), [link](https://github.com/labring/sealos/pull/4040/files?diff=unified&w=0#diff-073ebdbc11446d7181ee4c02c0ea8ac50587ffb816c91ab532043fbaed052557L186-R188), [link](https://github.com/labring/sealos/pull/4040/files?diff=unified&w=0#diff-073ebdbc11446d7181ee4c02c0ea8ac50587ffb816c91ab532043fbaed052557L197-R198), [link](https://github.com/labring/sealos/pull/4040/files?diff=unified&w=0#diff-073ebdbc11446d7181ee4c02c0ea8ac50587ffb816c91ab532043fbaed052557L226-R226), [link](https://github.com/labring/sealos/pull/4040/files?diff=unified&w=0#diff-073ebdbc11446d7181ee4c02c0ea8ac50587ffb816c91ab532043fbaed052557L239-R238), [link](https://github.com/labring/sealos/pull/4040/files?diff=unified&w=0#diff-073ebdbc11446d7181ee4c02c0ea8ac50587ffb816c91ab532043fbaed052557L256-R254))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
