### PR TITLE
:bug: set default http sync registry

### DIFF
--- a/pkg/filesystem/registry/sync.go
+++ b/pkg/filesystem/registry/sync.go
@@ -150,7 +150,7 @@ func syncViaSSH(s *impl, targets []string) func(context.Context, string) error {
 		for i := range targets {
 			target := targets[i]
 			eg.Go(func() error {
-				return ssh.CopyDir(s.ssh, target, localDir, s.pathResolver.RootFSPath(), nil)
+				return ssh.CopyDir(s.ssh, target, localDir, s.pathResolver.RootFSRegistryPath(), nil)
 			})
 		}
 		return eg.Wait()


### PR DESCRIPTION
Signed-off-by: cuisongliu <cuisongliu@qq.com>

# Conflicts:
#	pkg/filesystem/registry/sync.go

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 64b1f2f</samp>

### Summary
🛠️🐛🚀

<!--
1.  🛠️ - This emoji represents the enhancement of the registry serve command with a debug mode, which is a useful feature for troubleshooting and debugging issues with the registry service.
2.  🐛 - This emoji represents the fix of a path issue in the syncViaSSH function, which is a bug that could cause errors or failures when syncing files between nodes.
3.  🚀 - This emoji represents the improvement of the reliability and usability of the registry service for sealos, which is a benefit for users who want to deploy and manage their own private container registry.
-->
This pull request adds a debug mode to the `registry serve` command and fixes a path issue in the `syncViaSSH` function. These changes help users to troubleshoot and manage the registry service for `sealos`.

> _Sing, O Muse, of the valiant deeds of sealos,_
> _The mighty tool that builds and manages clusters,_
> _How it enhanced its `registry serve` command_
> _With a debug mode, a boon for troubleshooters._

### Walkthrough
* Enable debug mode for registry server by adding `-d` flag to registry serve command ([link](https://github.com/labring/sealos/pull/4120/files?diff=unified&w=0#diff-9d77d600601adda24842f567809994d01cf84d860574c5ed89288c53c3a5f7f5L133-R133))
* Fix bug in syncViaSSH function by using correct path for remote registry directory from `RootFSRegistryPath` method ([link](https://github.com/labring/sealos/pull/4120/files?diff=unified&w=0#diff-9d77d600601adda24842f567809994d01cf84d860574c5ed89288c53c3a5f7f5L153-R153))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
