### PR TITLE
Optimize/cloud scripts

### DIFF
--- a/deploy/cloud/init.sh
+++ b/deploy/cloud/init.sh
@@ -1,23 +1,45 @@
 #!/bin/bash
+set -e
 export readonly ARCH=${1:-amd64}
 mkdir -p tars
 
-sealos pull --policy=always --platform=linux/"${ARCH}" ghcr.io/labring/sealos-cloud-user-controller:latest
-sealos pull --policy=always --platform=linux/"${ARCH}" ghcr.io/labring/sealos-cloud-terminal-controller:latest
-sealos pull --policy=always --platform=linux/"${ARCH}" ghcr.io/labring/sealos-cloud-app-controller:latest
-sealos pull --policy=always --platform=linux/"${ARCH}" ghcr.io/labring/sealos-cloud-resources-controller:latest
-sealos pull --policy=always --platform=linux/"${ARCH}" ghcr.io/labring/sealos-cloud-account-controller:latest
-sealos pull --policy=always --platform=linux/"${ARCH}" ghcr.io/labring/sealos-cloud-license-controller:latest
+RetryPullImageInterval=3
+RetrySleepSeconds=3
 
-sealos pull --policy=always --platform=linux/"${ARCH}" ghcr.io/labring/sealos-cloud-desktop-frontend:latest
-sealos pull --policy=always --platform=linux/"${ARCH}" ghcr.io/labring/sealos-cloud-terminal-frontend:latest
-sealos pull --policy=always --platform=linux/"${ARCH}" ghcr.io/labring/sealos-cloud-applaunchpad-frontend:latest
-sealos pull --policy=always --platform=linux/"${ARCH}" ghcr.io/labring/sealos-cloud-dbprovider-frontend:latest
-sealos pull --policy=always --platform=linux/"${ARCH}" ghcr.io/labring/sealos-cloud-costcenter-frontend:latest
-sealos pull --policy=always --platform=linux/"${ARCH}" ghcr.io/labring/sealos-cloud-template-frontend:latest
+retryPullImage() {
+    local image=$1
+    local retry=0
+    local retryMax=3
+    set +e
+    while [ $retry -lt $RetryPullImageInterval ]; do
+        sealos pull --policy=always --platform=linux/"${ARCH}" $image >/dev/null && break
+        retry=$(($retry + 1))
+        echo "retry pull image $image, retry times: $retry"
+        sleep $RetrySleepSeconds
+    done
+    set -e
+    if [ $retry -eq $retryMax ]; then
+        echo "pull image $image failed"
+        exit 1
+    fi
+}
 
-sealos pull --policy=always --platform=linux/"${ARCH}" ghcr.io/labring/sealos-cloud-database-service:latest
-sealos pull --policy=always --platform=linux/"${ARCH}" ghcr.io/labring/sealos-cloud-job-init-controller:latest
+retryPullImage ghcr.io/labring/sealos-cloud-user-controller:latest
+retryPullImage ghcr.io/labring/sealos-cloud-terminal-controller:latest
+retryPullImage ghcr.io/labring/sealos-cloud-app-controller:latest
+retryPullImage ghcr.io/labring/sealos-cloud-resources-controller:latest
+retryPullImage ghcr.io/labring/sealos-cloud-account-controller:latest
+retryPullImage ghcr.io/labring/sealos-cloud-license-controller:latest
+
+retryPullImage ghcr.io/labring/sealos-cloud-desktop-frontend:latest
+retryPullImage ghcr.io/labring/sealos-cloud-terminal-frontend:latest
+retryPullImage ghcr.io/labring/sealos-cloud-applaunchpad-frontend:latest
+retryPullImage ghcr.io/labring/sealos-cloud-dbprovider-frontend:latest
+retryPullImage ghcr.io/labring/sealos-cloud-costcenter-frontend:latest
+retryPullImage ghcr.io/labring/sealos-cloud-template-frontend:latest
+
+retryPullImage ghcr.io/labring/sealos-cloud-database-service:latest
+retryPullImage ghcr.io/labring/sealos-cloud-job-init-controller:latest
 
 sealos save -o tars/user.tar ghcr.io/labring/sealos-cloud-user-controller:latest
 sealos save -o tars/terminal.tar ghcr.io/labring/sealos-cloud-terminal-controller:latest


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7d69c10</samp>

### Summary
:wrench::sparkles::memo:

<!--
1.  :wrench: - This emoji represents a tool or a fix, and can be used to indicate the `set -e` command that makes the script more robust and reliable.
2.  :sparkles: - This emoji represents a new feature or enhancement, and can be used to indicate the support for nip.io as a wildcard domain name, which makes the installation easier and more flexible.
3.  :memo: - This emoji represents documentation or writing, and can be used to indicate the typo fix and the additional options and parameters that are documented in the script.
-->
This pull request improves the cloud installation scripts for sealos, a Kubernetes HA cluster tool. It adds support for nip.io as a wildcard domain name, fixes a typo, adds more error handling and conditional logic, and allows more customization of parameters and versions. It also makes the `init.sh` script more robust by exiting on any failure.

> _To make `init.sh` more robust_
> _We added a `set -e` with trust_
> _And to install cloud_
> _We made `install.sh` proud_
> _With nip.io and options to adjust_

### Walkthrough
*  Add `set -e` command to `init.sh` script to exit on error ([link](https://github.com/labring/sealos/pull/4169/files?diff=unified&w=0#diff-7c20f8ecac334e472df2875627ce9de0e4297d7c839ef4ed0da3e80cb4e16595L2-R43))
*  Fix typo and add example for prompts in `install.sh` script ([link](https://github.com/labring/sealos/pull/4169/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL109-R109), [link](https://github.com/labring/sealos/pull/4169/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL122-R122))
*  Add variables to check if kubectl and cluster are installed and ready in `install.sh` script ([link](https://github.com/labring/sealos/pull/4169/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL204-R214))
*  Skip pulling images, asking for IPs, and generating Clusterfile if cluster is installed in `install.sh` script ([link](https://github.com/labring/sealos/pull/4169/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL225-R235), [link](https://github.com/labring/sealos/pull/4169/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL259-R283), [link](https://github.com/labring/sealos/pull/4169/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL361-R374))
*  Skip applying Clusterfile and running Cilium script if cluster is ready in `install.sh` script ([link](https://github.com/labring/sealos/pull/4169/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL398-R409))
*  Add options to specify parameters and versions for images, cluster, and cloud components in `install.sh` script ([link](https://github.com/labring/sealos/pull/4169/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL473-R505))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
