### PR TITLE
fix database service ci.

### DIFF
--- a/.github/workflows/services.yml
+++ b/.github/workflows/services.yml
@@ -222,8 +222,11 @@ jobs:
         run: |
           CLUSTER_IMAGE_NAME=${{ steps.prepare.outputs.cluster_repo }}:${{ steps.prepare.outputs.tag_name }}
           sudo sealos build -t ${CLUSTER_IMAGE_NAME}-amd64 --platform linux/amd64 -f Kubefile
+          sudo rm -rf registry
           sudo sealos build -t ${CLUSTER_IMAGE_NAME}-arm64 --platform linux/arm64 -f Kubefile
+          sudo rm -rf registry
           sudo sealos images
+          bash docker/patch/manifest-cluster-images.sh $CLUSTER_IMAGE_NAME
       - name: Build ${{ matrix.module }}-service cluster image for latest
         run: |
           CLUSTER_IMAGE_NAME=${{ steps.prepare.outputs.cluster_repo }}:${{ steps.prepare.outputs.tag_name }}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d2748a8</samp>

### Summary
:hammer::wrench::globe_with_meridians:

<!--
1.  :hammer: - This emoji represents the work done to build the cluster image for different architectures and remove the registry directory. It conveys the idea of construction, improvement, or fixing something.
2.  :wrench: - This emoji represents the work done to run the script that creates the manifest list for the cluster image. It conveys the idea of configuration, adjustment, or maintenance of something.
3.  :globe_with_meridians: - This emoji represents the goal of supporting multi-arch cluster images for sealos, which can run on different platforms and devices. It conveys the idea of globalization, compatibility, or diversity of something.
-->
Add commands to clean registry directory and create manifest list for multi-arch cluster image in `.github/workflows/services.yml`. This enables sealos to build and push cluster images for both amd64 and arm64 architectures.

> _`sealos` builds twice_
> _removes registry, then runs_
> _`manifest-tool` script_

### Walkthrough
*  Add multi-arch support for sealos and its services ([link](https://github.com/labring/sealos/pull/4252/files?diff=unified&w=0#diff-48839d65f7bfedd91312ee406fd94da103ede7d3c7e791eb2c1657f46afdea00L225-R229),                             F0L252R


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
