### PR TITLE
fix account user null & language

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM node:current-alpine As base
+FROM node:18.15-alpine As base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 

--- a/frontend/desktop/src/components/account/index.tsx
+++ b/frontend/desktop/src/components/account/index.tsx
@@ -120,7 +120,12 @@ export default function Index({ disclosure }: { disclosure: UseDisclosureReturn 
 
   const openApp = useAppStore((s) => s.openApp);
   const installApp = useAppStore((s) => s.installedApps);
-  const { ns_uid, nsid, userId, k8s_username } = user;
+  const { ns_uid, nsid, userId, k8s_username } = user || {
+    ns_uid: '',
+    nsid: '',
+    userId: '',
+    k8s_username: ''
+  };
   const { data } = useQuery({
     queryKey: ['getAccount', { ns_uid, userId, k8s_username }],
     queryFn: () =>

--- a/frontend/desktop/src/pages/index.tsx
+++ b/frontend/desktop/src/pages/index.tsx
@@ -8,6 +8,7 @@ import useSessionStore from '@/stores/session';
 import { ApiResp } from '@/types';
 import { SystemConfigType } from '@/types/system';
 import { parseOpenappQuery } from '@/utils/format';
+import { compareFirstLanguages } from '@/utils/tools';
 import { Box, useColorMode } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
@@ -105,8 +106,7 @@ export default function Home({
 }
 
 export async function getServerSideProps({ req, res, locales }: any) {
-  const lang: string = req?.headers?.['accept-language'] || 'zh';
-  const local = lang.indexOf('zh') !== -1 ? 'zh' : 'en';
+  const local = compareFirstLanguages(req?.headers?.['accept-language'] || 'zh');
   res.setHeader('Set-Cookie', `NEXT_LOCALE=${local}; Max-Age=2592000; Secure; SameSite=None`);
 
   const sealos_cloud_domain = process.env.SEALOS_CLOUD_DOMAIN || 'cloud.sealos.io';

--- a/frontend/desktop/src/pages/signin.tsx
+++ b/frontend/desktop/src/pages/signin.tsx
@@ -1,4 +1,5 @@
 import SigninComponent from '@/components/signin';
+import { compareFirstLanguages } from '@/utils/tools';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 
 export default function SigninPage() {
@@ -6,8 +7,7 @@ export default function SigninPage() {
 }
 
 export async function getServerSideProps({ req, res, locales }: any) {
-  const lang: string = req?.headers?.['accept-language'] || 'zh';
-  const local = lang.indexOf('zh') !== -1 ? 'zh' : 'en';
+  const local = compareFirstLanguages(req?.headers?.['accept-language'] || 'zh');
   res.setHeader('Set-Cookie', `NEXT_LOCALE=${local}; Max-Age=2592000; Secure; SameSite=None`);
 
   const props = {

--- a/frontend/desktop/src/utils/tools.ts
+++ b/frontend/desktop/src/utils/tools.ts
@@ -83,3 +83,11 @@ export const vaildManage =
   };
 export const isUserRole = (role: any): role is UserRole =>
   [UserRole.Developer, UserRole.Manager, UserRole.Owner].includes(role);
+
+export function compareFirstLanguages(acceptLanguageHeader: string) {
+  const indexOfZh = acceptLanguageHeader.indexOf('zh');
+  const indexOfEn = acceptLanguageHeader.indexOf('en');
+  if (indexOfZh === -1) return 'en'; // 如果没有 "zh"，返回英文
+  if (indexOfEn === -1 || indexOfZh < indexOfEn) return 'zh';
+  return 'en';
+}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0fdbeff</samp>

### Summary
🛠️🌐♻️

<!--
1.  🛠️ - This emoji represents a tool or a fix, and can be used to indicate the addition of the fallback value for the user object and the definition of the `compareFirstLanguages` function in the `tools.ts` file. These changes are meant to improve the functionality and reliability of the code.
2.  🌐 - This emoji represents the globe or the world, and can be used to indicate the language detection logic and the cookie setting for the next locale. These changes are meant to enhance the user experience and the internationalization of the app.
3.  ♻️ - This emoji represents recycling or refactoring, and can be used to indicate the refactoring of the code to use the common utility function `compareFirstLanguages` in the `signin.tsx` and `index.tsx` pages. These changes are meant to improve the code quality and maintainability.
-->
The pull request refactors the language detection logic in the `index.tsx` and `signin.tsx` pages by using a common utility function `compareFirstLanguages` defined in `tools.ts`. It also adds a fallback value for the user object in `account/index.tsx` to prevent errors.

> _Oh we're the coders of the sea, and we work with skill and glee_
> _We refactor and we test, to make our code the best_
> _We use `compareFirstLanguages` to set the user's locale_
> _And we heave away, me hearties, heave away on the count of three_

### Walkthrough
*  Added a utility function `compareFirstLanguages` in `tools.ts` to determine the preferred language of the user based on the `accept-language` header ([link](https://github.com/labring/sealos/pull/4128/files?diff=unified&w=0#diff-962ed02c62d427fa7b5451162a5ec7089662d4166826101dd8a89a4998b63560R86-R93))
*  Replaced the original logic of checking the index of 'zh' and 'en' in the `accept-language` header with the `compareFirstLanguages` function in the `index.tsx` and `signin.tsx` pages, simplifying the code and making it more consistent ([link](https://github.com/labring/sealos/pull/4128/files?diff=unified&w=0#diff-c04141c0579122cad0175ca367c6a04f583111f500a9211b58fa3b207d2b2b53R11), [link](https://github.com/labring/sealos/pull/4128/files?diff=unified&w=0#diff-c04141c0579122cad0175ca367c6a04f583111f500a9211b58fa3b207d2b2b53L108-R109), [link](https://github.com/labring/sealos/pull/4128/files?diff=unified&w=0#diff-f4daef00368888e45ceb00f6832c7e2fec248cf288a93475e443cee60545332cR2), [link](https://github.com/labring/sealos/pull/4128/files?diff=unified&w=0#diff-f4daef00368888e45ceb00f6832c7e2fec248cf288a93475e443cee60545332cL9-R10))
*  Added a fallback value for the user object in the queryKey of the `account` component in case it is undefined or null, preventing potential errors when accessing the user properties ([link](https://github.com/labring/sealos/pull/4128/files?diff=unified&w=0#diff-f080c4cc5f58f00e0d58040ad4f90c0bdf6b500e0ea8d8711bacaa900803500bL123-R128))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
