### PR TITLE
fix monitor object storage

### DIFF
--- a/controllers/resources/controllers/monitor_controller.go
+++ b/controllers/resources/controllers/monitor_controller.go
@@ -26,7 +26,6 @@ import (
 	"sync"
 	"time"
 
-	userv1 "github.com/labring/sealos/controllers/user/api/v1"
 	"github.com/labring/sealos/controllers/user/controllers/helper/config"
 
 	"github.com/minio/minio-go/v7"
@@ -352,7 +351,7 @@ func (r *MonitorReconciler) getResourceUsage(namespace *corev1.Namespace) ([]*re
 			r.Logger.Error(err, "failed to get pod traffic used", "namespace", namespace)
 		}
 	}
-	if username := config.GetUserNameByNamespace(namespace.Name); r.ObjStorageClient != nil && namespace.Labels[userv1.UserLabelOwnerKey] == username {
+	if username := config.GetUserNameByNamespace(namespace.Name); r.ObjStorageClient != nil {
 		if err := r.getObjStorageUsed(username, &resNamed, &resUsed); err != nil {
 			r.Logger.Error(err, "failed to get object storage used", "username", username)
 		}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f1d020f</samp>

### Summary
🧹🔧📉

<!--
1.  🧹 - This emoji can be used to represent the removal of unused import and redundant label check, as it implies cleaning up or tidying the code.
2.  🔧 - This emoji can be used to represent the simplification of the code for getting resource usage by username, as it implies fixing or improving something.
3.  📉 - This emoji can be used to represent the reduction of complexity or lines of code, as it implies a downward trend or a decrease.
-->
Improved code quality and efficiency in `monitor_controller.go`. Reduced unnecessary imports and checks, and streamlined resource usage query.

> _No mercy for the wasteful, the code must be refined_
> _`monitor_controller` purged of the redundant and the blind_
> _Simplifying the logic, extracting the resource usage_
> _By username we track them, the users of the system_

### Walkthrough
*  Remove unnecessary import of `userv1` package in `monitor_controller.go` ([link](https://github.com/labring/sealos/pull/4362/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL29))
*  Simplify `getResourceUsage` function by removing redundant namespace label check for `userv1.UserLabelOwnerKey` ([link](https://github.com/labring/sealos/pull/4362/files?diff=unified&w=0#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dL355-R354))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
