### PR TITLE
fix: skip vingress when delete ingress.

### DIFF
--- a/controllers/admission/api/v1/ingress_webhook.go
+++ b/controllers/admission/api/v1/ingress_webhook.go
@@ -161,7 +161,8 @@ func (v *IngressValidator) ValidateDelete(ctx context.Context, obj runtime.Objec
 	}
 
 	ilog.Info("validating delete", "ingress namespace", i.Namespace, "ingress name", i.Name)
-	return v.validate(ctx, i)
+	// delete ingress, pass validate
+	return nil
 }
 
 func (v *IngressValidator) validate(ctx context.Context, i *netv1.Ingress) error {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at efe64c4</samp>

### Summary
🗑️🚪🔓

<!--
1.  🗑️ - This emoji represents the deletion of ingresses, as it is a common symbol for trash or garbage. It can also convey the idea of bypassing or ignoring something, as in throwing it away.
2.  🚪 - This emoji represents the ingress resource, as it is a common symbol for an entrance or a gateway. It can also convey the idea of opening or closing access, as in allowing or denying deletion requests.
3.  🔓 - This emoji represents the bypassing of the validation, as it is a common symbol for unlocking or freeing something. It can also convey the idea of removing or relaxing restrictions, as in allowing external ingresses.
-->
Bypass ingress deletion validation in `ingress_webhook.go` to support external ingresses. This change allows the removal of ingresses that are not managed by the admission controller.

> _`ingress` deletion_
> _bypass validation check_
> _autumn leaves falling_

### Walkthrough
*  Bypass ingress deletion validation and return nil ([link](https://github.com/labring/sealos/pull/4318/files?diff=unified&w=0#diff-85092151f8d0263b436e9a6e626fb989e64a3202deac7c687278fee8ffc3e44cL164-R165)) to allow deleting external ingresses that are not managed by the admission controller


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
