### PR TITLE
fix license db uri

### DIFF
--- a/deploy/cloud/scripts/init.sh
+++ b/deploy/cloud/scripts/init.sh
@@ -179,6 +179,7 @@ function sealos_run_frontend {
   --env cloudDomain=$cloudDomain \
   --env cloudPort="$cloudPort" \
   --env certSecretName="wildcard-cert" \
+  --env MONGODB_URI="${mongodbUri}/sealos-license?authSource=admin" \
   --env licensePurchaseDomain="license.sealos.io"
 
   echo "run cronjob frontend"


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6b2c9fa</samp>

### Summary
:card_file_box::link::key:

<!--
1.  :card_file_box: - This emoji represents databases, files, or storage, and can be used to indicate the change involves a MongoDB database.
2.  :link: - This emoji represents connections, links, or URLs, and can be used to indicate the change involves a connection string or a new cluster.
3.  :key: - This emoji represents keys, passwords, or licenses, and can be used to indicate the change involves the license information or service.
-->
This change sets the `MONGODB_URI` environment variable for the `sealos-license` service to connect to a new MongoDB cluster. It is part of a pull request that updates the deployment scripts in `deploy/cloud/scripts`.

> _`sealos-license` runs_
> _with `MONGODB_URI`_
> _a new cluster waits_

### Walkthrough
*  Add `MONGODB_URI` environment variable to `docker run` command for `sealos-license` service ([link](https://github.com/labring/sealos/pull/4211/files?diff=unified&w=0#diff-7f4df0129665fe81f0d8ddc6a9375d92c5062f99482ec60a9b3d4f401e667844R182))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
