### PR TITLE
typo: fix secret name in qa.

### DIFF
--- a/docs/4.0/docs/self-hosting/sealos/QA.md
+++ b/docs/4.0/docs/self-hosting/sealos/QA.md
@@ -51,10 +51,10 @@ Certificates are crucial for the security of your Sealos cluster. Follow these s
    On the `master0` node, backup your current certificate. This step is crucial to prevent loss of the certificate during the update process. Use this command:
 
    ```shell
-   $ kubectl get secret -n sealos-system wildcard-secret -o yaml > cert-backup.yaml
+   $ kubectl get secret -n sealos-system wildcard-cert -o yaml > cert-backup.yaml
    ```
 
-   This will save the `wildcard-secret` certificate in YAML format to `cert-backup.yaml`.
+   This will save the `wildcard-cert` certificate in YAML format to `cert-backup.yaml`.
 
 2. **Storing the New Certificate**:
 

--- a/docs/4.0/i18n/zh-Hans/self-hosting/sealos/QA.md
+++ b/docs/4.0/i18n/zh-Hans/self-hosting/sealos/QA.md
@@ -52,10 +52,10 @@ $ echo 1 > /proc/sys/net/ipv4/ip_forward
    在主节点 `master0` 上，您需要先备份当前使用的证书。这是一个防止更新过程中出现问题而导致证书丢失的重要步骤。使用以下命令进行备份：
 
    ```shell
-   $ kubectl get secret -n sealos-system wildcard-secret -o yaml > cert-backup.yaml
+   $ kubectl get secret -n sealos-system wildcard-cert -o yaml > cert-backup.yaml
    ```
 
-   此命令会将名为 `wildcard-secret` 的证书以 YAML 格式保存到文件 `cert-backup.yaml` 中。
+   此命令会将名为 `wildcard-cert` 的证书以 YAML 格式保存到文件 `cert-backup.yaml` 中。
 
 2. **保存新证书**：
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1475f30</samp>

### Summary
🐛📝🌐

<!--
1.  🐛 - This emoji represents a bug fix, which is appropriate for correcting a typo that could cause errors or confusion for users.
2.  📝 - This emoji represents documentation, which is appropriate for updating the written instructions for the certificate renewal process.
3.  🌐 - This emoji represents translation, which is appropriate for applying the same fix to the Chinese documentation as the English one.
-->
This pull request fixes a typo in the documentation of the certificate renewal process for sealos. It changes the name of the secret that contains the wildcard certificate from `wildcard-secret` to `wildcard-cert` in both the English and Chinese versions of `docs/4.0/docs/self-hosting/sealos/QA.md`.

> _`wildcard-cert` fix_
> _for sealos docs in two tongues_
> _autumn leaves renew_

### Walkthrough
* Fix the name of the secret that contains the wildcard certificate for sealos in the documentation ([link](https://github.com/labring/sealos/pull/4353/files?diff=unified&w=0#diff-dcd5f6a533907e20a914d45df7672c63028e1565fb06d2f41c285d09c401af80L54-R57), [link](https://github.com/labring/sealos/pull/4353/files?diff=unified&w=0#diff-95ae19236900890568d3536f67601d09b11016301c83b82aca17e2c45ab0e0b3L55-R58))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
