### PR TITLE
Optimize BillingRecordQuery to query separate recharge and arrival (recharge + gift) amounts

### DIFF
--- a/controllers/account/api/v1/billingrecordquery_types.go
+++ b/controllers/account/api/v1/billingrecordquery_types.go
@@ -61,7 +61,14 @@ type BillingRecordQueryItemInline struct {
 	Type      Type   `json:"type" bson:"type"`
 	AppType   string `json:"appType,omitempty" bson:"appType,omitempty"`
 	Costs     Costs  `json:"costs,omitempty" bson:"costs,omitempty"`
-	Amount    int64  `json:"amount,omitempty" bson:"amount"`
+	//Amount = PaymentAmount + GiftAmount
+	Amount int64 `json:"amount,omitempty" bson:"amount"`
+	// when Type = Recharge, PaymentAmount is the amount of recharge
+	Payment *PaymentForQuery `json:"payment,omitempty" bson:"payment,omitempty"`
+}
+
+type PaymentForQuery struct {
+	Amount int64 `json:"amount,omitempty" bson:"amount,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/controllers/account/config/crd/bases/account.sealos.io_billingrecordqueries.yaml
+++ b/controllers/account/config/crd/bases/account.sealos.io_billingrecordqueries.yaml
@@ -75,6 +75,7 @@ spec:
                 items:
                   properties:
                     amount:
+                      description: Amount = PaymentAmount + GiftAmount
                       format: int64
                       type: integer
                     appType:
@@ -90,6 +91,14 @@ spec:
                       type: string
                     order_id:
                       type: string
+                    payment:
+                      description: when Type = Recharge, PaymentAmount is the amount
+                        of recharge
+                      properties:
+                        amount:
+                          format: int64
+                          type: integer
+                      type: object
                     time:
                       format: date-time
                       type: string

--- a/controllers/account/deploy/manifests/deploy.yaml.tmpl
+++ b/controllers/account/deploy/manifests/deploy.yaml.tmpl
@@ -242,6 +242,7 @@ spec:
                 items:
                   properties:
                     amount:
+                      description: Amount = PaymentAmount + GiftAmount
                       format: int64
                       type: integer
                     appType:
@@ -257,6 +258,14 @@ spec:
                       type: string
                     order_id:
                       type: string
+                    payment:
+                      description: when Type = Recharge, PaymentAmount is the amount
+                        of recharge
+                      properties:
+                        amount:
+                          format: int64
+                          type: integer
+                      type: object
                     time:
                       format: date-time
                       type: string

--- a/controllers/pkg/database/mongodb_test.go
+++ b/controllers/pkg/database/mongodb_test.go
@@ -142,6 +142,38 @@ func TestMongoDB_QueryBillingRecords(t *testing.T) {
 	}
 }
 
+func TestMongoDB_QueryBillingRecords1(t *testing.T) {
+	dbCTX := context.Background()
+	m, err := NewMongoDB(dbCTX, os.Getenv("MONGODB_URI"))
+	if err != nil {
+		t.Errorf("failed to connect mongo: error = %v", err)
+	}
+	defer func() {
+		if err = m.Disconnect(dbCTX); err != nil {
+			t.Errorf("failed to disconnect mongo: error = %v", err)
+		}
+	}()
+	//now := time.Now().UTC()
+	billquery := &accountv1.BillingRecordQuery{
+		Spec: accountv1.BillingRecordQuerySpec{
+			StartTime: metav1.Time{Time: time.Now().UTC().Add(-time.Hour * 24 * 30)},
+			EndTime:   metav1.Time{Time: time.Now().UTC().Add(time.Hour * 24 * 30)},
+			Page:      1,
+			PageSize:  5,
+			Type:      1,
+		},
+	}
+	err = m.QueryBillingRecords(billquery, "")
+	if err != nil {
+		t.Errorf("failed to query billing records: error = %v", err)
+	}
+	data, err := yaml.Marshal(billquery)
+	if err != nil {
+		t.Errorf("failed to marshal billingRecordQuery: error = %v", err)
+	}
+	t.Logf("billingRecordQuery: %s\n", string(data))
+}
+
 var testTime = time.Date(2023, 5, 9, 5, 0, 0, 0, time.UTC)
 
 func TestMongoDB_QueryBillingRecords2(t *testing.T) {


### PR DESCRIPTION
…
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 96e6d3e</samp>

### Summary
:moneybag::memo::white_check_mark:

<!--
1.  :moneybag: - This emoji represents the addition of the `Payment` field to the `BillingRecordQueryItemInline` type and the `queryBillingRecordsByOrderID` function, which shows the amount of recharge for billing records of type `Recharge`.
2.  :memo: - This emoji represents the addition of the `description` field to the `BillingRecordQueryItemInline` schema in the CRD definition and the deploy template, which provides a human-readable explanation of the billing record type and the app name.
3.  :white_check_mark: - This emoji represents the addition of the `TestMongoDB_QueryBillingRecords1` function to the `mongodb_test.go` file, which tests the `QueryBillingRecords` function with a `BillingRecordQuery` that specifies the type as `Recharge`.
-->
Added `Payment` field to `BillingRecordQueryItem` type and related schemas, and updated database query and test functions accordingly. This change allows the API to return more accurate and detailed information about the billing records of different types, especially `Recharge`.

> _We're querying the billing records, me hearties, yo ho!_
> _We're adding the payment field, me hearties, yo ho!_
> _On the count of three, we'll pull the code, me hearties, yo ho!_
> _And we'll test it with MongoDB, me hearties, yo ho!_

### Walkthrough
*  Add `Payment` field to `BillingRecordQueryItemInline` type and schema to represent recharge amount ([link](https://github.com/labring/sealos/pull/4167/files?diff=unified&w=0#diff-5bf539795f3e21fe33978652b0e9424625e6a485a363720770339b17e6fa8549L64-R73), [link](https://github.com/labring/sealos/pull/4167/files?diff=unified&w=0#diff-f2ab243e289c0f2a1f108f50e60cfdad6aeddd56fbf7e2dc0bf05a6acafc7220R94-R101), [link](https://github.com/labring/sealos/pull/4167/files?diff=unified&w=0#diff-11c0253bf67d2025a97d6953bad0e237ce9ac7a60d0a35ae1e277e934ceaea0eR261-R268))
*  Add `description` field to `Amount` property in `BillingRecordQueryItemInline` type and schema to clarify its meaning ([link](https://github.com/labring/sealos/pull/4167/files?diff=unified&w=0#diff-5bf539795f3e21fe33978652b0e9424625e6a485a363720770339b17e6fa8549L64-R73), [link](https://github.com/labring/sealos/pull/4167/files?diff=unified&w=0#diff-f2ab243e289c0f2a1f108f50e60cfdad6aeddd56fbf7e2dc0bf05a6acafc7220R78), [link](https://github.com/labring/sealos/pull/4167/files?diff=unified&w=0#diff-11c0253bf67d2025a97d6953bad0e237ce9ac7a60d0a35ae1e277e934ceaea0eR245))
*  Modify `queryBillingRecordsByOrderID` function to handle `Payment` field in `BillingRecordQueryItem` type and assign it based on billing record type ([link](https://github.com/labring/sealos/pull/4167/files?diff=unified&w=0#diff-0eb9c380a960e9af595a4afa742bc1a6783c5ea9f1e7570448438521b5b41d46L657-R691))
*  Add `TestMongoDB_QueryBillingRecords1` function to test `QueryBillingRecords` function with `Recharge` type in `mongodb_test.go` ([link](https://github.com/labring/sealos/pull/4167/files?diff=unified&w=0#diff-a126f522b0bf02974f6f06cb25dcf2bd66f62276b372d5fbfc93959f7e15c136R145-R176))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
