### PR TITLE
optimize scripts

### DIFF
--- a/scripts/cloud/install.sh
+++ b/scripts/cloud/install.sh
@@ -241,7 +241,7 @@ pull_image() {
 
   echo -ne "\033[1F\033[2K"
   get_prompt "pull_image" $inline && echo "$image_name:$image_version"
-  sealos pull -q "${image_registry}/${image_repository}/$image_name:${image_version#v:}" >/dev/null
+  sealos pull -q "${image_registry}/${image_repository}/${image_name}:${image_version}" >/dev/null
 }
 
 collect_input() {

--- a/scripts/cloud/install.sh
+++ b/scripts/cloud/install.sh
@@ -18,16 +18,18 @@ CLOUD_VERSION="latest"
 #input_cert=
 #cert_path=
 #key_path=
-#local_install=y/n
-kubernetes_version=1.25.6
-cilium_version=1.12.14
-cert_manager_version=1.8.0
-helm_version=3.12.0
-openebs_version=3.4.0
-reflector_version=7.0.151
-ingress_nginx_version=1.5.1
-kubeblocks_version=0.6.2
-metrics_server_version=0.6.4
+#single=y/n
+image_registry=${image_registry:-"docker.io"}
+image_repository=${image_repository:-"labring"}
+kubernetes_version=${kubernetes_version:-"1.25.6"}
+cilium_version=${cilium_version:-"1.12.14"}
+cert_manager_version=${cert_manager_version:-"1.8.0"}
+helm_version=${helm_version:-"3.12.0"}
+openebs_version=${openebs_version:-"3.4.0"}
+reflector_version=${reflector_version:-"7.0.151"}
+ingress_nginx_version=${ingress_nginx_version:-"1.5.1"}
+kubeblocks_version=${kubeblocks_version:-"0.6.2"}
+metrics_server_version=${metrics_server_version:-"0.6.4"}
 
 
 # Define English and Chinese prompts
@@ -35,7 +37,7 @@ declare -A PROMPTS_EN PROMPTS_CN
 
 PROMPTS_EN=(
     ["pre_prompt"]="Depends on iptables, please make sure iptables is installed, multi-node needs to configure ssh password-free login or the same password, using self-signed certificate to complete the installation requires self-trust certificate"
-    ["pull_image"]="Pulling images"
+    ["pull_image"]="Pulling image: "
     ["install_sealos"]="Sealos CLI is not installed. Do you want to install it now? (y/n): "
     ["input_master_ips"]="Please enter Master IPs (press Enter to skip this step for local installation; comma separated for multiple master nodes, e.g: 192.168.0.1,192.168.0.2,192.168.0.3)"
     ["invalid_ips"]="Invalid IPs or no IPs provided. Please try again."
@@ -47,7 +49,7 @@ PROMPTS_EN=(
     ["input_certificate"]="Do you want to input a certificate? (y/n): "
     ["certificate_path"]="Please input the certificate path: "
     ["private_key_path"]="Please input the private key path: "
-    ["choose_language"]="Choose language / 选择语言:"
+    ["choose_language"]="Choose prompt language / 选择提示语言:"
     ["enter_choice"]="Enter your choice (1/2): "
     ["k8s_installation"]="Installing Kubernetes cluster."
     ["ingress_installation"]="Installing ingress-nginx-controller and kubeblocks."
@@ -60,12 +62,44 @@ PROMPTS_EN=(
     ["cilium_requirement"]="When running Cilium using the container image cilium/cilium, the host system must meet these requirements:
 Hosts with either AMD64 or AArch64 architecture
 Linux kernel >= 4.19.57 or equivalent (e.g., 4.18 on RHEL8)"
-    ["mongo_avx_requirement"]="MongoDB 5.0 version depends on CPU that supports AVX instruction set, the current environment does not support avx, so only mongo4.0 version can be used. For more information, see: https://www.mongodb.com/docs/v5.0/administration/production-notes/"
+    ["mongo_avx_requirement"]="MongoDB 5.0 version depends on CPU that supports AVX instruction set, the current environment does not support avx, has been switched to mongo4.0 version, for more information, see:https://www.mongodb.com/docs/v5.0/administration/production-notes/"
+    ["usage"]="Usage: $0 [options]
+
+Options:
+   --image_registry             # Image registry address (default: docker.io)
+   --image_repository           # Image repository name (default: labring)
+   --kubernetes_version         # Kubernetes version (default: 1.25.6)
+   --cilium_version             # Cilium version (default: 1.12.14)
+   --cert_manager_version       # Cert Manager version (default: 1.8.0)
+   --helm_version               # Helm version (default: 3.12.0)
+   --openebs_version            # OpenEBS version (default: 3.4.0)
+   --reflector_version          # Reflector version (default: 7.0.151)
+   --ingress_nginx_version      # Ingress Nginx version (default: 1.5.1)
+   --kubeblocks_version         # Kubeblocks version (default: 0.6.2)
+   --metrics_server_version     # Metrics Server version (default: 0.6.4)
+   --cloud_version              # Sealos Cloud version (default: latest)
+   --mongodb_version            # MongoDB version (default: mongodb-5.0)
+   --master_ips                 # Master node IP list, comma separated (single node and current execution node can be left blank)
+   --node_ips                   # Node node IP list, comma separated, can be skipped
+   --ssh_private_key            # SSH private key path (default: $HOME/.ssh/id_rsa)
+   --ssh_password               # SSH password
+   --pod_cidr                   # Pod subnet (default: 100.64.0.0/10)
+   --service_cidr               # Service subnet (default: 10.96.0.0/22)
+   --cloud_domain               # Cloud domain
+   --cloud_port                 # Cloud port (default: 443)
+   --cert_path                  # Certificate path
+   --key_path                   # Private key path
+   --single                     # Whether to install locally: y/n
+   --zh                         # Chinese prompt
+   --en                         # English prompt
+   --help                       # Help information"
 )
 
 PROMPTS_CN=(
     ["pre_prompt"]="依赖iptables，请确保iptables已经安装，多节点需要配置ssh免密登录或密码一致, 使用自签证书安装完成后需要自信任证书"
-    ["pull_image"]="正在拉取镜像"
+    ["pull_image"]="正在拉取镜像: "
+    ["pull_image_success"]="镜像拉取成功: "
+    ["pull_image_failed"]="镜像拉取失败: "
     ["install_sealos"]="Sealos CLI没有安装，是否安装？(y/n): "
     ["input_master_ips"]="请输入Master IPs (单节点本地安装可回车跳过该步骤；多个master节点使用逗号分隔, 例: 192.168.0.1,192.168.0.2,192.168.0.3): "
     ["invalid_ips"]="IP无效或没有提供IP，请再试一次。"
@@ -74,7 +108,7 @@ PROMPTS_CN=(
     ["service_subnet"]="请输入service子网 (回车使用默认值: 10.96.0.0/22): "
     ["cloud_domain"]="请输入云域名:（例:127.0.0.1.nip.io) "
     ["cloud_port"]="请输入云端口 (回车使用默认值: 443): "
-    ["input_certificate"]="请输入证书吗？(y/n): "
+    ["input_certificate"]="是否需要输入证书？(y/n): "
     ["certificate_path"]="请输入证书路径: "
     ["private_key_path"]="请输入私钥路径: "
     ["choose_language"]="请选择语言:"
@@ -90,30 +124,71 @@ PROMPTS_CN=(
     ["cilium_requirement"]="正在使用Cilium作为网络插件，主机系统必须满足以下要求:
 具有AMD64或AArch64架构的主机
 Linux内核> = 4.19.57或等效版本（例如，在RHEL8上为4.18）"
-    ["mongo_avx_requirement"]="MongoDB 5.0版本依赖支持 AVX 指令集的 CPU，当前环境不支持avx，所以仅可使用mongo4.0版本，更多信息查看:https://www.mongodb.com/docs/v5.0/administration/production-notes/"
+    ["mongo_avx_requirement"]="MongoDB 5.0版本依赖支持 AVX 指令集的 CPU，当前环境不支持avx，已切换为mongo4.0版本，更多信息查看:https://www.mongodb.com/docs/v5.0/administration/production-notes/"
+    ["usage"]="Usage: $0 [options]=[value] [options]=[value] ...
+
+Options:
+   --image_registry             # 镜像仓库地址 (默认: docker.io)
+   --image_repository           # 镜像仓库名称 (默认: labring)
+   --kubernetes_version         # Kubernetes版本 (默认: 1.25.6)
+   --cilium_version             # Cilium版本 (默认: 1.12.14)
+   --cert_manager_version       # Cert Manager版本 (默认: 1.8.0)
+   --helm_version               # Helm版本 (默认: 3.12.0)
+   --openebs_version            # OpenEBS版本 (默认: 3.4.0)
+   --reflector_version          # Reflector版本 (默认: 7.0.151)
+   --ingress_nginx_version      # Ingress Nginx版本 (默认: 1.5.1)
+   --kubeblocks_version         # Kubeblocks版本 (默认: 0.6.2)
+   --metrics_server_version     # Metrics Server版本 (默认: 0.6.4)
+   --cloud_version              # Sealos Cloud版本 (默认: latest)
+   --mongodb_version            # MongoDB版本 (默认: mongodb-5.0)
+   --master_ips                 # Master节点IP列表,使用英文逗号分割 (单节点且为当前执行节点可不填写)
+   --node_ips                   # Node节点IP列表,使用英文逗号分割
+   --ssh_private_key            # SSH私钥路径 (默认: $HOME/.ssh/id_rsa)
+   --ssh_password               # SSH密码
+   --pod_cidr                   # Pod子网 (默认: 100.64.0.0/10)
+   --service_cidr               # Service子网 (默认: 10.96.0.0/22)
+   --cloud_domain               # 云域名
+   --cloud_port                 # 云端口 (默认: 443)
+   --cert_path                  # 证书路径
+   --key_path                   # 私钥路径
+   --single                     # 是否本地安装 (y/n)
+   --zh                         # 中文提示
+   --en                         # 英文提示
+   --help                       # 帮助信息"
 )
 
 # Choose Language
 get_prompt() {
     local key="$1"
+    local inline="$2"
+    local prompts=""
     if [[ $LANGUAGE == "CN" ]]; then
-        echo -e "${PROMPTS_CN[$key]}"
+        prompts="${PROMPTS_CN[$key]}"
     else
-        echo -e "${PROMPTS_EN[$key]}"
+        prompts="${PROMPTS_EN[$key]}"
+    fi
+    if [[ -n "$inline" ]]; then
+        echo -ne "$prompts"
+    else
+        echo -e "$prompts"
     fi
 }
 
-get_prompt "choose_language"
-echo "1. English"
-echo "2. 中文"
-read -p "$(get_prompt "enter_choice")" lang_choice
-echo -ne "\033[4F\033[2K"
-
-if [[ $lang_choice == "2" ]]; then
-    LANGUAGE="CN"
-else
-    LANGUAGE="EN"
-fi
+set_language() {
+  if [[ $LANGUAGE == "" ]]; then
+      get_prompt "choose_language"
+      echo "1. English"
+      echo "2. 中文"
+      get_prompt "enter_choice"
+      read -p " " lang_choice
+      if [[ $lang_choice == "2" ]]; then
+          LANGUAGE="CN"
+      fi
+  fi
+  if [[ $LANGUAGE != "CN" ]]; then
+      LANGUAGE="EN"
+  fi
+}
 
 #TODO mongo 5.0 need avx support, if not support, change to 4.0
 setMongoVersion() {
@@ -146,17 +221,27 @@ init() {
     fi
 
     get_prompt "pre_prompt"
-    get_prompt "pull_image"
-    sealos pull -q docker.io/labring/kubernetes:v${kubernetes_version#v:-1.25.6} >/dev/null
-    sealos pull -q docker.io/labring/cilium:v${cilium_version#v:-1.12.14} >/dev/null
-    sealos pull -q docker.io/labring/cert-manager:v${cert_manager_version#v:-1.8.0} >/dev/null
-    sealos pull -q docker.io/labring/helm:v${helm_version#v:-3.12.0} >/dev/null
-    sealos pull -q docker.io/labring/openebs:v${openebs_version#v:-3.4.0} >/dev/null
-    sealos pull -q docker.io/labring/ingress-nginx:v${ingress_nginx_version#v:-1.5.1} >/dev/null
-    sealos pull -q docker.io/labring/kubeblocks:v${kubeblocks_version#v:-0.6.2} >/dev/null
-    sealos pull -q docker.io/labring/metrics-server:v${metrics_server_version#v:-0.6.4} >/dev/null
-    sealos pull -q docker.io/labring/kubernetes-reflector:v${reflector_version#v:-7.0.151} >/dev/null
-    sealos pull -q docker.io/labring/sealos-cloud:${CLOUD_VERSION} >/dev/null
+    echo ""
+    pull_image "kubernetes" "v${kubernetes_version#v:-1.25.6}"
+    pull_image "cilium" "v${cilium_version#v:-1.12.14}"
+    pull_image "cert-manager" "v${cert_manager_version#v:-1.8.0}"
+    pull_image "helm" "v${helm_version#v:-3.12.0}"
+    pull_image "openebs" "v${openebs_version#v:-3.4.0}"
+    pull_image "ingress-nginx" "v${ingress_nginx_version#v:-1.5.1}"
+    pull_image "kubeblocks" "v${kubeblocks_version#v:-0.6.2}"
+    pull_image "metrics-server" "v${metrics_server_version#v:-0.6.4}"
+    pull_image "kubernetes-reflector" "v${reflector_version#v:-7.0.151}"
+    pull_image "sealos-cloud" "${CLOUD_VERSION}"
+}
+
+pull_image() {
+  image_name=$1
+  image_version=$2
+  inline="y"
+
+  echo -ne "\033[1F\033[2K"
+  get_prompt "pull_image" $inline && echo "$image_name:$image_version"
+  sealos pull -q "${image_registry}/${image_repository}/$image_name:${image_version#v:}" >/dev/null
 }
 
 collect_input() {
@@ -172,12 +257,12 @@ collect_input() {
     }
 
     # Master and Node IPs
-    if [[ $local_install != "y" ]]; then
+    if [[ $single != "y" && $master_ips == "" ]]; then
         while :; do
             read -p "$(get_prompt "input_master_ips")" master_ips
             if validate_ips "$master_ips"; then
                 if [[ -z "$master_ips" ]]; then
-                    local_install="y"
+                    single="y"
                 fi
                 break
             else
@@ -185,7 +270,7 @@ collect_input() {
             fi
         done
     fi
-    if [[ $local_install != "y" ]]; then
+    if [[ $single != "y" ]]; then
         while :; do
             read -p "$(get_prompt "input_node_ips")" node_ips
             if validate_ips "$node_ips"; then
@@ -203,15 +288,15 @@ collect_input() {
 
     fi
 
-    read -p "$(get_prompt "pod_subnet")" pod_cidr
+    [[ $pod_cidr != "" ]] || read -p "$(get_prompt "pod_subnet")" pod_cidr
 
-    read -p "$(get_prompt "service_subnet")" service_cidr
+    [[ $service_cidr != "" ]] || read -p "$(get_prompt "service_subnet")" service_cidr
 
-    read -p "$(get_prompt "cloud_domain")" cloud_domain
+    [[ $cloud_domain != "" ]] || read -p "$(get_prompt "cloud_domain")" cloud_domain
 
-    read -p "$(get_prompt "cloud_port")" cloud_port
+    [[ $cloud_port != "" ]] || read -p "$(get_prompt "cloud_port")" cloud_port
 
-    read -p "$(get_prompt "input_certificate")" input_cert
+    [[ $input_cert != "" || ($cert_path != "" && $key_path != "") ]] || read -p "$(get_prompt "input_certificate")" input_cert
 
     if [[ $input_cert == "y" || $input_cert == "Y" ]]; then
         read -p "$(get_prompt "certificate_path")" cert_path
@@ -235,7 +320,7 @@ metadata:
   name: secret
 spec:
   path: manifests/tls-secret.yaml
-  match: docker.io/labring/sealos-cloud:latest
+  match: ${image_registry}/${image_repository}/sealos-cloud:latest
   strategy: merge
   data: |
     data:
@@ -259,13 +344,13 @@ spec:
       kind: DaemonSet
       service:
         type: NodePort
-  match: docker.io/labring/ingress-nginx:v${ingress_nginx_version#v:-1.5.1}
+  match: ${image_registry}/${image_repository}/ingress-nginx:v${ingress_nginx_version#v:-1.5.1}
   path: charts/ingress-nginx/values.yaml
   strategy: merge
 "
     echo "$ingress_config" > $CLOUD_DIR/ingress-nginx-config.yaml
 
-    sealos_gen_cmd="sealos gen labring/kubernetes:v${kubernetes_version#v:-1.25.6}\
+    sealos_gen_cmd="sealos gen ${image_registry}/${image_repository}/kubernetes:v${kubernetes_version#v:-1.25.6}\
         ${master_ips:+--masters $master_ips}\
         ${node_ips:+--nodes $node_ips}\
         --pk=${ssh_private_key:-$HOME/.ssh/id_rsa}\
@@ -308,15 +393,15 @@ loading_animation() {
 }
 
 execute_commands() {
-    command -v kubelet > /dev/null 2>&1 || (get_prompt "k8s_installation" && sealos apply -f $CLOUD_DIR/Clusterfile)
-    command -v helm > /dev/null 2>&1 || sealos run "labring/helm:v${helm_version#v:-3.12.0}"
+    kubectl get no > /dev/null 2>&1 || (get_prompt "k8s_installation" && sealos apply -f $CLOUD_DIR/Clusterfile)
+    command -v helm > /dev/null 2>&1 || sealos run "${image_registry}/${image_repository}/helm:v${helm_version#v:-3.12.0}"
     get_prompt "cilium_requirement"
     if kubectl get no | grep NotReady > /dev/null 2>&1; then
-      sealos run "labring/cilium:v${cilium_version#v:-1.12.14}"
+      sealos run "${image_registry}/${image_repository}/cilium:v${cilium_version#v:-1.12.14}"
     fi
     wait_cluster_ready
-    sealos run "labring/cert-manager:v${cert_manager_version#v:-1.8.0}"
-    sealos run "labring/openebs:v${openebs_version#v:-3.4.0}"
+    sealos run "${image_registry}/${image_repository}/cert-manager:v${cert_manager_version#v:-1.8.0}"
+    sealos run "${image_registry}/${image_repository}/openebs:v${openebs_version#v:-3.4.0}"
     kubectl get sc openebs-backup > /dev/null 2>&1 || kubectl create -f - <<EOF
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -328,12 +413,12 @@ volumeBindingMode: WaitForFirstConsumer
 EOF
 
     get_prompt "ingress_installation"
-    sealos run docker.io/labring/kubernetes-reflector:v${reflector_version#v:-7.0.151}\
-        docker.io/labring/ingress-nginx:v${ingress_nginx_version#v:-1.5.1}\
-        docker.io/labring/kubeblocks:v${kubeblocks_version#v:-0.6.2}\
+    sealos run ${image_registry}/${image_repository}/kubernetes-reflector:v${reflector_version#v:-7.0.151}\
+        ${image_registry}/${image_repository}/ingress-nginx:v${ingress_nginx_version#v:-1.5.1}\
+        ${image_registry}/${image_repository}/kubeblocks:v${kubeblocks_version#v:-0.6.2}\
         --config-file $CLOUD_DIR/ingress-nginx-config.yaml
 
-    sealos run "labring/metrics-server:v${metrics_server_version#v:-0.6.4}"
+    sealos run "${image_registry}/${image_repository}/metrics-server:v${metrics_server_version#v:-0.6.4}"
 
     get_prompt "patching_ingress"
     kubectl -n ingress-nginx patch ds ingress-nginx-controller -p '{"spec":{"template":{"spec":{"tolerations":[{"key":"node-role.kubernetes.io/control-plane","operator":"Exists","effect":"NoSchedule"}]}}}}'
@@ -342,22 +427,60 @@ EOF
 
     setMongoVersion
     if [[ -n "$tls_crt_base64" ]] || [[ -n "$tls_key_base64" ]]; then
-        sealos run docker.io/labring/sealos-cloud:latest\
+        sealos run ${image_registry}/${image_repository}/sealos-cloud:latest\
         --env cloudDomain="$cloud_domain"\
         --env cloudPort="${cloud_port:-443}"\
         --env mongodbVersion="${mongodb_version:-mongodb-5.0}"\
         --config-file $CLOUD_DIR/tls-secret.yaml
     else
-        sealos run docker.io/labring/sealos-cloud:latest\
+        sealos run ${image_registry}/${image_repository}/sealos-cloud:latest\
         --env cloudDomain="$cloud_domain"\
         --env cloudPort="${cloud_port:-443}"\
         --env mongodbVersion="${mongodb_version:-mongodb-5.0}"
     fi
 }
 
-# Main script execution
+for i in "$@"; do
+  case ${i,,} in
+  --image_registry=*) image_registry="${i#*=}"; shift ;;
+  --image_repository=*) image_repository="${i#*=}"; shift ;;
+  --kubernetes_version=*) kubernetes_version="${i#*=}"; shift ;;
+  --cilium_version=*) cilium_version="${i#*=}"; shift ;;
+  --cert_manager_version=*) cert_manager_version="${i#*=}"; shift ;;
+  --helm_version=*) helm_version="${i#*=}"; shift ;;
+  --openebs_version=*) openebs_version="${i#*=}"; shift ;;
+  --reflector_version=*) reflector_version="${i#*=}"; shift ;;
+  --ingress_nginx_version=*) ingress_nginx_version="${i#*=}"; shift ;;
+  --kubeblocks_version=*) kubeblocks_version="${i#*=}"; shift ;;
+  --metrics_server_version=*) metrics_server_version="${i#*=}"; shift ;;
+  --cloud_version=*) CLOUD_VERSION="${i#*=}"; shift ;;
+  --mongodb_version=*) mongodb_version="${i#*=}"; shift ;;
+  --master_ips=*) master_ips="${i#*=}"; shift ;;
+  --node_ips=*) node_ips="${i#*=}"; shift ;;
+  --ssh_private_key=*) ssh_private_key="${i#*=}"; shift ;;
+  --ssh_password=*) ssh_password="${i#*=}"; shift ;;
+  --pod_cidr=*) pod_cidr="${i#*=}"; shift ;;
+  --service_cidr=*) service_cidr="${i#*=}"; shift ;;
+  --cloud_domain=*) cloud_domain="${i#*=}"; shift ;;
+  --cloud_port=*) cloud_port="${i#*=}"; shift ;;
+  --cert_path=*) cert_path="${i#*=}"; shift ;;
+  --key_path=*) key_path="${i#*=}"; shift ;;
+  --single) single="y"; shift ;;
+  --zh | zh ) LANGUAGE="CN"; shift ;;
+  --en | en ) LANGUAGE="EN"; shift ;;
+  -c | --config) source ${i#*=} > /dev/null; shift ;;
+  -h | --help) HELP=true; shift ;;
+  -d | --debug) set -x; shift ;;
+  -*) echo "Unknown option $i"; exit 1 ;;
+  *) ;;
+  esac
+done
+
+[[ $HELP == "" ]] || get_prompt "usage"
+[[ $HELP == "" ]] || exit 0
+set_language
 init
