### PR TITLE
fix sync image 

### DIFF
--- a/pkg/filesystem/registry/sync.go
+++ b/pkg/filesystem/registry/sync.go
@@ -150,7 +150,7 @@ func syncViaSSH(s *impl, targets []string) func(context.Context, string) error {
 		for i := range targets {
 			target := targets[i]
 			eg.Go(func() error {
-				return ssh.CopyDir(s.ssh, target, localDir, s.pathResolver.RootFSPath(), constants.IsRegistryDir)
+				return ssh.CopyDir(s.ssh, target, localDir, s.pathResolver.RootFSPath(), nil)
 			})
 		}
 		return eg.Wait()


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5baf68c</samp>

### Summary
:wastebasket::package::zap:

<!--
1.  :wastebasket: This emoji represents the removal of an argument or a feature that is no longer needed or used. It conveys the idea of cleaning up or simplifying the code.
2.  :package: This emoji represents the change in the way the registry directory is handled, as it is now a separate volume mount and not part of the workspace directory. It conveys the idea of packaging or isolating the registry files from other files.
3.  :zap: This emoji represents the improvement in performance or efficiency that the change may bring, as it avoids unnecessary checks or copying of files that are not part of the registry directory. It conveys the idea of speed or optimization.
-->
Simplify registry directory copying by removing unused argument. The change affects the `ssh.CopyDir` function call in `pkg/filesystem/registry/sync.go`.

> _`CopyDir` simpler_
> _No need to filter files now_
> _Registry is clear_

### Walkthrough
*  Simplify the `ssh.CopyDir` function call by removing the `constants.IsRegistryDir` argument ([link](https://github.com/labring/sealos/pull/4119/files?diff=unified&w=0#diff-9d77d600601adda24842f567809994d01cf84d860574c5ed89288c53c3a5f7f5L153-R153))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
