### PR TITLE
fix monitor bug

### DIFF
--- a/controllers/pkg/objectstorage/objectstorage_test.go
+++ b/controllers/pkg/objectstorage/objectstorage_test.go
@@ -26,7 +26,7 @@ func TestGetUserObjectStorageFlow(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	bytes, err := GetUserObjectStorageFlow(cli, os.Getenv("PROM_URL"), os.Getenv("MINIO_USERNAME"))
+	bytes, err := GetUserObjectStorageFlow(cli, os.Getenv("PROM_URL"), os.Getenv("MINIO_USERNAME"), os.Getenv("MINIO_INSTANCE"))
 	if err != nil {
 		t.Error(err)
 	}

--- a/service/database/api/req.go
+++ b/service/database/api/req.go
@@ -113,10 +113,10 @@ var (
 	}
 
 	Minio = map[string]string{
-		"minio_bucket_usage_object_total":     "minio_bucket_usage_object_total{bucket=\"@\"}",
-		"minio_bucket_usage_total_bytes":      "minio_bucket_usage_total_bytes{bucket=\"@\"}",
-		"minio_bucket_traffic_received_bytes": "sum(minio_bucket_traffic_received_bytes{bucket=\"@\"}) by (bucket, instance, job, namespace)",
-		"minio_bucket_traffic_sent_bytes":     "sum(minio_bucket_traffic_sent_bytes{bucket=\"@\"}) by (bucket, instance, job, namespace)",
+		"minio_bucket_usage_object_total":     "minio_bucket_usage_object_total{bucket=\"@\", instance=\"#\"}",
+		"minio_bucket_usage_total_bytes":      "minio_bucket_usage_total_bytes{bucket=\"@\", instance=\"#\"}",
+		"minio_bucket_traffic_received_bytes": "sum(minio_bucket_traffic_received_bytes{bucket=\"@\", instance=\"#\"}) by (bucket, instance, job, namespace)",
+		"minio_bucket_traffic_sent_bytes":     "sum(minio_bucket_traffic_sent_bytes{bucket=\"@\", instance=\"#\"}) by (bucket, instance, job, namespace)",
 	}
 
 	Kafka = map[string]string{

--- a/service/database/deploy/manifests/deploy.yaml
+++ b/service/database/deploy/manifests/deploy.yaml
@@ -37,6 +37,8 @@ spec:
         env:
         - name: PROMETHEUS_SERVICE_HOST
           value: http://kb-addon-prometheus-server.
+        - name: OBJECT_STORAGE_INSTANCE
+          value:
         image: ghcr.io/labring/sealos-database-service:latest
         imagePullPolicy: Always
         name: database-monitor

--- a/service/database/request/req.go
+++ b/service/database/request/req.go
@@ -84,6 +84,10 @@ func GetQuery(query *api.PromRequest) (string, error) {
 	}
 
 	fmt.Println(query.Cluster)
+	if query.Type == "minio" {
+		instance := os.Getenv("OBJECT_STORAGE_INSTANCE")
+		result = strings.ReplaceAll(result, "#", instance)
+	}
 	result = strings.ReplaceAll(result, "#", query.NS)
 	result = strings.ReplaceAll(result, "@", query.Cluster)
 	return result, nil


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7e8fe2e</samp>

### Summary
📊🗄️🌐

<!--
1.  📊 - This emoji represents the use of Prometheus metrics and queries to monitor the MinIO instances.
2.  🗄️ - This emoji represents the object storage functionality and the MinIO service.
3.  🌐 - This emoji represents the support for multiple instances and clusters of MinIO.
-->
Added support for multiple MinIO instances in the object storage service. Modified the `objectstorage` package, the `api` package, and the `request` package to use the `instance` parameter or label in the Prometheus queries for the MinIO metrics. Modified the `deploy.yaml` file to add an environment variable to configure the MinIO instance name.

> _`objectstorage` changed_
> _to query multiple `MinIO`s_
> _autumn of metrics_

### Walkthrough
*  Add `instance` parameter to `GetObjectStorageFlow` and `GetUserObjectStorageFlow` functions to support multiple MinIO instances ([link](https://github.com/labring/sealos/pull/4352/files?diff=unified&w=0#diff-3c299aad5485d57c211e266798467d066838c749cbf8daad5208fe23e630b8f1L58-R59), [link](https://github.com/labring/sealos/pull/4352/files?diff=unified&w=0#diff-3c299aad5485d57c211e266798467d066838c749cbf8daad5208fe23e630b8f1L82-R82), [link](https://github.com/labring/sealos/pull/4352/files?diff=unified&w=0#diff-3c299aad5485d57c211e266798467d066838c749cbf8daad5208fe23e630b8f1L90-R90), [link](https://github.com/labring/sealos/pull/4352/files?diff=unified&w=0#diff-12a5add395fb767fdf5065af43f336075e2c070619fbfd598f6fbc3677a31bb6L29-R29))
*  Add `instance` parameter to `QueryPrometheus` function and include it in the Prometheus queries for MinIO metrics ([link](https://github.com/labring/sealos/pull/4352/files?diff=unified&w=0#diff-3c299aad5485d57c211e266798467d066838c749cbf8daad5208fe23e630b8f1L100-R100), [link](https://github.com/labring/sealos/pull/4352/files?diff=unified&w=0#diff-3c299aad5485d57c211e266798467d066838c749cbf8daad5208fe23e630b8f1L112-R112), [link](https://github.com/labring/sealos/pull/4352/files?diff=unified&w=0#diff-3c299aad5485d57c211e266798467d066838c749cbf8daad5208fe23e630b8f1L122-R122))
*  Modify `Minio` map in `api/req.go` to include `instance` label in the Prometheus queries for MinIO metrics ([link](https://github.com/labring/sealos/pull/4352/files?diff=unified&w=0#diff-2feebedc3d95ea1941d9d70c24e408296a0bc1e9ff1c3126481cc4893455eb16L116-R119))
*  Add `OBJECT_STORAGE_INSTANCE` environment variable to `deploy.yaml` to configure the service to use the specific MinIO instance ([link](https://github.com/labring/sealos/pull/4352/files?diff=unified&w=0#diff-784ef1f73847a9ca5ce0754526c1e6c97bc621f5d1949102d18e9ce5df8fc64fR40-R41))
*  Replace `#` symbol in the Prometheus queries with the value of `OBJECT_STORAGE_INSTANCE` environment variable in `GetQuery` function ([link](https://github.com/labring/sealos/pull/4352/files?diff=unified&w=0#diff-3935e5ee9b37ea37add190598502ccbcb98aacdb3c418a534bde85f7db23b910R87-R90))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
