### PR TITLE
Fix/cloud port

### DIFF
--- a/controllers/terminal/deploy/Kubefile
+++ b/controllers/terminal/deploy/Kubefile
@@ -7,7 +7,7 @@ COPY manifests manifests
 
 ENV userNamespace="user-system"
 ENV cloudDomain="127.0.0.1.nip.io"
-ENV port=""
+ENV cloudPort=""
 ENV wildcardCertSecretName="wildcard-cert"
 ENV wildcardCertSecretNamespace="sealos-system"
 

--- a/controllers/terminal/deploy/manifests/deploy.yaml.tmpl
+++ b/controllers/terminal/deploy/manifests/deploy.yaml.tmpl
@@ -444,7 +444,7 @@ spec:
         - name: DOMAIN
           value: {{ .cloudDomain }}
         - name: PORT
-          value: {{ .port }}
+          value: {{ .cloudPort }}
         - name: SECRET_NAME
           value: {{ .wildcardCertSecretName }}
         - name: SECRET_NAMESPACE

--- a/frontend/providers/cronjob/deploy/manifests/appcr.yaml.tmpl
+++ b/frontend/providers/cronjob/deploy/manifests/appcr.yaml.tmpl
@@ -6,8 +6,8 @@ metadata:
 spec:
   data:
     desc: CronJob
-    url: "https://cronjob.{{ .cloudDomain }}"
-  icon: "https://cronjob.{{ .cloudDomain }}/logo.svg"
+    url: "https://cronjob.{{ .cloudDomain }}{{ if .cloudPort }}:{{ .cloudPort }}{{ end }}"
+  icon: "https://cronjob.{{ .cloudDomain }}{{ if .cloudPort }}:{{ .cloudPort }}{{ end }}/logo.svg"
   menuData:
     helpDropDown: false
     nameColor: text-black

--- a/frontend/providers/license/deploy/manifests/appcr.yaml.tmpl
+++ b/frontend/providers/license/deploy/manifests/appcr.yaml.tmpl
@@ -6,8 +6,8 @@ metadata:
 spec:
   data:
     desc: license
-    url: "https://license.{{ .cloudDomain }}"
-  icon: "https://license.{{ .cloudDomain }}/logo.svg"
+    url: "https://license.{{ .cloudDomain }}{{ if .cloudPort }}:{{ .cloudPort }}{{ end }}"
+  icon: "https://license.{{ .cloudDomain }}{{ if .cloudPort }}:{{ .cloudPort }}{{ end }}/logo.svg"
   menuData:
     helpDropDown: false
     nameColor: text-black

