### PR TITLE
add kafka monitor

### DIFF
--- a/service/database/api/req.go
+++ b/service/database/api/req.go
@@ -118,4 +118,12 @@ var (
 		"minio_bucket_traffic_received_bytes": "sum(minio_bucket_traffic_received_bytes{bucket=\"@\"}) by (bucket, instance, job, namespace)",
 		"minio_bucket_traffic_sent_bytes":     "sum(minio_bucket_traffic_sent_bytes{bucket=\"@\"}) by (bucket, instance, job, namespace)",
 	}
+
+	Kafka = map[string]string{
+		"cpu":           "round(max by (pod) (rate(container_cpu_usage_seconds_total{namespace=~\"#\",pod=~\"@-kafka-\\\\d\" ,container=\"kafka\"}[5m])) / on (pod) (max by (pod) (container_spec_cpu_quota{namespace=~\"#\", pod=~\"@-kafka-\\\\d\",container=\"kafka\"} / 100000)) * 100,0.01)",
+		"memory":        "round(max by (pod)(container_memory_usage_bytes{namespace=~\"#\",pod=~\"@-kafka-\\\\d\",container=\"kafka\" })/ on (pod) (max by (pod) (container_spec_memory_limit_bytes{namespace=~\"#\", pod=~\"@-kafka-\\\\d\",container=\"kafka\"})) * 100,0.01)",
+		"disk_capacity": "(max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_capacity_bytes {namespace=~\"#\", persistentvolumeclaim=~\"data-@-kafka-\\\\d\"}))",
+		"disk":          "round((max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_used_bytes {namespace=~\"#\", persistentvolumeclaim=~\"data-@-kafka-\\\\d\"})) / (max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_capacity_bytes {namespace=~\"#\", persistentvolumeclaim=~\"data-@-kafka-\\\\d\"})) * 100, 0.01)",
+		"disk_used":     "(max by (persistentvolumeclaim,namespace) (kubelet_volume_stats_used_bytes {namespace=~\"#\", persistentvolumeclaim=~\"data-@-kafka-\\\\d\"}))",
+	}
 )

--- a/service/database/request/req.go
+++ b/service/database/request/req.go
@@ -77,6 +77,8 @@ func GetQuery(query *api.PromRequest) (string, error) {
 		result = api.Pgsql[query.Query]
 	case "minio":
 		result = api.Minio[query.Query]
+	case "kafka":
+		result = api.Kafka[query.Query]
 	default:
 		fmt.Println(query.Type)
 	}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1e015ee</samp>

### Summary
🗺️📊🚀

<!--
1.  🗺️ - This emoji represents a map, which is the data structure used to store the Kafka queries. It also suggests the idea of mapping different metrics to different queries.
2.  📊 - This emoji represents a chart or graph, which is the output of the Prometheus queries. It also suggests the idea of visualizing and analyzing the Kafka metrics.
3.  🚀 - This emoji represents a rocket, which is a symbol of speed and performance. It also suggests the idea of improving the efficiency and reliability of the Kafka pods.
-->
This pull request adds support for Kafka metrics to the `service/database` package. It defines a new map of Prometheus queries for Kafka pods in `api/req.go` and uses it in the `GetQuery` function in `request/req.go`.

> _`api` package_
> _adds `Kafka` map for metrics_
> _autumn harvest time_

### Walkthrough
*  Add a new map variable `Kafka` to store Prometheus queries for Kafka metrics ([link](https://github.com/labring/sealos/pull/4349/files?diff=unified&w=0#diff-2feebedc3d95ea1941d9d70c24e408296a0bc1e9ff1c3126481cc4893455eb16R121-R128))
*  Implement a new case in the `GetQuery` function to handle requests for `kafka` type and assign the result to the corresponding query from the `Kafka` map ([link](https://github.com/labring/sealos/pull/4349/files?diff=unified&w=0#diff-3935e5ee9b37ea37add190598502ccbcb98aacdb3c418a534bde85f7db23b910R80-R81))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
