### PR TITLE
feat: add cronjob app to cloud.

### DIFF
--- a/deploy/cloud/init.sh
+++ b/deploy/cloud/init.sh
@@ -38,6 +38,7 @@ retryPullImage ghcr.io/labring/sealos-cloud-dbprovider-frontend:latest
 retryPullImage ghcr.io/labring/sealos-cloud-costcenter-frontend:latest
 retryPullImage ghcr.io/labring/sealos-cloud-template-frontend:latest
 retryPullImage ghcr.io/labring/sealos-cloud-license-frontend:latest
+retryPullImage ghcr.io/labring/sealos-cloud-cronjob-frontend:latest
 
 retryPullImage ghcr.io/labring/sealos-cloud-database-service:latest
 retryPullImage ghcr.io/labring/sealos-cloud-job-init-controller:latest
@@ -56,6 +57,7 @@ sealos save -o tars/frontend-costcenter.tar ghcr.io/labring/sealos-cloud-costcen
 sealos save -o tars/frontend-applaunchpad.tar ghcr.io/labring/sealos-cloud-applaunchpad-frontend:latest
 sealos save -o tars/frontend-template.tar ghcr.io/labring/sealos-cloud-template-frontend:latest
 sealos save -o tars/frontend-license.tar ghcr.io/labring/sealos-cloud-license-frontend:latest
+sealos save -o tars/frontend-cronjob.tar ghcr.io/labring/sealos-cloud-cronjob-frontend:latest
 
 sealos save -o tars/database-service.tar ghcr.io/labring/sealos-cloud-database-service:latest
 sealos save -o tars/job-init.tar ghcr.io/labring/sealos-cloud-job-init-controller:latest

