### PR TITLE
Optimize the bucket controller logic of object storage

### DIFF
--- a/controllers/objectstorage/controllers/objectstoragebucket_controller.go
+++ b/controllers/objectstorage/controllers/objectstoragebucket_controller.go
@@ -143,22 +143,7 @@ func (r *ObjectStorageBucketReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, err
 	}
 
-	var totalSize int64
 	var update bool
-
-	// list objects in the bucket and calculate the total space used
-	objects := r.OSClient.ListObjects(ctx, bucketName, minio.ListObjectsOptions{
-		Recursive: true,
-	})
-
-	for object := range objects {
-		totalSize += object.Size
-	}
-
-	if bucket.Status.Size != totalSize {
-		bucket.Status.Size = totalSize
-		update = true
-	}
 
 	if bucket.Status.Name != bucketName {
 		bucket.Status.Name = bucketName

--- a/controllers/objectstorage/deploy/manifests/deploy.yaml
+++ b/controllers/objectstorage/deploy/manifests/deploy.yaml
@@ -498,7 +498,7 @@ spec:
               value: '{{ .OSExternalEndpoint }}'
             - name: OSUDetectionCycleSeconds
               value: "300"
-            - name: MinioBucketDetectionCycleSeconds
+            - name: OSBDetectionCycleSeconds
               value: "300"
           image: ghcr.io/labring/sealos-objectstorage-controller:latest
           imagePullPolicy: Always


### PR DESCRIPTION
Fix env name.
Remove the logic of calculating the storage space size of the bucket controller.