### PR TITLE
feat: language automatic detection

### DIFF
--- a/frontend/desktop/next-i18next.config.js
+++ b/frontend/desktop/next-i18next.config.js
@@ -4,7 +4,7 @@
 
 module.exports = {
   i18n: {
-    defaultLocale: 'en',
+    defaultLocale: 'zh',
     locales: ['en', 'zh'],
     localeDetection: false
   }

--- a/frontend/desktop/src/pages/index.tsx
+++ b/frontend/desktop/src/pages/index.tsx
@@ -107,6 +107,8 @@ export default function Home({
 export async function getServerSideProps({ req, res, locales }: any) {
   const lang: string = req?.headers?.['accept-language'] || 'zh';
   const local = lang.indexOf('zh') !== -1 ? 'zh' : 'en';
+  res.setHeader('Set-Cookie', `NEXT_LOCALE=${local}; Max-Age=2592000; Secure; SameSite=None`);
+
   const sealos_cloud_domain = process.env.SEALOS_CLOUD_DOMAIN || 'cloud.sealos.io';
 
   return {

--- a/frontend/desktop/src/pages/license/index.tsx
+++ b/frontend/desktop/src/pages/license/index.tsx
@@ -65,7 +65,7 @@ export default function LicensePage() {
 }
 
 export async function getServerSideProps({ req, res, locales }: any) {
-  const local = req?.cookies?.NEXT_LOCALE || 'en';
+  const local = req?.cookies?.NEXT_LOCALE || 'zh';
 
   return {
     props: {

--- a/frontend/desktop/src/pages/signin.tsx
+++ b/frontend/desktop/src/pages/signin.tsx
@@ -8,6 +8,7 @@ export default function SigninPage() {
 export async function getServerSideProps({ req, res, locales }: any) {
   const lang: string = req?.headers?.['accept-language'] || 'zh';
   const local = lang.indexOf('zh') !== -1 ? 'zh' : 'en';
+  res.setHeader('Set-Cookie', `NEXT_LOCALE=${local}; Max-Age=2592000; Secure; SameSite=None`);
 
   const props = {
     ...(await serverSideTranslations(local, undefined, null, locales || []))

--- a/frontend/packages/client-sdk/src/master.ts
+++ b/frontend/packages/client-sdk/src/master.ts
@@ -194,7 +194,7 @@ class MasterSDK {
         messageId: data.messageId,
         success: true,
         data: {
-          lng: getCookie('NEXT_LOCALE') || 'en'
+          lng: getCookie('NEXT_LOCALE') || 'zh'
         }
       });
     } else {

--- a/frontend/providers/applaunchpad/next-i18next.config.js
+++ b/frontend/providers/applaunchpad/next-i18next.config.js
@@ -5,8 +5,8 @@
 
 module.exports = {
   i18n: {
-    defaultLocale: 'en',
+    defaultLocale: 'zh',
     locales: ['en', 'zh'],
     localeDetection: false
   }
-};
+}

--- a/frontend/providers/applaunchpad/src/pages/_app.tsx
+++ b/frontend/providers/applaunchpad/src/pages/_app.tsx
@@ -99,7 +99,7 @@ const App = ({ Component, pageProps }: AppProps) => {
   }, [setScreenWidth]);
 
   useEffect(() => {
-    const changeI18n = async (data: any) => {
+    const changeI18n = async (data: { currentLanguage: string }) => {
       const lastLang = getLangStore();
       const newLang = data.currentLanguage;
       if (lastLang !== newLang) {
@@ -132,7 +132,7 @@ const App = ({ Component, pageProps }: AppProps) => {
   }, [router.pathname]);
 
   useEffect(() => {
-    const lang = getLangStore() || 'en';
+    const lang = getLangStore() || 'zh';
     i18n?.changeLanguage?.(lang);
   }, [refresh, router.pathname]);
 

--- a/frontend/providers/applaunchpad/src/utils/cookieUtils.ts
+++ b/frontend/providers/applaunchpad/src/utils/cookieUtils.ts
@@ -1,6 +1,6 @@
 import Cookies from 'js-cookie';
 
-export const LANG_KEY = 'NEXT_LOCALE_LANG';
+export const LANG_KEY = 'NEXT_LOCALE';
 
 export const setLangStore = (value: string) => {
   return Cookies.set(LANG_KEY, value, { expires: 30, sameSite: 'None', secure: true });

--- a/frontend/providers/applaunchpad/src/utils/i18n.ts
+++ b/frontend/providers/applaunchpad/src/utils/i18n.ts
@@ -3,7 +3,7 @@ import { LANG_KEY } from './cookieUtils';
 
 export const serviceSideProps = (content: any) => {
   return serverSideTranslations(
-    content.req.cookies[LANG_KEY] || 'en',
+    content.req.cookies[LANG_KEY] || 'zh',
     undefined,
     null,
     content.locales

--- a/frontend/providers/costcenter/next-i18next.config.js
+++ b/frontend/providers/costcenter/next-i18next.config.js
@@ -5,8 +5,8 @@
 
 module.exports = {
   i18n: {
-    defaultLocale: 'en',
-    locales: ['en', 'zh', 'zh-Hans'],
+    defaultLocale: 'zh',
+    locales: ['en', 'zh'],
     localeDetection: false
   }
-};
+}

--- a/frontend/providers/costcenter/src/stores/session.ts
+++ b/frontend/providers/costcenter/src/stores/session.ts
@@ -21,7 +21,7 @@ const useSessionStore = create<SessionState>()(
     persist(
       immer((set, get) => ({
         session: {} as SessionV1,
-        locale: 'en',
+        locale: 'zh',
         setSession: (ss: SessionV1) => set({ session: ss }),
         setSessionProp: (key: keyof SessionV1, value: any) => {
           set((state) => {

--- a/frontend/providers/cronjob/next-i18next.config.js
+++ b/frontend/providers/cronjob/next-i18next.config.js
@@ -5,8 +5,8 @@
 
 module.exports = {
   i18n: {
-    defaultLocale: 'en',
+    defaultLocale: 'zh',
     locales: ['en', 'zh'],
     localeDetection: false
   }
-};
+}

--- a/frontend/providers/cronjob/src/pages/_app.tsx
+++ b/frontend/providers/cronjob/src/pages/_app.tsx
@@ -121,7 +121,7 @@ function App({ Component, pageProps }: AppProps) {
   }, [router.pathname]);
 
   useEffect(() => {
-    const lang = getLangStore() || 'en';
+    const lang = getLangStore() || 'zh';
     i18n?.changeLanguage?.(lang);
   }, [refresh, router.asPath]);
 

--- a/frontend/providers/cronjob/src/utils/cookieUtils.ts
+++ b/frontend/providers/cronjob/src/utils/cookieUtils.ts
@@ -1,6 +1,6 @@
 import Cookies from 'js-cookie';
 
-export const LANG_KEY = 'NEXT_LOCALE_LANG';
+export const LANG_KEY = 'NEXT_LOCALE';
 
 export const setLangStore = (value: string) => {
   return Cookies.set(LANG_KEY, value, { expires: 30, sameSite: 'None', secure: true });

--- a/frontend/providers/cronjob/src/utils/i18n.ts
+++ b/frontend/providers/cronjob/src/utils/i18n.ts
@@ -3,7 +3,7 @@ import { LANG_KEY } from './cookieUtils';
 
 export const serviceSideProps = (content: any) => {
   return serverSideTranslations(
-    content.req.cookies[LANG_KEY] || 'en',
+    content.req.cookies[LANG_KEY] || 'zh',
     undefined,
     null,
     content.locales

--- a/frontend/providers/dbprovider/next-i18next.config.js
+++ b/frontend/providers/dbprovider/next-i18next.config.js
@@ -5,8 +5,8 @@
 
 module.exports = {
   i18n: {
-    defaultLocale: 'en',
-    locales: ['en', 'zh', 'zh-Hans'],
+    defaultLocale: 'zh',
+    locales: ['en', 'zh'],
     localeDetection: false
   }
-};
+}

--- a/frontend/providers/dbprovider/src/pages/_app.tsx
+++ b/frontend/providers/dbprovider/src/pages/_app.tsx
@@ -126,7 +126,7 @@ function App({ Component, pageProps }: AppProps) {
   }, [router.pathname]);
 
   useEffect(() => {
-    const lang = getLangStore() || 'en';
+    const lang = getLangStore() || 'zh';
     i18n?.changeLanguage?.(lang);
   }, [refresh, router.asPath]);
 

--- a/frontend/providers/dbprovider/src/utils/cookieUtils.ts
+++ b/frontend/providers/dbprovider/src/utils/cookieUtils.ts
@@ -1,6 +1,6 @@
 import Cookies from 'js-cookie';
 
-export const LANG_KEY = 'NEXT_LOCALE_LANG';
+export const LANG_KEY = 'NEXT_LOCALE';
 
 export const setLangStore = (value: string) => {
   return Cookies.set(LANG_KEY, value, { expires: 30, sameSite: 'None', secure: true });

--- a/frontend/providers/dbprovider/src/utils/i18n.ts
+++ b/frontend/providers/dbprovider/src/utils/i18n.ts
@@ -3,7 +3,7 @@ import { LANG_KEY } from './cookieUtils';
 
 export const serviceSideProps = (content: any) => {
   return serverSideTranslations(
-    content.req.cookies[LANG_KEY] || 'en',
+    content.req.cookies[LANG_KEY] || 'zh',
     undefined,
     null,
     content.locales

--- a/frontend/providers/license/next-i18next.config.js
+++ b/frontend/providers/license/next-i18next.config.js
@@ -5,8 +5,8 @@
 
 module.exports = {
   i18n: {
-    defaultLocale: 'en',
+    defaultLocale: 'zh',
     locales: ['en', 'zh'],
     localeDetection: false
   }
-};
+}

--- a/frontend/providers/license/src/pages/_app.tsx
+++ b/frontend/providers/license/src/pages/_app.tsx
@@ -121,7 +121,7 @@ function App({ Component, pageProps }: AppProps) {
   }, [router.pathname]);
 
   useEffect(() => {
-    const lang = getLangStore() || 'en';
+    const lang = getLangStore() || 'zh';
     i18n?.changeLanguage?.(lang);
   }, [refresh, router.asPath]);
 

--- a/frontend/providers/license/src/utils/cookieUtils.ts
+++ b/frontend/providers/license/src/utils/cookieUtils.ts
@@ -1,6 +1,6 @@
 import Cookies from 'js-cookie';
 
-export const LANG_KEY = 'NEXT_LOCALE_LANG';
+export const LANG_KEY = 'NEXT_LOCALE';
 
 export const setLangStore = (value: string) => {
   return Cookies.set(LANG_KEY, value, { expires: 30, sameSite: 'None', secure: true });

--- a/frontend/providers/template/next-i18next.config.js
+++ b/frontend/providers/template/next-i18next.config.js
@@ -5,8 +5,8 @@
 
 module.exports = {
   i18n: {
-    defaultLocale: 'en',
-    locales: ['en', 'zh', 'zh-Hans'],
+    defaultLocale: 'zh',
+    locales: ['en', 'zh'],
     localeDetection: false
   }
-};
+}

--- a/frontend/providers/template/src/pages/_app.tsx
+++ b/frontend/providers/template/src/pages/_app.tsx
@@ -113,7 +113,7 @@ const App = ({ Component, pageProps, domain }: AppProps & { domain: string }) =>
   }, [router.pathname]);
 
   useEffect(() => {
-    const lang = getLangStore() || 'en';
+    const lang = getLangStore() || 'zh';
     i18n?.changeLanguage?.(lang);
   }, [refresh, router.pathname]);
 

--- a/frontend/providers/template/src/utils/cookieUtils.ts
+++ b/frontend/providers/template/src/utils/cookieUtils.ts
@@ -1,6 +1,6 @@
 import Cookies from 'js-cookie';
 
-export const LANG_KEY = 'NEXT_LOCALE_LANG';
+export const LANG_KEY = 'NEXT_LOCALE';
 
 export const setLangStore = (value: string) => {
   return Cookies.set(LANG_KEY, value, { expires: 30, sameSite: 'None', secure: true });

--- a/frontend/providers/template/src/utils/i18n.ts
+++ b/frontend/providers/template/src/utils/i18n.ts
@@ -3,7 +3,7 @@ import { LANG_KEY } from './cookieUtils';
 
 export const serviceSideProps = (content: any) => {
   return serverSideTranslations(
-    content.req.cookies[LANG_KEY] || 'en',
+    content.req.cookies[LANG_KEY] || 'zh',
     undefined,
     null,
     content.locales


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 965cf62</samp>

### Summary
🌐🍪🛠️

<!--
1.  🌐 - This emoji represents the global or international aspect of the changes, as they involve switching the primary language of the frontend desktop application and the providers from English to Chinese. It also implies that the application and the services support multiple languages and locales, and that the language preference can be changed by the user or the cookie.
2.  🍪 - This emoji represents the cookie aspect of the changes, as they involve setting and reading the NEXT_LOCALE cookie value to persist the language preference across pages and requests. It also implies that the cookie is an important factor in determining the language of the frontend and the backend, and that the cookie name is consistent across the providers and the frontend desktop application.
3.  🛠️ - This emoji represents the tool or service aspect of the changes, as they involve updating the next-i18next configuration and the serverSideTranslations function for the frontend desktop application and the providers. It also implies that the changes improve the functionality and the quality of the application and the services, and that they use a common tool or library for internationalization.
-->
This pull request changes the default locale from 'en' to 'zh' for the frontend desktop application and several providers, such as applaunchpad, costcenter, cronjob, dbprovider, and license. It also updates the cookie names, the function parameters, and the data properties to use the `NEXT_LOCALE` value or 'zh' as the language preference. These changes are to support Chinese as the primary language for the sealos platform.

> _Sing, O Muse, of the mighty pull request_
> _That changed the default locale to 'zh'_
> _And made the frontend desktop application_
> _Speak the language of the dragon and the phoenix._

### Walkthrough
*  Change the default locale for the next-i18next configuration from 'en' to 'zh' in the frontend desktop application and the applaunchpad, costcenter, cronjob, dbprovider, and license providers ([link](https://github.com/labring/sealos/pull/4114/files?diff=unified&w=0#diff-481e65e1560644671e375ec1bacf60b325c22b6db5e07ebba80735e971cf588eL7-R7), [link](https://github.com/labring/sealos/pull/4114/files?diff=unified&w=0#diff-4270c25d2d4d20ee55308e1d0f16d3f9e716a69eed863ebe1dc36f63e71b78b4L8-R12), [link](https://github.com/labring/sealos/pull/4114/files?diff=unified&w=0#diff-ef42e06d82344c4f1617b4f61a987244dc9bacb03ae8299ea8968da406416a45L8-R12), [link](https://github.com/labring/sealos/pull/4114/files?diff=unified&w=0#diff-f1481caaee5766be9e29c10ff853fe5eebe5d5a84fb7f37a5d0c446b1ffd2651L8-R12), [link](https://github.com/labring/sealos/pull/4114/files?diff=unified&w=0#diff-c096c40745650524d039b8648df636fa03562bee68a8f912c91dde53f81d077eL8-R12), [link](https://github.com/labring/sealos/pull/4114/files?diff=unified&w=0#diff-34f78d120dd268ad12d528c6b37ed5a7e28acf8ae44f94d251b33cf40e6c65baL8-R12))
*  Add a cookie header to the getServerSideProps functions in the index and signin pages of the frontend desktop application to set the NEXT_LOCALE value to the local variable derived from the request cookies or the default locale ([link](https://github.com/labring/sealos/pull/4114/files?diff=unified&w=0#diff-c04141c0579122cad0175ca367c6a04f583111f500a9211b58fa3b207d2b2b53R110-R111), [link](https://github.com/labring/sealos/pull/4114/files?diff=unified&w=0#diff-f4daef00368888e45ceb00f6832c7e2fec248cf288a93475e443cee60545332cR11))
*  Change the local variable in the getServerSideProps function in the license page of the frontend desktop application from defaulting to 'en' to defaulting to 'zh' ([link](https://github.com/labring/sealos/pull/4114/files?diff=unified&w=0#diff-ca3504c8d987bf14bedcc592eddf89d95519e7423f8a1b2cc3ffe3bf6c8518dcL68-R68))
*  Change the data returned by the MasterSDK class in the client-sdk package to use the NEXT_LOCALE cookie value or 'zh' as the lng property instead of 'en' ([link](https://github.com/labring/sealos/pull/4114/files?diff=unified&w=0#diff-eb01c4844385592fca4616e5bf3e2ecb6366e3e22ff6d6acbf0cee9db225ea8eL197-R197))
*  Change the type of the data parameter in the changeI18n function in the `_app.tsx` page of the applaunchpad provider from any to { currentLanguage: string } ([link](https://github.com/labring/sealos/pull/4114/files?diff=unified&w=0#diff-ebd69d41e82f5d5fbc4c8884ac0789e5e3e743e88c10031cebbf19d53120ea02L102-R102))
*  Change the lang variable in the useEffect hooks in the `_app.tsx` pages of the applaunchpad, cronjob, and dbprovider providers from defaulting to 'en' to defaulting to 'zh' ([link](https://github.com/labring/sealos/pull/4114/files?diff=unified&w=0#diff-ebd69d41e82f5d5fbc4c8884ac0789e5e3e743e88c10031cebbf19d53120ea02L135-R135), [link](https://github.com/labring/sealos/pull/4114/files?diff=unified&w=0#diff-9a02d430886ed479236e48950e5a2e867eb5019597516e008e0bc5d7324f124eL124-R124), [link](https://github.com/labring/sealos/pull/4114/files?diff=unified&w=0#diff-ed93ee59d9c7208ec4b3941117521bf9fed9bf925c6cd5af0b238085afd613c3L129-R129))
*  Change the LANG_KEY constant in the cookieUtils modules of the applaunchpad and cronjob providers from 'NEXT_LOCALE_LANG' to 'NEXT_LOCALE' ([link](https://github.com/labring/sealos/pull/4114/files?diff=unified&w=0#diff-3e513fcbdceac3cd9b4998605e43119710d849b710f1ea82237e19adf0db3c66L3-R3), [link](https://github.com/labring/sealos/pull/4114/files?diff=unified&w=0#diff-c9e3868e19780eb98cfe17c43c590b3c29075bc4114aab96c59b649fa2391034L3-R3))
*  Change the first argument of the serverSideTranslations function in the serviceSideProps function in the i18n modules of the applaunchpad, cronjob, and dbprovider providers from defaulting to 'en' to defaulting to 'zh' ([link](https://github.com/labring/sealos/pull/4114/files?diff=unified&w=0#diff-eea1f9e3673da58e2d233d40ed53a6f7f68e8f320738483c6b7e1a2f15de5383L6-R6), [link](https://github.com/labring/sealos/pull/4114/files?diff=unified&w=0#diff-ca8748e12d5262764a8061a22e93555422e21585b7586765b6c6176c51c84ebfL6-R6), [link](https://github.com/labring/sealos/pull/4114/files?diff=unified&w=0#diff-806feb080127f43f7ebc28de9ae5b07085bca6ccb8f354580a82f7111f402777L6-R6))
*  Remove the 'zh-Hans' locale from the locales array in the next-i18next configuration in the costcenter and dbprovider providers as it is redundant with 'zh' ([link](https://github.com/labring/sealos/pull/4114/files?diff=unified&w=0#diff-ef42e06d82344c4f1617b4f61a987244dc9bacb03ae8299ea8968da406416a45L8-R12), [link](https://github.com/labring/sealos/pull/4114/files?diff=unified&w=0#diff-c096c40745650524d039b8648df636fa03562bee68a8f912c91dde53f81d077eL8-R12))
*  Change the locale property in the useSessionStore hook in the session module of the costcenter provider from 'en' to 'zh' ([link](https://github.com/labring/sealos/pull/4114/files?diff=unified&w=0#diff-5a6a5e8505a6a7399f4fa7bf2e8dfe8737742b428de5568be970e1b724ac3ef6L24-R24))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
