### PR TITLE
bugfix: fix sudo -E bash -c '$cmd' with cmd that contains single quotations

### DIFF
--- a/pkg/ssh/sshcmd.go
+++ b/pkg/ssh/sshcmd.go
@@ -38,10 +38,15 @@ func (c *Client) Ping(host string) error {
 }
 
 func (c *Client) wrapCommands(cmds ...string) string {
+	cmdJoined := strings.Join(cmds, "; ")
 	if !c.Option.sudo || c.Option.user == defaultUsername {
-		return strings.Join(cmds, "; ")
+		return cmdJoined
 	}
-	return fmt.Sprintf("sudo -E /bin/bash -c '%s'", strings.Join(cmds, "; "))
+
+	// Escape single quotes in cmd, fix https://github.com/labring/sealos/issues/4424
+	// e.g. echo 'hello world' -> `sudo -E /bin/bash -c 'echo "hello world"'`
+	cmdEscaped := strings.ReplaceAll(cmdJoined, `'`, `"`)
+	return fmt.Sprintf("sudo -E /bin/bash -c '%s'", cmdEscaped)
 }
 
 func (c *Client) CmdAsyncWithContext(ctx context.Context, host string, cmds ...string) error {


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->

this is a bug fix for https://github.com/labring/sealos/issues/4424 ,


the cmd of metrics-server in cluster's yaml has a signle quotation `'` in `--set args='{--kubelet-insecure-tls=true,--kubelet-preferred-address-types=InternalIP}'`, which will cause a problem with the single quotation in `sudo -E /bin/bash -c '$cmd'` 

```yaml
- cmd:
    - helm upgrade -i metrics-server charts/metrics-server -n kube-system --set args='{--kubelet-insecure-tls=true,--kubelet-preferred-address-types=InternalIP}'
    imageName: registry.cn-shanghai.aliyuncs.com/labring/metrics-server:v0.6.4
    labels:
      io.buildah.version: 1.30.0
    mountPoint: /var/lib/containers/storage/overlay/e080cdaa0e7b16bd43e9635a8079538ee1b891aa2838c5ccf31b0ce191fe2cc0/merged
    name: default-ggcfdsaf
    type: application
```

if we find a cmd to wrap that contains single quotations, we can replace it with double quotations to avoid problems.