### PR TITLE
fix: merge cluster.spec.env

### DIFF
--- a/pkg/apply/processor/create.go
+++ b/pkg/apply/processor/create.go
@@ -97,9 +97,11 @@ func (c *CreateProcessor) preProcess(cluster *v2.Cluster) error {
 	if err := MountClusterImages(c.Buildah, cluster, false); err != nil {
 		return err
 	}
+	// env in cluster.spec will be merged into every mounts object
+	env := maps.FromSlice(cluster.Spec.Env)
 	// extra env must been set at the very first
 	for i := range cluster.Status.Mounts {
-		cluster.Status.Mounts[i].Env = maps.Merge(cluster.Status.Mounts[i].Env, c.ExtraEnvs)
+		cluster.Status.Mounts[i].Env = maps.Merge(cluster.Status.Mounts[i].Env, env, c.ExtraEnvs)
 	}
 
 	rt, err := factory.New(cluster, c.ClusterFile.GetRuntimeConfig())


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 620758e</samp>

### Summary
🌎🛠️🌡️

<!--
1.  🌎 - This emoji represents the global scope of the environment variables that are added by the change. It also conveys the idea of a cluster or a group of nodes that share the same configuration.
2.  🛠️ - This emoji represents the tooling or the process of merging the environment variables from different sources. It also conveys the idea of building or fixing something.
3.  🌡️ - This emoji represents the environment or the context in which the cluster and the mounts operate. It also conveys the idea of temperature or pressure, which could be related to the performance or the stability of the cluster.
-->
Add global environment variables for cluster mounts. The change modifies the `preProcess` function in `pkg/apply/processor/create.go` to merge the cluster spec's `env` field with the existing environment variables for each mount object.

> _`env` from spec_
> _merges with mount variables_
> _autumn of cluster_

### Walkthrough
*  Add global environment variables for cluster mounts ([link](https://github.com/labring/sealos/pull/4100/files?diff=unified&w=0#diff-a198a9c7960d3df36d37378bc12c9b6095f19934739f72cc0c3e79d7a44e2442L100-R104))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
