### PR TITLE
fix: return cors anno as nil if port is 443.

### DIFF
--- a/controllers/terminal/controllers/terminal_controller.go
+++ b/controllers/terminal/controllers/terminal_controller.go
@@ -474,7 +474,7 @@ func getSecretNamespace() string {
 }
 
 func (r *TerminalReconciler) getPort() string {
-	if r.terminalPort == "" {
+	if r.terminalPort == "" || r.terminalPort == "80" || r.terminalPort == "443" {
 		return ""
 	}
 	return ":" + r.terminalPort


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 19e6364</samp>

### Summary
🛠️🌐🚪

<!--
1.  🛠️ - This emoji can be used to indicate that the change is a bug fix or an improvement of an existing feature or functionality. The `getPort` function was modified to handle some edge cases and avoid potential problems, so this emoji is suitable to convey that idea.
2.  🌐 - This emoji can be used to indicate that the change is related to the web, the internet, or network connections. The `getPort` function is used to create terminal URLs based on the terminal port, which is a network-related parameter. This emoji is also suitable to convey that idea.
3.  🚪 - This emoji can be used to indicate that the change is related to ports, doors, or openings. The `getPort` function is specifically dealing with terminal ports, which are numerical identifiers for network endpoints. This emoji is also suitable to convey that idea.
-->
Improved terminal controller logic and error handling. Modified `getPort` function to avoid using reserved ports for terminal connections in `controllers/terminal/controllers/terminal_controller.go`.

> _`getPort` returns_
> _empty string for some ports_
> _avoiding conflicts_

### Walkthrough
*  Return empty port for terminal if it is empty, 80 or 443 to avoid conflicts with HTTP and HTTPS protocols ([link](https://github.com/labring/sealos/pull/4356/files?diff=unified&w=0#diff-39f755c585164a06c548b8d890a2dc0b2da829d0d95b8709020dd2d343dece82L477-R477))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
