### PR TITLE
feature: environment variable based template rendering in sealos create

### DIFF
--- a/pkg/constants/contants.go
+++ b/pkg/constants/contants.go
@@ -18,6 +18,8 @@ import (
 	"github.com/containers/storage/pkg/homedir"
 )
 
+const TemplateSuffix = ".tmpl"
+
 const (
 	LvsCareStaticPodName    = "kube-sealos-lvscare"
 	YamlFileSuffix          = "yaml"

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -16,22 +16,14 @@ package env
 
 // nosemgrep: go.lang.security.audit.xss.import-text-template.import-text-template
 import (
-	"errors"
-	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 
-	"github.com/labring/sealos/pkg/template"
 	"github.com/labring/sealos/pkg/types/v1beta1"
-	fileutil "github.com/labring/sealos/pkg/utils/file"
 	"github.com/labring/sealos/pkg/utils/logger"
 	"github.com/labring/sealos/pkg/utils/maps"
 	stringsutil "github.com/labring/sealos/pkg/utils/strings"
 )
-
-const templateSuffix = ".tmpl"
 
 type Interface interface {
 	// WrapShell :If host already set env like DATADISK=/data
@@ -73,47 +65,11 @@ func (p *processor) WrapShell(host, shell string) string {
 }
 
 func (p *processor) RenderAll(host, dir string, envs map[string]string) error {
-	return filepath.Walk(dir, func(path string, info os.FileInfo, errIn error) error {
-		if errIn != nil {
-			return errIn
-		}
-		if info.IsDir() || !strings.HasSuffix(info.Name(), templateSuffix) {
-			return nil
-		}
-		fileName := strings.TrimSuffix(path, templateSuffix)
-		if fileutil.IsExist(fileName) {
-			if err := os.Remove(fileName); err != nil {
-				logger.Warn(err)
-			}
-		}
-
-		writer, err := os.OpenFile(fileName, os.O_CREATE|os.O_RDWR, os.ModePerm)
-		if err != nil {
-			return fmt.Errorf("failed to open file [%s] when render env: %v", path, err)
-		}
-
-		defer writer.Close()
-		body, err := fileutil.ReadAll(path)
-		if err != nil {
-			return err
-		}
-
-		t, isOk, err := template.TryParse(string(body))
-		if isOk {
-			if err != nil {
-				return fmt.Errorf("failed to create template: %s %v", path, err)
-			}
-			if host != "" {
-				data := maps.MergeMap(envs, p.getHostEnvInCache(host))
-				if err := t.Execute(writer, data); err != nil {
-					return fmt.Errorf("failed to render env template: %s %v", path, err)
-				}
-			}
-		} else {
-			return errors.New("parse template failed")
-		}
-		return nil
-	})
+	data := envs
+	if host != "" {
+		data = maps.MergeMap(envs, p.getHostEnvInCache(host))
+	}
+	return stringsutil.RenderTemplatesWithEnv(dir, data)
 }
 
 func (p *processor) getHostEnvInCache(hostIP string) map[string]string {

--- a/pkg/filesystem/rootfs/rootfs_default.go
+++ b/pkg/filesystem/rootfs/rootfs_default.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"path"
 
 	"golang.org/x/sync/errgroup"
 
@@ -152,23 +151,7 @@ func (f *defaultRootfs) unmountRootfs(cluster *v2.Cluster, ipList []string) erro
 }
 
 func renderTemplatesWithEnv(mountDir string, ipList []string, p env.Interface, envs map[string]string) error {
-	var (
-		renderEtc       = path.Join(mountDir, constants.EtcDirName)
-		renderScripts   = path.Join(mountDir, constants.ScriptsDirName)
-		renderManifests = path.Join(mountDir, constants.ManifestsDirName)
-	)
-
-	// currently only render once
-	for _, dir := range []string{renderEtc, renderScripts, renderManifests} {
-		logger.Debug("render env dir: %s", dir)
-		if file.IsExist(dir) {
-			err := p.RenderAll(ipList[0], dir, envs)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
+	return p.RenderAll(ipList[0], mountDir, envs)
 }
 
 func newDefaultRootfs(mounts []v2.MountImage) (filesystem.Mounter, error) {

--- a/pkg/utils/strings/strings.go
+++ b/pkg/utils/strings/strings.go
@@ -18,12 +18,19 @@ package strings
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
 	"unicode"
+
+	"github.com/labring/sealos/pkg/constants"
+	"github.com/labring/sealos/pkg/template"
+	"github.com/labring/sealos/pkg/utils/file"
 
 	"github.com/labring/sealos/pkg/utils/logger"
 )
@@ -221,6 +228,67 @@ func RenderTextFromEnv(text string, envs map[string]string) string {
 		text = strings.ReplaceAll(text, o, n)
 	}
 	return text
+}
+
+func RenderTemplatesWithEnv(filePaths string, envs map[string]string) error {
+	var (
+		renderEtc       = filepath.Join(filePaths, constants.EtcDirName)
+		renderScripts   = filepath.Join(filePaths, constants.ScriptsDirName)
+		renderManifests = filepath.Join(filePaths, constants.ManifestsDirName)
+	)
+
+	for _, dir := range []string{renderEtc, renderScripts, renderManifests} {
+		logger.Debug("render env dir: %s", dir)
+		if !file.IsExist(dir) {
+			logger.Debug("Directory %s does not exist, skipping", dir)
+			continue
+		}
+
+		if err := filepath.Walk(dir, func(path string, info os.FileInfo, errIn error) error {
+			if errIn != nil {
+				return errIn
+			}
+			if info.IsDir() || !strings.HasSuffix(info.Name(), constants.TemplateSuffix) {
+				return nil
+			}
+
+			fileName := strings.TrimSuffix(path, constants.TemplateSuffix)
+			if file.IsExist(fileName) {
+				if err := os.Remove(fileName); err != nil {
+					logger.Warn("failed to remove existing file [%s]: %v", fileName, err)
+				}
+			}
+
+			writer, err := os.OpenFile(fileName, os.O_CREATE|os.O_RDWR, os.ModePerm)
+			if err != nil {
+				return fmt.Errorf("failed to open file [%s] for rendering: %v", path, err)
+			}
+			defer writer.Close()
+
+			body, err := file.ReadAll(path)
+			if err != nil {
+				return err
+			}
+
+			t, isOk, err := template.TryParse(string(body))
+			if isOk {
+				if err != nil {
+					return fmt.Errorf("failed to create template: %s %v", path, err)
+				}
+				if err := t.Execute(writer, envs); err != nil {
+					return fmt.Errorf("failed to render env template: %s %v", path, err)
+				}
+			} else {
+				return errors.New("parse template failed")
+			}
+
+			return nil
+		}); err != nil {
+			return fmt.Errorf("failed to render templates in directory %s: %v", dir, err)
+		}
+	}
+
+	return nil
 }
 
 func TrimQuotes(s string) string {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 28ed856</samp>

### Summary
🆕🔄🚀

<!--
1.  🆕 for adding a new feature to render template files with environment variables when creating a container image.
2.  🔄 for refactoring the code to use existing constants and functions from other packages, and to remove unnecessary dependencies.
3.  🚀 for improving the code readability and efficiency of rendering templates for the root filesystem and the strings package.
-->
This pull request adds a new feature to the `buildah` package to render template files with environment variables when creating a container image. It also refactors and improves the code of the `env`, `rootfs`, and `strings` packages to support this feature and enhance readability and efficiency. It updates the `constants` package with a new constant for template files.

> _Sing, O Muse, of the glorious deeds of the buildah team,_
> _Who with skill and wisdom crafted the code to render templates,_
> _And added a new flag and field to the `buildah` package,_
> _To create container images with environment variables._

### Walkthrough
*  Add `env` field and flag to `createOptions` type and `RegisterFlags` function to allow specifying environment variables for template files when creating a container image ([link](https://github.com/labring/sealos/pull/4258/files?diff=unified&w=0#diff-58d7cc78400df81b474dbdb004cbae50ccbb6edf8659d6ab34d81eb0b0eb3ae4R43),[link](https://github.com/labring/sealos/pull/4258/files?diff=unified&w=0#diff-58d7cc78400df81b474dbdb004cbae50ccbb6edf8659d6ab34d81eb0b0eb3ae4R57))
*  Call `runRender` function in `create` function to render the template files with the environment variables if the `env` option is not empty ([link](https://github.com/labring/sealos/pull/4258/files?diff=unified&w=0#diff-58d7cc78400df81b474dbdb004cbae50ccbb6edf8659d6ab34d81eb0b0eb3ae4R83-R89))
*  Implement `runRender` function in `pkg/buildah/create.go` to render the template files in the mount points with the environment variables using the `errgroup` package ([link](https://github.com/labring/sealos/pull/4258/files?diff=unified&w=0#diff-58d7cc78400df81b474dbdb004cbae50ccbb6edf8659d6ab34d81eb0b0eb3ae4R127-R144))
*  Add `TemplateSuffix` constant to `pkg/constants/contants.go` to store the suffix for template files ([link](https://github.com/labring/sealos/pull/4258/files?diff=unified&w=0#diff-80e4b3200a45b253d0fc815465ad7197888772d365d86b32a3365a52a440bf51R21-R22))
*  Use `TemplateSuffix` constant from `constants` package instead of `templateSuffix` constant in `pkg/env/env.go` ([link](https://github.com/labring/sealos/pull/4258/files?diff=unified&w=0#diff-688294d2a07f1d5aa5afe0db41e55097fb8de2f5f9a38537564cbad54bad4136L34-L35))
*  Simplify `RenderAll` function in `pkg/env/env.go` by using `RenderTemplatesWithEnv` function from `stringsutil` package instead of walking the directory and parsing the template files manually ([link](https://github.com/labring/sealos/pull/4258/files?diff=unified&w=0#diff-688294d2a07f1d5aa5afe0db41e55097fb8de2f5f9a38537564cbad54bad4136L76-R72))
*  Simplify `renderTemplatesWithEnv` function in `pkg/filesystem/rootfs/rootfs_default.go` by passing the `mountDir` directly to the `RenderAll` function instead of looping over the subdirectories ([link](https://github.com/labring/sealos/pull/4258/files?diff=unified&w=0#diff-61493411683095682b775e1da8c4c1cca669f6a7807f480f6d747d4fb153fbe8L155-R154))
*  Implement `RenderTemplatesWithEnv` function in `pkg/utils/strings/strings.go` that renders the template files in a given directory with the environment variables using the `template` package ([link](https://github.com/labring/sealos/pull/4258/files?diff=unified&w=0#diff-82b41b8126e4fd18dd3847b75fd2060a8b5de00c716db1fd05ce9f14edecd253R233-R293))
*  Import additional packages in `pkg/buildah/create.go` and `pkg/utils/strings/strings.go` to use their functions and types ([link](https://github.com/labring/sealos/pull/4258/files?diff=unified&w=0#diff-58d7cc78400df81b474dbdb004cbae50ccbb6edf8659d6ab34d81eb0b0eb3ae4L18-R27),[link](https://github.com/labring/sealos/pull/4258/files?diff=unified&w=0#diff-82b41b8126e4fd18dd3847b75fd2060a8b5de00c716db1fd05ce9f14edecd253L21-R25))
*  Import `stringsutil` package as an alias in `pkg/buildah/create.go` ([link](https://github.com/labring/sealos/pull/4258/files?diff=unified&w=0#diff-58d7cc78400df81b474dbdb004cbae50ccbb6edf8659d6ab34d81eb0b0eb3ae4R35-R36))
*  Remove unused imports in `pkg/env/env.go` and `pkg/filesystem/rootfs/rootfs_default.go` ([link](https://github.com/labring/sealos/pull/4258/files?diff=unified&w=0#diff-688294d2a07f1d5aa5afe0db41e55097fb8de2f5f9a38537564cbad54bad4136L19-R22),[link](https://github.com/labring/sealos/pull/4258/files?diff=unified&w=0#diff-61493411683095682b775e1da8c4c1cca669f6a7807f480f6d747d4fb153fbe8L23))
*  Add a blank line for readability in `create` function in `pkg/buildah/create.go` ([link](https://github.com/labring/sealos/pull/4258/files?diff=unified&w=0#diff-58d7cc78400df81b474dbdb004cbae50ccbb6edf8659d6ab34d81eb0b0eb3ae4R95))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->

refer to #4233 