### PR TITLE
fix(frontend/desktop): fix login different account error

### DIFF
--- a/frontend/desktop/src/components/account/index.tsx
+++ b/frontend/desktop/src/components/account/index.tsx
@@ -14,7 +14,7 @@ import {
   PopoverContent,
   PopoverBody
 } from '@chakra-ui/react';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
 import { useMemo } from 'react';
@@ -140,9 +140,11 @@ export default function Index({ disclosure }: { disclosure: UseDisclosureReturn 
     }
     return real_balance;
   }, [data]);
+  const queryclient = useQueryClient();
   const logout = (e: React.MouseEvent<HTMLElement>) => {
     e.preventDefault();
     delSession();
+    queryclient.clear();
     router.replace('/signin');
   };
   const needPassword = useGlobalStore((s) => s.needPassword);


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9e016b2</samp>

### Summary
🔒🧹🚪

<!--
1.  🔒 - This emoji conveys the idea of security and protection, which is relevant for a feature that clears the query cache to prevent unauthorized access to user data.
2.  🧹 - This emoji suggests the action of cleaning or clearing something, which is what the `queryclient.clear()` method does to the query cache. It also implies a sense of tidiness and freshness, which are desirable qualities for a user interface.
3.  🚪 - This emoji represents the concept of logout or exit, which is the trigger for the query cache clearing feature. It also implies a sense of closure and finality, which are appropriate for a logout action.
-->
This pull request enhances the logout functionality of the frontend by clearing the query cache with `queryclient.clear()`. This prevents any stale or sensitive data from persisting in the browser after the user logs out.

> _`useQueryClient`_
> _Clears the cache on logout_
> _A fresh spring breeze_

### Walkthrough
*  Invalidate query cache on logout to prevent user data persistence ([link](https://github.com/labring/sealos/pull/4168/files?diff=unified&w=0#diff-f080c4cc5f58f00e0d58040ad4f90c0bdf6b500e0ea8d8711bacaa900803500bL17-R17), [link](https://github.com/labring/sealos/pull/4168/files?diff=unified&w=0#diff-f080c4cc5f58f00e0d58040ad4f90c0bdf6b500e0ea8d8711bacaa900803500bL143-R147))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