-source $1 > /dev/null 2>&1 || collect_input
+collect_input
 prepare_configs
 execute_commands
 


### PR DESCRIPTION
  Expose image registry and repository as environment variable Settings, optimize image log pulling, optimize avx to switch to mongo4.0 log information, `bash install.sh -h` usage

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c905ef9</samp>

### Summary
🛠️🗣️🖼️

<!--
1.  🛠️ - This emoji represents the refactoring and simplification of the code, as well as the addition of variables and command-line options to customize the installation script.
2.  🗣️ - This emoji represents the improvement of the user prompts and feedback in both English and Chinese, as well as the translation of some messages into Chinese.
3.  🖼️ - This emoji represents the customization of the image sources and versions for the installation script, as well as the ability to choose different images for different components.
-->
This pull request enhances the `scripts/cloud/install.sh` script by adding more flexibility and clarity for the user. It allows the user to specify different image sources and versions for the cloud installation, and improves the language and format of the prompts and messages. It also refactors some code to make it more concise and readable.

> _To install the script with more ease_
> _You can now choose the image sources_
> _And the versions you like_
> _With some options to pick_
> _And the prompts are in English and Chinese_

### Walkthrough
*  Add variables for image sources and versions and allow overriding them by command-line arguments ([link](https://github.com/labring/sealos/pull/4130/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL21-R32), [link](https://github.com/labring/sealos/pull/4130/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL238-R323), [link](https://github.com/labring/sealos/pull/4130/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL262-R347), [link](https://github.com/labring/sealos/pull/4130/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL268-R353), [link](https://github.com/labring/sealos/pull/4130/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL311-R404), [link](https://github.com/labring/sealos/pull/4130/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL331-R421), [link](https://github.com/labring/sealos/pull/4130/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL345-R430), [link](https://github.com/labring/sealos/pull/4130/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL351-R436), [link](https://github.com/labring/sealos/pull/4130/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL358-R483))
*  Refactor the script to use functions for getting prompts, pulling images, and setting language ([link](https://github.com/labring/sealos/pull/4130/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL63-R102), [link](https://github.com/labring/sealos/pull/4130/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL99-R192), [link](https://github.com/labring/sealos/pull/4130/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL149-R246))
*  Modify the prompts to include image names and versions, clarify language choice, and show usage and success/failure messages ([link](https://github.com/labring/sealos/pull/4130/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL38-R40), [link](https://github.com/labring/sealos/pull/4130/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL50-R52), [link](https://github.com/labring/sealos/pull/4130/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL93-R157))
*  Add the corresponding Chinese prompts for the modified messages ([link](https://github.com/labring/sealos/pull/4130/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL63-R102), [link](https://github.com/labring/sealos/pull/4130/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL93-R157))
*  Rename the variable local_install to single and check the values of master_ips and other parameters before prompting the user for input ([link](https://github.com/labring/sealos/pull/4130/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL175-R265), [link](https://github.com/labring/sealos/pull/4130/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL188-R273), [link](https://github.com/labring/sealos/pull/4130/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL206-R299))
*  Replace the check for kubelet with the check for kubectl ([link](https://github.com/labring/sealos/pull/4130/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL311-R404))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
