### PR TITLE
Fix/cloud scripts

### DIFF
--- a/.github/workflows/controllers.yml
+++ b/.github/workflows/controllers.yml
@@ -103,14 +103,14 @@ jobs:
       - name: Build ${{ matrix.module.name }} amd64
         working-directory: controllers/${{ matrix.module.path }}
         run: |
-          GOARCH=amd64 make build
+          GOARCH=amd64 TARGETARCH=amd64 make build
           mv bin/manager bin/controller-${{ matrix.module.name }}-amd64
           chmod +x bin/controller-${{ matrix.module.name }}-amd64
 
       - name: Build ${{ matrix.module.name }} arm64
         working-directory: controllers/${{ matrix.module.path }}
         run: |
-          GOARCH=arm64 make build
+          GOARCH=arm64 TARGETARCH=arm64 make build
           mv bin/manager bin/controller-${{ matrix.module.name }}-arm64
           chmod +x bin/controller-${{ matrix.module.name }}-arm64
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2f00654</samp>

### Summary
🏗️🚀🛠️

<!--
1.  🏗️ - This emoji represents the `make build` command and the building of the binary output.
2.  🚀 - This emoji represents the sealos cloud installation and the launching of the Kubernetes cluster.
3.  🛠️ - This emoji represents the improvements and optimizations made to the `install.sh` script.
-->
This pull request enhances the sealos cloud installation and the cross-platform build process. It adds the `TARGETARCH` variable to the `make build` command in `.github/workflows/controllers.yml` to ensure binary compatibility. It also improves the `install.sh` script in `scripts/cloud/install.sh` by adding local installation support, updating the image version, and adding more prompts, checks, and optimizations.

> _We build the sealos cloud with `TARGETARCH`_
> _We defy the platform limits with our code and our march_
> _We install the script with local and remote options_
> _We optimize the image and the storage with our actions_

### Walkthrough
*  Add `TARGETARCH` environment variable to `make build` command for amd64 and arm64 architectures ([link](https://github.com/labring/sealos/pull/4115/files?diff=unified&w=0#diff-8e0e4903d4e4f8b8844d36370ca2d71c7c72d03ddb7a9cdcedc6328dfc5da8faL106-R106), [link](https://github.com/labring/sealos/pull/4115/files?diff=unified&w=0#diff-8e0e4903d4e4f8b8844d36370ca2d71c7c72d03ddb7a9cdcedc6328dfc5da8faL113-R113))
*  Update `CLOUD_VERSION` variable to use `latest` tag instead of fixed version ([link](https://github.com/labring/sealos/pull/4115/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL8-R8))
*  Add `local_install` variable to indicate single node or multiple node installation ([link](https://github.com/labring/sealos/pull/4115/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aR21), [link](https://github.com/labring/sealos/pull/4115/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL114-R126), [link](https://github.com/labring/sealos/pull/4115/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL154-R220))
*  Add `pre_prompt` and `pull_image` prompts to inform user of dependencies and image pulling progress ([link](https://github.com/labring/sealos/pull/4115/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL36-R40), [link](https://github.com/labring/sealos/pull/4115/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL64-R93))
*  Remove unnecessary sentence from `patching_ingress` prompt ([link](https://github.com/labring/sealos/pull/4115/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL51-R54))
*  Add error handling for `grep avx /proc/cpuinfo` command and set `mongodb_version` accordingly ([link](https://github.com/labring/sealos/pull/4115/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aR110))
*  Pull images before installation with `sealos pull` command to avoid timeouts or errors ([link](https://github.com/labring/sealos/pull/4115/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aR147-R159))
*  Expand `--masters` and `--nodes` flags only if variables are not empty and use default values for subnets if variables are empty ([link](https://github.com/labring/sealos/pull/4115/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL154-R220), [link](https://github.com/labring/sealos/pull/4115/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL230-R275))
*  Suppress output and errors of `command -v` and `source` commands ([link](https://github.com/labring/sealos/pull/4115/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL230-R275), [link](https://github.com/labring/sealos/pull/4115/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL277-R314), [link](https://github.com/labring/sealos/pull/4115/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL327-R360))
*  Group `get_prompt` and `sealos apply` commands in subshell and inform user of Kubernetes cluster installation ([link](https://github.com/labring/sealos/pull/4115/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL277-R314))
*  Check if `openebs-backup` storage class exists and create it if not ([link](https://github.com/labring/sealos/pull/4115/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL287-R320))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
