### PR TITLE
Fix/cloud init scripts

### DIFF
--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -53,6 +53,19 @@ sealos apply -f Clusterfile
 
 Note: if you want to change pod cidr, please edit the `Clusterfile` before run `sealos apply`
 
+### OpenEBS sc create
+
+```shell
+kubectl create -f - <<EOF
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-backup
+provisioner: openebs.io/local
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+EOF
+```
 
 ### Ingress-nginx setup
 We use ingress-nginx to expose our services. You can install ingress-nginx by using sealos:

--- a/deploy/cloud/manifests/db-metrics.yaml
+++ b/deploy/cloud/manifests/db-metrics.yaml
@@ -1,0 +1,83 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: database-monitor
+  name: database-monitor-config
+  namespace: sealos
+data:
+  config.yml: |
+    server:
+      addr: ":9090"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: database-monitor
+  name: database-monitor-deployment
+  namespace: sealos
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: database-monitor
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: database-monitor
+    spec:
+      containers:
+      - args:
+        - /config/config.yml
+        command:
+        - /manager
+        env:
+        - name: PROMETHEUS_SERVICE_HOST
+          value: http://kb-addon-prometheus-server.
+        image: ghcr.io/labring/sealos-cloud-database-monitor:latest
+        imagePullPolicy: Always
+        name: database-monitor
+        ports:
+        - containerPort: 9090
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 1m
+            memory: 500M
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /config
+          name: config-vol
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: database-monitor-config
+        name: config-vol
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: database-monitor
+  name: database-monitor
+  namespace: sealos
+spec:
+  ports:
+    - name: http
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+  selector:
+    app: database-monitor

