### PR TITLE
update kb 0.6.2

### DIFF
--- a/service/database/api/req.go
+++ b/service/database/api/req.go
@@ -71,11 +71,11 @@ var (
 		"db_size": "pg_database_size_bytes{namespace=~\"#\", app_kubernetes_io_instance=~\"@\"}",
 
 		"active_connections": " pg_stat_activity_count{namespace=~\"#\", app_kubernetes_io_instance=~\"@\",state=\"active\"}",
-		"rollbacks":          "rate (pg_stat_database_xact_rollback{namespace=~\"#\", app_kubernetes_io_instance=~\"@\"}[1m])",
-		"commits":            "rate (pg_stat_database_xact_commit{namespace=~\"#\", app_kubernetes_io_instance=~\"@\"}[1m])",
+		"rollbacks":          "rate (pg_stat_database_xact_rollback_total{namespace=~\"#\", app_kubernetes_io_instance=~\"@\"}[1m])",
+		"commits":            "rate (pg_stat_database_xact_commit_total{namespace=~\"#\", app_kubernetes_io_instance=~\"@\"}[1m])",
 		"tx_duration":        "max without(state) (max_over_time(pg_stat_activity_max_tx_duration{namespace=~\"#\", app_kubernetes_io_instance=~\"@\"}[1m]))",
-		"block_read_time":    "rate(pg_stat_database_blk_read_time{namespace=~\"#\", app_kubernetes_io_instance=~\"@\"}[1m])",
-		"block_write_time":   "rate(pg_stat_database_blk_write_time{namespace=~\"#\", app_kubernetes_io_instance=~\"@\"}[1m])",
+		"block_read_time":    "rate(pg_stat_database_blk_read_time_total{namespace=~\"#\", app_kubernetes_io_instance=~\"@\"}[1m])",
+		"block_write_time":   "rate(pg_stat_database_blk_write_time_total{namespace=~\"#\", app_kubernetes_io_instance=~\"@\"}[1m])",
 	}
 
 	Mongo = map[string]string{


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9e8ad5c</samp>

### Summary
📊🐘🛠️

<!--
1.  📊 This emoji represents the Prometheus metrics and the changes to the names and queries.
2.  🐘 This emoji represents the PostgreSQL database and the exporter that exposes its metrics.
3.  🛠️ This emoji represents the fix for the compatibility issues and the improvement of the naming conventions.
-->
Update database metric names to match postgres-exporter v0.10.0. Rename Prometheus metrics in `service/database/api/req.go` to use the `_total` suffix.

> _Metrics renamed_
> _`_total` suffix added_
> _Autumn of exporter_

### Walkthrough
*  Update Prometheus metric names to use `_total` suffix ([link](https://github.com/labring/sealos/pull/4059/files?diff=unified&w=0#diff-2feebedc3d95ea1941d9d70c24e408296a0bc1e9ff1c3126481cc4893455eb16L74-R78))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
