### PR TITLE
:bug: support env for export

### DIFF
--- a/pkg/clusterfile/pre_process.go
+++ b/pkg/clusterfile/pre_process.go
@@ -17,6 +17,8 @@ package clusterfile
 import (
 	"bytes"
 	"errors"
+	"os"
+	"strings"
 
 	"helm.sh/helm/v3/pkg/cli/values"
 	"helm.sh/helm/v3/pkg/getter"
@@ -43,6 +45,13 @@ func (c *ClusterFile) Process() (err error) {
 	}
 	c.once.Do(func() {
 		err = func() error {
+			for i := range c.customEnvs {
+				kv := strings.SplitN(c.customEnvs[i], "=", 2)
+				if len(kv) == 2 {
+					logger.Debug("set env: %s=%s", kv[0], kv[1])
+					_ = os.Setenv(kv[0], kv[1])
+				}
+			}
 			clusterFileData, err := c.loadClusterFile()
 			if err != nil {
 				return err


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 10a2550</samp>

### Summary
🌎➕🔧

<!--
1.  🌎 This emoji can represent the concept of environment variables, which are key-value pairs that affect the behavior of a program or process in a specific context. It can also suggest the idea of customizing or configuring a cluster to suit different needs or scenarios.
2.  ➕ This emoji can indicate the action of adding or introducing a new feature or functionality, such as support for custom environment variables. It can also imply the idea of expanding or enhancing the capabilities or options of a cluster configuration.
3.  🔧 This emoji can symbolize the notion of tools or utilities, such as the `os` and `strings` packages, that are used to manipulate or work with data or systems. It can also convey the idea of fixing or adjusting something, such as setting the environment variables for a cluster.
-->
Added support for custom environment variables in cluster configuration. This allows users to pass environment variables to `sealos` commands using the `customEnvs` field in the cluster file. Modified `pkg/clusterfile/pre_process.go` to implement this feature.

> _We're setting sail with custom envs_
> _We'll parse and set them with `os` and `strings`_
> _Heave away, me hearties, heave away_
> _We'll make our cluster run the way we please_

### Walkthrough
* Import and use `os` and `strings` packages to set custom environment variables ([link](https://github.com/labring/sealos/pull/4136/files?diff=unified&w=0#diff-25e6eae2bde5b361242a7173eb219cd3f5686d7bcac8b899364296300255dbb1R20-R21), [link](https://github.com/labring/sealos/pull/4136/files?diff=unified&w=0#diff-25e6eae2bde5b361242a7173eb219cd3f5686d7bcac8b899364296300255dbb1R48-R54))
* Split each element of `c.customEnvs` by the first `=` sign and assign the key and value to `kv` ([link](https://github.com/labring/sealos/pull/4136/files?diff=unified&w=0#diff-25e6eae2bde5b361242a7173eb219cd3f5686d7bcac8b899364296300255dbb1R48-R54))
* Log and set the environment variable using `os.Setenv` if the split results in two elements ([link](https://github.com/labring/sealos/pull/4136/files?diff=unified&w=0#diff-25e6eae2bde5b361242a7173eb219cd3f5686d7bcac8b899364296300255dbb1R48-R54))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
