### PR TITLE
fix: create new container mount when force override

### DIFF
--- a/pkg/apply/processor/install.go
+++ b/pkg/apply/processor/install.go
@@ -147,11 +147,12 @@ func (c *InstallProcessor) PreProcess(cluster *v2.Cluster) error {
 			if !ForceOverride {
 				continue
 			}
-			ctrName = mount.Name
 			logger.Debug("trying to override app %s", img)
-		} else {
-			ctrName = rand.Generator(8)
+			if err := c.Buildah.Delete(mount.Name); err != nil {
+				return err
+			}
 		}
+		ctrName = rand.Generator(8)
 		cluster.Spec.Image = stringsutil.Merge(cluster.Spec.Image, img)
 		bderInfo, err := c.Buildah.Create(ctrName, img)
 		if err != nil {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f0bbe89</samp>

### Summary
🐛🗑️🎲

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request. It conveys that the change addresses an existing issue or error in the code.
2.  🗑️ - This emoji represents a deletion, which is part of the change logic. It conveys that the change removes an existing container that conflicts with the image to be overridden.
3.  🎲 - This emoji represents a randomization, which is also part of the change logic. It conveys that the change creates a new container with a random name to avoid naming collisions.
-->
Fix bug in `install` processor of sealos that prevents overriding images. Delete existing container with same image name before creating new one.

> _`sealos` fixes bug_
> _deletes old container first_
> _then creates new one_

### Walkthrough
*  Delete existing container before overriding image ([link](https://github.com/labring/sealos/pull/4068/files?diff=unified&w=0#diff-dc16722036c8f44c78015609d3ab3424d2f4d09543296a24d98e6ebea7a2dbb9L150-R155))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
