### PR TITLE
Optimize/remote cmd return error

### DIFF
--- a/pkg/runtime/k3s/lifecycle.go
+++ b/pkg/runtime/k3s/lifecycle.go
@@ -62,8 +62,7 @@ func (k *K3s) resetNode(host string) error {
 		logger.Error("failed to clean node, exec command %s failed, %v", removeKubeConfig, removeKubeConfigErr)
 	}
 	if slices.Contains(k.cluster.GetNodeIPAndPortList(), host) {
-		vipAndPort := fmt.Sprintf("%s:%d", k.cluster.GetVIP(), k.config.APIServerPort)
-		ipvsclearErr := k.remoteUtil.IPVSClean(host, vipAndPort)
+		ipvsclearErr := k.remoteUtil.IPVSClean(host, k.getVipAndPort())
 		if ipvsclearErr != nil {
 			logger.Error("failed to clear ipvs rules for node %s: %v", host, ipvsclearErr)
 		}

--- a/pkg/ssh/remote.go
+++ b/pkg/ssh/remote.go
@@ -191,7 +191,10 @@ func NewRemoteFromSSH(clusterName string, sshInterface Interface) *Remote {
 
 func (s *Remote) executeRemoteUtilSubcommand(ip, cmd string) error {
 	cmd = fmt.Sprintf("%s %s", s.pathResolver.RootFSSealctlPath(), cmd)
-	return s.execer.CmdAsync(ip, cmd)
+	if err := s.execer.CmdAsync(ip, cmd); err != nil {
+		return fmt.Errorf("failed to execute remote command `%s`: %v", cmd, err)
+	}
+	return nil
 }
 
 func (s *Remote) outputRemoteUtilSubcommand(ip, cmd string) (string, error) {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f3045d1</samp>

### Summary
🔧🚨📝

<!--
1.  🔧 - This emoji represents refactoring or fixing code, as it suggests using a tool to improve something.
2.  🚨 - This emoji represents adding or improving error handling or testing, as it suggests alerting or warning about a problem or a failure.
3.  📝 - This emoji represents improving documentation or comments, as it suggests writing or explaining something.
-->
This pull request refactors the code for formatting the VIP and port string in `pkg/runtime/k3s/lifecycle.go` and adds error handling for remote command execution in `pkg/ssh/remote.go`. These changes improve the readability, maintainability, and robustness of the code.

> _`k.getVipAndPort()`_
> _Refactors repeated logic_
> _Code is more concise_

### Walkthrough
* Refactor code to use helper function for VIP and port formatting ([link](https://github.com/labring/sealos/pull/4407/files?diff=unified&w=0#diff-18b1fd2bd860036843fa344a0cd7d1ab962be73078b9afdad30e9835009da6afL65-R65))
* Return error if remote command execution fails and log it ([link](https://github.com/labring/sealos/pull/4407/files?diff=unified&w=0#diff-7b37f13f1a2f948d5e12c88b23195e7928670cfccc89bbbc893fda98e44978beL194-R197))


<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note

If using copilot4prs, please add the following information:
- `copilot:all` all the content, in one go!
- `copilot:summary` a one-paragraph summary of the changes in the pull request.
- `copilot:walkthrough` a detailed list of changes, including links to the relevant pieces of code.
- `copilot:poem` a poem about the changes in the pull request.
-->
