### PR TITLE
refactor(main): unmount override container (#4161)

### DIFF
--- a/pkg/types/v1beta1/cluster_args.go
+++ b/pkg/types/v1beta1/cluster_args.go
@@ -135,36 +135,13 @@ func (c *Cluster) GetRootfsImage() *MountImage {
 	return image
 }
 
-func (c *Cluster) FindImage(targetImage string) *MountImage {
-	var image *MountImage
-	if c.Status.Mounts != nil {
-		for _, img := range c.Status.Mounts {
-			if img.ImageName == targetImage {
-				image = &img
-				break
-			}
+func (c *Cluster) FindImage(name string) (int, *MountImage) {
+	for i, img := range c.Status.Mounts {
+		if img.ImageName == name {
+			return i, &img
 		}
 	}
-	return image
-}
-
-func (c *Cluster) SetMountImage(targetMount *MountImage) {
-	tgMount := targetMount.DeepCopy()
-	if c.Status.Mounts != nil {
-		if tgMount != nil {
-			hasMount := false
-			for i, img := range c.Status.Mounts {
-				if img.Name == tgMount.Name && img.Type == tgMount.Type {
-					c.Status.Mounts[i] = *tgMount
-					hasMount = true
-					break
-				}
-			}
-			if !hasMount {
-				c.Status.Mounts = append(c.Status.Mounts, *tgMount)
-			}
-		}
-	}
+	return -1, nil
 }
 
 func (c *Cluster) ReplaceRootfsImage() {


### PR DESCRIPTION
(cherry picked from commit 4fed20a298b95f89782d84ad9349f456efdd0646)

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e489328</samp>

### Summary
🔧🗃️🚀

<!--
1.  🔧 for modifying the `cluster.FindImage` method and removing the `cluster.SetMountImage` method.
2.  🗃️ for importing the `sort` package and improving the logic of handling `MountImage` instances.
3.  🚀 for appending new mounts to the end of the slice and avoiding conflicts or errors.
-->
This pull request enhances the handling of `MountImage` instances in the `cluster.Status.Mounts` slice by sorting, deduplicating, and appending them. It also simplifies the `cluster.FindImage` method and removes the `cluster.SetMountImage` method. These changes aim to avoid conflicts or errors when applying the cluster configuration.

> _Sing, O Muse, of the skillful coder who modified the cluster code_
> _To find the image and its index, and return them both with ease_
> _No longer needing to set the mount, he removed the method old_
> _And made the slice of mounts more ordered, with the help of sorting god_

### Walkthrough
*  Ensure that `cluster.Status.Mounts` slice is consistent and up-to-date with the latest `MountImage` instances ([link](https://github.com/labring/sealos/pull/4208/files?diff=unified&w=0#diff-dc16722036c8f44c78015609d3ab3424d2f4d09543296a24d98e6ebea7a2dbb9L142-R163), [link](https://github.com/labring/sealos/pull/4208/files?diff=unified&w=0#diff-dc16722036c8f44c78015609d3ab3424d2f4d09543296a24d98e6ebea7a2dbb9L170-R193))
  - Import `sort` package in `pkg/apply/processor/install.go` ([link](https://github.com/labring/sealos/pull/4208/files?diff=unified&w=0#diff-dc16722036c8f44c78015609d3ab3424d2f4d09543296a24d98e6ebea7a2dbb9R20))
  - Create a map of `ImageName` to the index of the last occurrence in the slice and sort the indexes ([link](https://github.com/labring/sealos/pull/4208/files?diff=unified&w=0#diff-dc16722036c8f44c78015609d3ab3424d2f4d09543296a24d98e6ebea7a2dbb9L142-R163))
  - Create a new slice of `MountImage` instances based on the sorted indexes and assign it to the cluster status ([link](https://github.com/labring/sealos/pull/4208/files?diff=unified&w=0#diff-dc16722036c8f44c78015609d3ab3424d2f4d09543296a24d98e6ebea7a2dbb9L142-R163))
  - Check if a new `MountImage` instance already exists in the slice before appending it and remove the old one if found ([link](https://github.com/labring/sealos/pull/4208/files?diff=unified&w=0#diff-dc16722036c8f44c78015609d3ab3424d2f4d09543296a24d98e6ebea7a2dbb9L170-R193))
* Modify `cluster.FindImage` method to return both the index and the pointer to the `MountImage` instance in `pkg/types/v1beta1/cluster_args.go` ([link](https://github.com/labring/sealos/pull/4208/files?diff=unified&w=0#diff-c335119368d682a84a20bc7e6d59acde63ad1d97cdd46444904199407abcf6e3L138-R146))
  - Remove `cluster.SetMountImage` method as it is no longer needed ([link](https://github.com/labring/sealos/pull/4208/files?diff=unified&w=0#diff-c335119368d682a84a20bc7e6d59acde63ad1d97cdd46444904199407abcf6e3L138-R146))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
