### PR TITLE
fix: init job for user with a uuid label.

### DIFF
--- a/controllers/job/init/internal/util/controller/user.go
+++ b/controllers/job/init/internal/util/controller/user.go
@@ -43,7 +43,12 @@ func newAdminUser(ctx context.Context, c client.Client) (*userv1.User, error) {
 	if err := c.Get(ctx, client.ObjectKeyFromObject(u), u); client.IgnoreNotFound(err) != nil {
 		return nil, err
 	}
-	u.SetLabels(map[string]string{"uid": common.AdminUID(), "updateTime": time.Now().Format(time.RFC3339)})
+	if u.Labels == nil {
+		u.SetLabels(map[string]string{"uid": common.AdminUID(), "updateTime": time.Now().Format(time.RFC3339)})
+	} else if u.Labels["uid"] == "" {
+		u.Labels["uid"] = common.AdminUID()
+		u.Labels["updateTime"] = time.Now().Format(time.RFC3339)
+	}
 	return u, nil
 }
 

--- a/controllers/job/init/internal/util/controller/user.go
+++ b/controllers/job/init/internal/util/controller/user.go
@@ -40,15 +40,9 @@ func newKubernetesClient() (client.Client, error) {
 func newAdminUser(ctx context.Context, c client.Client) (*userv1.User, error) {
 	var u = &userv1.User{}
 	u.SetName(DefaultAdminUserName)
-	err := c.Get(ctx, client.ObjectKeyFromObject(u), u)
-	if err != nil {
-		if client.IgnoreNotFound(err) == nil {
-			// admin user exists
-			return u, nil
-		}
+	if err := c.Get(ctx, client.ObjectKeyFromObject(u), u); client.IgnoreNotFound(err) != nil {
 		return nil, err
 	}
-	// admin user not exists
 	u.SetLabels(map[string]string{"uid": common.AdminUID(), "updateTime": time.Now().Format(time.RFC3339)})
 	return u, nil
 }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8e2bd8b</samp>

### Summary
🛠️🚀🔒

<!--
1.  🛠️ - This emoji represents a wrench or a tool, and it can be used to indicate a refactoring or a bug fix. In this case, the function was refactored to simplify the error handling and avoid unnecessary operations, and also to fix a potential bug where the admin user might not have the required labels.
2.  🚀 - This emoji represents a rocket or a launch, and it can be used to indicate a performance improvement or a new feature. In this case, the function was improved to ensure that the admin user has a uid label and an updateTime label, which might be useful for other features or queries that rely on these labels.
3.  🔒 - This emoji represents a lock or a security, and it can be used to indicate a security enhancement or a protection. In this case, the function was enhanced to check if the admin user already exists and avoid creating a duplicate or overwriting an existing user, which might compromise the security or integrity of the user data.
-->
Refactor `newAdminUser` function to simplify error handling, check for existing user, and add labels. This improves the user controller logic and fixes some bugs.

> _`newAdminUser` refactored_
> _Error handling simplified_
> _Autumn leaves fall gently_

### Walkthrough
* Refactor `newAdminUser` function to simplify error handling and ensure uid and updateTime labels ([link](https://github.com/labring/sealos/pull/4147/files?diff=unified&w=0#diff-2fb0b3c44ce466d794de088a4e53433611b1c2e158b3709c8ee55900e7499e9dL43-R51))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
