### PR TITLE
Fix: remove deprecated rlcp options

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -242,7 +242,6 @@ archives:
     builds_info:
       group: root
       owner: root
-    rlcp: true
     files:
       - README*
       - readme*


### PR DESCRIPTION
[deprecated rlcp](https://github.com/goreleaser/goreleaser/blob/main/www/docs/deprecations.md#archivesrlcp)

Fix:
```
error=yaml: unmarshal errors:
line 245: field rlcp not found in type config.Archive
```