### PR TITLE
fix: make the usage of '--env' flag more precisely

### DIFF
--- a/cmd/sealos/cmd/gen.go
+++ b/cmd/sealos/cmd/gen.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/labring/sealos/pkg/apply"
+	"github.com/labring/sealos/pkg/utils/logger"
 )
 
 var exampleGen = `
@@ -65,6 +66,7 @@ func newGenCmd() *cobra.Command {
 			var outputWriter io.WriteCloser
 			switch out {
 			case "", "stdout":
+				logger.Info("if you want to save the output of gen command, use '--output' option instead of redirecting to file")
 				outputWriter = os.Stdout
 			default:
 				outputWriter, err = os.Create(out)

--- a/pkg/apply/args.go
+++ b/pkg/apply/args.go
@@ -65,7 +65,7 @@ type RunArgs struct {
 func (arg *RunArgs) RegisterFlags(fs *pflag.FlagSet) {
 	arg.Cluster.RegisterFlags(fs, "run with", "run")
 	arg.SSH.RegisterFlags(fs)
-	fs.StringSliceVarP(&arg.CustomEnv, "env", "e", []string{}, "environment variables to set during command execution")
+	fs.StringSliceVarP(&arg.CustomEnv, "env", "e", []string{}, "environment variables to be set for images")
 	fs.StringSliceVar(&arg.CustomCMD, "cmd", []string{}, "override CMD directive in images")
 	fs.StringSliceVar(&arg.CustomConfigFiles, "config-file", []string{}, "path of custom config files, to use to replace the resource")
 }
@@ -80,7 +80,7 @@ type Args struct {
 func (arg *Args) RegisterFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVar(&arg.Values, "values", []string{}, "values file to apply into Clusterfile")
 	fs.StringSliceVar(&arg.Sets, "set", []string{}, "set values on the command line")
-	fs.StringSliceVar(&arg.CustomEnv, "env", []string{}, "environment variables to set during command execution")
+	fs.StringSliceVar(&arg.CustomEnv, "env", []string{}, "environment variables to be set for images")
 	fs.StringSliceVar(&arg.CustomConfigFiles, "config-file", []string{}, "path of custom config files, to use to replace the resource")
 }
 

--- a/pkg/apply/gen.go
+++ b/pkg/apply/gen.go
@@ -26,6 +26,7 @@ import (
 	"github.com/labring/sealos/pkg/runtime/factory"
 	"github.com/labring/sealos/pkg/types/v1beta1"
 	"github.com/labring/sealos/pkg/utils/iputils"
+	"github.com/labring/sealos/pkg/utils/logger"
 )
 
 func NewClusterFromGenArgs(cmd *cobra.Command, args *RunArgs, imageNames []string) ([]byte, error) {
@@ -42,6 +43,11 @@ func NewClusterFromGenArgs(cmd *cobra.Command, args *RunArgs, imageNames []strin
 
 	if err := c.runArgs(cmd, args, imageNames); err != nil {
 		return nil, err
+	}
+	if flagChanged(cmd, "env") {
+		logger.Info("setting global envs for cluster, will be used in all run commands later")
+		v, _ := cmd.Flags().GetStringSlice("env")
+		cluster.Spec.Env = append(cluster.Spec.Env, v...)
 	}
 
 	img, err := genImageInfo(imageNames[0])

--- a/pkg/clusterfile/clusterfile.go
+++ b/pkg/clusterfile/clusterfile.go
@@ -31,7 +31,6 @@ type ClusterFile struct {
 	customValues             []string
 	customSets               []string
 	customEnvs               []string
-	setDefaults              bool
 
 	cluster       *v2.Cluster
 	configs       []v2.Config
@@ -60,12 +59,6 @@ func (c *ClusterFile) GetRuntimeConfig() runtime.Config {
 }
 
 type OptionFunc func(*ClusterFile)
-
-func WithSetDefaults(v bool) OptionFunc {
-	return func(c *ClusterFile) {
-		c.setDefaults = v
-	}
-}
 
 func WithCustomConfigFiles(files []string) OptionFunc {
 	return func(c *ClusterFile) {

--- a/pkg/clusterfile/pre_process.go
+++ b/pkg/clusterfile/pre_process.go
@@ -17,8 +17,6 @@ package clusterfile
 import (
 	"bytes"
 	"errors"
-	"os"
-	"strings"
 
 	"helm.sh/helm/v3/pkg/cli/values"
 	"helm.sh/helm/v3/pkg/getter"
@@ -45,12 +43,6 @@ func (c *ClusterFile) Process() (err error) {
 	}
 	c.once.Do(func() {
 		err = func() error {
-			for i := range c.customEnvs {
-				kv := strings.SplitN(c.customEnvs[i], "=", 2)
-				if len(kv) == 2 {
-					_ = os.Setenv(kv[0], kv[1])
-				}
-			}
 			clusterFileData, err := c.loadClusterFile()
 			if err != nil {
 				return err
@@ -161,7 +153,7 @@ func (c *ClusterFile) DecodeRuntimeConfig(data []byte) error {
 	if cfg != nil {
 		c.runtimeConfig = cfg
 	} else {
-		kubeadmConfig, err := types.LoadKubeadmConfigs(string(data), c.setDefaults, decode.CRDFromString)
+		kubeadmConfig, err := types.LoadKubeadmConfigs(string(data), false, decode.CRDFromString)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5b96fb6</samp>

### Summary
🌟📝🧹

<!--
1.  🌟 - This emoji represents the enhancement of the gen command and the use of a consistent logger package. It suggests that the change adds some new or improved functionality or quality to the sealos tool.
2.  📝 - This emoji represents the update of the descriptions of the env flag for the apply and gen commands. It suggests that the change modifies some documentation or comments to clarify the meaning or usage of the flag.
3.  🧹 - This emoji represents the simplification of the ClusterFile type and the clusterfile package, as well as the removal of unused or unnecessary code. It suggests that the change cleans up some code or reduces complexity or redundancy.
-->
This pull request improves the sealos gen command and the clusterfile package by using consistent logging, simplifying the code, and clarifying the flags. It also fixes a bug in the gen command related to default values for kubeadm configs.

> _The sealos gen command got a boost_
> _With logger and output to choose_
> _The env flag is clear_
> _The clusterfile is sheer_
> _And kubeadm configs don't get reduced_

### Walkthrough
* Import logger package and add log messages for gen command ([link](https://github.com/labring/sealos/pull/4060/files?diff=unified&w=0#diff-5203ef43da3f65a8c3b52759666c99e1dbc2d3cbf31ed235deee1be99f6ec546R26), [link](https://github.com/labring/sealos/pull/4060/files?diff=unified&w=0#diff-5203ef43da3f65a8c3b52759666c99e1dbc2d3cbf31ed235deee1be99f6ec546R69), [link](https://github.com/labring/sealos/pull/4060/files?diff=unified&w=0#diff-b4c7028460ee8a2207d8376a99e5b1ad4cc3db7178e77f2e1038ea0fff506eb2R24), [link](https://github.com/labring/sealos/pull/4060/files?diff=unified&w=0#diff-b4c7028460ee8a2207d8376a99e5b1ad4cc3db7178e77f2e1038ea0fff506eb2R47-R51))
* Modify description of env flag in apply and gen commands to clarify its usage ([link](https://github.com/labring/sealos/pull/4060/files?diff=unified&w=0#diff-8334468083024c8eb7d789fe2f25d57044fb7681d69ee9a78404c6adf237b1c4L68-R68), [link](https://github.com/labring/sealos/pull/4060/files?diff=unified&w=0#diff-8334468083024c8eb7d789fe2f25d57044fb7681d69ee9a78404c6adf237b1c4L83-R83))
* Append global environment variables from env flag to cluster spec ([link](https://github.com/labring/sealos/pull/4060/files?diff=unified&w=0#diff-b4c7028460ee8a2207d8376a99e5b1ad4cc3db7178e77f2e1038ea0fff506eb2R47-R51))
* Remove setDefaults field and option from `ClusterFile` type and `LoadKubeadmConfigs` function, as it is no longer needed ([link](https://github.com/labring/sealos/pull/4060/files?diff=unified&w=0#diff-bbe780a26fb3a849fd5602523d26cf161d00af8fff5530e6929966325001bdb3L34), [link](https://github.com/labring/sealos/pull/4060/files?diff=unified&w=0#diff-bbe780a26fb3a849fd5602523d26cf161d00af8fff5530e6929966325001bdb3L64-L69), [link](https://github.com/labring/sealos/pull/4060/files?diff=unified&w=0#diff-25e6eae2bde5b361242a7173eb219cd3f5686d7bcac8b899364296300255dbb1L164-R156))
* Remove logic to set environment variables from customEnvs slice to os environment, as it is no longer needed to process the clusterfile ([link](https://github.com/labring/sealos/pull/4060/files?diff=unified&w=0#diff-25e6eae2bde5b361242a7173eb219cd3f5686d7bcac8b899364296300255dbb1L48-L53))
* Remove unused os and strings packages from clusterfile package ([link](https://github.com/labring/sealos/pull/4060/files?diff=unified&w=0#diff-25e6eae2bde5b361242a7173eb219cd3f5686d7bcac8b899364296300255dbb1L20-L21))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
