### PR TITLE
fix: return converted component configs

### DIFF
--- a/pkg/runtime/kubernetes/types/kubeadm_config.go
+++ b/pkg/runtime/kubernetes/types/kubeadm_config.go
@@ -50,8 +50,17 @@ func NewKubeadmConfig() *KubeadmConfig {
 }
 
 func (k *KubeadmConfig) GetComponents() []any {
+	converted, err := k.ToConvertedKubeadmConfig()
+	if err != nil {
+		logger.Error("failed to convert kubeadmConfig: %v", err)
+		return nil
+	}
 	return []any{
-		k.InitConfiguration, k.ClusterConfiguration, k.JoinConfiguration, k.KubeProxyConfiguration, k.KubeletConfiguration,
+		converted.InitConfiguration,
+		converted.ClusterConfiguration,
+		converted.JoinConfiguration,
+		converted.KubeProxyConfiguration,
+		converted.KubeletConfiguration,
 	}
 }
 
@@ -146,8 +155,7 @@ func (k *KubeadmConfig) ToConvertedKubeadmConfig() (*ConvertedKubeadmConfig, err
 		conversion.InitConfiguration = v1beta2InitConfiguration
 		conversion.ClusterConfiguration = v1beta2ClusterConfiguration
 		conversion.JoinConfiguration = v1beta2JoinConfiguration
-
-	case KubeadmV1beta3:
+	case KubeadmV1beta3, "": // defaults to v1beta3
 		var v1beta3InitConfiguration v1beta3.InitConfiguration
 		var v1beta3ClusterConfiguration v1beta3.ClusterConfiguration
 		var v1beta3JoinConfiguration v1beta3.JoinConfiguration
@@ -169,7 +177,7 @@ func (k *KubeadmConfig) ToConvertedKubeadmConfig() (*ConvertedKubeadmConfig, err
 		conversion.InitConfiguration = v1beta3InitConfiguration
 		conversion.ClusterConfiguration = v1beta3ClusterConfiguration
 		conversion.JoinConfiguration = v1beta3JoinConfiguration
-	default:
+	default: // unknown version
 		conversion.JoinConfiguration = k.JoinConfiguration
 		conversion.InitConfiguration = k.InitConfiguration
 		conversion.ClusterConfiguration = k.ClusterConfiguration


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at eb87ad1</samp>

### Summary
🔄🚀🛠️

<!--
1.  🔄 - This emoji represents the refactoring aspect of the change, as the code was restructured to use a different method for converting the kubeadm config.
2.  🚀 - This emoji represents the improvement aspect of the change, as the code is now more robust and compatible with different kubeadm API versions.
3.  🛠️ - This emoji represents the bugfix aspect of the change, as the code is now less prone to errors when dealing with the kubeadm config.
-->
Refactor `GetComponents` method of `KubeadmConfig` to use external kubeadm API version. This improves compatibility and simplifies config handling in sealos.

> _`KubeadmConfig` changed_
> _To convert before return_
> _Simpler and safer_

### Walkthrough
* Convert the internal kubeadm config to the external version before returning the components in `GetComponents` ([link](https://github.com/labring/sealos/pull/4121/files?diff=unified&w=0#diff-28bf679f318f0039d1cffc3ff8c01a3f40b12950d79d76d2ea774628776270ceL53-R62))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
