### PR TITLE
Fix env for BD_TOKEN

### DIFF
--- a/.github/workflows/deploy-docs-preview.yml
+++ b/.github/workflows/deploy-docs-preview.yml
@@ -21,6 +21,7 @@ concurrency:
 
 env:
   BUILD_PATH: "./docs/website"
+  BD_TOKEN: ${{ secrets.BD_TOKEN }}
 
 jobs:
   build:
@@ -93,8 +94,6 @@ jobs:
           github-comment: false
           # vercel-args: '--local-config vercel.json' # Optional
           working-directory: ${{ env.BUILD_PATH }}/build
-        env:
-          BD_TOKEN: "${{ secrets.BD_TOKEN }}"
 
   docsOutput:
     needs: [ build ]

--- a/.github/workflows/deploy-docs-site.yml
+++ b/.github/workflows/deploy-docs-site.yml
@@ -21,6 +21,7 @@ concurrency:
 
 env:
   BUILD_PATH: "./docs/website"
+  BD_TOKEN: ${{ secrets.BD_TOKEN }}
 
 jobs:
   build:
@@ -76,5 +77,3 @@ jobs:
           github-comment: false
           vercel-args: '--prod'
           working-directory: ${{ env.BUILD_PATH }}/build
-        env:
-          BD_TOKEN: "${{ secrets.BD_TOKEN }}"

--- a/.github/workflows/docs-site-image.yml
+++ b/.github/workflows/docs-site-image.yml
@@ -59,7 +59,7 @@ jobs:
           file: ./docs/website/Dockerfile
           push: true
           build-args: |
-            BD_TOKEN=${{ env.BD_TOKEN }}
+            BD_TOKEN=${{ secrets.BD_TOKEN }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c1afaa9</samp>

### Summary
🔑🧹🚀

<!--
1.  🔑 - This emoji represents the use of secrets instead of environment variables for sensitive information, such as the BuildDocs token. It also implies security and authentication.
2.  🧹 - This emoji represents the simplification and cleanup of the workflow configuration, by removing unnecessary or redundant code and using a single `env` section for common variables.
3.  🚀 - This emoji represents the deployment of the docs site and preview to BuildDocs, as well as the speed and efficiency of the workflow.
-->
This pull request updates the workflows for building and deploying the documentation site using BuildDocs. It simplifies the configuration, adds the `BD_TOKEN` variable for authentication, and fixes the usage of the secret variable in the `docs-site-image.yml` file.

> _We are the secrets of the code_
> _We unleash the power of the `BD_TOKEN`_
> _We simplify the env of the docs_
> _We deploy the site with BuildDocs_

### Walkthrough
*  Add `BD_TOKEN` environment variable to authenticate with BuildDocs service in `deploy-docs-preview` and `deploy-docs-site` jobs ([link](https://github.com/labring/sealos/pull/4268/files?diff=unified&w=0#diff-6ded02ae5ed9feb0feeccc4b412e6fd413f0ce238d98ba7ff96585ccbd8d9a4aR24), [link](https://github.com/labring/sealos/pull/4268/files?diff=unified&w=0#diff-58498050b4d4be83cf6f4481619cf94f5f8dcd7e5f08015f690a8025ff905eb6R24))
* Remove redundant `env` sections from `build-and-push-image` steps in `.github/workflows/deploy-docs-preview.yml` and `.github/workflows/deploy-docs-site.yml` ([link](https://github.com/labring/sealos/pull/4268/files?diff=unified&w=0#diff-6ded02ae5ed9feb0feeccc4b412e6fd413f0ce238d98ba7ff96585ccbd8d9a4aL96-L97), [link](https://github.com/labring/sealos/pull/4268/files?diff=unified&w=0#diff-58498050b4d4be83cf6f4481619cf94f5f8dcd7e5f08015f690a8025ff905eb6L79-L80))
* Use secret variable instead of environment variable for `BD_TOKEN` in `build-args` section of `build-and-push-image` step in `.github/workflows/docs-site-image.yml` ([link](https://github.com/labring/sealos/pull/4268/files?diff=unified&w=0#diff-86190d8e68d80d1beb88018cf93d280e30db6ebf687d0187c2255619a053a4ccL62-R62))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
