### PR TITLE
optimize cloud deploy scripts

### DIFF
--- a/deploy/cloud/init.sh
+++ b/deploy/cloud/init.sh
@@ -8,7 +8,6 @@ sealos pull --policy=always --platform=linux/"${ARCH}" ghcr.io/labring/sealos-cl
 sealos pull --policy=always --platform=linux/"${ARCH}" ghcr.io/labring/sealos-cloud-terminal-frontend:latest
 sealos pull --policy=always --platform=linux/"${ARCH}" ghcr.io/labring/sealos-cloud-applaunchpad-frontend:latest
 sealos pull --policy=always --platform=linux/"${ARCH}" ghcr.io/labring/sealos-cloud-dbprovider-frontend:latest
-sealos pull --policy=always --platform=linux/"${ARCH}" ghcr.io/labring/sealos-cloud-resources-metering-controller:latest
 sealos pull --policy=always --platform=linux/"${ARCH}" ghcr.io/labring/sealos-cloud-resources-controller:latest
 sealos pull --policy=always --platform=linux/"${ARCH}" ghcr.io/labring/sealos-cloud-account-controller:latest
 sealos pull --policy=always --platform=linux/"${ARCH}" ghcr.io/labring/sealos-cloud-costcenter-frontend:latest

--- a/deploy/cloud/scripts/init.sh
+++ b/deploy/cloud/scripts/init.sh
@@ -39,7 +39,7 @@ function gen_mongodbUri() {
     kubectl apply -f manifests/mongodb.yaml
     echo "waiting for mongodb secret generated"
     # if there is no sealos-mongodb-conn-credential secret then wait for mongodb ready
-    while [ -z "$(kubectl get secret -n sealos sealos-mongodb-conn-credential)" ]; do
+    while [ -z "$(kubectl get secret -n sealos sealos-mongodb-conn-credential 2>/dev/null)" ]; do
       sleep 3
     done
     chmod +x scripts/gen-mongodb-uri.sh
@@ -93,10 +93,6 @@ function sealos_run_controller {
 
   # run resources monitoring controller
   sealos run tars/monitoring.tar \
-  --env MONGO_URI="$mongodbUri" --env DEFAULT_NAMESPACE="resources-system"
-
-  # run resources metering controller
-  sealos run tars/metering.tar \
   --env MONGO_URI="$mongodbUri" --env DEFAULT_NAMESPACE="resources-system"
 
   # run account controller

--- a/deploy/cloud/scripts/init.sh
+++ b/deploy/cloud/scripts/init.sh
@@ -38,10 +38,19 @@ function gen_mongodbUri() {
     echo "no mongodb uri found, create mongodb and gen mongodb uri"
     kubectl apply -f manifests/mongodb.yaml
     echo "waiting for mongodb secret generated"
+    message="Waiting for MongoDB ready"
     # if there is no sealos-mongodb-conn-credential secret then wait for mongodb ready
     while [ -z "$(kubectl get secret -n sealos sealos-mongodb-conn-credential 2>/dev/null)" ]; do
-      sleep 3
+      echo -ne "\r$message   \e[K"
+      sleep 0.5
+      echo -ne "\r$message .  \e[K"
+      sleep 0.5
+      echo -ne "\r$message .. \e[K"
+      sleep 0.5
+      echo -ne "\r$message ...\e[K"
+      sleep 0.5
     done
+    echo "mongodb secret has been generated successfully."
     chmod +x scripts/gen-mongodb-uri.sh
     mongodbUri=$(scripts/gen-mongodb-uri.sh)
   fi

--- a/scripts/cloud/install.sh
+++ b/scripts/cloud/install.sh
@@ -1,12 +1,74 @@
 #!/bin/bash
 
-
 set -e
 
 # Configurations
 CLOUD_DIR="/root/.sealos/cloud"
-SEALOS_VERSION="v4.3.3"
-# TODO add support for multiple cloud versions
+SEALOS_VERSION="v4.3.4"
+
+# Define English and Chinese prompts
+declare -A PROMPTS_EN PROMPTS_CN
+
+PROMPTS_EN=(
+    ["install_sealos"]="Sealos CLI is not installed. Do you want to install it now? (y/n): "
+    ["input_master_ips"]="Please enter Master IPs (comma separated, at least one required): "
+    ["invalid_ips"]="Invalid IPs or no IPs provided. Please try again."
+    ["input_node_ips"]="Please enter Node IPs (comma separated, leave empty if none): "
+    ["pod_subnet"]="Please enter pod subnet (default: 100.64.0.0/10): "
+    ["service_subnet"]="Please enter service subnet (default: 10.96.0.0/22): "
+    ["cloud_domain"]="Please enter cloud domain: "
+    ["cloud_port"]="Please enter cloud port (default: 443): "
+    ["input_certificate"]="Do you want to input a certificate? (y/n): "
+    ["certificate_path"]="Please input the certificate path: "
+    ["private_key_path"]="Please input the private key path: "
+    ["choose_language"]="Choose language / 选择语言:"
+    ["enter_choice"]="Enter your choice (1/2): "
+    ["k8s_installation"]="Installing Kubernetes cluster."
+    ["ingress_installation"]="Installing ingress-nginx-controller and kubeblocks."
+    ["patching_ingress"]="Patching ingress-nginx-controller tolerations to allow it to run on master node. If you don't want it to run on master node, please skip this step."
+    ["installing_cloud"]="Installing sealos cloud."
+)
+
+PROMPTS_CN=(
+    ["install_sealos"]="Sealos CLI没有安装，是否安装？(y/n): "
+    ["input_master_ips"]="请输入Master IPs (多个master节点使用逗号分隔, 例：192.168.0.1,192.168.0.2,192.168.0.3) \n"
+    ["invalid_ips"]="IP无效或没有提供IP，请再试一次。"
+    ["input_node_ips"]="请输入Node IPs (多个node节点使用逗号分隔，可跳过): "
+    ["pod_subnet"]="请输入pod子网 (回车使用默认值: 100.64.0.0/10): "
+    ["service_subnet"]="请输入service子网 (回车使用默认值: 10.96.0.0/22): "
+    ["cloud_domain"]="请输入云域名: "
+    ["cloud_port"]="请输入云端口 (回车使用默认值: 443): "
+    ["input_certificate"]="您要输入证书吗？(y/n): "
+    ["certificate_path"]="请输入证书路径: "
+    ["private_key_path"]="请输入私钥路径: "
+    ["choose_language"]="选择语言:"
+    ["enter_choice"]="请输入您的选择 (1/2): "
+    ["k8s_installation"]="正在安装Kubernetes集群。"
+    ["ingress_installation"]="正在安装ingress-nginx-controller和kubeblocks。"
+    ["patching_ingress"]="正在修改ingress-nginx-controller的容忍度，以允许它在主节点上运行。如果您不希望它在主节点上运行，请跳过此步骤。"
+    ["installing_cloud"]="正在安装sealos cloud。"
+)
+
+# Choose Language
+get_prompt() {
+    local key="$1"
+    if [[ $LANGUAGE == "CN" ]]; then
+        echo -e "${PROMPTS_CN[$key]}"
+    else
+        echo -e "${PROMPTS_EN[$key]}"
+    fi
+}
+
+get_prompt "choose_language"
+echo "1. English"
+echo "2. 中文"
+read -p "$(get_prompt "enter_choice")" lang_choice
+
+if [[ $lang_choice == "2" ]]; then
+    LANGUAGE="CN"
+else
+    LANGUAGE="EN"
+fi
 
 # Initialization
 init() {
@@ -14,8 +76,8 @@ init() {
 
     # Check for sealos CLI
     if ! command -v sealos &> /dev/null; then
-        echo "Sealos CLI is not installed."
-        read -p "Do you want to install it now? (y/n): " installChoice
+        get_prompt "install_sealos"
+        read -p " " installChoice
         if [[ $installChoice == "y" || $installChoice == "Y" ]]; then
             curl -sfL https://raw.githubusercontent.com/labring/sealos/${SEALOS_VERSION}/scripts/install.sh |
               sh -s ${SEALOS_VERSION} labring/sealos
@@ -28,29 +90,47 @@ init() {
     fi
 }
 
-# Gather user input
 collect_input() {
+    # Utility function to validate IP address
+    validate_ips() {
+        local ips="$1"
+        for ip in $(echo "$ips" | tr ',' ' '); do
+            if ! [[ $ip =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                return 1
+            fi
+        done
+        return 0
+    }
+
     # Master and Node IPs
-    read -p "Please enter Master IPs (comma separated, at least one required): " masterIps
-    while [[ -z "$masterIps" ]]; do
-        read -p "At least one Master IP is required. Please try again: " masterIps
+    while :; do
+        read -p "$(get_prompt "input_master_ips")" masterIps
+        if validate_ips "$masterIps" && [[ ! -z "$masterIps" ]]; then
+            break
+        else
+            get_prompt "invalid_ips"
+        fi
     done
-    read -p "Please enter Node IPs (comma separated, leave empty if none): " nodeIps
+    while :; do
+        read -p "$(get_prompt "input_node_ips")" nodeIps
+        if validate_ips "$nodeIps"; then
+            break
+        else
+            get_prompt "invalid_ips"
+        fi
+    done
 
-    # Cluster settings
-    read -p "Please enter pod subnet (default: 100.64.0.0/10): " podCidr
-    read -p "Please enter service subnet (default: 10.96.0.0/22): " serviceCidr
-    read -p "Please enter cloud domain: " cloudDomain
-
-    # Certificate handling
-    read -p "Do you want to input a certificate? (y/n): " inputCert
+    read -p "$(get_prompt "pod_subnet")" podCidr
+    read -p "$(get_prompt "service_subnet")" serviceCidr
+    read -p "$(get_prompt "cloud_domain")" cloudDomain
+    read -p "$(get_prompt "cloud_port")" cloudPort
+    read -p "$(get_prompt "input_certificate")" inputCert
     if [[ $inputCert == "y" || $inputCert == "Y" ]]; then
-        read -p "Please input the certificate path: " certPath
-        read -p "Please input the private key path: " keyPath
+        read -p "$(get_prompt "certificate_path")" certPath
+        read -p "$(get_prompt "private_key_path")" keyPath
     fi
 }
 
-# Prepare configurations
 prepare_configs() {
     if [[ $inputCert == "y" || $inputCert == "Y" ]]; then
         # Convert certificate and key to base64
@@ -113,28 +193,29 @@ spec:
     sed -i "s|10.96.0.0/22|${serviceCidr:-10.96.0.0/22}|g" $CLOUD_DIR/Clusterfile
 }
 
-# Execute commands based on collected input and prepared configs
 execute_commands() {
-    echo "Installing Kubernetes cluster."
+    get_prompt "k8s_installation"
     sealos apply -f $CLOUD_DIR/Clusterfile
 
-    echo "Installing ingress-nginx-controller and kubeblocks."
+    get_prompt "ingress_installation"
     sealos run docker.io/labring/kubernetes-reflector:v7.0.151\
         docker.io/labring/ingress-nginx:v1.5.1\
         docker.io/labring/kubeblocks:v0.6.2\
         --config-file $CLOUD_DIR/ingress-nginx-config.yaml
 
-    echo "Patching ingress-nginx-controller tolerations to allow it to run on master node. If you don't want it to run on master node, please skip this step."
+    get_prompt "patching_ingress"
     kubectl -n ingress-nginx patch ds ingress-nginx-controller -p '{"spec":{"template":{"spec":{"tolerations":[{"key":"node-role.kubernetes.io/control-plane","operator":"Exists","effect":"NoSchedule"}]}}}}'
 
-    echo "Installing sealos cloud."
+    get_prompt "installing_cloud"
     if [[ $inputCert == "y" || $inputCert == "Y" ]]; then
         sealos run docker.io/labring/sealos-cloud:latest\
         --env cloudDomain="$cloudDomain"\
+        --env cloudPort="${cloudPort:-443}"\
         --config-file $CLOUD_DIR/tls-secret.yaml
     else
         sealos run docker.io/labring/sealos-cloud:latest\
-        --env cloudDomain="$cloudDomain"
+        --env cloudDomain="$cloudDomain"\
+        --env cloudPort="${cloudPort:-443}"
     fi
 }
 
@@ -143,3 +224,9 @@ init
 collect_input
 prepare_configs
 execute_commands
+
+# Print sealos cloud login info
+echo "Sealos cloud login info:"
+echo "URL: https://$cloudDomain:$cloudPort"
+echo "admin Username: admin"
+echo "admin Password: sealos2023"


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 85566b1</samp>

### Summary
🗑️🚀🌐

<!--
1.  🗑️ for removing the unused image pull command.
2.  🚀 for improving the output and performance of the installation script.
3.  🌐 for adding multilingual prompts and cloud configuration options.
-->
This pull request enhances the sealos cloud installation process by improving the scripts `deploy/cloud/scripts/init.sh` and `scripts/cloud/install.sh`. It also removes an obsolete command from `deploy/cloud/init.sh`. These changes aim to make the installation faster, more user-friendly, and more secure.

> _The sealos cloud script got a makeover_
> _It removed an unused controller_
> _And added some features_
> _To handle more languages and meters_
> _And print the login info when it's over_

### Walkthrough
*  Add language selection and prompts for sealos cloud installation ([link](https://github.com/labring/sealos/pull/4070/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL3-R72), [link](https://github.com/labring/sealos/pull/4070/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL17-R80), [link](https://github.com/labring/sealos/pull/4070/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL116-R200))
*  Update sealos version to v4.3.4 and add cloud port option ([link](https://github.com/labring/sealos/pull/4070/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL3-R72), [link](https://github.com/labring/sealos/pull/4070/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL31-R133), [link](https://github.com/labring/sealos/pull/4070/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL127-R218))
*  Validate user input for IP addresses and set default values for subnets ([link](https://github.com/labring/sealos/pull/4070/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL31-R133))
*  Pass cloud port to sealos run command for `deploy/cloud/init.sh` ([link](https://github.com/labring/sealos/pull/4070/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL127-R218), [link](https://github.com/labring/sealos/pull/4070/files?diff=unified&w=0#diff-7c20f8ecac334e472df2875627ce9de0e4297d7c839ef4ed0da3e80cb4e16595L11))
*  Remove unused resources metering controller from `deploy/cloud/init.sh` and `deploy/cloud/scripts/init.sh` ([link](https://github.com/labring/sealos/pull/4070/files?diff=unified&w=0#diff-7c20f8ecac334e472df2875627ce9de0e4297d7c839ef4ed0da3e80cb4e16595L11), [link](https://github.com/labring/sealos/pull/4070/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844L42-R42), [link](https://github.com/labring/sealos/pull/4070/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844L98-L101))
*  Print sealos cloud login info after installation ([link](https://github.com/labring/sealos/pull/4070/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aR227-R232))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
