### PR TITLE
fix license base64 decode salt.

### DIFF
--- a/controllers/job/init/deploy/manifests/deploy.yaml
+++ b/controllers/job/init/deploy/manifests/deploy.yaml
@@ -39,7 +39,7 @@ spec:
               secretKeyRef:
                 name: desktop-frontend-secret
                 key: mongodb_uri
-          - name: PASSWORD_SALT_KEY
+          - name: PASSWORD_SALT
             valueFrom:
               secretKeyRef:
                 name: desktop-frontend-secret

--- a/controllers/job/init/internal/util/database/password.go
+++ b/controllers/job/init/internal/util/database/password.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"crypto/sha256"
-	"encoding/base64"
 	"encoding/hex"
 	"os"
 )
@@ -11,12 +10,8 @@ var (
 	saltKey = os.Getenv("PASSWORD_SALT_KEY")
 )
 
-func hashPassword(password string) (string, error) {
+func hashPassword(password string) string {
 	hash := sha256.New()
-	validSalt, err := base64.StdEncoding.DecodeString(saltKey)
-	if err != nil {
-		return "", err
-	}
-	hash.Write([]byte(password + string(validSalt)))
-	return hex.EncodeToString(hash.Sum(nil)), nil
+	hash.Write([]byte(password + saltKey))
+	return hex.EncodeToString(hash.Sum(nil))
 }

--- a/controllers/job/init/internal/util/database/user.go
+++ b/controllers/job/init/internal/util/database/user.go
@@ -56,11 +56,7 @@ func PresetAdminUser(ctx context.Context) error {
 }
 
 func newAdminUser() (*User, error) {
-	hashedPassword, err := hashPassword(DefaultAdminPassword)
-	if err != nil {
-		return nil, err
-	}
-	return newUser(uuid.New().String(), DefaultAdminUserName, DefaultAdminUserName, hashedPassword, controller.DefaultAdminUserName), nil
+	return newUser(uuid.New().String(), DefaultAdminUserName, DefaultAdminUserName, hashPassword(DefaultAdminPassword), controller.DefaultAdminUserName), nil
 }
 
 func newUser(uid, name, passwordUser, hashedPassword, k8sUser string) *User {

--- a/deploy/cloud/scripts/init.sh
+++ b/deploy/cloud/scripts/init.sh
@@ -172,7 +172,7 @@ function sealos_authorize {
   # wait for admin user create
   echo "Waiting for admin user create"
 
-  while [ -z "$(kubectl get ns -n ns-admin 2>/dev/null)" ]; do
+  while [ -z "$(kubectl get ns ns-admin 2>/dev/null)" ]; do
     sleep 1
   done
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6154bf1</samp>

### Summary
🔧🔑🚀

<!--
1.  🔧 for fixing a bug or improving the code quality
2.  🔑 for changing a secret or password-related feature
3.  🚀 for deploying or launching a new version of the application
-->
Improved password hashing and fixed a script bug in the init job controller. Changed the environment variable name for the password salt in `deploy.yaml` and simplified the hashing function in `password.go`. Corrected the `kubectl get ns` command in `init.sh`.

> _To hash passwords with a salt_
> _We fixed some code that was at fault_
> _We changed the env var_
> _And the function by far_
> _And the `kubectl` command we did halt_

### Walkthrough
*  Simplify password hashing function to use plain string salt and return string ([link](https://github.com/labring/sealos/pull/4127/files?diff=unified&w=0#diff-3b4a32d9581f1c6e4ba71fc6275d6c6004ca2e006f72b27e2e3af48e099cbeddL14-R16),[link](https://github.com/labring/sealos/pull/4127/files?diff=unified&w=0#diff-3b4a32d9581f1c6e4ba71fc6275d6c6004ca2e006f72b27e2e3af48e099cbeddL5),[link](https://github.com/labring/sealos/pull/4127/files?diff=unified&w=0#diff-5befc350ab32c556b6d1a8f18524dfdc58d6147711b1094daa127d6fd948a842L59-R59))
  - Update environment variable name for salt to match Go code ([link](https://github.com/labring/sealos/pull/4127/files?diff=unified&w=0#diff-8543d003497a7e5bba522aeaafc99725eec71e73ffd07e3a6920b435cad7fc3aL42-R42))
  - Remove unused import of `encoding/base64` package ([link](https://github.com/labring/sealos/pull/4127/files?diff=unified&w=0#diff-3b4a32d9581f1c6e4ba71fc6275d6c6004ca2e006f72b27e2e3af48e099cbeddL5))
  - Change function signature and return value to string ([link](https://github.com/labring/sealos/pull/4127/files?diff=unified&w=0#diff-3b4a32d9581f1c6e4ba71fc6275d6c6004ca2e006f72b27e2e3af48e099cbeddL14-R16))
  - Adjust function call and remove error handling in `user.go` ([link](https://github.com/labring/sealos/pull/4127/files?diff=unified&w=0#diff-5befc350ab32c556b6d1a8f18524dfdc58d6147711b1094daa127d6fd948a842L59-R59))
* Fix `kubectl get ns` command to use argument instead of flag for namespace name ([link](https://github.com/labring/sealos/pull/4127/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844L175-R175))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
