### PR TITLE
fix: if string addr has not colon

### DIFF
--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -28,6 +28,7 @@ import (
 	"github.com/labring/sealos/pkg/ssh"
 	"github.com/labring/sealos/pkg/unshare"
 	fileutil "github.com/labring/sealos/pkg/utils/file"
+	"github.com/labring/sealos/pkg/utils/iputils"
 	"github.com/labring/sealos/pkg/utils/logger"
 	netutil "github.com/labring/sealos/pkg/utils/net"
 )
@@ -138,10 +139,7 @@ func (w *wrap) isLocal(addr string) bool {
 	if unshare.IsRootless() {
 		return false
 	}
-	host, _, err := net.SplitHostPort(addr)
-	if err != nil {
-		return false
-	}
+	host := iputils.GetHostIP(addr)
 	if host == "localhost" || host == "127.0.0.1" || w.localAddresses.Has(host) {
 		return true
 	}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1583a8d</samp>

### Summary
📦🛠️🚀

<!--
1.  📦 This emoji can be used to indicate that a new package or dependency was added to the project, in this case `iputils`.
2.  🛠️ This emoji can be used to indicate that a bug or issue was fixed or improved, in this case the `isLocal` function logic and error handling.
3.  🚀 This emoji can be used to indicate that a feature or enhancement was added or improved, in this case the ability to handle different address formats and extract host IP.
-->
Improved host IP detection in `isLocal` function. Added `iputils` package and handled various address formats in `pkg/exec/exec.go`.

> _`iputils` is the key to our salvation_
> _We can parse any address in creation_
> _No more errors in our `isLocal` function_
> _We are the masters of network detection_

### Walkthrough
* Import `iputils` package to use `GetHostIP` function for extracting host IP from address strings ([link](https://github.com/labring/sealos/pull/4045/files?diff=unified&w=0#diff-cfdf1e880709b8205cdd9d561b0db1eff5f23e36ea1a2863090957eac4c46e65R31))
* Refactor `isLocal` function to use `GetHostIP` instead of `net.SplitHostPort` for more robust and consistent address parsing ([link](https://github.com/labring/sealos/pull/4045/files?diff=unified&w=0#diff-cfdf1e880709b8205cdd9d561b0db1eff5f23e36ea1a2863090957eac4c46e65L141-R142))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