--- a/deploy/cloud/scripts/init.sh
+++ b/deploy/cloud/scripts/init.sh
@@ -120,7 +120,7 @@ function sealos_run_frontend {
   echo "run desktop frontend"
   sealos run tars/frontend-desktop.tar \
     --env cloudDomain=$cloudDomain \
-    --env cloudPort=$cloudPort \
+    --env cloudPort="$cloudPort" \
     --env certSecretName="wildcard-cert" \
     --env passwordEnabled="true" \
     --config-file etc/sealos/desktop-config.yaml
@@ -128,25 +128,25 @@ function sealos_run_frontend {
   echo "run applaunchpad frontend"
   sealos run tars/frontend-applaunchpad.tar \
   --env cloudDomain=$cloudDomain \
-  --env cloudPort=$cloudPort \
+  --env cloudPort="$cloudPort" \
   --env certSecretName="wildcard-cert"
 
   echo "run terminal frontend"
   sealos run tars/frontend-terminal.tar \
   --env cloudDomain=$cloudDomain \
-  --env cloudPort=$cloudPort \
+  --env cloudPort="$cloudPort" \
   --env certSecretName="wildcard-cert"
 
   echo "run dbprovider frontend"
   sealos run tars/frontend-dbprovider.tar \
   --env cloudDomain=$cloudDomain \
-  --env cloudPort=$cloudPort \
+  --env cloudPort="$cloudPort" \
   --env certSecretName="wildcard-cert"
 
   echo "run cost center frontend"
   sealos run tars/frontend-costcenter.tar \
   --env cloudDomain=$cloudDomain \
-  --env cloudPort=$cloudPort \
+  --env cloudPort="$cloudPort" \
   --env certSecretName="wildcard-cert" \
   --env transferEnabled="true" \
   --env rechargeEnabled="false"
@@ -154,22 +154,29 @@ function sealos_run_frontend {
   echo "run template frontend"
   sealos run tars/frontend-template.tar \
   --env cloudDomain=$cloudDomain \
-  --env cloudPort=$cloudPort \
+  --env cloudPort="$cloudPort" \
   --env certSecretName="wildcard-cert"
 
   echo "run license frontend"
   sealos run tars/frontend-license.tar \
   --env cloudDomain=$cloudDomain \
-  --env cloudPort=$cloudPort \
-  --env certSecretName="wildcard-cert"
+  --env cloudPort="$cloudPort" \
+  --env certSecretName="wildcard-cert" \
   --env licensePurchaseDomain="license.sealos.io"
+
+  echo "run cronjob frontend"
+  sealos run tars/frontend-cronjob.tar \
+  --env cloudDomain=$cloudDomain \
+  --env cloudPort="$cloudPort" \
+  --env certSecretName="wildcard-cert"
+
 
   echo "run db monitoring"
   sealos run tars/database-service.tar
 }
 
 function resource_exists {
-  kubectl get $1 >/dev/null 2>&1
+  kubectl get "$1" >/dev/null 2>&1
 }
 
 

--- a/frontend/providers/cronjob/Makefile
+++ b/frontend/providers/cronjob/Makefile
@@ -1,4 +1,4 @@
-SERVICE_NAME=sealos-db-provider
+SERVICE_NAME=sealos-cronjob
 # Image URL to use all building/pushing image targets
 IMG ?= $(SERVICE_NAME):latest
 
@@ -34,4 +34,4 @@ run: ## Run a dev service from host.
 
 .PHONY: docker-build
 docker-build: ## Build docker image with the desktop-frontend.
-	docker build -t sealos-db-provider:latest . --network host  --build-arg HTTP_PROXY=http://127.0.0.1:7890 --build-arg HTTPS_PROXY=http://127.0.0.1:7890
+	docker build -t sealos-cronjob:latest . --network host  --build-arg HTTP_PROXY=http://127.0.0.1:7890 --build-arg HTTPS_PROXY=http://127.0.0.1:7890

--- a/frontend/providers/cronjob/deploy/Kubefile
+++ b/frontend/providers/cronjob/deploy/Kubefile
@@ -6,6 +6,7 @@ COPY registry registry
 COPY manifests manifests
 
 ENV cloudDomain="127.0.0.1.nip.io"
+ENV cloudPort=""
 ENV certSecretName="wildcard-cert"
 
 CMD ["kubectl apply -f manifests"]

--- a/frontend/providers/cronjob/deploy/manifests/ingress.yaml.tmpl
+++ b/frontend/providers/cronjob/deploy/manifests/ingress.yaml.tmpl
@@ -1,12 +1,32 @@
+# Copyright © 2023 sealos.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "PUT, GET, POST, DELETE, PATCH, OPTIONS"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://{{ .cloudDomain }}{{ if .cloudPort }}:{{ .cloudPort }}{{ end }}, https://*.{{ .cloudDomain }}{{ if .cloudPort }}:{{ .cloudPort }}{{ end }}"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    nginx.ingress.kubernetes.io/cors-max-age: "600"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_clear_headers "X-Frame-Options:";
-      more_set_headers "Content-Security-Policy: default-src * blob: data: *.{{ .cloudDomain }} {{ .cloudDomain }}; img-src * data: blob: resource: *.{{ .cloudDomain }} {{ .cloudDomain }}; connect-src * wss: blob: resource:; style-src 'self' 'unsafe-inline' blob: *.{{ .cloudDomain }} {{ .cloudDomain }} resource:; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: *.{{ .cloudDomain }} {{ .cloudDomain }} resource: *.baidu.com *.bdstatic.com; frame-src 'self' {{ .cloudDomain }} mailto: tel: weixin: mtt: *.baidu.com; frame-ancestors 'self' https://{{ .cloudDomain }} https://*.{{ .cloudDomain }}";
+      more_set_headers "Content-Security-Policy: default-src * blob: data: *.{{ .cloudDomain }}{{ if .cloudPort }}:{{ .cloudPort }}{{ end }} {{ .cloudDomain }}{{ if .cloudPort }}:{{ .cloudPort }}{{ end }}; img-src * data: blob: resource: *.{{ .cloudDomain }}{{ if .cloudPort }}:{{ .cloudPort }}{{ end }} {{ .cloudDomain }}{{ if .cloudPort }}:{{ .cloudPort }}{{ end }}; connect-src * wss: blob: resource:; style-src 'self' 'unsafe-inline' blob: *.{{ .cloudDomain }}{{ if .cloudPort }}:{{ .cloudPort }}{{ end }} {{ .cloudDomain }}{{ if .cloudPort }}:{{ .cloudPort }}{{ end }} resource:; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: *.{{ .cloudDomain }}{{ if .cloudPort }}:{{ .cloudPort }}{{ end }} {{ .cloudDomain }}{{ if .cloudPort }}:{{ .cloudPort }}{{ end }} resource: *.baidu.com *.bdstatic.com https://js.stripe.com; frame-src 'self' *.{{ .cloudDomain }}{{ if .cloudPort }}:{{ .cloudPort }}{{ end }} {{ .cloudDomain }}{{ if .cloudPort }}:{{ .cloudPort }}{{ end }} mailto: tel: weixin: mtt: *.baidu.com https://js.stripe.com; frame-ancestors 'self' https://{{ .cloudDomain }}{{ if .cloudPort }}:{{ .cloudPort }}{{ end }} https://*.{{ .cloudDomain }}{{ if .cloudPort }}:{{ .cloudPort }}{{ end }}";
       more_set_headers "X-Xss-Protection: 1; mode=block";
       
       if ($request_uri ~* \.(js|css|gif|jpe?g|png)) {

--- a/frontend/providers/license/deploy/manifests/ingress.yaml.tmpl
+++ b/frontend/providers/license/deploy/manifests/ingress.yaml.tmpl
@@ -50,4 +50,4 @@ spec:
   tls:
     - hosts:
         - license.{{ .cloudDomain }}
-      secretName: wildcard-cert
+      secretName: {{ .certSecretName }}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at af6c13b</samp>

### Summary
🌐🔒🕒

<!--
1.  🌐 - This emoji represents the cloudPort environment variable and the GitHub container registry, which are related to the cloud or internet.
2. 🔒 - This emoji represents the wildcard certificate and the security headers, which are related to encryption or protection.
3. 🕒 - This emoji represents the cronjob frontend application, which is related to scheduling or timing.
-->
This pull request updates the deployment and configuration of the sealos cloud platform and the cronjob and license frontend applications. It improves the security, robustness, and clarity of the code and uses the GitHub container registry for the cronjob frontend image. It also introduces a new environment variable for the cloudPort and a variable for the wildcard certificate secret name.

> _To deploy sealos-cronjob with ease_
> _We added some env vars and keys_
> _We saved the image as tar_
> _And quoted args with care_
> _And tweaked the ingress and CORS policies_

### Walkthrough
*  Pull and save the image of the cronjob frontend from the GitHub container registry ([link](https://github.com/labring/sealos/pull/4201/files?diff=unified&w=0#diff-7c20f8ecac334e472df2875627ce9de0e4297d7c839ef4ed0da3e80cb4e16595R41), [link](https://github.com/labring/sealos/pull/4201/files?diff=unified&w=0#diff-7c20f8ecac334e472df2875627ce9de0e4297d7c839ef4ed0da3e80cb4e16595R60))
*  Run the cronjob frontend as a sealos application and pass the cloudPort as an environment variable ([link](https://github.com/labring/sealos/pull/4201/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844L163-R173), [link](https://github.com/labring/sealos/pull/4201/files?diff=unified&w=0#diff-3a81ef2a55eb9e2eb7e26fcbf4e5e9295f789442b9746823d375ef402b2ad1d2R9))
*  Enable CORS and set the backend protocol to HTTP for the cronjob frontend ingress ([link](https://github.com/labring/sealos/pull/4201/files?diff=unified&w=0#diff-e645a65b53c8e395c97f0ad83944274a63244a3b9760f12f465bf1e5bda7938fL7-R29))
*  Include the cloudPort in the content security policy and the cors-allow-origin headers for the cronjob frontend ingress ([link](https://github.com/labring/sealos/pull/4201/files?diff=unified&w=0#diff-e645a65b53c8e395c97f0ad83944274a63244a3b9760f12f465bf1e5bda7938fL7-R29))
*  Add double quotes around the cloudPort variable to prevent word splitting and globbing in the `deploy/cloud/scripts/init.sh` file ([link](https://github.com/labring/sealos/pull/4201/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844L123-R123), [link](https://github.com/labring/sealos/pull/4201/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844L131-R131), [link](https://github.com/labring/sealos/pull/4201/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844L137-R137), [link](https://github.com/labring/sealos/pull/4201/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844L143-R143), [link](https://github.com/labring/sealos/pull/4201/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844L149-R149), [link](https://github.com/labring/sealos/pull/4201/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844L157-R157))
*  Add double quotes around the resource argument to prevent word splitting and globbing in the `deploy/cloud/scripts/init.sh` file ([link](https://github.com/labring/sealos/pull/4201/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844L172-R179))
*  Rename the service name and the image tag from sealos-db-provider to sealos-cronjob in the `frontend/providers/cronjob/Makefile` file ([link](https://github.com/labring/sealos/pull/4201/files?diff=unified&w=0#diff-190f543ff160f18ebab0725d2751bb3a719abb42e049d81a263108081aa64854L1-R1), [link](https://github.com/labring/sealos/pull/4201/files?diff=unified&w=0#diff-190f543ff160f18ebab0725d2751bb3a719abb42e049d81a263108081aa64854L37-R37))
*  Replace the hardcoded secret name for the wildcard certificate with a variable in the `frontend/providers/license/deploy/manifests/ingress.yaml.tmpl` file ([link](https://github.com/labring/sealos/pull/4201/files?diff=unified&w=0#diff-c044bb33c61e72df5a48f157dcadfc5e199c0b0b21b392ba5d1ef3fecd03a93aL53-R53))
*  Add a license header to the `frontend/providers/cronjob/deploy/manifests/ingress.yaml.tmpl` file ([link](https://github.com/labring/sealos/pull/4201/files?diff=unified&w=0#diff-e645a65b53c8e395c97f0ad83944274a63244a3b9760f12f465bf1e5bda7938fR1-R14))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
