### PR TITLE
Fix vingress

### DIFF
--- a/controllers/admission/api/v1/ingress_webhook.go
+++ b/controllers/admission/api/v1/ingress_webhook.go
@@ -161,7 +161,8 @@ func (v *IngressValidator) ValidateDelete(ctx context.Context, obj runtime.Objec
 	}
 
 	ilog.Info("validating delete", "ingress namespace", i.Namespace, "ingress name", i.Name)
-	return v.validate(ctx, i)
+	// delete ingress, pass validate
+	return nil
 }
 
 func (v *IngressValidator) validate(ctx context.Context, i *netv1.Ingress) error {

--- a/controllers/admission/api/v1/ingress_webhook.go
+++ b/controllers/admission/api/v1/ingress_webhook.go
@@ -154,7 +154,7 @@ func (v *IngressValidator) ValidateUpdate(ctx context.Context, _, newObj runtime
 	return v.validate(ctx, ni)
 }
 
-func (v *IngressValidator) ValidateDelete(ctx context.Context, obj runtime.Object) error {
+func (v *IngressValidator) ValidateDelete(_ context.Context, obj runtime.Object) error {
 	i, ok := obj.(*netv1.Ingress)
 	if !ok {
 		return errors.New("obj convert Ingress is error")


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3ded3d1</samp>

### Summary
🚫🗑️🪡

<!--
1.  🚫 - This emoji can be used to represent the action of disabling validation for ingress deletion, as it conveys the idea of stopping or blocking something.
2.  🗑️ - This emoji can be used to represent the action of replacing unused `ctx` parameter with blank identifier, as it conveys the idea of throwing away or discarding something.
3.  🪡 - This emoji can be used to represent the admission webhook, as it conveys the idea of stitching or connecting something. Alternatively, one could use 🎣 to represent the webhook as a fishing hook.
-->
Fix a bug that prevented ingress deletion by disabling validation in the `ingress_webhook` controller. Refactor the code to remove an unused parameter.

> _Sing, O Muse, of the valiant code reviewers_
> _Who scrutinized the changes of the pull request_
> _And found the flaws and merits of the `webhook`_
> _That guards the ingress from unwanted access._

### Walkthrough
*  Allow ingress deletion without validation ([link](https://github.com/labring/sealos/pull/4319/files?diff=unified&w=0#diff-85092151f8d0263b436e9a6e626fb989e64a3202deac7c687278fee8ffc3e44cL164-R165)) in `ingress_webhook.go`


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