--- a/scripts/cloud/install.sh
+++ b/scripts/cloud/install.sh
@@ -294,7 +294,7 @@ collect_input() {
               fi
           done
         fi
-        if [[ -z "$node_ips" ]]; then
+        if [[ -z "$node_ips" && $single != "y" ]]; then
           while :; do
               read -p "$(get_prompt "input_node_ips")" node_ips
               if validate_ips "$node_ips"; then
@@ -443,7 +443,7 @@ EOF
 
     get_prompt "patching_ingress"
     kubectl -n ingress-nginx patch ds ingress-nginx-controller -p '{"spec":{"template":{"spec":{"tolerations":[{"key":"node-role.kubernetes.io/control-plane","operator":"Exists","effect":"NoSchedule"}]}}}}'
-    kubectl get daemonset ingress-nginx-controller -n ingress-nginx -o json | grep https-port= >/dev/null || kubectl patch daemonset ingress-nginx-controller -n ingress-nginx --type='json' -p="[{'op': 'add', 'path': '/spec/template/spec/containers/0/args/-', 'value': '--https-port=${$cloud_port:-443}'}]"
+    kubectl get daemonset ingress-nginx-controller -n ingress-nginx -o json | grep https-port= >/dev/null || kubectl patch daemonset ingress-nginx-controller -n ingress-nginx --type='json' -p="[{'op': 'add', 'path': '/spec/template/spec/containers/0/args/-', 'value': '--https-port=${cloud_port:-443}'}]"
 
     get_prompt "installing_cloud"
 

--- a/scripts/cloud/install.sh
+++ b/scripts/cloud/install.sh
@@ -443,6 +443,7 @@ EOF
 
     get_prompt "patching_ingress"
     kubectl -n ingress-nginx patch ds ingress-nginx-controller -p '{"spec":{"template":{"spec":{"tolerations":[{"key":"node-role.kubernetes.io/control-plane","operator":"Exists","effect":"NoSchedule"}]}}}}'
+    kubectl get daemonset ingress-nginx-controller -n ingress-nginx -o json | grep https-port= >/dev/null || kubectl patch daemonset ingress-nginx-controller -n ingress-nginx --type='json' -p="[{'op': 'add', 'path': '/spec/template/spec/containers/0/args/-', 'value': '--https-port=${$cloud_port:-443}'}]"
 
     get_prompt "installing_cloud"
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2b70794</samp>

### Summary
🔧🚢🌐

<!--
1.  🔧 - This emoji represents a wrench or a tool, and can be used to indicate a change in configuration or environment variables, such as renaming the `port` variable to `cloudPort`.
2.  🚢 - This emoji represents a ship or a deployment, and can be used to indicate a change in the deployment template or the application manifest, such as updating the `deploy.yaml.tmpl` and the `appcr.yaml.tmpl` templates.
3.  🌐 - This emoji represents a globe or the internet, and can be used to indicate a change in the network or the web access, such as appending the `cloudPort` variable to the provider URLs and icons.
-->
This pull request enhances the cloud installation of sealos by allowing single-node deployments and custom port configurations. It also updates the `Kubefile` and the `appcr.yaml.tmpl` templates of the `terminal`, `cronjob`, and `license` providers to use the new `cloudPort` variable.

> _To deploy sealos on the cloud_
> _We renamed `port` to avoid a crowd_
> _Of other ports in use_
> _That might cause some abuse_
> _And updated `deploy.yaml` and `appcr` to be proud_

### Walkthrough
*  Rename `port` environment variable to `cloudPort` to avoid confusion with other ports ([link](https://github.com/labring/sealos/pull/4271/files?diff=unified&w=0#diff-39fee567e1de0e2c1257e3c0147614b591930cf5dc5931e75ea25ce8d0779c5dL10-R10))
*  Update `deploy.yaml.tmpl` template to use `cloudPort` for `PORT` environment variable of `terminal` container ([link](https://github.com/labring/sealos/pull/4271/files?diff=unified&w=0#diff-5f7ea67facfb5818c0b4c04cbe297b80cf1ab1ce9d79e2d7e1dc077963d026b9L447-R447))
*  Update `appcr.yaml.tmpl` templates for `cronjob` and `license` providers to append `cloudPort` to `url` and `icon` fields if not empty ([link](https://github.com/labring/sealos/pull/4271/files?diff=unified&w=0#diff-0fa7bad62d0b56fa6a5d3a52a2e33f63d324a60bede4ba9cec5dc8c0a341da2bL9-R10), [link](https://github.com/labring/sealos/pull/4271/files?diff=unified&w=0#diff-0a58165e7a91e4aa1cced2e3211bb81faef30f0714e49482887d777c79953780L9-R10))
*  Update `install.sh` script to skip asking for `node_ips` input if `single` is set to `y` for single-node installation ([link](https://github.com/labring/sealos/pull/4271/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aL297-R297))
*  Update `install.sh` script to patch `ingress-nginx-controller` daemonset to use `cloudPort` as `https-port` argument if not empty ([link](https://github.com/labring/sealos/pull/4271/files?diff=unified&w=0#diff-fcf88055ffe922f377228a27e7cf884b593d998ebcba5098d59f516a9040b20aR446))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
