### PR TITLE
Fix vingress

### DIFF
--- a/controllers/admission/api/v1/ingress_webhook.go
+++ b/controllers/admission/api/v1/ingress_webhook.go
@@ -161,7 +161,8 @@ func (v *IngressValidator) ValidateDelete(ctx context.Context, obj runtime.Objec
 	}
 
 	ilog.Info("validating delete", "ingress namespace", i.Namespace, "ingress name", i.Name)
-	return v.validate(ctx, i)
+	// delete ingress, pass validate
+	return nil
 }
 
 func (v *IngressValidator) validate(ctx context.Context, i *netv1.Ingress) error {

--- a/controllers/admission/api/v1/ingress_webhook.go
+++ b/controllers/admission/api/v1/ingress_webhook.go
@@ -154,7 +154,7 @@ func (v *IngressValidator) ValidateUpdate(ctx context.Context, _, newObj runtime
 	return v.validate(ctx, ni)
 }
 
-func (v *IngressValidator) ValidateDelete(ctx context.Context, obj runtime.Object) error {
+func (v *IngressValidator) ValidateDelete(_ context.Context, obj runtime.Object) error {
 	i, ok := obj.(*netv1.Ingress)
 	if !ok {
 		return errors.New("obj convert Ingress is error")

--- a/controllers/admission/cmd/main.go
+++ b/controllers/admission/cmd/main.go
@@ -18,10 +18,9 @@ package main
 
 import (
 	"flag"
+	v1 "github.com/labring/sealos/controllers/admission/api/v1"
 	"os"
 	"strings"
-
-	v1 "github.com/labring/sealos/controllers/admission/api/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -70,16 +69,18 @@ func main() {
 
 	setupLog.Info("ingress annotations:", "annotation", ingressAnnotationString)
 	ingressAnnotations := make(map[string]string)
-	kvs := strings.Split(ingressAnnotationString, ",")
-	for _, kv := range kvs {
-		parts := strings.Split(kv, "=")
-		if len(parts) == 2 {
-			key := parts[0]
-			value := parts[1]
-			ingressAnnotations[key] = value
-		} else {
-			setupLog.Error(nil, "ingress annotation format error", "annotation", kv)
-			os.Exit(1)
+	if ingressAnnotationString != "" {
+		kvs := strings.Split(ingressAnnotationString, ",")
+		for _, kv := range kvs {
+			parts := strings.Split(kv, "=")
+			if len(parts) == 2 {
+				key := parts[0]
+				value := parts[1]
+				ingressAnnotations[key] = value
+			} else {
+				setupLog.Error(nil, "ingress annotation format error", "annotation", kv)
+				os.Exit(1)
+			}
 		}
 	}
 

--- a/controllers/admission/cmd/main.go
+++ b/controllers/admission/cmd/main.go
@@ -66,6 +66,8 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
 	setupLog.Info("ingress annotations:", "annotation", ingressAnnotationString)
 	ingressAnnotations := make(map[string]string)
 	kvs := strings.Split(ingressAnnotationString, ",")
@@ -80,8 +82,6 @@ func main() {
 			os.Exit(1)
 		}
 	}
-
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4719e9b</samp>

### Summary
🪵🚩🚫

<!--
1.  🪵 - This emoji can be used to represent logging, as it is a log of wood and also sounds like the word "log". It can also suggest improving the quality or performance of logging by cutting or splitting logs.
2.  🚩 - This emoji can be used to represent flag options, as it is a common symbol for flags and also implies setting or changing parameters or preferences. It can also suggest enhancing the functionality or flexibility of flag options by adding or modifying them.
3.  🚫 - This emoji can be used to represent avoiding duplicate logger instances, as it is a universal sign for prohibition or rejection. It can also suggest reducing the complexity or redundancy of logger instances by eliminating or preventing them.
-->
Improve logging for admission webhook controller. Use `zap` flags and fix logger duplication in `controllers/admission/cmd/main.go`.

> _We're the webhook crew and we know what to do_
> _We log every action with `zap` so true_
> _We don't need no duplicates, we keep our code clean_
> _We use the flag options from the `args` we glean_

### Walkthrough
*  Configure zap logger for controller-runtime manager using command-line flags ([link](https://github.com/labring/sealos/pull/4320/files?diff=unified&w=0#diff-03f4cc75479be78b2e722a42a2fa0ae9392e5df7f0370a8ddd5f6209eab9aea6R69-R70))
*  Remove redundant logger setting to avoid creating extra zap instance ([link](https://github.com/labring/sealos/pull/4320/files?diff=unified&w=0#diff-03f4cc75479be78b2e722a42a2fa0ae9392e5df7f0370a8ddd5f6209eab9aea6L84-L85))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
