### PR TITLE
Feat/traffic proto

### DIFF
--- a/controllers/pkg/database/mongodb.go
+++ b/controllers/pkg/database/mongodb.go
@@ -56,6 +56,7 @@ const (
 	PermanentRetention = "PERMANENT_RETENTION"
 )
 
+// override this value at build time
 const defaultCryptoKey = "Af0b2Bc5e9d0C84adF0A5887cF43aB63"
 
 var cryptoKey = defaultCryptoKey
@@ -73,7 +74,7 @@ type MongoDB struct {
 
 type AccountBalanceSpecBSON struct {
 	// Time    metav1.Time `json:"time" bson:"time"`
-	// time字段如果为time.Time类型无法转换为json crd，所以使用metav1.Time，但是使用metav1.Time无法插入到mongo中，所以需要转换为time.Time
+	// If the Time field is of the time. time type, it cannot be converted to json crd, so use metav1.Time. However, metav1.Time cannot be inserted into mongo, so you need to convert it to time.Time
 	Time                                   time.Time `json:"time" bson:"time"`
 	accountv1.BillingRecordQueryItemInline `json:",inline" bson:",inline"`
 }
@@ -135,9 +136,8 @@ func (m *MongoDB) GetUnsettingBillingHandler(owner string) ([]resources.BillingH
 }
 
 func (m *MongoDB) UpdateBillingStatus(orderID string, status resources.BillingStatus) error {
-	// 创建一个查询过滤器
+	// create a query filter
 	filter := bson.M{"order_id": orderID}
-	// 更新文档
 	update := bson.M{
 		"$set": bson.M{
 			"status": status,
@@ -456,8 +456,6 @@ func (m *MongoDB) GenerateMeteringData(startTime, endTime time.Time, prices map[
 		Name:     resourceMap[name].Name(),
 	})
 */
-//按照type, name, namespace 来统计billing数据
-//统计该time范围内 所有type, name, namespace相同的monitor数据的used平均值或总值（按照其PropertyType）得出一个billing数据并写入billing表
 func (m *MongoDB) GenerateBillingData(startTime, endTime time.Time, prols *resources.PropertyTypeLS, namespaces []string, owner string) (orderID []string, amount int64, err error) {
 	minutes := endTime.Sub(startTime).Minutes()
 
@@ -473,18 +471,18 @@ func (m *MongoDB) GenerateBillingData(startTime, endTime time.Time, prols *resou
 		primitive.E{Key: "category", Value: "$_id.category"},
 	}
 
-	// 初始化 used 阶段
+	// initialize the used phase
 	usedStage := bson.M{}
 
-	// 根据 EnumMap 动态构建 $group 和 $project 阶段
+	// Build the $group and $project phases dynamically from EnumMap
 	for key, value := range prols.EnumMap {
 		keyStr := strconv.Itoa(int(key))
 
 		// $max - $min;
-		// 当max不为零值时，为了防止特殊情况某条数据未获取到值，所以使用零值外的最小值
-		// 该小时仅1条数据或该小时无数据时 max-min=0
+		// When max is not zero, the minimum value other than the zero value is used to prevent some data from obtaining a value in special cases
+		// max-min=0 if the hour has only one data piece or no data piece
 		if value.PriceType == resources.DIF {
-			// 对于非0的$min
+			// for non 0 $min
 			minWithCondition := bson.D{
 				{Key: "$min", Value: bson.D{
 					{Key: "$cond", Value: bson.A{
@@ -500,7 +498,7 @@ func (m *MongoDB) GenerateBillingData(startTime, endTime time.Time, prols *resou
 				primitive.E{Key: keyStr + "_min", Value: minWithCondition},
 			)
 
-			// 添加到 used 阶段
+			// added to the used phase
 			usedStage[keyStr] = bson.D{{Key: "$subtract", Value: bson.A{
 				"$" + keyStr + "_max",
 				"$" + keyStr + "_min",
@@ -512,10 +510,10 @@ func (m *MongoDB) GenerateBillingData(startTime, endTime time.Time, prols *resou
 			"$" + keyStr, bson.D{{Key: "$cond", Value: bson.A{bson.D{{Key: "$gt", Value: bson.A{"$count", minutes}}}, "$count", minutes}}}}}}}}}}
 	}
 
-	// 将 used 阶段添加到 $project 阶段
+	// add the used phase to the $project phase
 	projectStage = append(projectStage, primitive.E{Key: "used", Value: usedStage})
 
-	// 构建 pipeline
+	// construction-pipeline
 	pipeline := mongo.Pipeline{
 		{{Key: "$match", Value: bson.D{{Key: "time", Value: bson.D{{Key: "$gte", Value: startTime}, {Key: "$lt", Value: endTime}}}, {Key: "category", Value: bson.D{{Key: "$in", Value: namespaces}}}}}},
 		{{Key: "$group", Value: groupStage}},
@@ -796,7 +794,7 @@ func (m *MongoDB) QueryBillingRecords(billingRecordQuery *accountv1.BillingRecor
 
 	totalCount := 0
 
-	// 总数量
+	// total quantity
 	cursorAll, err := billingColl.Aggregate(ctx, pipelineAll)
 	if err != nil {
 		return fmt.Errorf("failed to execute aggregate all query: %w", err)
@@ -812,7 +810,7 @@ func (m *MongoDB) QueryBillingRecords(billingRecordQuery *accountv1.BillingRecor
 		totalCount = int(result.Result)
 	}
 
-	// 消费总金额Costs Executing the second pipeline for getting the total count, recharge and deduction amount
+	// Costs Executing the second pipeline for getting the total count, recharge and deduction amount
 	cursorCountAndAmount, err := billingColl.Aggregate(ctx, pipelineCountAndAmount)
 	if err != nil {
 		return fmt.Errorf("failed to execute aggregate query for count and amount: %w", err)
@@ -838,7 +836,7 @@ func (m *MongoDB) QueryBillingRecords(billingRecordQuery *accountv1.BillingRecor
 		}
 	}
 
-	// 充值总金额
+	// the total amount
 	cursorRechargeAmount, err := billingColl.Aggregate(ctx, pipelineRechargeAmount)
 	if err != nil {
 		return fmt.Errorf("failed to execute aggregate query for recharge amount: %w", err)
@@ -909,7 +907,7 @@ func (m *MongoDB) getMonitorCollection(collTime time.Time) *mongo.Collection {
 }
 
 func (m *MongoDB) getMonitorCollectionName(collTime time.Time) string {
-	// 按天计算尾缀，如202012月1号 尾缀为20201201
+	// Calculate the suffix by day, for example, the suffix on the first day of 202012 is 20201201
 	return fmt.Sprintf("%s_%s", m.MonitorConnPrefix, collTime.Format("20060102"))
 }
 
@@ -935,15 +933,15 @@ func (m *MongoDB) CreateBillingIfNotExist() error {
 		return fmt.Errorf("failed to create collection for billing: %w", err)
 	}
 
-	// 创建索引
+	// create index
 	_, err = m.getBillingCollection().Indexes().CreateMany(ctx, []mongo.IndexModel{
 		{
-			// 唯一索引 owner + order_id
+			// unique index owner order_id
 			Keys:    bson.D{primitive.E{Key: "owner", Value: 1}, primitive.E{Key: "order_id", Value: 1}},
 			Options: options.Index().SetUnique(true),
 		},
 		{
-			// owner + time + type 索引
+			// owner + time + type indexes
 			Keys: bson.D{
 				primitive.E{Key: "owner", Value: 1},
 				primitive.E{Key: "time", Value: 1},

--- a/controllers/pkg/database/mongodb.go
+++ b/controllers/pkg/database/mongodb.go
@@ -546,7 +546,7 @@ func (m *MongoDB) GenerateBillingData(startTime, endTime time.Time, prols *resou
 		}
 
 		//TODO delete
-		logger.Info("generate billing data", "result", result)
+		//logger.Info("generate billing data", "result", result)
 
 		if _, ok := appCostsMap[result.Namespace]; !ok {
 			appCostsMap[result.Namespace] = make(map[uint8][]resources.AppCost)
@@ -602,7 +602,7 @@ func (m *MongoDB) GenerateBillingData(startTime, endTime time.Time, prols *resou
 				return nil, 0, fmt.Errorf("insert error: %v", err)
 			}
 			//TODO delete
-			logger.Info("generate billing data", "billing", billing)
+			//logger.Info("generate billing data", "billing", billing)
 		}
 	}
 

--- a/controllers/pkg/database/mongodb.go
+++ b/controllers/pkg/database/mongodb.go
@@ -480,6 +480,9 @@ func (m *MongoDB) GenerateBillingData(startTime, endTime time.Time, prols *resou
 	for key, value := range prols.EnumMap {
 		keyStr := strconv.Itoa(int(key))
 
+		// $max - $min;
+		// 当max不为零值时，为了防止特殊情况某条数据未获取到值，所以使用零值外的最小值
+		// 该小时仅1条数据或该小时无数据时 max-min=0
 		if value.PriceType == resources.DIF {
 			// 对于非0的$min
 			minWithCondition := bson.D{

--- a/controllers/pkg/go.mod
+++ b/controllers/pkg/go.mod
@@ -18,6 +18,7 @@ replace (
 
 require (
 	github.com/containers/storage v1.50.2
+	github.com/dinoallo/sealos-networkmanager-protoapi v0.0.0-20230928031328-cf9649d6af49
 	github.com/dustin/go-humanize v1.0.1
 	github.com/gin-gonic/gin v1.9.1
 	github.com/go-logr/logr v1.2.4
@@ -113,6 +114,8 @@ require (
 	golang.org/x/text v0.10.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.3.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230525234030-28d5490b6b19 // indirect
+	google.golang.org/grpc v1.57.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/controllers/pkg/go.sum
+++ b/controllers/pkg/go.sum
@@ -32,6 +32,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dinoallo/sealos-networkmanager-protoapi v0.0.0-20230928031328-cf9649d6af49 h1:4GI5eviCwbPxDE311KryyyPUTO7IDVyHGp3Iyl+fEZY=
+github.com/dinoallo/sealos-networkmanager-protoapi v0.0.0-20230928031328-cf9649d6af49/go.mod h1:sbm1DAsayX+XsXCOC2CFAAU9JZhX0SPKwnybDjSd0Ls=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
@@ -359,6 +361,8 @@ google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98
 google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20220107163113-42d7afdf6368/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20230525234030-28d5490b6b19 h1:0nDDozoAU19Qb2HwhXadU8OcsiO/09cnTqhUtq2MEOM=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20230525234030-28d5490b6b19/go.mod h1:66JfowdXAEgad5O9NnYcsNPLCPZJD++2L9X0PCMODrA=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
@@ -366,6 +370,8 @@ google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
+google.golang.org/grpc v1.57.0 h1:kfzNeI/klCGD2YPMUlaGNT3pxvYfga7smW3Vth8Zsiw=
+google.golang.org/grpc v1.57.0/go.mod h1:Sd+9RMTACXwmub0zcNY2c4arhtrbBYD1AUHI/dt16Mo=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/controllers/pkg/resources/named.go
+++ b/controllers/pkg/resources/named.go
@@ -9,12 +9,12 @@ import (
 )
 
 /*
-数据库： app.kubernetes.io/instance=gitea  app.kubernetes.io/managed-by=kubeblocks apps.kubeblocks.io/component-name
-应用：app: xxx
-终端： TerminalID: xxx
-定时任务：job-name: xxx
-other: xxx
-map[string][]string{}
+AppType (sort by label) :
+	Database： app.kubernetes.io/instance=gitea  app.kubernetes.io/managed-by=kubeblocks apps.kubeblocks.io/component-name
+	AppLaunchpad：app: xxx
+	Terminal： TerminalID: xxx
+	Cronjob：job-name: xxx
+	Other: in addition to the above all labels
 */
 
 const (

--- a/controllers/pkg/resources/named.go
+++ b/controllers/pkg/resources/named.go
@@ -33,12 +33,13 @@ const (
 type ResourceNamed struct {
 	_name string
 	// db or app or terminal or job or other
-	_type string
+	_type  string
+	labels map[string]string
 }
 
 func NewResourceNamed(cr client.Object) *ResourceNamed {
-	p := &ResourceNamed{}
 	labels := cr.GetLabels()
+	p := &ResourceNamed{labels: labels}
 	switch {
 	case labels[DBPodLabelComponentNameKey] != "":
 		p._type = DB
@@ -61,6 +62,24 @@ func NewResourceNamed(cr client.Object) *ResourceNamed {
 
 func (p *ResourceNamed) Type() uint8 {
 	return AppType[p._type]
+}
+
+func (p *ResourceNamed) Labels() map[string]string {
+	label := make(map[string]string)
+	switch p.Type() {
+	case db:
+		label[DBPodLabelComponentNameKey] = p.labels[DBPodLabelComponentNameKey]
+		label[DBPodLabelInstanceKey] = p.labels[DBPodLabelInstanceKey]
+	case terminal:
+		label[TerminalIDLabelKey] = p.labels[TerminalIDLabelKey]
+	case app:
+		label[AppLabelKey] = p.labels[AppLabelKey]
+	case job:
+		label[JobNameLabelKey] = p.labels[JobNameLabelKey]
+		//case other:
+		//default:
+	}
+	return label
 }
 
 func (p *ResourceNamed) TypeString() string {

--- a/controllers/pkg/resources/resources.go
+++ b/controllers/pkg/resources/resources.go
@@ -233,32 +233,41 @@ type PropertyTypeLS struct {
 	EnumMap   map[uint8]PropertyType
 }
 
+const (
+	// 平均值
+	AVG = "AVG"
+	// 累加值
+	SUM = "SUM"
+	// 差值
+	DIF = "DIF"
+)
+
 var DefaultPropertyTypeList = []PropertyType{
 	{
 		Name:       "cpu",
 		Enum:       0,
-		PriceType:  "AVG",
+		PriceType:  AVG,
 		UnitPrice:  67,
 		UnitString: "1m",
 	},
 	{
 		Name:       "memory",
 		Enum:       1,
-		PriceType:  "AVG",
+		PriceType:  AVG,
 		UnitPrice:  33,
 		UnitString: "1Mi",
 	},
 	{
 		Name:       "storage",
 		Enum:       2,
-		PriceType:  "AVG",
+		PriceType:  AVG,
 		UnitPrice:  2,
 		UnitString: "1Mi",
 	},
 	{
 		Name:       "network",
 		Enum:       3,
-		PriceType:  "AVG",
+		PriceType:  DIF,
 		UnitPrice:  781,
 		UnitString: "1Mi",
 	},

--- a/controllers/pkg/resources/resources.go
+++ b/controllers/pkg/resources/resources.go
@@ -83,7 +83,7 @@ type Monitor struct {
 	Type     uint8       `json:"type" bson:"type"`
 	Name     string      `json:"name" bson:"name"`
 	Used     EnumUsedMap `json:"used" bson:"used"`
-	Property string      `json:"property" bson:"property"`
+	Property string      `json:"property,omitempty" bson:"property,omitempty"`
 }
 
 type BillingType int

--- a/controllers/resources/controllers/monitor_controller.go
+++ b/controllers/resources/controllers/monitor_controller.go
@@ -312,8 +312,10 @@ func (r *MonitorReconciler) getResourceUsage(namespace string) ([]*resources.Mon
 		}
 		return isEmpty, used
 	}
-	if err := r.getPodTrafficUsed(namespace, &resourceMap, &podsRes); err != nil {
-		return nil, fmt.Errorf("failed to get pod traffic used: %v", err)
+	if r.TrafficSvcConn != "" {
+		if err := r.getPodTrafficUsed(namespace, &resourceMap, &podsRes); err != nil {
+			return nil, fmt.Errorf("failed to get pod traffic used: %v", err)
+		}
 	}
 	for name, podResource := range podsRes {
 		isEmpty, used := getResourceUsed(podResource)

--- a/controllers/resources/controllers/monitor_controller.go
+++ b/controllers/resources/controllers/monitor_controller.go
@@ -408,3 +408,7 @@ func initResources() (rs map[corev1.ResourceName]*quantity) {
 func initGpuResources() *quantity {
 	return &quantity{Quantity: resource.NewQuantity(0, resource.DecimalSI), detail: ""}
 }
+
+func (r *MonitorReconciler) DropMonitorCollectionOlder() error {
+	return r.DBClient.DropMonitorCollectionsOlderThan(30)
+}

--- a/controllers/resources/controllers/monitor_controller.go
+++ b/controllers/resources/controllers/monitor_controller.go
@@ -347,7 +347,7 @@ func (r *MonitorReconciler) getPodTrafficUsed(namespace string, resourceMap *map
 		tfs := sealos_networkmanager.TrafficStatRequest{
 			Namespace:       namespace,
 			Type:            &tType,
-			Identity:        []uint32{2, 7},
+			Identity:        []uint32{2, 8},
 			LabelsIn:        named.GetInLabels(),
 			LabelsNotIn:     labelsNotIn,
 			LabelsNotExists: named.GetNotExistLabels(),

--- a/controllers/resources/deploy/Kubefile
+++ b/controllers/resources/deploy/Kubefile
@@ -7,6 +7,7 @@ COPY manifests manifests
 
 ENV DEFAULT_NAMESPACE resources-system
 ENV MONGO_URI "mongodb://mongo:27017/resources"
+ENV TRAFFICS_SERVICE_CONNECT_ADDRESS "sealos-networkmanager-info-service.sealos-networkmanager-system:50051"
 
 
 CMD ["kubectl apply -f manifests/deploy.yaml -f manifests/deploy-manager.yaml -n $DEFAULT_NAMESPACE && ( kubectl create -f manifests/mongo-secret.yaml -n $DEFAULT_NAMESPACE || true )"]

--- a/controllers/resources/deploy/manifests/deploy-manager.yaml
+++ b/controllers/resources/deploy/manifests/deploy-manager.yaml
@@ -60,6 +60,7 @@ spec:
                 secretKeyRef:
                   key: TRAFFICS_SERVICE_CONNECT_ADDRESS
                   name: mongo-secret
+                  optional: true
           image: ghcr.io/labring/sealos-resources-controller:latest
           imagePullPolicy: Always
           livenessProbe:

--- a/controllers/resources/deploy/manifests/deploy-manager.yaml
+++ b/controllers/resources/deploy/manifests/deploy-manager.yaml
@@ -55,6 +55,11 @@ spec:
                 secretKeyRef:
                   key: MONGO_URI
                   name: mongo-secret
+            - name: TRAFFICS_SERVICE_CONNECT_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  key: TRAFFICS_SERVICE_CONNECT_ADDRESS
+                  name: mongo-secret
           image: ghcr.io/labring/sealos-resources-controller:latest
           imagePullPolicy: Always
           livenessProbe:

--- a/controllers/resources/deploy/manifests/mongo-secret.yaml.tmpl
+++ b/controllers/resources/deploy/manifests/mongo-secret.yaml.tmpl
@@ -5,3 +5,4 @@ metadata:
   namespace: {{ .DEFAULT_NAMESPACE }}
 stringData:
   MONGO_URI: "{{ .MONGO_URI }}"
+  TRAFFICS_SERVICE_CONNECT_ADDRESS: "{{ default "" .TRAFFICS_SERVICE_CONNECT_ADDRESS }}"

--- a/controllers/resources/go.mod
+++ b/controllers/resources/go.mod
@@ -3,12 +3,14 @@ module github.com/labring/sealos/controllers/resources
 go 1.20
 
 require (
+	github.com/dinoallo/sealos-networkmanager-protoapi v0.0.0-20230928031328-cf9649d6af49
 	github.com/go-logr/logr v1.2.4
 	github.com/labring/sealos/controllers/pkg v0.0.0-00010101000000-000000000000
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.27.8
 	github.com/spf13/cobra v1.7.0
 	golang.org/x/sync v0.4.0
+	google.golang.org/grpc v1.57.0
 	k8s.io/api v0.27.4
 	k8s.io/apimachinery v0.27.4
 	k8s.io/client-go v0.27.4
@@ -80,6 +82,7 @@ require (
 	golang.org/x/time v0.3.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.3.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230525234030-28d5490b6b19 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect

--- a/controllers/resources/go.sum
+++ b/controllers/resources/go.sum
@@ -24,6 +24,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dinoallo/sealos-networkmanager-protoapi v0.0.0-20230928031328-cf9649d6af49 h1:4GI5eviCwbPxDE311KryyyPUTO7IDVyHGp3Iyl+fEZY=
+github.com/dinoallo/sealos-networkmanager-protoapi v0.0.0-20230928031328-cf9649d6af49/go.mod h1:sbm1DAsayX+XsXCOC2CFAAU9JZhX0SPKwnybDjSd0Ls=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
@@ -343,6 +345,8 @@ google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98
 google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20220107163113-42d7afdf6368/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20230525234030-28d5490b6b19 h1:0nDDozoAU19Qb2HwhXadU8OcsiO/09cnTqhUtq2MEOM=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20230525234030-28d5490b6b19/go.mod h1:66JfowdXAEgad5O9NnYcsNPLCPZJD++2L9X0PCMODrA=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
@@ -350,6 +354,8 @@ google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
+google.golang.org/grpc v1.57.0 h1:kfzNeI/klCGD2YPMUlaGNT3pxvYfga7smW3Vth8Zsiw=
+google.golang.org/grpc v1.57.0/go.mod h1:Sd+9RMTACXwmub0zcNY2c4arhtrbBYD1AUHI/dt16Mo=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/controllers/resources/main.go
+++ b/controllers/resources/main.go
@@ -143,6 +143,9 @@ func main() {
 			if err != nil {
 				reconciler.Logger.Error(err, "failed to create monitor time series")
 			}
+			if err := reconciler.DropMonitorCollectionOlder(); err != nil {
+				reconciler.Logger.Error(err, "failed to drop monitor collection")
+			}
 			<-ticker.C
 		}
 	})


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 088b70c</samp>

### Summary
🚀🌐🧹

<!--
1.  🚀 - This emoji represents the enhancement of the `resources` package to support kubeblocks backup jobs and network traffic queries based on app type labels, which is a new feature that improves the performance and functionality of the project.
2.  🌐 - This emoji represents the change of using a gRPC client for querying the network traffic data from the sealos network manager service, which is a major improvement that enables communication with a different service using a different protocol.
3.  🧹 - This emoji represents the cleanup and update of the `database` and `resources` packages, which is a minor improvement that removes unused or redundant code, fixes some issues, and improves the readability and maintainability of the code.
-->
This pull request improves the `controllers` package by adding support for kubeblocks backup jobs and network traffic queries, using gRPC to communicate with the sealos network manager service, and updating the comments, dependencies, and environment variables. It also cleans up some unused and outdated code and comments in the `database` and `resources` packages.

> _We're breaking the sealos, we're querying the traffic_
> _We're refactoring the code, we're cleaning up the `Kubefile`_
> _We're adding new dependencies, we're handling new price types_
> _We're translating the comments, we're rocking the `resources`_

### Walkthrough
*  Add support for querying network traffic data from the sealos network manager service and using it for billing calculation ([link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-4f321c44e1f1e1d654d113c577d36787146ce0ceb76df5cfce12d0209e8a89a7L36-R45),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-4f321c44e1f1e1d654d113c577d36787146ce0ceb76df5cfce12d0209e8a89a7R59-R61),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-4f321c44e1f1e1d654d113c577d36787146ce0ceb76df5cfce12d0209e8a89a7R73-R159),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dR22),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dR29-R32),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dR60),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dR69-R70),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dR95),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dR314-R318),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-590dcc64bca3a687c765ee9fd30645c6a3d10104cac7bb6e1c5ebf241d163042R10),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-b4dccafa4ea00018a482b69440de5bfa4a9ef65a54e9dfcb9201f73e47ab09eaR58-R63),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-7680146d8a41a86d0544c8e6f9d32698d5f0062a91aae0c23fb4bb3dfad685a1R7))
*  Refactor the function `podResourceUsage` to separate the logic of getting the resource usage data from the logic of inserting them into the database, and rename it to `getResourceUsage` ([link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL114-R123),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL212-R221),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL220-R243),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL266-R283),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL304-R325))
*  Rename the function `podResourceUsage` to `podResourceUsageInsert` to reflect its purpose of inserting the pod resource usage data into the database ([link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL114-R123),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL212-R221))
*  Modify the price type for the network bandwidth resource from `AVG` to `DIF`, which represents the difference between the maximum and minimum values of the resource usage metric ([link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46L476-R516),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-6807f16252513ceff2e6c32a70db899e14b3f2e6cec6e1a2d888dd2d777d8220L194-R191),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-6807f16252513ceff2e6c32a70db899e14b3f2e6cec6e1a2d888dd2d777d8220L261-R255))
*  Add a field `labels` to the type `ResourceNamed` to store the labels of the resource object, and use it for querying the network traffic data from the sealos network manager service ([link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-4f321c44e1f1e1d654d113c577d36787146ce0ceb76df5cfce12d0209e8a89a7L36-R45),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-4f321c44e1f1e1d654d113c577d36787146ce0ceb76df5cfce12d0209e8a89a7R73-R159))
*  Add a constant `KubeBlocksBackUpName` to represent the name of the backup job for kubeblocks data, and handle it in the `NewResourceNamed` function ([link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-4f321c44e1f1e1d654d113c577d36787146ce0ceb76df5cfce12d0209e8a89a7R33),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-4f321c44e1f1e1d654d113c577d36787146ce0ceb76df5cfce12d0209e8a89a7R59-R61))
*  Translate comments from Chinese to English in various files and functions ([link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46R59),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46L76-R77),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46L138-R140),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46L770-R797),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46L786-R813),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46L812-R839),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46L883-R910),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46L909-R944),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-4f321c44e1f1e1d654d113c577d36787146ce0ceb76df5cfce12d0209e8a89a7L6-R17),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-6807f16252513ceff2e6c32a70db899e14b3f2e6cec6e1a2d888dd2d777d8220L55-R41),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-6807f16252513ceff2e6c32a70db899e14b3f2e6cec6e1a2d888dd2d777d8220L194-R191),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-6807f16252513ceff2e6c32a70db899e14b3f2e6cec6e1a2d888dd2d777d8220L226-R211))
*  Remove comments that are written in Chinese and describe the logic of generating billing data based on type, name, and namespace ([link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46L459-L460))
*  Add comments with `TODO` tags to indicate that the logging statements below should be deleted later ([link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46R546-R548),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46R602-R603))
*  Add a dependency to the package `github.com/dinoallo/sealos-networkmanager-protoapi` in the `go.mod` file of the package `controllers/pkg`, which provides the protobuf definitions and generated code for the sealos network manager service ([link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-d2ace71fd9419285e685c85481fa6604caf151e3a6360d004bcdef3f39eed41dR21),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-d2ace71fd9419285e685c85481fa6604caf151e3a6360d004bcdef3f39eed41dR117-R118))
*  Remove unused import statements from various files and packages ([link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-6807f16252513ceff2e6c32a70db899e14b3f2e6cec6e1a2d888dd2d777d8220L32-L34),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-6807f16252513ceff2e6c32a70db899e14b3f2e6cec6e1a2d888dd2d777d8220L40-L48))
*  Add, remove, or update checksums for various packages in the `go.work.sum` file, based on the changes in the dependencies ([link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-20cee3a725d1c5d2c595ff5372e6593d3bcaa7aebd8319866f65e90c6924f247L1027),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-20cee3a725d1c5d2c595ff5372e6593d3bcaa7aebd8319866f65e90c6924f247L1057),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-20cee3a725d1c5d2c595ff5372e6593d3bcaa7aebd8319866f65e90c6924f247R1076-R1077),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-20cee3a725d1c5d2c595ff5372e6593d3bcaa7aebd8319866f65e90c6924f247L1234),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-20cee3a725d1c5d2c595ff5372e6593d3bcaa7aebd8319866f65e90c6924f247R1249-R1250),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-20cee3a725d1c5d2c595ff5372e6593d3bcaa7aebd8319866f65e90c6924f247R1258-R1259),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-20cee3a725d1c5d2c595ff5372e6593d3bcaa7aebd8319866f65e90c6924f247L1306-R1316),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-20cee3a725d1c5d2c595ff5372e6593d3bcaa7aebd8319866f65e90c6924f247L1349-R1353),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-20cee3a725d1c5d2c595ff5372e6593d3bcaa7aebd8319866f65e90c6924f247L1411-L1412),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-20cee3a725d1c5d2c595ff5372e6593d3bcaa7aebd8319866f65e90c6924f247L1809-L1810),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-20cee3a725d1c5d2c595ff5372e6593d3bcaa7aebd8319866f65e90c6924f247L1831),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-20cee3a725d1c5d2c595ff5372e6593d3bcaa7aebd8319866f65e90c6924f247L1903),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-20cee3a725d1c5d2c595ff5372e6593d3bcaa7aebd8319866f65e90c6924f247L2058),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-20cee3a725d1c5d2c595ff5372e6593d3bcaa7aebd8319866f65e90c6924f247L2239),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-20cee3a725d1c5d2c595ff5372e6593d3bcaa7aebd8319866f65e90c6924f247L2272-R2264),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-20cee3a725d1c5d2c595ff5372e6593d3bcaa7aebd8319866f65e90c6924f247L2489),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-20cee3a725d1c5d2c595ff5372e6593d3bcaa7aebd8319866f65e90c6924f247L2536),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-20cee3a725d1c5d2c595ff5372e6593d3bcaa7aebd8319866f65e90c6924f247R2608-R2611))
*  Remove some constants from the package `resources` that are related to the database and collection names, as they are moved to the package `database` ([link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-6807f16252513ceff2e6c32a70db899e14b3f2e6cec6e1a2d888dd2d777d8220L40-L48))
*  Remove some code from the package `resources` that is related to the infra resource usage, as it is not used in the current logic ([link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-6807f16252513ceff2e6c32a70db899e14b3f2e6cec6e1a2d888dd2d777d8220L350-L362),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-6807f16252513ceff2e6c32a70db899e14b3f2e6cec6e1a2d888dd2d777d8220L384-L395),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-6807f16252513ceff2e6c32a70db899e14b3f2e6cec6e1a2d888dd2d777d8220L411-R417),[link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-6807f16252513ceff2e6c32a70db899e14b3f2e6cec6e1a2d888dd2d777d8220L496-R503))
*  Remove the unused parameter `ctx` from the function `getGPUResourceUsage` ([link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL311-R378))
*  Add a line to the function `initResources` to initialize the `resources.ResourceNetwork` key in the resource usage map with a zero quantity ([link](https://github.com/labring/sealos/pull/4095/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dR404))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
