### PR TITLE
small feat: add database tips one user select 1 replicas

### DIFF
--- a/frontend/providers/dbprovider/public/locales/zh/common.json
+++ b/frontend/providers/dbprovider/public/locales/zh/common.json
@@ -121,6 +121,7 @@
   "Auto Backup": "自动备份",
   "Containers": "容器",
   "Redis does not support backup at this time": "Redis 暂时不支持备份",
+  "The Single-node database is only suitable for development testing.": "单节点数据库仅适用开发测试",
   "The multi-replica Redis includes High Availability (HA) nodes. Please note, the anticipated price already encompasses the cost for the HA nodes.": "Redis 多副本包含 HA 节点，请悉知，预估价格已包含 HA 节点费用",
   "CronExpression": "循环周期",
   "Monday": "周一",

--- a/frontend/providers/dbprovider/src/pages/db/edit/components/Form.tsx
+++ b/frontend/providers/dbprovider/src/pages/db/edit/components/Form.tsx
@@ -33,7 +33,7 @@ import Tip from '@/components/Tip';
 import QuotaBox from './QuotaBox';
 import { obj2Query } from '@/api/tools';
 import { throttle } from 'lodash';
-import { InfoOutlineIcon } from '@chakra-ui/icons';
+import { InfoOutlineIcon, WarningIcon } from '@chakra-ui/icons';
 
 const Form = ({
   formHook,
@@ -332,6 +332,14 @@ const Form = ({
                     setValue('replicas', val || 1);
                   }}
                 />
+                {getValues('replicas') === 1 && (
+                  <Tip
+                    ml={4}
+                    icon={<WarningIcon />}
+                    text="The Single-node database is only suitable for development testing."
+                    size="sm"
+                  />
+                )}
                 {getValues('dbType') === DBTypeEnum.redis && getValues('replicas') > 1 && (
                   <Tip
                     ml={4}


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
Follow guidance, add a small notification to users when they select one replicas in database page.
![1706109212296](https://github.com/labring/sealos/assets/157351579/22b17f51-49f7-4541-9b51-1e1ee6cc8334)
