### PR TITLE
fix: launchpad rollingupdate

### DIFF
--- a/frontend/providers/applaunchpad/src/utils/deployYaml2Json.ts
+++ b/frontend/providers/applaunchpad/src/utils/deployYaml2Json.ts
@@ -36,8 +36,8 @@ export const json2DeployCr = (data: AppEditType, type: 'deployment' | 'statefuls
     strategy: {
       type: 'RollingUpdate',
       rollingUpdate: {
-        maxUnavailable: 1,
-        maxSurge: 0
+        maxUnavailable: 0,
+        maxSurge: 1
       }
     }
   };


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4b16261</samp>

### Summary
🔄🚀🌐

<!--
1.  🔄 This emoji represents the change from the default `rollingUpdate` strategy to a zero-downtime one, as it implies updating or refreshing something without interruption.
2.  🚀 This emoji represents the deployment resource, as it implies launching or deploying something to a target environment.
3.  🌐 This emoji represents the JSON object, as it implies a web or network format for data exchange.
-->
Improve zero-downtime deployment strategy for `applaunchpad` provider. Change `frontend/providers/applaunchpad/src/utils/deployYaml2Json.ts` to use `rollingUpdate` with `maxUnavailable: 0` and `maxSurge: 1`.

> _`json2DeployCr`_
> _Zero-downtime rolling update -_
> _Autumn leaves falling_

### Walkthrough
*  Modify the `rollingUpdate` strategy to use a zero-downtime approach for Kubernetes deployments ([link](https://github.com/labring/sealos/pull/4279/files?diff=unified&w=0#diff-9ab86159facb4b23aba0fce56898aa5ad9d4b2347685afe9ac476f763b8e1a63L39-R40))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
