### PR TITLE
fix: Add "Deploy" translation key to English locale

### DIFF
--- a/frontend/providers/cronjob/public/locales/en/common.json
+++ b/frontend/providers/cronjob/public/locales/en/common.json
@@ -193,5 +193,6 @@
   "Log": "Log",
   "Basic": "Basic",
   "Username for the image registry": "Username for the image registry'",
-  "The password cannot be empty": "The password cannot be empty"
+  "The password cannot be empty": "The password cannot be empty",
+  "Deploy": "Deploy"
 }


### PR DESCRIPTION
This pull request is to address the UI bug for inconsistent translation in CronJob "Deploy" button. The detailed description for this UI bug is in issue #4568 .

