### PR TITLE
Fix conflicts

### DIFF
--- a/cmd/sealos/cmd/gen.go
+++ b/cmd/sealos/cmd/gen.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/labring/sealos/pkg/apply"
+	"github.com/labring/sealos/pkg/utils/logger"
 )
 
 var exampleGen = `
@@ -63,6 +64,7 @@ func newGenCmd() *cobra.Command {
 			var outputWriter io.WriteCloser
 			switch out {
 			case "", "stdout":
+				logger.Info("if you want to save the output of gen command, use '--output' option instead of redirecting to file")
 				outputWriter = os.Stdout
 			default:
 				outputWriter, err = os.Create(out)

--- a/pkg/apply/args.go
+++ b/pkg/apply/args.go
@@ -65,7 +65,7 @@ type RunArgs struct {
 func (arg *RunArgs) RegisterFlags(fs *pflag.FlagSet) {
 	arg.Cluster.RegisterFlags(fs, "run with", "run")
 	arg.SSH.RegisterFlags(fs)
-	fs.StringSliceVarP(&arg.CustomEnv, "env", "e", []string{}, "environment variables to set during command execution")
+	fs.StringSliceVarP(&arg.CustomEnv, "env", "e", []string{}, "environment variables to be set for images")
 	fs.StringSliceVar(&arg.CustomCMD, "cmd", []string{}, "override CMD directive in images")
 	fs.StringSliceVar(&arg.CustomConfigFiles, "config-file", []string{}, "path of custom config files, to use to replace the resource")
 }
@@ -80,7 +80,7 @@ type Args struct {
 func (arg *Args) RegisterFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVar(&arg.Values, "values", []string{}, "values file to apply into Clusterfile")
 	fs.StringSliceVar(&arg.Sets, "set", []string{}, "set values on the command line")
-	fs.StringSliceVar(&arg.CustomEnv, "env", []string{}, "environment variables to set during command execution")
+	fs.StringSliceVar(&arg.CustomEnv, "env", []string{}, "environment variables to be set for images")
 	fs.StringSliceVar(&arg.CustomConfigFiles, "config-file", []string{}, "path of custom config files, to use to replace the resource")
 }
 

--- a/pkg/apply/gen.go
+++ b/pkg/apply/gen.go
@@ -26,6 +26,7 @@ import (
 	"github.com/labring/sealos/pkg/runtime"
 	"github.com/labring/sealos/pkg/types/v1beta1"
 	"github.com/labring/sealos/pkg/utils/iputils"
+	"github.com/labring/sealos/pkg/utils/logger"
 )
 
 func NewClusterFromGenArgs(cmd *cobra.Command, args *RunArgs, imageNames []string) ([]byte, error) {
@@ -42,6 +43,11 @@ func NewClusterFromGenArgs(cmd *cobra.Command, args *RunArgs, imageNames []strin
 
 	if err := c.runArgs(cmd, args, imageNames); err != nil {
 		return nil, err
+	}
+	if flagChanged(cmd, "env") {
+		logger.Info("setting global envs for cluster, will be used in all run commands later")
+		v, _ := cmd.Flags().GetStringSlice("env")
+		cluster.Spec.Env = append(cluster.Spec.Env, v...)
 	}
 
 	img, err := genImageInfo(imageNames[0])

--- a/pkg/clusterfile/clusterfile.go
+++ b/pkg/clusterfile/clusterfile.go
@@ -31,7 +31,6 @@ type ClusterFile struct {
 	customValues       []string
 	customSets         []string
 	customEnvs         []string
-	setDefaults        bool
 	Cluster            *v2.Cluster
 	Configs            []v2.Config
 	KubeConfig         *runtime.KubeadmConfig
@@ -59,12 +58,6 @@ func (c *ClusterFile) GetKubeadmConfig() *runtime.KubeadmConfig {
 }
 
 type OptionFunc func(*ClusterFile)
-
-func WithSetDefaults(v bool) OptionFunc {
-	return func(c *ClusterFile) {
-		c.setDefaults = v
-	}
-}
 
 func WithCustomConfigFiles(files []string) OptionFunc {
 	return func(c *ClusterFile) {

--- a/pkg/clusterfile/pre_process.go
+++ b/pkg/clusterfile/pre_process.go
@@ -17,8 +17,6 @@ package clusterfile
 import (
 	"bytes"
 	"errors"
-	"os"
-	"strings"
 
 	"helm.sh/helm/v3/pkg/cli/values"
 	"helm.sh/helm/v3/pkg/getter"
@@ -48,12 +46,6 @@ func (c *ClusterFile) Process() (err error) {
 	}
 	c.once.Do(func() {
 		err = func() error {
-			for i := range c.customEnvs {
-				kv := strings.SplitN(c.customEnvs[i], "=", 2)
-				if len(kv) == 2 {
-					_ = os.Setenv(kv[0], kv[1])
-				}
-			}
 			clusterFileData, err := c.loadClusterFile()
 			if err != nil {
 				return err
@@ -159,7 +151,7 @@ func (c *ClusterFile) DecodeConfigs(data []byte) error {
 }
 
 func (c *ClusterFile) DecodeKubeadmConfig(data []byte) error {
-	kubeadmConfig, err := runtime.LoadKubeadmConfigs(string(data), c.setDefaults, runtime.DecodeCRDFromString)
+	kubeadmConfig, err := runtime.LoadKubeadmConfigs(string(data), false, runtime.DecodeCRDFromString)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
fix: make the usage of '--env' flag more precisely (#4060) (#4063)

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 61dc33e</samp>

### Summary
🌟📝🌍

<!--
1.  🌟 for enhancing the gen command with logging and the --output option.
2. 📝 for updating the documentation of the --env flag.
3. 🌍 for supporting custom environment variables for the cluster spec using the --env flag.
-->
This pull request improves the `sealos gen` command by adding logging, custom environment variables, and --output option support. It also simplifies the clusterfile generation and pre-processing logic by removing unused and redundant code.

> _To enhance the clusterfile gen_
> _We added logging and --env_
> _We simplified the type_
> _And removed some hype_
> _About defaulting kubeadm config_

### Walkthrough
* Remove the setDefaults field and option from the ClusterFile type and its constructors, as it is no longer needed for loading kubeadm configs ([link](https://github.com/labring/sealos/pull/4065/files?diff=unified&w=0#diff-bbe780a26fb3a849fd5602523d26cf161d00af8fff5530e6929966325001bdb3L34), [link](https://github.com/labring/sealos/pull/4065/files?diff=unified&w=0#diff-bbe780a26fb3a849fd5602523d26cf161d00af8fff5530e6929966325001bdb3L63-L68), [link](https://github.com/labring/sealos/pull/4065/files?diff=unified&w=0#diff-25e6eae2bde5b361242a7173eb219cd3f5686d7bcac8b899364296300255dbb1L162-R154))
* Add a conditional block to append the custom environment variables to the cluster spec and log a message if the --env flag is changed by the user in the `gen` command ([link](https://github.com/labring/sealos/pull/4065/files?diff=unified&w=0#diff-b4c7028460ee8a2207d8376a99e5b1ad4cc3db7178e77f2e1038ea0fff506eb2R47-R51))
* Modify the description of the --env flag in the `apply` and `gen` commands to clarify that the environment variables are set for the images, not during the command execution ([link](https://github.com/labring/sealos/pull/4065/files?diff=unified&w=0#diff-8334468083024c8eb7d789fe2f25d57044fb7681d69ee9a78404c6adf237b1c4L68-R68), [link](https://github.com/labring/sealos/pull/4065/files?diff=unified&w=0#diff-8334468083024c8eb7d789fe2f25d57044fb7681d69ee9a78404c6adf237b1c4L83-R83))
* Remove the loop that sets the custom environment variables as os environment variables in the `pre_process.go` file, as this is no longer needed for loading kubeadm configs ([link](https://github.com/labring/sealos/pull/4065/files?diff=unified&w=0#diff-25e6eae2bde5b361242a7173eb219cd3f5686d7bcac8b899364296300255dbb1L51-L56))
* Remove the unused os and strings packages from the `pre_process.go` file ([link](https://github.com/labring/sealos/pull/4065/files?diff=unified&w=0#diff-25e6eae2bde5b361242a7173eb219cd3f5686d7bcac8b899364296300255dbb1L20-L21))
* Import the logger package and add log messages to inform the user about the output of the `gen` command and the kubeadm config loading process ([link](https://github.com/labring/sealos/pull/4065/files?diff=unified&w=0#diff-5203ef43da3f65a8c3b52759666c99e1dbc2d3cbf31ed235deee1be99f6ec546R27), [link](https://github.com/labring/sealos/pull/4065/files?diff=unified&w=0#diff-5203ef43da3f65a8c3b52759666c99e1dbc2d3cbf31ed235deee1be99f6ec546R67), [link](https://github.com/labring/sealos/pull/4065/files?diff=unified&w=0#diff-b4c7028460ee8a2207d8376a99e5b1ad4cc3db7178e77f2e1038ea0fff506eb2R29))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
