### PR TITLE
fix:db service labels

### DIFF
--- a/frontend/providers/dbprovider/src/utils/json2Yaml.ts
+++ b/frontend/providers/dbprovider/src/utils/json2Yaml.ts
@@ -1010,8 +1010,10 @@ export const json2NetworkService = ({
     kind: 'Service',
     metadata: {
       name: `${dbDetail.dbName}-export`,
-      'app.kubernetes.io/instance': dbDetail.dbName,
-      'apps.kubeblocks.io/component-name': dbDetail.dbType,
+      labels: {
+        'app.kubernetes.io/instance': dbDetail.dbName,
+        'apps.kubeblocks.io/component-name': dbDetail.dbType
+      },
       ownerReferences: [
         {
           apiVersion: dbStatefulSet.apiVersion,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at cd0db36</samp>

### Summary
🏷️🧭🎛️

<!--
1.  🏷️ - This emoji represents the use of labels instead of annotations, as labels are often depicted as tags or stickers that can be attached to resources.
2.  🧭 - This emoji represents the alignment with the Kubernetes recommended labels, as these labels help to navigate and identify applications and components in a cluster.
3.  🎛️ - This emoji represents the simplification of the selector logic for the network service, as selectors are like knobs or switches that can be used to filter and match resources.
-->
Changed `metadata` object of network service resource to use `labels` instead of `annotations` for some keys in `frontend/providers/dbprovider/src/utils/json2Yaml.ts`. This improves alignment with Kubernetes conventions and simplifies selector logic.

> _`metadata` shifts_
> _from `annotations` to `labels`_
> _spring cleaning the code_

### Walkthrough
*  Change `metadata` object of network service resource to use `labels` instead of `annotations` for identifying application and component ([link](https://github.com/labring/sealos/pull/4344/files?diff=unified&w=0#diff-dbfdf7f57dc6e2caf2884409586ab2da585f46024959973487d84a2631539392L1013-R1016))
*  Adjust network service tests to reflect the label changes in `frontend/providers/dbprovider/src/utils/__tests__/yaml2Json.test.ts` and `frontend/providers/dbprovider/src/utils/__tests__/json2Yaml.test.ts` ([link](https://github.com/labring/sealos/pull/4344/files?diff=unified&w=0#diff-dbfdf7f57dc6e2caf2884409586ab2da585f46024959973487d84a2631539392L1013-R1016))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
