### PR TITLE
fix(costcenter): fix unit & invoice amount

### DIFF
--- a/frontend/providers/costcenter/package.json
+++ b/frontend/providers/costcenter/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.1",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --port 3001",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/frontend/providers/costcenter/src/components/invoice/invoiceTable.tsx
+++ b/frontend/providers/costcenter/src/components/invoice/invoiceTable.tsx
@@ -63,7 +63,7 @@ export function InvoiceTable({
                 </Flex>
               </Td>
               <Td>{format(item.createdTime, 'MM-dd HH:mm')}</Td>
-              <Td color={'#219BF4'}>{item.amount}</Td>
+              <Td color={'#219BF4'}>{item.payment?.amount || item.amount}</Td>
             </Tr>
           ))}
         </Tbody>

--- a/frontend/providers/costcenter/src/pages/create_invoice/index.tsx
+++ b/frontend/providers/costcenter/src/pages/create_invoice/index.tsx
@@ -208,11 +208,11 @@ function Invoice() {
                   data={[...tableResult]}
                   onSelect={(checked, item) => {
                     if (checked) {
-                      setInvoiceAmount(invoiceAmount + item.amount);
+                      setInvoiceAmount(invoiceAmount + (item.payment?.amount || item.amount));
                       setInvoiceCount(invoiceCount + 1);
                       selectBillings.current.push({ ...item });
                     } else {
-                      setInvoiceAmount(invoiceAmount - item.amount);
+                      setInvoiceAmount(invoiceAmount - (item.payment?.amount || item.amount));
                       setInvoiceCount(invoiceCount - 1);
                       const idx = selectBillings.current.findIndex(
                         (billing) => billing.order_id === item.order_id

--- a/frontend/providers/costcenter/src/pages/valuation/index.tsx
+++ b/frontend/providers/costcenter/src/pages/valuation/index.tsx
@@ -151,7 +151,9 @@ function Valuation() {
         return [
           {
             title: x.resourceType,
-            price: [1, 24, 168, 720, 8760].map((v) => (v * x.price * (props.scale || 1)) / 1000000),
+            price: [1, 24, 168, 720, 8760].map(
+              (v) => Math.floor(v * x.price * (props.scale || 1)) / 1000000
+            ),
             unit: props.unit,
             bg: props.bg,
             idx: props.idx,
@@ -219,10 +221,8 @@ function Valuation() {
                           {t(x.title)}
                         </Text>
                       </Td>
-                      <Td>
-                        {x.unit}/{t(CYCLE[cycleIdx])}
-                      </Td>
-                      <Td>{x.price[cycleIdx]}</Td>
+                      <Td>{x.unit + (x.title !== 'network' ? `/${t(CYCLE[cycleIdx])}` : '')}</Td>
+                      <Td>{x.title === 'network' ? x.price[0] : x.price[cycleIdx]}</Td>
                     </Tr>
                   ))}
                 </Tbody>

--- a/frontend/providers/costcenter/src/types/invoice.ts
+++ b/frontend/providers/costcenter/src/types/invoice.ts
@@ -23,6 +23,9 @@ export type ReqGenInvoice = {
     order_id: string;
     amount: number;
     // timeStamp
+    payment?: {
+      amount: number;
+    };
     createdTime: number;
   }[];
 };


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 176b85c</samp>

### Summary
💰🛠️📊

<!--
1.  💰 - This emoji represents the changes related to the payment amount and the invoice calculation. It conveys the idea of money, billing, and partial payments.
2. 🛠️ - This emoji represents the changes related to the port and the newline in `package.json`. It conveys the idea of fixing, tweaking, or improving something.
3. 📊 - This emoji represents the changes related to the valuation component and the presentation of the price and unit columns. It conveys the idea of data, charts, or analysis.
-->
Updated the frontend code for the costcenter provider to handle partial payments for billings and invoices. Changed the port for the `dev` script and the display of network resource prices.

> _Oh we're the coders of the sea, we make the invoices neat_
> _We show the payment or the amount, whichever is complete_
> _We round the prices and the units, we match the API_
> _So heave away, me hearties, heave away on the count of three_

### Walkthrough
*  Modify `InvoiceTable` and `Invoice` components to handle partial payments ([link](https://github.com/labring/sealos/pull/4185/files?diff=unified&w=0#diff-11cf01e8199ab153598a692e30a4551d4e516b17cc2fadbfb524ab0a6435ad77L66-R66), [link](https://github.com/labring/sealos/pull/4185/files?diff=unified&w=0#diff-84e29d389f19a64ad455a77af5b62e092c197ae6df51946fcee18d874b344660L211-R215))
*  Add optional payment property to `ReqGenInvoice` type to match backend API ([link](https://github.com/labring/sealos/pull/4185/files?diff=unified&w=0#diff-4b3c65271bd3775f6d1e738a2a3cc53dcaa2ee2a45fa1bf065b173e73332ad6cR26-R28))
*  Round down price values to the nearest millionth in `Valuation` component ([link](https://github.com/labring/sealos/pull/4185/files?diff=unified&w=0#diff-244a68651117c45a381484e7dc796c9ecf7acac2fef32dace7bf1c58d715b8a3L154-R156))
*  Display unit and price conditionally based on resource type in `Valuation` component ([link](https://github.com/labring/sealos/pull/4185/files?diff=unified&w=0#diff-244a68651117c45a381484e7dc796c9ecf7acac2fef32dace7bf1c58d715b8a3L222-R225))
*  Specify port 3001 for next.js development server in `dev` script ([link](https://github.com/labring/sealos/pull/4185/files?diff=unified&w=0#diff-34d38e3d749383a68496dd6da64c7aa812c2bb675609691dbc1b9943d4d23da6L6-R6))
*  Add newline at the end of `package.json` file ([link](https://github.com/labring/sealos/pull/4185/files?diff=unified&w=0#diff-34d38e3d749383a68496dd6da64c7aa812c2bb675609691dbc1b9943d4d23da6L56-L55))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
