### PR TITLE
feat: template other resource

### DIFF
--- a/frontend/desktop/next-i18next.config.js
+++ b/frontend/desktop/next-i18next.config.js
@@ -5,7 +5,7 @@
 module.exports = {
   i18n: {
     defaultLocale: 'en',
-    locales: ['en', 'zh', 'zh-Hans'],
+    locales: ['en', 'zh'],
     localeDetection: false
   }
 };

--- a/frontend/desktop/src/pages/index.tsx
+++ b/frontend/desktop/src/pages/index.tsx
@@ -105,7 +105,8 @@ export default function Home({
 }
 
 export async function getServerSideProps({ req, res, locales }: any) {
-  const local = req?.cookies?.NEXT_LOCALE || 'en';
+  const lang: string = req?.headers?.['accept-language'] || 'zh';
+  const local = lang.indexOf('zh') !== -1 ? 'zh' : 'en';
   const sealos_cloud_domain = process.env.SEALOS_CLOUD_DOMAIN || 'cloud.sealos.io';
 
   return {

--- a/frontend/desktop/src/pages/signin.tsx
+++ b/frontend/desktop/src/pages/signin.tsx
@@ -6,7 +6,8 @@ export default function SigninPage() {
 }
 
 export async function getServerSideProps({ req, res, locales }: any) {
-  const local = req?.cookies?.NEXT_LOCALE || 'en';
+  const lang: string = req?.headers?.['accept-language'] || 'zh';
+  const local = lang.indexOf('zh') !== -1 ? 'zh' : 'en';
 
   const props = {
     ...(await serverSideTranslations(local, undefined, null, locales || []))

--- a/frontend/providers/template/src/api/delete.ts
+++ b/frontend/providers/template/src/api/delete.ts
@@ -22,30 +22,39 @@ export const delInstanceByName = (instanceName: string) =>
 export const delJobByName = (instanceName: string) =>
   DELETE('/api/resource/delJob', { instanceName });
 
-export const deleteResourceByKind = (instanceName: string, kind: ResourceKindType) => {
-  switch (kind) {
-    case 'CronJob':
-      return delCronJobByName(instanceName);
-    case 'App':
-      return deleteAppCRD(instanceName);
-    case 'Secret':
-      return deleteSecret(instanceName);
-    case 'AppLaunchpad':
-      return delApplaunchpad(instanceName);
-    case 'DataBase':
-      return delDBByName(instanceName);
-    case 'Instance':
-      return delInstanceByName(instanceName);
-    case 'Job':
-      return delJobByName(instanceName);
-    default:
-      throw new Error(`Unsupported kind: ${kind}`);
-  }
+export const delConfigMapByName = (instanceName: string) =>
+  DELETE('/api/resource/delConfigMap', { instanceName });
+
+export const delIssuerByName = (instanceName: string) =>
+  DELETE('/api/resource/deleteIssuer', { instanceName });
+
+export const delRoleByName = (instanceName: string) =>
+  DELETE('/api/resource/delRole', { instanceName });
+
+export const delRoleBindingByName = (instanceName: string) =>
+  DELETE('/api/resource/delRoleBinding', { instanceName });
+
+export const delServiceAccountByName = (instanceName: string) =>
+  DELETE('/api/resource/delServiceAccount', { instanceName });
+
+const deleteResourceByKind: Record<ResourceKindType, (instanceName: string) => void> = {
+  CronJob: (instanceName: string) => delCronJobByName(instanceName),
+  App: (instanceName: string) => deleteAppCRD(instanceName),
+  Secret: (instanceName: string) => deleteSecret(instanceName),
+  AppLaunchpad: (instanceName: string) => delApplaunchpad(instanceName),
+  DataBase: (instanceName: string) => delDBByName(instanceName),
+  Instance: (instanceName: string) => delInstanceByName(instanceName),
+  Job: (instanceName: string) => delJobByName(instanceName),
+  ConfigMap: (instanceName: string) => delConfigMapByName(instanceName),
+  Issuer: (instanceName: string) => delIssuerByName(instanceName),
+  Role: (instanceName: string) => delRoleByName(instanceName),
+  RoleBinding: (instanceName: string) => delRoleBindingByName(instanceName),
+  ServiceAccount: (instanceName: string) => delServiceAccountByName(instanceName)
 };
 
 export const deleteAllResources = async (resources: BaseResourceType[]) => {
   const deletePromises = resources.map((resource) => {
-    return deleteResourceByKind(resource.name, resource.kind);
+    return deleteResourceByKind[resource.kind](resource.name);
   });
   const reuslt = await Promise.allSettled(deletePromises);
   console.log(reuslt);

--- a/frontend/providers/template/src/constants/keys.ts
+++ b/frontend/providers/template/src/constants/keys.ts
@@ -12,5 +12,6 @@ export const gpuResourceKey = 'nvidia.com/gpu';
 export const templateDeployKey = 'cloud.sealos.io/deploy-on-sealos';
 // db
 export const kubeblocksTypeKey = 'clusterdefinition.kubeblocks.io/name';
+export const dbProviderKey = 'sealos-db-provider-cr';
 // labels
 export const componentLabel = 'app.kubernetes.io/component';

--- a/frontend/providers/template/src/pages/api/app/listOtherByName.ts
+++ b/frontend/providers/template/src/pages/api/app/listOtherByName.ts
@@ -1,16 +1,15 @@
-import { templateDeployKey } from '@/constants/keys';
+import { dbProviderKey, deployManagerKey, templateDeployKey } from '@/constants/keys';
 import { authSession } from '@/services/backend/auth';
 import { CRDMeta, getK8s } from '@/services/backend/kubernetes';
 import { jsonRes } from '@/services/backend/response';
 import { ApiResp } from '@/services/kubernet';
-import { AppCrdType } from '@/types/appCRD';
 import { IncomingMessage } from 'http';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
   try {
     const { instanceName } = req.query as { instanceName: string };
-    const { namespace, k8sCore, k8sCustomObjects, k8sBatch } = await getK8s({
+    const { namespace, k8sCore, k8sCustomObjects, k8sBatch, k8sAuth } = await getK8s({
       kubeconfig: await authSession(req.headers)
     });
     const labelSelector = `${templateDeployKey}=${instanceName}`;
@@ -22,6 +21,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       plural: 'apps'
     };
 
+    // secret
     const secretPromise = k8sCore.listNamespacedSecret(
       namespace,
       undefined,
@@ -31,6 +31,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       labelSelector
     );
 
+    // job
     const jobPromise = k8sBatch.listNamespacedJob(
       namespace,
       undefined,
@@ -40,6 +41,26 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       labelSelector
     );
 
+    // issuer
+    const certIssuerPromise = k8sCustomObjects.listNamespacedCustomObject(
+      'cert-manager.io',
+      'v1',
+      namespace,
+      'issuers',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      labelSelector
+    ) as Promise<{
+      response: IncomingMessage;
+      body: {
+        items: { kind?: string }[];
+        kind: 'IssuerList';
+      };
+    }>;
+
+    // app cr
     const appCrdResourcePromise = k8sCustomObjects.listNamespacedCustomObject(
       appCRD.group,
       appCRD.version,
@@ -53,17 +74,61 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     ) as Promise<{
       response: IncomingMessage;
       body: {
-        items: AppCrdType[];
+        items: { kind?: string }[];
         kind: 'AppList';
       };
     }>;
 
+    // role
+    const rolePromise = k8sAuth.listNamespacedRole(
+      namespace,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      `${labelSelector},!${dbProviderKey}`
+    );
+    const roleBindingPromise = k8sAuth.listNamespacedRoleBinding(
+      namespace,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      `${labelSelector},!${dbProviderKey}`
+    );
+    const saPromise = k8sCore.listNamespacedServiceAccount(
+      namespace,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      `${labelSelector},!${dbProviderKey}`
+    );
+    const configMapPromise = k8sCore.listNamespacedConfigMap(
+      namespace,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      `${labelSelector},!${dbProviderKey},!${deployManagerKey}`
+    );
     // 使用 Promise.allSettled 获取所有结果 [secretResult, jobResult, customResourceResult]
-    const result = await Promise.allSettled([secretPromise, jobPromise, appCrdResourcePromise]);
+    const result = await Promise.allSettled([
+      secretPromise,
+      jobPromise,
+      appCrdResourcePromise,
+      certIssuerPromise,
+      rolePromise,
+      roleBindingPromise,
+      saPromise,
+      configMapPromise
+    ]);
+
     const data = result
       .map((res) => {
         if (res.status === 'fulfilled') {
           return res.value.body.items.map((item) => {
+            // console.log(item, '==');
             return {
               ...item,
               kind: item.kind ? item.kind : res.value?.body?.kind?.replace('List', '')

--- a/frontend/providers/template/src/pages/api/resource/delConfigMap.ts
+++ b/frontend/providers/template/src/pages/api/resource/delConfigMap.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { ApiResp } from '@/services/kubernet';
+import { authSession } from '@/services/backend/auth';
+import { getK8s } from '@/services/backend/kubernetes';
+import { jsonRes } from '@/services/backend/response';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
+  try {
+    const { instanceName } = req.query as { instanceName: string };
+    if (!instanceName) {
+      throw new Error('deploy name is empty');
+    }
+
+    const { namespace, k8sCore } = await getK8s({
+      kubeconfig: await authSession(req.headers)
+    });
+
+    const result = await k8sCore.deleteNamespacedConfigMap(instanceName, namespace);
+
+    jsonRes(res, { data: result });
+  } catch (err: any) {
+    jsonRes(res, {
+      code: 500,
+      error: err
+    });
+  }
+}

--- a/frontend/providers/template/src/pages/api/resource/delRole.ts
+++ b/frontend/providers/template/src/pages/api/resource/delRole.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { ApiResp } from '@/services/kubernet';
+import { authSession } from '@/services/backend/auth';
+import { getK8s } from '@/services/backend/kubernetes';
+import { jsonRes } from '@/services/backend/response';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
+  try {
+    const { instanceName } = req.query as { instanceName: string };
+    if (!instanceName) {
+      throw new Error('deploy name is empty');
+    }
+
+    const { namespace, k8sAuth } = await getK8s({
+      kubeconfig: await authSession(req.headers)
+    });
+
+    const result = await k8sAuth.deleteNamespacedRole(instanceName, namespace);
+
+    jsonRes(res, { data: result });
+  } catch (err: any) {
+    jsonRes(res, {
+      code: 500,
+      error: err
+    });
+  }
+}

--- a/frontend/providers/template/src/pages/api/resource/delRoleBinding.ts
+++ b/frontend/providers/template/src/pages/api/resource/delRoleBinding.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { ApiResp } from '@/services/kubernet';
+import { authSession } from '@/services/backend/auth';
+import { getK8s } from '@/services/backend/kubernetes';
+import { jsonRes } from '@/services/backend/response';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
+  try {
+    const { instanceName } = req.query as { instanceName: string };
+    if (!instanceName) {
+      throw new Error('deploy name is empty');
+    }
+
+    const { namespace, k8sAuth } = await getK8s({
+      kubeconfig: await authSession(req.headers)
+    });
+
+    const result = await k8sAuth.deleteClusterRoleBinding(instanceName, namespace);
+
+    jsonRes(res, { data: result });
+  } catch (err: any) {
+    jsonRes(res, {
+      code: 500,
+      error: err
+    });
+  }
+}

--- a/frontend/providers/template/src/pages/api/resource/delServiceAccount.ts
+++ b/frontend/providers/template/src/pages/api/resource/delServiceAccount.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { ApiResp } from '@/services/kubernet';
+import { authSession } from '@/services/backend/auth';
+import { getK8s } from '@/services/backend/kubernetes';
+import { jsonRes } from '@/services/backend/response';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
+  try {
+    const { instanceName } = req.query as { instanceName: string };
+    if (!instanceName) {
+      throw new Error('deploy name is empty');
+    }
+
+    const { namespace, k8sCore } = await getK8s({
+      kubeconfig: await authSession(req.headers)
+    });
+
+    const result = await k8sCore.deleteNamespacedServiceAccount(instanceName, namespace);
+
+    jsonRes(res, { data: result });
+  } catch (err: any) {
+    jsonRes(res, {
+      code: 500,
+      error: err
+    });
+  }
+}

--- a/frontend/providers/template/src/pages/api/resource/deleteIssuer.ts
+++ b/frontend/providers/template/src/pages/api/resource/deleteIssuer.ts
@@ -6,27 +6,28 @@ import { jsonRes } from '@/services/backend/response';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
   try {
-    const { namespace } = req.query as { namespace: string };
-    const { k8sCustomObjects } = await getK8s({
+    const { instanceName } = req.query as { instanceName: string };
+    const { k8sCustomObjects, namespace } = await getK8s({
       kubeconfig: await authSession(req.headers)
     });
 
     const customResource: CRDMeta = {
-      group: 'app.sealos.io',
+      group: 'cert-manager.io',
       version: 'v1',
       namespace: namespace,
-      plural: 'apps'
+      plural: 'issuers'
     };
 
-    // 获取指定命名空间中的所有自定义资源
-    const customResourceList = await k8sCustomObjects.listNamespacedCustomObject(
+    // 删除指定名称的自定义资源
+    const reuslt = await k8sCustomObjects.deleteNamespacedCustomObject(
       customResource.group,
       customResource.version,
       customResource.namespace,
-      customResource.plural
+      customResource.plural,
+      instanceName
     );
 
-    jsonRes(res, { data: customResourceList, message: 'retrieved successfully' });
+    jsonRes(res, { data: reuslt });
   } catch (err: any) {
     jsonRes(res, {
       code: 500,

--- a/frontend/providers/template/src/types/resource.ts
+++ b/frontend/providers/template/src/types/resource.ts
@@ -11,6 +11,11 @@ export type ResourceKindType =
   | 'App'
   | 'Job'
   | 'Secret'
+  | 'Issuer'
+  | 'Role'
+  | 'RoleBinding'
+  | 'ServiceAccount'
+  | 'ConfigMap'
   | 'Instance';
 
 export type OtherResourceListItemType = {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ba78a3c</samp>

### Summary
🌐🗑️📄

<!--
1.  🌐 - This emoji represents the changes related to internationalization and localization, such as removing the redundant locale and using the accept-language header.
2.  🗑️ - This emoji represents the changes related to deleting resources, such as adding new API endpoints and functions for different kinds of resources.
3.  📄 - This emoji represents the changes related to adding new files and documentation, such as the license service files and the README.md.
-->
Added new API endpoints and UI features for the frontend providers template to support more Kubernetes resources related to an app. Refactored some existing code to improve readability and maintainability. Created a new license service with Next.js, Chakra UI, and MongoDB. Configured the ESLint, Prettier, and i18n options for the license service.

> _`next-i18next` changed_
> _use `accept-language` header_
> _no more `NEXT_LOCALE`_

### Walkthrough
*  Remove `zh-Hans` locale from supported locales in `next-i18next.config.js` ([link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-481e65e1560644671e375ec1bacf60b325c22b6db5e07ebba80735e971cf588eL8-R8))
*  Use `accept-language` header instead of `NEXT_LOCALE` cookie to determine user's preferred language in `getServerSideProps` functions in `index.tsx` and `signin.tsx` ([link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-c04141c0579122cad0175ca367c6a04f583111f500a9211b58fa3b207d2b2b53L108-R109), [link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-f4daef00368888e45ceb00f6832c7e2fec248cf288a93475e443cee60545332cL9-R10))
*  Refactor `deleteResourceByKind` function to use a record object instead of a switch statement and add new delete functions for `ConfigMap`, `Issuer`, `Role`, `RoleBinding`, and `ServiceAccount` resources in `delete.ts` ([link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-977e3316844b4af24d190cc9f3857e24045ac61296ecdb505e64a69febd52171L25-R57))
*  Add `dbProviderKey` constant to store the label selector for the database provider custom resource in `keys.ts` ([link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-61bf23b53c9b802d6d47dc0a077849a39e2d3ce097702d03833a96162558c714R15))
*  Import `deployManagerKey` constant and `k8sAuth` service and add new sections of code to handle the listing of issuer, role, role binding, service account, and config map resources in `listOtherByName.ts` ([link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-15156da12be8db7afd9bcd9186397f1750d2c6c8e95389599ce1b27521b8d085L1-R5), [link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-15156da12be8db7afd9bcd9186397f1750d2c6c8e95389599ce1b27521b8d085L13-R12), [link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-15156da12be8db7afd9bcd9186397f1750d2c6c8e95389599ce1b27521b8d085R24), [link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-15156da12be8db7afd9bcd9186397f1750d2c6c8e95389599ce1b27521b8d085R34), [link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-15156da12be8db7afd9bcd9186397f1750d2c6c8e95389599ce1b27521b8d085R44-R63), [link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-15156da12be8db7afd9bcd9186397f1750d2c6c8e95389599ce1b27521b8d085L56-R131))
*  Add new files to implement the API endpoints for deleting config map, issuer, role, role binding, and service account resources by name using the corresponding services in `delConfigMap.ts`, `deleteIssuer.ts`, `delRole.ts`, `delRoleBinding.ts`, and `delServiceAccount.ts` ([link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-fc23fac3a2df8261abefc40a467934eb4ef68ae82fdb57077190fa8ab392832aR1-R27), [link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-2c029c2dbb57ec400b2aefae0f89589cf867dc372e6ebdcba2884cf5bfd0c85dL9-R30), [link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-a1a36f3ebea4d2366711899d5a6158f223e3f34f08e062dbdd17e326499a1597R1-R27), [link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-274992de44669a932e0f4b2ebfc56b410043dcf1208670c33c6821b38ae0691eR1-R27), [link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-a4f887bd9e029ad0039dc60402dc1d9580b1df3fd5cc99820fd7b1a3c1288a84R1-R27))
*  Add new kinds of resources to `ResourceKindType` type in `resource.ts` ([link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-d80d70dfa69d35bfa6ebf5a9379444e3b4ba0346cb1844a869f165b6193f62d5R14-R18))
*  Add new files to configure the ESLint, Git, Prettier, and Next.js options for the license service in `.eslintrc.json`, `.gitignore`, `.prettierignore`, `.prettierrc.js`, `next-i18next.config.js`, and `next.config.js` ([link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-4dc45f2c5b511b73edc1732a574f753fa3875bb0b52a688f035d3de6342c129cR1-R3), [link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-076bc5268ef4d7a9f7c1739d385258978243f0a9f00ae6ed0d7c88c7c9619123R1-R35), [link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-9d22ca62f06c83644daa9f73ed05ba2bafa9c5a952084f7d56865f3a29c8ff43R1-R18), [link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-cc53c0fc2ea26fe29671d0e37c11874e5e54582e76ce76df39c745e50c19b5e1R1-R20), [link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-b9a72d0ca92c80410d45502de15fba9f928db97ed33f56e11a1c355d24fb2fccR1-R11), [link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-5d7109d67e86acda2df45da2cf0094112c2e286fc3d10013b3a0fe8c20071389R1-R13))
*  Add new file to specify the dependencies and scripts for the license service in `package.json` ([link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-3f2d8b8017ec2a1d278f4ddf928fec48ecd8673884bad870b1f922a1ea1342a2L1-R50))
*  Add new file to provide the basic information and instructions for the license service in `README.md` ([link](https://github.com/labring/sealos/pull/4098/files?diff=unified&w=0#diff-81126ed3e4311993e2e759b253f9047f3b3d1f7840c8ad57e5f3cd984689ce3dR1-R40))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
