### PR TITLE
feat: optimize resource monitoring logic, performance and fix nil pointer issue

### DIFF
--- a/controllers/resources/controllers/monitor_controller.go
+++ b/controllers/resources/controllers/monitor_controller.go
@@ -328,15 +328,14 @@ func (r *MonitorReconciler) monitorResourceUsage(namespace *corev1.Namespace) er
 func (r *MonitorReconciler) monitorPodResourceUsage(namespace string, resUsed map[string]map[corev1.ResourceName]*quantity, resNamed map[string]*resources.ResourceNamed) error {
 	podList := &corev1.PodList{}
 	if err := r.List(context.Background(), podList, &client.ListOptions{
-		Namespace:     namespace,
-		FieldSelector: fields.OneTermNotEqualSelector("spec.nodeName", ""),
+		Namespace: namespace,
 	}); err != nil {
 		return fmt.Errorf("failed to list pods: %v", err)
 	}
 
 	for i := range podList.Items {
 		pod := &podList.Items[i]
-		if pod.Status.Phase == corev1.PodSucceeded && time.Since(pod.Status.StartTime.Time) > 1*time.Minute {
+		if pod.Spec.NodeName == "" || pod.Status.Phase == corev1.PodSucceeded && time.Since(pod.Status.StartTime.Time) > 1*time.Minute {
 			continue
 		}
 		podResNamed := resources.NewResourceNamed(pod)

--- a/controllers/resources/controllers/monitor_controller.go
+++ b/controllers/resources/controllers/monitor_controller.go
@@ -136,6 +136,22 @@ func NewMonitorReconciler(mgr ctrl.Manager) (*MonitorReconciler, error) {
 	return r, nil
 }
 
+func (r *MonitorReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.PersistentVolumeClaim{}, "status.phase", func(rawObj client.Object) []string {
+		pvc := rawObj.(*corev1.PersistentVolumeClaim)
+		return []string{string(pvc.Status.Phase)}
+	}); err != nil {
+		return err
+	}
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Service{}, "spec.type", func(rawObj client.Object) []string {
+		svc := rawObj.(*corev1.Service)
+		return []string{string(svc.Spec.Type)}
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (r *MonitorReconciler) StartReconciler(ctx context.Context) error {
 	r.startPeriodicReconcile()
 	if r.TrafficClient != nil || r.ObjStorageClient != nil {

--- a/controllers/resources/controllers/monitor_controller.go
+++ b/controllers/resources/controllers/monitor_controller.go
@@ -136,7 +136,7 @@ func NewMonitorReconciler(mgr ctrl.Manager) (*MonitorReconciler, error) {
 	return r, nil
 }
 
-func (r *MonitorReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func InitIndexField(mgr ctrl.Manager) error {
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.PersistentVolumeClaim{}, "status.phase", func(rawObj client.Object) []string {
 		pvc := rawObj.(*corev1.PersistentVolumeClaim)
 		return []string{string(pvc.Status.Phase)}

--- a/controllers/resources/controllers/monitor_controller.go
+++ b/controllers/resources/controllers/monitor_controller.go
@@ -143,13 +143,10 @@ func (r *MonitorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}); err != nil {
 		return err
 	}
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Service{}, "spec.type", func(rawObj client.Object) []string {
+	return mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Service{}, "spec.type", func(rawObj client.Object) []string {
 		svc := rawObj.(*corev1.Service)
 		return []string{string(svc.Spec.Type)}
-	}); err != nil {
-		return err
-	}
-	return nil
+	})
 }
 
 func (r *MonitorReconciler) StartReconciler(ctx context.Context) error {

--- a/controllers/resources/main.go
+++ b/controllers/resources/main.go
@@ -118,6 +118,11 @@ func main() {
 		setupLog.Error(err, "failed to init monitor reconciler")
 		os.Exit(1)
 	}
+	err = reconciler.SetupWithManager(mgr)
+	if err != nil {
+		setupLog.Error(err, "failed to init monitor reconciler")
+		os.Exit(1)
+	}
 	reconciler.DBClient, err = mongo.NewMongoInterface(context.Background(), os.Getenv(database.MongoURI))
 	if err != nil {
 		setupLog.Error(err, "failed to init db client")

--- a/controllers/resources/main.go
+++ b/controllers/resources/main.go
@@ -102,10 +102,13 @@ func main() {
 	}
 
 	setupLog.Info("starting manager")
-	//if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-	//	setupLog.Error(err, "problem running manager")
-	//	os.Exit(1)
-	//}
+
+	err = controllers.InitIndexField(mgr)
+	if err != nil {
+		setupLog.Error(err, "failed to init index field")
+		os.Exit(1)
+	}
+
 	go func() {
 		if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 			setupLog.Error(err, "problem running manager")
@@ -114,11 +117,6 @@ func main() {
 	}()
 
 	reconciler, err := controllers.NewMonitorReconciler(mgr)
-	if err != nil {
-		setupLog.Error(err, "failed to init monitor reconciler")
-		os.Exit(1)
-	}
-	err = reconciler.SetupWithManager(mgr)
 	if err != nil {
 		setupLog.Error(err, "failed to init monitor reconciler")
 		os.Exit(1)


### PR DESCRIPTION
feat: optimize resource monitoring logic, performance and fix nil pointer issue

This commit introduces several optimizations to the resource monitoring logic, improves its overall performance, and addresses a potential nil pointer issue with `ObjStorageClient`.

**Code Structure Improvements:**

- Refactored resource usage monitoring logic into dedicated functions for Pods, PVCs, backups, and Services, enhancing code readability and maintainability.

**Performance Enhancements:**

- Implemented `FieldSelector` in `monitorPodResourceUsage`, `monitorPVCResourceUsage`, and `monitorServiceResourceUsage` to filter resources efficiently, minimizing API request overhead.
- Introduced a `gpuMutex` to safeguard the `NvidiaGpu` map, preventing concurrent read-write issues and potential race conditions.

**Bug Fixes:**

- Added a nil check for `ObjStorageClient` in relevant functions to prevent potential panics caused by accessing a nil pointer. This ensures the monitoring process continues smoothly even if the object storage client is not configured. https://github.com/labring/sealos/pull/4780/files#diff-ed55e3d94d63443dc853d1dd28cc8899b61633a6e290bc2c5d6925eb0cd41d6dR275
