### PR TITLE
fix database service ci

### DIFF
--- a/.github/workflows/services.yml
+++ b/.github/workflows/services.yml
@@ -224,9 +224,7 @@ jobs:
           sudo sealos build -t ${CLUSTER_IMAGE_NAME}-amd64 --platform linux/amd64 -f Kubefile
           sudo rm -rf registry
           sudo sealos build -t ${CLUSTER_IMAGE_NAME}-arm64 --platform linux/arm64 -f Kubefile
-          sudo rm -rf registry
           sudo sealos images
-          bash docker/patch/manifest-cluster-images.sh $CLUSTER_IMAGE_NAME
       - name: Build ${{ matrix.module }}-service cluster image for latest
         run: |
           CLUSTER_IMAGE_NAME=${{ steps.prepare.outputs.cluster_repo }}:${{ steps.prepare.outputs.tag_name }}
@@ -234,6 +232,7 @@ jobs:
           sudo sealos tag ${CLUSTER_IMAGE_NAME}-amd64  ${CLUSTER_IMAGE_NAME_LATEST}-amd64
           sudo sealos tag ${CLUSTER_IMAGE_NAME}-arm64  ${CLUSTER_IMAGE_NAME_LATEST}-arm64
           sudo sealos images
+          bash docker/patch/manifest-cluster-images.sh $CLUSTER_IMAGE_NAME
           bash docker/patch/manifest-cluster-images.sh $CLUSTER_IMAGE_NAME_LATEST
       - name: Renew issue and Sync Images
         uses: labring/gh-rebot@v0.0.6

--- a/.github/workflows/services.yml
+++ b/.github/workflows/services.yml
@@ -222,8 +222,11 @@ jobs:
         run: |
           CLUSTER_IMAGE_NAME=${{ steps.prepare.outputs.cluster_repo }}:${{ steps.prepare.outputs.tag_name }}
           sudo sealos build -t ${CLUSTER_IMAGE_NAME}-amd64 --platform linux/amd64 -f Kubefile
+          sudo rm -rf registry
           sudo sealos build -t ${CLUSTER_IMAGE_NAME}-arm64 --platform linux/arm64 -f Kubefile
+          sudo rm -rf registry
           sudo sealos images
+          bash docker/patch/manifest-cluster-images.sh $CLUSTER_IMAGE_NAME
       - name: Build ${{ matrix.module }}-service cluster image for latest
         run: |
           CLUSTER_IMAGE_NAME=${{ steps.prepare.outputs.cluster_repo }}:${{ steps.prepare.outputs.tag_name }}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6e59a84</samp>

### Summary
:wastebasket::wrench::test_tube:

<!--
1.  :wastebasket: - This emoji represents the deletion of the local docker registry, which is a cleanup step that prevents potential conflicts or errors with future runs of the workflow.
2.  :wrench: - This emoji represents the patching of the cluster images manifest file, which is a configuration step that ensures the correct image name and tag are used for testing the cluster images.
3.  :test_tube: - This emoji represents the testing of the cluster images, which is the main purpose of the workflow and verifies that the images work as expected.
-->
This pull request enhances the cluster image testing workflow by cleaning up the local docker registry and updating the image references in the manifest file. This ensures that the workflow uses the correct and latest images for testing.

> _Sing, O Muse, of the valiant deeds of the coder_
> _Who sought to improve the testing of the cluster images_
> _And bravely modified the `services.yml` file_
> _Adding steps to purge the docker registry and patch the manifest_

### Walkthrough
* Patch the cluster images manifest file with the correct image name and tag ([link](https://github.com/labring/sealos/pull/4253/files?diff=unified&w=0#diff-48839d65f7bfedd91312ee406fd94da103ede7d3c7e791eb2c1657f46afdea00R235)). This ensures that the sealos cluster installer uses the images that were built and pushed by the workflow, and not the default ones. The image name and tag are dynamically generated by the workflow based on the branch name and commit hash. The script that performs the patching is `hack/patch-manifest.sh`.


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
