### PR TITLE
fix admin user label.

### DIFF
--- a/controllers/job/init/internal/util/controller/user.go
+++ b/controllers/job/init/internal/util/controller/user.go
@@ -37,19 +37,33 @@ func newKubernetesClient() (client.Client, error) {
 	return c, nil
 }
 
+func newAdminUser(ctx context.Context, c client.Client) (*userv1.User, error) {
+	var u = &userv1.User{}
+	u.SetName(DefaultAdminUserName)
+	err := c.Get(ctx, client.ObjectKeyFromObject(u), u)
+	if err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			// admin user exists
+			return u, nil
+		}
+		return nil, err
+	}
+	// admin user not exists
+	u.SetLabels(map[string]string{"uid": common.AdminUID(), "updateTime": time.Now().Format(time.RFC3339)})
+	return u, nil
+}
+
 func PresetAdminUser(ctx context.Context) error {
 	c, err := newKubernetesClient()
 	if err != nil {
 		return err
 	}
-	_, err = ctrl.CreateOrUpdate(ctx, c, &userv1.User{
-		ObjectMeta: ctrl.ObjectMeta{
-			Name:   DefaultAdminUserName,
-			Labels: map[string]string{"uid": common.AdminUID(), "updateTime": time.Now().Format(time.RFC3339)},
-		},
-	}, func() error { return nil })
+	adminUser, err := newAdminUser(ctx, c)
 	if err != nil {
 		return err
 	}
-	return nil
+	_, err = ctrl.CreateOrUpdate(ctx, c, adminUser, func() error {
+		return nil
+	})
+	return err
 }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2f579ad</samp>

### Summary
🎨♻️🔐

<!--
1.  🎨 - This emoji represents a change that improves the structure or format of the code, such as refactoring or formatting.
2.  ♻️ - This emoji represents a change that removes or reduces code duplication, such as extracting a common function or constant.
3.  🔐 - This emoji represents a change that enhances security or privacy, such as creating or getting the admin user.
-->
Refactor `controller` package to simplify admin user creation and retrieval. Extract common logic to `controller/user.go`.

> _We are the controllers of the code_
> _We wield the power of the admin mode_
> _We refactor the logic to make it clear_
> _We create or get the user with no fear_

### Walkthrough
*  Add a new function `newAdminUser` to create or get an admin user object ([link](https://github.com/labring/sealos/pull/4139/files?diff=unified&w=0#diff-2fb0b3c44ce466d794de088a4e53433611b1c2e158b3709c8ee55900e7499e9dR40-R55))
*  Simplify the `PresetAdminUser` function by using `newAdminUser` instead of creating a user object inline ([link](https://github.com/labring/sealos/pull/4139/files?diff=unified&w=0#diff-2fb0b3c44ce466d794de088a4e53433611b1c2e158b3709c8ee55900e7499e9dL45-R68))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
