### PR TITLE
fix(4.3): revert cert feature

### DIFF
--- a/pkg/runtime/init.go
+++ b/pkg/runtime/init.go
@@ -73,6 +73,10 @@ func (k *KubeadmRuntime) GenerateCert() error {
 	return k.sendNewCertAndKey([]string{k.getMaster0IPAndPort()})
 }
 
+func (k *KubeadmRuntime) SendNewCertAndKeyToMasters() error {
+	return k.sendNewCertAndKey(k.getMasterIPAndPortList())
+}
+
 func (k *KubeadmRuntime) CreateKubeConfig() error {
 	logger.Info("start to create kubeconfig...")
 	hostName, err := k.execHostname(k.getMaster0IPAndPort())

--- a/pkg/runtime/update_cert.go
+++ b/pkg/runtime/update_cert.go
@@ -130,29 +130,12 @@ func (k *KubeadmRuntime) UpdateCertByInit() error {
 func (k *KubeadmRuntime) initCert() error {
 	pipeline := []func() error{
 		k.GenerateCert,
-		k.syncCert,
+		k.SendNewCertAndKeyToMasters,
 	}
 	for _, f := range pipeline {
 		if err := f(); err != nil {
 			return fmt.Errorf("failed to generate cert %v", err)
 		}
-	}
-	return nil
-}
-
-func (k *KubeadmRuntime) syncCert() error {
-	for _, master := range k.getMasterIPAndPortList()[1:] {
-		logger.Debug("start to generate cert for master %s", master)
-		err := k.execCert(master)
-		if err != nil {
-			return fmt.Errorf("failed to create cert for master %s: %v", master, err)
-		}
-
-		err = k.copyMasterKubeConfig(master)
-		if err != nil {
-			return err
-		}
-		logger.Info("succeeded generate cert %s as master", master)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fc69ef3</samp>

### Summary
📨🔐🚀

<!--
1.  📨 - This emoji represents the sending of the new certificate and key to the master nodes. It conveys the idea of communication and delivery of the files.
2.  🔐 - This emoji represents the security and encryption of the certificate and key. It conveys the idea of protection and confidentiality of the data.
3.  🚀 - This emoji represents the performance and speed of the new function. It conveys the idea of efficiency and improvement of the certificate renewal process.
-->
This pull request refactors the certificate renewal logic for the master nodes in the cluster. It introduces a new function `SendNewCertAndKeyToMasters` in `pkg/runtime/init.go` that uses a more efficient method of sending the certificate and key files to the nodes. It also modifies `pkg/runtime/update_cert.go` to use this function instead of the previous `syncCert` function.

> _Oh we're the kubeadm crew and we've got a job to do_
> _We're renewing certs and keys for all the masters in the sea_
> _We've got a new function `SendNewCertAndKeyToMasters`_
> _And we'll call it on the count of three_

### Walkthrough
*  Refactor certificate renewal logic to use a new function `SendNewCertAndKeyToMasters` ([link](https://github.com/labring/sealos/pull/4053/files?diff=unified&w=0#diff-a5c5c72ff847a1c3d9046186d31b3d04e935aa9408b40f79567cccadb57ef793R76-R79), [link](https://github.com/labring/sealos/pull/4053/files?diff=unified&w=0#diff-b9346ab0b059d899b51c5743163c8ab95bc73fb4dedc926e6bd683db2777f207L133-R133))
  - Remove redundant and inefficient `syncCert` function from `pkg/runtime/update_cert.go` ([link](https://github.com/labring/sealos/pull/4053/files?diff=unified&w=0#diff-b9346ab0b059d899b51c5743163c8ab95bc73fb4dedc926e6bd683db2777f207L143-L159))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
