### PR TITLE
:bug: support env for export

### DIFF
--- a/pkg/clusterfile/pre_process.go
+++ b/pkg/clusterfile/pre_process.go
@@ -17,6 +17,8 @@ package clusterfile
 import (
 	"bytes"
 	"errors"
+	"os"
+	"strings"
 
 	"helm.sh/helm/v3/pkg/cli/values"
 	"helm.sh/helm/v3/pkg/getter"
@@ -46,6 +48,13 @@ func (c *ClusterFile) Process() (err error) {
 	}
 	c.once.Do(func() {
 		err = func() error {
+			for i := range c.customEnvs {
+				kv := strings.SplitN(c.customEnvs[i], "=", 2)
+				if len(kv) == 2 {
+					logger.Debug("set env: %s=%s", kv[0], kv[1])
+					_ = os.Setenv(kv[0], kv[1])
+				}
+			}
 			clusterFileData, err := c.loadClusterFile()
 			if err != nil {
 				return err


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d5d3854</samp>

### Summary
🌎➕🔧

<!--
1.  🌎 This emoji could represent the support for custom environment variables, which can be used to configure different aspects of the cluster depending on the context or location of the deployment.
2.  ➕ This emoji could represent the addition of new functionality and code, as well as the import of new packages to enable the feature.
3.  🔧 This emoji could represent the parsing and setting of the user-provided variables, which can be seen as a tool or mechanism to customize the cluster configuration.
-->
Added support for custom environment variables in cluster configuration. Modified `pkg/clusterfile/pre_process.go` to parse and set the `c.customEnvs` slice using `os` and `strings` packages.

> _We're setting sail with custom envs_
> _We'll parse and split them with our friends_
> _`os.Setenv` and `strings.SplitN`_
> _Heave away and haul, me hearties_

### Walkthrough
* Import and use `os` and `strings` packages to set custom environment variables ([link](https://github.com/labring/sealos/pull/4135/files?diff=unified&w=0#diff-25e6eae2bde5b361242a7173eb219cd3f5686d7bcac8b899364296300255dbb1R20-R21), [link](https://github.com/labring/sealos/pull/4135/files?diff=unified&w=0#diff-25e6eae2bde5b361242a7173eb219cd3f5686d7bcac8b899364296300255dbb1R51-R57))
* Split each element of `c.customEnvs` by the first `=` sign and assign the key and value to `kv` ([link](https://github.com/labring/sealos/pull/4135/files?diff=unified&w=0#diff-25e6eae2bde5b361242a7173eb219cd3f5686d7bcac8b899364296300255dbb1R51-R57))
* Log and set the environment variable if the split results in two elements ([link](https://github.com/labring/sealos/pull/4135/files?diff=unified&w=0#diff-25e6eae2bde5b361242a7173eb219cd3f5686d7bcac8b899364296300255dbb1R51-R57))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
