### PR TITLE
fix: admission for ingress delete

### DIFF
--- a/controllers/admission/cmd/main.go
+++ b/controllers/admission/cmd/main.go
@@ -18,10 +18,9 @@ package main
 
 import (
 	"flag"
+	v1 "github.com/labring/sealos/controllers/admission/api/v1"
 	"os"
 	"strings"
-
-	v1 "github.com/labring/sealos/controllers/admission/api/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -70,16 +69,18 @@ func main() {
 
 	setupLog.Info("ingress annotations:", "annotation", ingressAnnotationString)
 	ingressAnnotations := make(map[string]string)
-	kvs := strings.Split(ingressAnnotationString, ",")
-	for _, kv := range kvs {
-		parts := strings.Split(kv, "=")
-		if len(parts) == 2 {
-			key := parts[0]
-			value := parts[1]
-			ingressAnnotations[key] = value
-		} else {
-			setupLog.Error(nil, "ingress annotation format error", "annotation", kv)
-			os.Exit(1)
+	if ingressAnnotationString != "" {
+		kvs := strings.Split(ingressAnnotationString, ",")
+		for _, kv := range kvs {
+			parts := strings.Split(kv, "=")
+			if len(parts) == 2 {
+				key := parts[0]
+				value := parts[1]
+				ingressAnnotations[key] = value
+			} else {
+				setupLog.Error(nil, "ingress annotation format error", "annotation", kv)
+				os.Exit(1)
+			}
 		}
 	}
 

--- a/controllers/admission/cmd/main.go
+++ b/controllers/admission/cmd/main.go
@@ -18,9 +18,10 @@ package main
 
 import (
 	"flag"
-	v1 "github.com/labring/sealos/controllers/admission/api/v1"
 	"os"
 	"strings"
+
+	v1 "github.com/labring/sealos/controllers/admission/api/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/controllers/admission/cmd/main.go
+++ b/controllers/admission/cmd/main.go
@@ -66,6 +66,8 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
 	setupLog.Info("ingress annotations:", "annotation", ingressAnnotationString)
 	ingressAnnotations := make(map[string]string)
 	kvs := strings.Split(ingressAnnotationString, ",")
@@ -80,8 +82,6 @@ func main() {
 			os.Exit(1)
 		}
 	}
-
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1053cb8</samp>

### Summary
🐛🚀📝

<!--
1.  🐛 This emoji represents a bug fix, as the pull request is intended to resolve a bug that causes the admission controller to crash.
2.  🚀 This emoji represents a performance improvement, as the pull request avoids unnecessary parsing of an empty flag, which could save some CPU and memory resources.
3.  📝 This emoji represents a documentation update, as the pull request adds a comment to explain why the logger is initialized before using it, which could help other developers understand the code better.
-->
Fix a bug in the admission controller that causes it to crash when the `ingressAnnotationString` flag is not set. Move the logger initialization and add a flag validation in `controllers/admission/cmd/main.go`.

> _`SetLogger` first_
> _Avoid parsing empty flag_
> _Winter bug is fixed_

### Walkthrough
* Initialize the logger before using it in `main.go` ([link](https://github.com/labring/sealos/pull/4327/files?diff=unified&w=0#diff-03f4cc75479be78b2e722a42a2fa0ae9392e5df7f0370a8ddd5f6209eab9aea6L69-R87))
* Validate the `ingressAnnotationString` flag before parsing it in `main.go` ([link](https://github.com/labring/sealos/pull/4327/files?diff=unified&w=0#diff-03f4cc75479be78b2e722a42a2fa0ae9392e5df7f0370a8ddd5f6209eab9aea6L69-R87))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
