### PR TITLE
refactor env keys

### DIFF
--- a/pkg/apply/applydrivers/apply_drivers_default.go
+++ b/pkg/apply/applydrivers/apply_drivers_default.go
@@ -275,7 +275,7 @@ func (c *Applier) deleteCluster() error {
 }
 
 func (c *Applier) syncWorkdir() {
-	if v, _ := system.Get(system.SYNC_WORKDIR_ENV_KEY); v != "" {
+	if v, _ := system.Get(system.SyncWorkDirEnvKey); v != "" {
 		vb, _ := strconv.ParseBool(v)
 		if !vb {
 			return

--- a/pkg/apply/applydrivers/apply_drivers_default.go
+++ b/pkg/apply/applydrivers/apply_drivers_default.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
@@ -31,6 +32,7 @@ import (
 	"github.com/labring/sealos/pkg/constants"
 	"github.com/labring/sealos/pkg/exec"
 	"github.com/labring/sealos/pkg/ssh"
+	"github.com/labring/sealos/pkg/system"
 	v2 "github.com/labring/sealos/pkg/types/v1beta1"
 	"github.com/labring/sealos/pkg/utils/confirm"
 	"github.com/labring/sealos/pkg/utils/iputils"
@@ -273,6 +275,12 @@ func (c *Applier) deleteCluster() error {
 }
 
 func (c *Applier) syncWorkdir() {
+	if v, _ := system.Get(system.SYNC_WORKDIR_ENV_KEY); v != "" {
+		vb, _ := strconv.ParseBool(v)
+		if !vb {
+			return
+		}
+	}
 	workDir := constants.ClusterDir(c.ClusterDesired.Name)
 	logger.Debug("sync workdir: %s", workDir)
 	ipList := c.ClusterDesired.GetMasterIPAndPortList()
@@ -295,8 +303,14 @@ func (c *Applier) syncWorkdir() {
 // save cluster to file after apply
 func (c *Applier) saveClusterFile() {
 	clusterPath := constants.Clusterfile(c.ClusterDesired.Name)
-	logger.Debug("save objects into local: %s, objects: %v", clusterPath, c.getWriteBackObjects())
-	saveErr := yaml.MarshalFile(clusterPath, c.getWriteBackObjects()...)
+	objects := c.getWriteBackObjects()
+	if logger.IsDebugMode() {
+		out, err := yaml.MarshalConfigs(objects...)
+		if err == nil {
+			logger.Debug("save objects into local: %s, objects: %s", clusterPath, string(out))
+		}
+	}
+	saveErr := yaml.MarshalFile(clusterPath, objects...)
 	if saveErr != nil {
 		logger.Error("failed to serialize into file: %s error, %s", clusterPath, saveErr)
 	}

--- a/pkg/ssh/scp.go
+++ b/pkg/ssh/scp.go
@@ -20,18 +20,14 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
-
-	"github.com/labring/sealos/pkg/system"
 
 	"github.com/pkg/sftp"
 	"github.com/schollz/progressbar/v3"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/labring/sealos/pkg/utils/file"
-	"github.com/labring/sealos/pkg/utils/hash"
 	"github.com/labring/sealos/pkg/utils/logger"
 	"github.com/labring/sealos/pkg/utils/progress"
 )
@@ -198,20 +194,6 @@ func (c *Client) doCopy(client *sftp.Client, host, src, dest string, epu *progre
 			}
 		}
 	} else {
-		fn := func(host string, name string) bool {
-			exists, err := checkIfRemoteFileExists(client, name)
-			if err != nil {
-				logger.Error("failed to detect remote file exists: %v", err)
-			}
-			return exists
-		}
-		if isCheckFileMD5() && fn(host, dest) {
-			rfp, _ := client.Stat(dest)
-			if lfp.Size() == rfp.Size() && hash.FileDigest(src) == c.RemoteSha256Sum(host, dest) {
-				logger.Debug("remote dst %s already exists and is the latest version, skip copying process", dest)
-				return nil
-			}
-		}
 		lf, err := os.Open(filepath.Clean(src))
 		if err != nil {
 			return fmt.Errorf("failed to open: %v", err)
@@ -240,37 +222,8 @@ func (c *Client) doCopy(client *sftp.Client, host, src, dest string, epu *progre
 		if err = client.PosixRename(destTmp, dest); err != nil {
 			return fmt.Errorf("failed to rename %s to %s: %v", destTmp, dest, err)
 		}
-		if isCheckFileMD5() {
-			dh := c.RemoteSha256Sum(host, dest)
-			if dh == "" {
-				// when ssh connection failed, remote sha256 is default to "", so ignore it.
-				return nil
-			}
-			sh := hash.FileDigest(src)
-			if sh != dh {
-				return fmt.Errorf("sha256 sum not match %s(%s) != %s(%s), maybe network corruption?", src, sh, dest, dh)
-			}
-		}
+
 		_ = epu.Add(1)
 	}
 	return nil
-}
-
-func checkIfRemoteFileExists(client *sftp.Client, fp string) (bool, error) {
-	_, err := client.Stat(fp)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
-}
-
-func isCheckFileMD5() bool {
-	if v, err := system.Get(system.ScpChecksumConfigKey); err == nil {
-		boolVal, _ := strconv.ParseBool(v)
-		return boolVal
-	}
-	return true
 }

--- a/pkg/system/env.go
+++ b/pkg/system/env.go
@@ -92,6 +92,11 @@ var configOptions = []ConfigOption{
 		Description: "path of container storage config file, setting this env will override the default location",
 		OSEnv:       ContainerStorageConfEnvKey,
 	},
+	{
+		Key:          SYNC_WORKDIR_ENV_KEY,
+		Description:  "whether to sync runtime root dir to all master nodes for backup purpose",
+		DefaultValue: "true",
+	},
 }
 
 const (
@@ -102,6 +107,7 @@ const (
 	BuildahLogLevelConfigKey   = "BUILDAH_LOG_LEVEL"
 	ContainerStorageConfEnvKey = "CONTAINERS_STORAGE_CONF"
 	ScpChecksumConfigKey       = "SCP_CHECKSUM"
+	SYNC_WORKDIR_ENV_KEY       = "SYNC_WORKDIR"
 )
 
 func (*envSystemConfig) getValueOrDefault(key string) (*ConfigOption, error) {

--- a/pkg/system/env.go
+++ b/pkg/system/env.go
@@ -83,17 +83,12 @@ var configOptions = []ConfigOption{
 		OSEnv:       BuildahLogLevelConfigKey,
 	},
 	{
-		Key:          ScpChecksumConfigKey,
-		Description:  "whether to check the md5sum value is consistent during the copy process.",
-		DefaultValue: "false",
-	},
-	{
 		Key:         ContainerStorageConfEnvKey,
 		Description: "path of container storage config file, setting this env will override the default location",
 		OSEnv:       ContainerStorageConfEnvKey,
 	},
 	{
-		Key:          SYNC_WORKDIR_ENV_KEY,
+		Key:          SyncWorkDirEnvKey,
 		Description:  "whether to sync runtime root dir to all master nodes for backup purpose",
 		DefaultValue: "true",
 	},
@@ -106,8 +101,7 @@ const (
 	BuildahFormatConfigKey     = "BUILDAH_FORMAT"
 	BuildahLogLevelConfigKey   = "BUILDAH_LOG_LEVEL"
 	ContainerStorageConfEnvKey = "CONTAINERS_STORAGE_CONF"
-	ScpChecksumConfigKey       = "SCP_CHECKSUM"
-	SYNC_WORKDIR_ENV_KEY       = "SYNC_WORKDIR"
+	SyncWorkDirEnvKey          = "SYNC_WORKDIR"
 )
 
 func (*envSystemConfig) getValueOrDefault(key string) (*ConfigOption, error) {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 97e05af</samp>

### Summary
:sparkles::fire::wrench:

<!--
1.  :sparkles: for adding a new feature and a debugging enhancement to the `applydrivers` package.
2.  :fire: for removing the checksum feature from the `ssh` package.
3.  :wrench: for adding a new configuration option to the `system` package.
-->
This pull request adds a sync feature to backup the runtime root directory to master nodes, removes the checksum feature from the `scp.go` file, and adds a new environment variable `SYNC_WORKDIR` to configure the sync feature. These changes aim to improve the usability and reliability of sealos.

> _Sing, O Muse, of the mighty deeds of the sealos team_
> _Who with skill and cunning wrought many a useful scheme_
> _To enhance the `applydrivers` package with a sync feature divine_
> _And to log the cluster objects as YAML, clear and fine_

### Walkthrough
*  Add sync feature to optionally sync the runtime root directory to all master nodes for backup purposes ([link](https://github.com/labring/sealos/pull/4066/files?diff=unified&w=0#diff-d1f1631a24e7fe7fb68c634146ce33bba145222a02effcb95e24d8e3cd6ce80bR22), [link](https://github.com/labring/sealos/pull/4066/files?diff=unified&w=0#diff-d1f1631a24e7fe7fb68c634146ce33bba145222a02effcb95e24d8e3cd6ce80bR35), [link](https://github.com/labring/sealos/pull/4066/files?diff=unified&w=0#diff-eaaf2377b1fb084a0d060b3f7191ba1fb3760d54285aec3aa4b0ace2486d3bf8L86-R94), [link](https://github.com/labring/sealos/pull/4066/files?diff=unified&w=0#diff-eaaf2377b1fb084a0d060b3f7191ba1fb3760d54285aec3aa4b0ace2486d3bf8L104-R104))
*  Remove checksum feature from `scp.go` to improve performance and reliability when copying files ([link](https://github.com/labring/sealos/pull/4066/files?diff=unified&w=0#diff-b16c36d4f08b48cbf3c1ea3ba2e4cc74463e7581ea73b0827620e04841061051L23-R25), [link](https://github.com/labring/sealos/pull/4066/files?diff=unified&w=0#diff-b16c36d4f08b48cbf3c1ea3ba2e4cc74463e7581ea73b0827620e04841061051L34), [link](https://github.com/labring/sealos/pull/4066/files?diff=unified&w=0#diff-b16c36d4f08b48cbf3c1ea3ba2e4cc74463e7581ea73b0827620e04841061051L201-L214), [link](https://github.com/labring/sealos/pull/4066/files?diff=unified&w=0#diff-b16c36d4f08b48cbf3c1ea3ba2e4cc74463e7581ea73b0827620e04841061051L243-R229))
*  Add debug mode to `saveClusterFile` function to log cluster objects as YAML strings before saving them ([link](https://github.com/labring/sealos/pull/4066/files?diff=unified&w=0#diff-d1f1631a24e7fe7fb68c634146ce33bba145222a02effcb95e24d8e3cd6ce80bR278-R283))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
