### PR TITLE
use default `Identity` for traffic stat request

### DIFF
--- a/controllers/resources/controllers/monitor_controller.go
+++ b/controllers/resources/controllers/monitor_controller.go
@@ -347,7 +347,6 @@ func (r *MonitorReconciler) getPodTrafficUsed(namespace string, resourceMap *map
 		tfs := sealos_networkmanager.TrafficStatRequest{
 			Namespace:       namespace,
 			Type:            &tType,
-			Identity:        []uint32{2, 8},
 			LabelsIn:        named.GetInLabels(),
 			LabelsNotIn:     labelsNotIn,
 			LabelsNotExists: named.GetNotExistLabels(),


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0a007ff</samp>

### Summary
🚮🧹🙅

<!--
1.  🚮 This emoji means "put litter in its place" and can be used to indicate that something was removed or deleted from the code. In this case, the `Identity` field was removed from the `Traffic` struct.
2.  🧹 This emoji means "broom" and can be used to indicate that something was cleaned up or simplified in the code. In this case, the code was simplified by removing an unused and redundant field from the struct.
3.  🙅 This emoji means "person gesturing no" and can be used to indicate that something was rejected or avoided in the code. In this case, the code avoided confusion by removing a field that was not relevant for the function's purpose.
-->
Removed unused `Identity` field from `Traffic` struct in `monitor_controller.go`. This improves code clarity and efficiency for calculating pod traffic usage.

> _`Identity` gone_
> _From `Traffic` struct, unused_
> _Simpler code, like spring_

### Walkthrough
* Remove `Identity` field from `Traffic` struct in `getPodTrafficUsed` function ([link](https://github.com/labring/sealos/pull/4104/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL350)). This field was not used and was redundant, as it represented the pod's security identity, which is not relevant for calculating traffic usage. The change simplifies the code and avoids confusion in `controllers/resources/controllers/monitor_controller.go`.


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
