### PR TITLE
fix: remove default vip

### DIFF
--- a/pkg/runtime/kubernetes/types/default_kubeadm_config.go
+++ b/pkg/runtime/kubernetes/types/default_kubeadm_config.go
@@ -94,9 +94,9 @@ apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 mode: "ipvs"
 metricsBindAddress: 0.0.0.0
-ipvs:
-  excludeCIDRs:
-    - "10.103.97.2/32"
+#ipvs:
+#  excludeCIDRs:
+#    - "10.103.97.2/32"
 
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a42cdde</samp>

### Summary
:bug::wrench::balance_scale:

<!--
1.  :bug: - This emoji represents a bug fix, which is the main goal of this change.
2.  :wrench: - This emoji represents a configuration change, which is the method of this change.
3.  :balance_scale: - This emoji represents a balance or trade-off, which is the implication of this change. By commenting out the `ipvs.excludeCIDRs` field, the user may lose some flexibility or control over the IPVS load balancing rules, but gain compatibility with the `sealos` tool and the Kubernetes API server.
-->
Comment out `ipvs.excludeCIDRs` field in default kubeadm config to prevent IPVS conflicts with API server address.

> _`ipvs.excludeCIDRs`_
> _Commented out to fix bug_
> _Winter of `sealos`_

### Walkthrough
*  Comment out `ipvs.excludeCIDRs` field in `kubeadm` configuration to avoid IP conflicts with API server ([link](https://github.com/labring/sealos/pull/4087/files?diff=unified&w=0#diff-610e37032fc46298396812e73b95e83b76236e654dfcd5c55c89a8265e80c34eL97-R99))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
