### PR TITLE
Docs: fix bug for building documentation site

### DIFF
--- a/.github/workflows/deploy-docs-preview.yml
+++ b/.github/workflows/deploy-docs-preview.yml
@@ -46,15 +46,6 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           submodules: recursive # Fetch submodules
           fetch-depth: 0 # Fetch all history for .GitInfo and .Lastmod
-      - name: Copy Files and Directories
-        run: |
-          mkdir -p ${{ env.BUILD_PATH }}/i18n/zh-Hans/docusaurus-plugin-content-docs/
-          cp -r docs/4.0/i18n/zh-Hans/ ${{ env.BUILD_PATH }}/i18n/zh-Hans/docusaurus-plugin-content-docs/current/
-          cp docs/4.0/i18n/zh-Hans/current.json  ${{ env.BUILD_PATH }}/i18n/zh-Hans/docusaurus-plugin-content-docs/current.json
-          cp docs/4.0/code.json  ${{ env.BUILD_PATH }}/i18n/zh-Hans/code.json
-          mkdir -p ${{ env.BUILD_PATH }}/i18n/zh-Hans/docusaurus-plugin-content-blog/
-          cp -r blog/zh-Hans/ ${{ env.BUILD_PATH }}/i18n/zh-Hans/docusaurus-plugin-content-blog
-          cp blog/zh-Hans/options.json  ${{ env.BUILD_PATH }}/i18n/zh-Hans/docusaurus-plugin-content-blog/options.json
 
       - name: Detect package manager
         id: detect-package-manager

--- a/.github/workflows/deploy-docs-site.yml
+++ b/.github/workflows/deploy-docs-site.yml
@@ -30,12 +30,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Copy Files and Directories
-        run: |
-          mkdir -p ${{ env.BUILD_PATH }}/i18n/zh-Hans/docusaurus-plugin-content-docs/
-          cp -r docs/4.0/i18n/zh-Hans/ ${{ env.BUILD_PATH }}/i18n/zh-Hans/docusaurus-plugin-content-docs/current/
-          cp docs/4.0/i18n/zh-Hans/current.json  ${{ env.BUILD_PATH }}/i18n/zh-Hans/docusaurus-plugin-content-docs/current.json
-          cp docs/4.0/code.json  ${{ env.BUILD_PATH }}/i18n/zh-Hans/code.json
 
       - name: Detect package manager
         id: detect-package-manager

--- a/docs/blog/zh-Hans/2023/11/10/velero的使用.md
+++ b/docs/blog/zh-Hans/2023/11/10/velero的使用.md
@@ -5,7 +5,7 @@ authors: [xiao-jay]
 tags: [kubernetes,sealos]
 ---
 
-## velero的使用111
+## velero的使用
 
 文档：https://velero.io/
 

--- a/docs/website/Dockerfile
+++ b/docs/website/Dockerfile
@@ -8,13 +8,6 @@ WORKDIR /app
 
 COPY . /app
 
-RUN mkdir website/i18n/zh-Hans/docusaurus-plugin-content-docs/; \
-    cp -r 4.0/i18n/zh-Hans/ website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/; \
-    cp 4.0/i18n/zh-Hans/current.json  website/i18n/zh-Hans/docusaurus-plugin-content-docs/current.json; \
-    cp 4.0/code.json  website/i18n/zh-Hans/code.json; \
-    mkdir website/i18n/zh-Hans/docusaurus-plugin-content-blog/; \
-    cp -r blog/zh-Hans/ website/i18n/zh-Hans/docusaurus-plugin-content-blog; \
-    cp blog/zh-Hans/options.json  website/i18n/zh-Hans/docusaurus-plugin-content-blog/options.json
 WORKDIR /app/website
 
 RUN yarn install

--- a/docs/website/package.json
+++ b/docs/website/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "sync-zh-files": "mkdir -p i18n/zh-Hans/docusaurus-plugin-content-docs && cp -r ../4.0/i18n/zh-Hans/ i18n/zh-Hans/docusaurus-plugin-content-docs/current/ && cp ../4.0/i18n/zh-Hans/current.json  i18n/zh-Hans/docusaurus-plugin-content-docs/current.json && cp ../4.0/code.json i18n/zh-Hans/code.json && mkdir -p i18n/zh-Hans/docusaurus-plugin-content-blog && cp -r ../blog/zh-Hans/ i18n/zh-Hans/docusaurus-plugin-content-blog && cp ../blog/zh-Hans/options.json  i18n/zh-Hans/docusaurus-plugin-content-blog/options.json",
+    "sync-zh-files": "mkdir -p i18n/zh-Hans/docusaurus-plugin-content-docs && cp -r ../4.0/i18n/zh-Hans i18n/zh-Hans/docusaurus-plugin-content-docs/current && cp ../4.0/i18n/zh-Hans/current.json  i18n/zh-Hans/docusaurus-plugin-content-docs/current.json && cp ../4.0/code.json i18n/zh-Hans/code.json && mkdir -p i18n/zh-Hans/docusaurus-plugin-content-blog && cp -r ../blog/zh-Hans/* i18n/zh-Hans/docusaurus-plugin-content-blog/ && cp ../blog/zh-Hans/options.json  i18n/zh-Hans/docusaurus-plugin-content-blog/options.json",
     "docusaurus": "docusaurus",
     "start": "yarn sync-zh-files && tsc && docusaurus start",
     "start-zh": "yarn sync-zh-files && tsc && docusaurus start --locale zh-Hans",


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2bfd254</samp>

### Summary
🚚🐛🔄

<!--
1.  🚚 This emoji represents the removal of the copying steps from the workflows and the Dockerfile, as it implies moving or transporting something.
2.  🐛 This emoji represents the fixing of the typo in the blog post title, as it implies fixing a bug or a mistake.
3.  🔄 This emoji represents the modification of the sync-zh-files script, as it implies updating or refreshing something.
-->
This pull request removes the redundant copying of Chinese translation files and directories in the deploy-docs-preview, deploy-docs-site, and Dockerfile workflows, and simplifies the sync-zh-files script in the `website/package.json` file. The overall purpose is to optimize the documentation site build process and avoid duplication of files.

> _`sync-zh-files` runs_
> _Copying Chinese docs and blogs_
> _No more duplication_

### Walkthrough
*  Remove the step of copying the Chinese translation files and directories from the docs and blog folders to the build path in the deploy-docs-preview and deploy-docs-site workflows ([link](https://github.com/labring/sealos/pull/4310/files?diff=unified&w=0#diff-6ded02ae5ed9feb0feeccc4b412e6fd413f0ce238d98ba7ff96585ccbd8d9a4aL49-L57), [link](https://github.com/labring/sealos/pull/4310/files?diff=unified&w=0#diff-58498050b4d4be83cf6f4481619cf94f5f8dcd7e5f08015f690a8025ff905eb6L33-L38)). This simplifies the workflows and avoids duplication of files, since the `sync-zh-files` script in the `website/package.json` already does the same copying before running the `docusaurus start` or `docusaurus build` commands. These workflows are triggered by pull requests or pushes to the master branch and build a preview or production site for the documentation using docusaurus.


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
