### PR TITLE
fix notification read status

### DIFF
--- a/controllers/account/controllers/debt_controller.go
+++ b/controllers/account/controllers/debt_controller.go
@@ -345,6 +345,8 @@ const (
 	//languageEn = "en"
 	languageZh       = "zh"
 	debtChoicePrefix = "debt-choice-"
+	readStatusLabel  = "isRead"
+	falseStatus      = "false"
 )
 
 var NoticeTemplateEN = map[int]string{
@@ -426,6 +428,10 @@ func (r *DebtReconciler) sendNotice(ctx context.Context, user string, oweAmount 
 		ntf.Namespace = namespaces[i]
 		if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, ntf, func() error {
 			ntf.Spec = *ntfSpec
+			if ntf.Labels == nil {
+				ntf.Labels = make(map[string]string)
+			}
+			ntf.Labels[readStatusLabel] = falseStatus
 			return nil
 		}); err != nil {
 			return err


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3437890</samp>

### Summary
:sparkles::label::eyes:

<!--
1.  :sparkles: This emoji is often used to indicate a new feature or enhancement, and it can convey the idea of adding some sparkle or flair to the app. It could be used as the first emoji in the commit message to summarize the main change.
2.  :label: This emoji is related to labels, tags, or stickers, and it can represent the use of constants for the label keys and values. It could be used as the second emoji in the commit message to provide more detail about the implementation.
3.  :eyes: This emoji is associated with eyes, vision, or watching, and it can symbolize the user's ability to mark notifications as read or unread. It could be used as the third emoji in the commit message to highlight the user experience or benefit of the feature.
-->
Add feature to mark notifications as read or unread in `debt_controller.go`. Use constants for label keys and values and set default to unread.

> _New feature added_
> _Mark `notifications` as read_
> _Unread by default_

### Walkthrough
*  Add a new label to indicate the read status of notifications (`readStatusLabel`, `falseStatus`)
  - Define two constants for the label key and value in `debt_controller.go` ([link](https://github.com/labring/sealos/pull/4369/files?diff=unified&w=0#diff-8fc7d7a46552d16d295481d2bf26c8896ad0327f2592539fb877286270b5625bR348-R349))
  - Initialize and set the label for every notification in `debt_controller.go` ([link](https://github.com/labring/sealos/pull/4369/files?diff=unified&w=0#diff-8fc7d7a46552d16d295481d2bf26c8896ad0327f2592539fb877286270b5625bR431-R434))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
