### PR TITLE
fix: ssh sync registry contents to target dir

### DIFF
--- a/pkg/filesystem/registry/sync.go
+++ b/pkg/filesystem/registry/sync.go
@@ -147,7 +147,7 @@ func getRegistryServeCommand(pathResolver constants.PathResolver, port string) s
 }
 
 func syncViaSSH(_ context.Context, s *impl, target string, localDir string) error {
-	return ssh.CopyDir(s.execer, target, localDir, s.pathResolver.RootFSPath(), nil)
+	return ssh.CopyDir(s.execer, target, localDir, s.pathResolver.RootFSRegistryPath(), nil)
 }
 
 func syncViaHTTP(ctx context.Context, target string, localDir string) error {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4b6b6cf</samp>

### Summary
🐛🔄🚀

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change. The `syncViaSSH` function was not working as intended before the change, and the emoji conveys that the change fixes a problem.
2.  🔄 - This emoji represents a sync operation, which is the secondary effect of the change. The `syncViaSSH` function is responsible for syncing the registry data across nodes, and the emoji conveys that the change improves this functionality.
3.  🚀 - This emoji represents a performance improvement, which is the tertiary benefit of the change. The `syncViaSSH` function is part of a feature that allows faster and more reliable deployment of applications using the registry data, and the emoji conveys that the change enhances this feature.
-->
Fix registry data sync bug and add SSH support. Use `RootFSRegistryPath` instead of `RootFSPath` in `syncViaSSH` function in `pkg/filesystem/registry/sync.go`.

> _`syncViaSSH` fixed_
> _Registry data now flows_
> _Like autumnal leaves_

### Walkthrough
* Fix bug where registry data was not synced to the correct directory on the remote node by using `RootFSRegistryPath` instead of `RootFSPath` in `syncViaSSH` function ([link](https://github.com/labring/sealos/pull/4123/files?diff=unified&w=0#diff-9d77d600601adda24842f567809994d01cf84d860574c5ed89288c53c3a5f7f5L150-R150))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