--- a/deploy/cloud/scripts/init.sh
+++ b/deploy/cloud/scripts/init.sh
@@ -19,6 +19,9 @@ function prepare {
   # apply notifications crd
   kubectl apply -f manifests/notifications_crd.yaml
 
+  # apply kb database metrics
+  kubectl apply -f manifests/db-metrics.yaml
+
   # gen mongodb uri
   gen_mongodbUri
 

--- a/frontend/providers/costcenter/deploy/manifests/appcr.yaml.tmpl
+++ b/frontend/providers/costcenter/deploy/manifests/appcr.yaml.tmpl
@@ -7,7 +7,7 @@ spec:
   data:
     desc: sealos CLoud costcenter
     url: "https://costcenter.{{ .cloudDomain }}{{ if .cloudPort }}:{{ .cloudPort }}{{ end }}"
-  icon: "https://costcenter.{{ .cloudDomain }}{{ if .cloudPort }}:{{ .cloudPort }}{{ end }}/logo.png"
+  icon: "https://costcenter.{{ .cloudDomain }}{{ if .cloudPort }}:{{ .cloudPort }}{{ end }}/logo.svg"
   i18n:
     zh:
       name: 费用中心

--- a/scripts/cloud/install.sh
+++ b/scripts/cloud/install.sh
@@ -273,27 +273,6 @@ loading_animation() {
     sleep "$duration"
 }
 
-#master_ips=34.150.68.213
-#node_ips=
-#ssh_private_key=
-#ssh_password=
-#pod_cidr=
-#service_cidr=
-#cloud_domain=34.150.68.213.nip.io
-#cloud_port=
-#input_cert=
-#cert_path=
-#key_path=
-#kubernetes_version=1.25.6
-#cilium_version=1.12.14
-#cert_manager_version=1.8.0
-#helm_version=3.12.0
-#openebs_version=3.4.0
-#reflector_version=7.0.151
-#ingress_nginx_version=1.5.1
-#kubeblocks_version=0.6.2
-#metrics_server_version=0.6.1
-
 execute_commands() {
     get_prompt "k8s_installation"
     command -v kubelet || sealos apply -f $CLOUD_DIR/Clusterfile
@@ -305,6 +284,15 @@ execute_commands() {
     wait_cluster_ready
     sealos run "labring/cert-manager:v${cert_manager_version#v:-1.8.0}"
     sealos run "labring/openebs:v${openebs_version#v:-3.4.0}"
+    kubectl create -f - <<EOF
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-backup
+provisioner: openebs.io/local
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+EOF
 
     get_prompt "ingress_installation"
     sealos run docker.io/labring/kubernetes-reflector:v${reflector_version#v:-7.0.151}\

--- a/scripts/cloud/install.sh
+++ b/scripts/cloud/install.sh
@@ -4,9 +4,30 @@ set -e
 
 # Configurations
 CLOUD_DIR="/root/.sealos/cloud"
-SEALOS_VERSION="v4.3.4"
+SEALOS_VERSION="v4.3.5"
 CLOUD_VERSION="v0.0.1"
-mongodbVersion="mongodb-5.0"
+#mongodb_version="mongodb-5.0"
+#master_ips=
+#node_ips=
+#ssh_private_key=
+#ssh_password=
+#pod_cidr=
+#service_cidr=
+#cloud_domain=
+#cloud_port=
+#input_cert=
+#cert_path=
+#key_path=
+kubernetes_version=1.25.6
+cilium_version=1.12.14
+cert_manager_version=1.8.0
+helm_version=3.12.0
+openebs_version=3.4.0
+reflector_version=7.0.151
+ingress_nginx_version=1.5.1
+kubeblocks_version=0.6.2
+metrics_server_version=0.6.4
+
 
 # Define English and Chinese prompts
 declare -A PROMPTS_EN PROMPTS_CN
@@ -33,6 +54,10 @@ PROMPTS_EN=(
     ["ssh_private_key"]="Please configure the ssh private key path, press Enter to use the default value '/root/.ssh/id_rsa' "
     ["ssh_password"]="Please enter the ssh password, press Enter to skip\n"
     ["wait_cluster_ready"]="Waiting for cluster to be ready, if you want to skip this step, please enter '1'"
+    ["cilium_requirement"]="When running Cilium using the container image cilium/cilium, the host system must meet these requirements:
+Hosts with either AMD64 or AArch64 architecture
+Linux kernel >= 4.19.57 or equivalent (e.g., 4.18 on RHEL8)"
+    ["mongo_avx_requirement"]="MongoDB 5.0 version depends on CPU that supports AVX instruction set, the current environment does not support avx, so only mongo4.0 version can be used. For more information, see: https://www.mongodb.com/docs/v5.0/administration/production-notes/"
 )
 
 PROMPTS_CN=(
@@ -57,6 +82,10 @@ PROMPTS_CN=(
     ["ssh_private_key"]="如需免密登录请配置ssh私钥路径，回车使用默认值'/root/.ssh/id_rsa' "
     ["ssh_password"]="请输入ssh密码，配置免密登录可回车跳过\n"
     ["wait_cluster_ready"]="正在等待集群就绪, 如果您想跳过此步骤，请输入'1'"
+    ["cilium_requirement"]="正在使用Cilium作为网络插件，主机系统必须满足以下要求：
+具有AMD64或AArch64架构的主机
+Linux内核> = 4.19.57或等效版本（例如，在RHEL8上为4.18）"
+    ["mongo_avx_requirement"]="MongoDB 5.0版本依赖支持 AVX 指令集的 CPU，当前环境不支持avx，所以仅可使用mongo4.0版本，更多信息查看：https://www.mongodb.com/docs/v5.0/administration/production-notes/"
 )
 
 # Choose Language
@@ -82,11 +111,10 @@ fi
 
 #TODO mongo 5.0 need avx support, if not support, change to 4.0
 setMongoVersion() {
-  cat /proc/cpuinfo | grep avx
+  grep avx /proc/cpuinfo > /dev/null
   if [ $? -ne 0 ]; then
-    mongodbVersion="mongodb-4.0"
-  else
-    mongodbVersion="mongodb-5.0"
+    get_prompt "mongo_avx_requirement"
+    mongodb_version="mongodb-4.0"
   fi
 }
 
@@ -124,16 +152,16 @@ collect_input() {
 
     # Master and Node IPs
     while :; do
-        read -p "$(get_prompt "input_master_ips")" masterIps
-        if validate_ips "$masterIps" && [[ ! -z "$masterIps" ]]; then
+        read -p "$(get_prompt "input_master_ips")" master_ips
+        if validate_ips "$master_ips" && [[ ! -z "$master_ips" ]]; then
             break
         else
             get_prompt "invalid_ips"
         fi
     done
     while :; do
-        read -p "$(get_prompt "input_node_ips")" nodeIps
-        if validate_ips "$nodeIps"; then
+        read -p "$(get_prompt "input_node_ips")" node_ips
+        if validate_ips "$node_ips"; then
             break
         else
             get_prompt "invalid_ips"
@@ -144,22 +172,22 @@ collect_input() {
         ssh_private_key="${HOME}/.ssh/id_rsa"
     fi
     read -p "$(get_prompt "ssh_password")" ssh_password
-    read -p "$(get_prompt "pod_subnet")" podCidr
-    read -p "$(get_prompt "service_subnet")" serviceCidr
-    read -p "$(get_prompt "cloud_domain")" cloudDomain
-    read -p "$(get_prompt "cloud_port")" cloudPort
-    read -p "$(get_prompt "input_certificate")" inputCert
-    if [[ $inputCert == "y" || $inputCert == "Y" ]]; then
-        read -p "$(get_prompt "certificate_path")" certPath
-        read -p "$(get_prompt "private_key_path")" keyPath
+    read -p "$(get_prompt "pod_subnet")" pod_cidr
+    read -p "$(get_prompt "service_subnet")" service_cidr
+    read -p "$(get_prompt "cloud_domain")" cloud_domain
+    read -p "$(get_prompt "cloud_port")" cloud_port
+    read -p "$(get_prompt "input_certificate")" input_cert
+    if [[ $input_cert == "y" || $input_cert == "Y" ]]; then
+        read -p "$(get_prompt "certificate_path")" cert_path
+        read -p "$(get_prompt "private_key_path")" key_path
     fi
 }
 
 prepare_configs() {
-    if [[ $inputCert == "y" || $inputCert == "Y" ]]; then
+    if [[ -n "${cert_path}" ]] || [[ -n "${key_path}" ]]; then
         # Convert certificate and key to base64
-        tls_crt_base64=$(cat $certPath | base64 | tr -d '\n')
-        tls_key_base64=$(cat $keyPath | base64 | tr -d '\n')
+        tls_crt_base64=$(cat $cert_path | base64 | tr -d '\n')
+        tls_key_base64=$(cat $key_path | base64 | tr -d '\n')
 
         # Define YAML content for certificate
         tls_config="
@@ -193,31 +221,27 @@ spec:
       kind: DaemonSet
       service:
         type: NodePort
-  match: docker.io/labring/ingress-nginx:v1.5.1
+  match: docker.io/labring/ingress-nginx:v${ingress_nginx_version#v:-1.5.1}
   path: charts/ingress-nginx/values.yaml
   strategy: merge
 "
     echo "$ingress_config" > $CLOUD_DIR/ingress-nginx-config.yaml
 
-    sealos_gen_cmd="sealos gen labring/kubernetes:v1.25.6\
-        labring/helm:v3.12.0\
-        labring/cilium:v1.12.14\
-        labring/cert-manager:v1.8.0\
-        labring/openebs:v3.4.0\
-        --masters $masterIps\
-        --pk=${ssh_private_key}\
-        --passwd=${ssh_password}\
-        "
+    echo "master_ips= ${master_ips}"
+    sealos_gen_cmd="sealos gen labring/kubernetes:v${kubernetes_version#v:-1.25.6}\
+        --masters $master_ips\
+        --pk=${ssh_private_key:-$HOME/.ssh/id_rsa}\
+        --passwd=${ssh_password} -o $CLOUD_DIR/Clusterfile"
 
-    if [ -n "$nodeIps" ]; then
-        sealos_gen_cmd+=" --nodes $nodeIps"
+    if [ -n "$node_ips" ]; then
+        sealos_gen_cmd+=" --nodes $node_ips"
     fi
 
-    $sealos_gen_cmd > $CLOUD_DIR/Clusterfile
+    command -v kubelet || $sealos_gen_cmd
 
     # Modify Clusterfile with sed
-    sed -i "s|100.64.0.0/10|${podCidr:-100.64.0.0/10}|g" $CLOUD_DIR/Clusterfile
-    sed -i "s|10.96.0.0/22|${serviceCidr:-10.96.0.0/22}|g" $CLOUD_DIR/Clusterfile
+    sed -i "s|100.64.0.0/10|${pod_cidr:-100.64.0.0/10}|g" $CLOUD_DIR/Clusterfile
+    sed -i "s|10.96.0.0/22|${service_cidr:-10.96.0.0/22}|g" $CLOUD_DIR/Clusterfile
 }
 
 wait_cluster_ready() {
@@ -249,18 +273,46 @@ loading_animation() {
     sleep "$duration"
 }
 
+#master_ips=34.150.68.213
+#node_ips=
+#ssh_private_key=
+#ssh_password=
+#pod_cidr=
+#service_cidr=
+#cloud_domain=34.150.68.213.nip.io
+#cloud_port=
+#input_cert=
+#cert_path=
+#key_path=
+#kubernetes_version=1.25.6
+#cilium_version=1.12.14
+#cert_manager_version=1.8.0
+#helm_version=3.12.0
+#openebs_version=3.4.0
+#reflector_version=7.0.151
+#ingress_nginx_version=1.5.1
+#kubeblocks_version=0.6.2
+#metrics_server_version=0.6.1
+
 execute_commands() {
     get_prompt "k8s_installation"
-    sealos apply -f $CLOUD_DIR/Clusterfile
+    command -v kubelet || sealos apply -f $CLOUD_DIR/Clusterfile
+    command -v helm || sealos run "labring/helm:v${helm_version#v:-3.12.0}"
+    get_prompt "cilium_requirement"
+    if kubectl get no | grep NotReady &>/dev/null; then
+      sealos run "labring/cilium:v${cilium_version#v:-1.12.14}"
+    fi
     wait_cluster_ready
+    sealos run "labring/cert-manager:v${cert_manager_version#v:-1.8.0}"
+    sealos run "labring/openebs:v${openebs_version#v:-3.4.0}"
 
     get_prompt "ingress_installation"
-    sealos run docker.io/labring/kubernetes-reflector:v7.0.151\
-        docker.io/labring/ingress-nginx:v1.5.1\
-        docker.io/labring/kubeblocks:v0.6.2\
+    sealos run docker.io/labring/kubernetes-reflector:v${reflector_version#v:-7.0.151}\
+        docker.io/labring/ingress-nginx:v${ingress_nginx_version#v:-1.5.1}\
+        docker.io/labring/kubeblocks:v${kubeblocks_version#v:-0.6.2}\
         --config-file $CLOUD_DIR/ingress-nginx-config.yaml
 
-    sealos run labring/metrics-server:v0.6.2
+    sealos run "labring/metrics-server:v${metrics_server_version#v:-0.6.4}"
 
     get_prompt "patching_ingress"
     kubectl -n ingress-nginx patch ds ingress-nginx-controller -p '{"spec":{"template":{"spec":{"tolerations":[{"key":"node-role.kubernetes.io/control-plane","operator":"Exists","effect":"NoSchedule"}]}}}}'
@@ -268,23 +320,23 @@ execute_commands() {
     get_prompt "installing_cloud"
 
     setMongoVersion
-    if [[ $inputCert == "y" || $inputCert == "Y" ]]; then
+    if [[ -n "$tls_crt_base64" ]] || [[ -n "$tls_key_base64" ]]; then
         sealos run docker.io/labring/sealos-cloud:latest\
-        --env cloudDomain="$cloudDomain"\
-        --env cloudPort="${cloudPort:-443}"\
-        --env mongodbVersion="${mongodbVersion:-mongodb-5.0}"\
+        --env cloudDomain="$cloud_domain"\
+        --env cloudPort="${cloud_port:-443}"\
+        --env mongodbVersion="${mongodb_version:-mongodb-5.0}"\
         --config-file $CLOUD_DIR/tls-secret.yaml
     else
         sealos run docker.io/labring/sealos-cloud:latest\
-        --env cloudDomain="$cloudDomain"\
-        --env cloudPort="${cloudPort:-443}"\
-        --env mongodbVersion="${mongodbVersion:-mongodb-5.0}"
+        --env cloudDomain="$cloud_domain"\
+        --env cloudPort="${cloud_port:-443}"\
+        --env mongodbVersion="${mongodb_version:-mongodb-5.0}"
     fi
 }
 
 # Main script execution
 init
-collect_input
+source $1 || collect_input
 prepare_configs
 execute_commands
 
@@ -292,4 +344,4 @@ GREEN='\033[0;32m'
 BOLD='\033[1m'
 RESET='\033[0m'
 
-echo -e "${BOLD}Sealos cloud login info:${RESET}\nCloud Version: ${GREEN}${CLOUD_VERSION}${RESET}\nURL: ${GREEN}https://$cloudDomain${cloudPort:+:$cloudPort}${RESET}\nadmin Username: ${GREEN}admin${RESET}\nadmin Password: ${GREEN}sealos2023${RESET}"
+echo -e "${BOLD}Sealos cloud login info:${RESET}\nCloud Version: ${GREEN}${CLOUD_VERSION}${RESET}\nURL: ${GREEN}https://$cloud_domain${cloud_port:+:$cloud_port}${RESET}\nadmin Username: ${GREEN}admin${RESET}\nadmin Password: ${GREEN}sealos2023${RESET}"

--- a/scripts/cloud/install.sh
+++ b/scripts/cloud/install.sh
@@ -224,14 +224,13 @@ wait_cluster_ready() {
     local prompt_msg=$(get_prompt "wait_cluster_ready")
     while true; do
         if kubectl get nodes | grep "NotReady" &> /dev/null; then
-            loading_animation "$prompt_msg"
+          loading_animation "$prompt_msg"
         else
-            break
+          echo && break # new line
         fi
-
-        read -t 1 -n 1 input
+        read -t 1 -n 1 -p "" input 2>/dev/null || true
         if [[ "$input" == "1" ]]; then
-            break
+          echo && break # new line
         fi
     done
 }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 89fc6f3</samp>

### Summary
🖼️🚀⏳

<!--
1.  🖼️ for the icon file extension change, since this emoji depicts a framed picture or artwork, which could be associated with graphics or images.
2.  🚀 for the pull request features, since this emoji conveys speed, innovation, or launching something new, which could be related to the support for MongoDB 5.0, AVX detection, and the metrics-server component, as well as the improved user interface and i18n support.
3.  ⏳ for the waiting animation for cluster readiness, since this emoji represents an hourglass with flowing sand, which could indicate waiting, patience, or time passing.
-->
This pull request enhances the cloud installation and deployment features of sealos. It adds MongoDB 5.0 and AVX support, a metrics-server component, and a waiting animation to `scripts/cloud/install.sh`. It also switches to svg icons for better scalability in `frontend/providers/costcenter/deploy/manifests/appcr.yaml.tmpl`.

> _This pull request has quite a lot_
> _From `icon.svg` to `metrics-server` pod_
> _It supports MongoDB five_
> _And AVX to thrive_
> _And a waiting animation that's not a dot_

### Walkthrough
* Change icon file extension to svg for better scalability ([link](https://github.com/labring/sealos/pull/4084/files?diff=unified&w=0#diff-e4f0dd85bc6f34921be4de70c904e70b5c4ae4bafc918e56492b0c8e5e4a9dc1L10-R10))
* Add variable `mongodbVersion` to store default MongoDB version ([link](https://github.com/labring/sealos/pull/4084/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aR9))
* Replace `precheck` function with `setMongoVersion` function to check CPU AVX support and set `mongodbVersion` accordingly ([link](https://github.com/labring/sealos/pull/4084/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL80-R91))
* Pass `mongodbVersion` as environment variable to `sealos-cloud` component to deploy MongoDB service ([link](https://github.com/labring/sealos/pull/4084/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL229-R281))
* Add `metrics-server` component to provide resource metrics for the cluster ([link](https://github.com/labring/sealos/pull/4084/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL229-R281))
* Add prompt message to allow user to skip waiting for cluster to be ready by entering '1' ([link](https://github.com/labring/sealos/pull/4084/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aR35), [link](https://github.com/labring/sealos/pull/4084/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aR59))
* Add `wait_cluster_ready` function to use loading animation and loop to check cluster nodes status ([link](https://github.com/labring/sealos/pull/4084/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL219-R255))
* Modify echo command for displaying cloud login info to use conditional expansion for cloud port ([link](https://github.com/labring/sealos/pull/4084/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL255-L254))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
