### PR TITLE
fix: the certificate validity period changed from 99 years to 1 year after the cluster is upgraded

### DIFF
--- a/pkg/runtime/kubernetes/upgrade.go
+++ b/pkg/runtime/kubernetes/upgrade.go
@@ -33,8 +33,8 @@ import (
 )
 
 const (
-	upgradeApplyCmd = "kubeadm upgrade apply --config %s --yes"
-	upradeNodeCmd   = "kubeadm upgrade node --skip-phases preflight"
+	upgradeApplyCmd = "kubeadm upgrade apply --certificate-renewal=false --config %s --yes"
+	upradeNodeCmd   = "kubeadm upgrade node --certificate-renewal=false --skip-phases preflight"
 	//drainNodeCmd    = "kubectl drain %s --ignore-daemonsets"
 	cordonNodeCmd   = "kubectl cordon %s"
 	uncordonNodeCmd = "kubectl uncordon %s"


### PR DESCRIPTION
Fix #4113 

Test k8s-v1.26.8 upgrad to k8s-v1.27.11

Before upgrading

```
kubectl get nodes
NAME                   STATUS   ROLES           AGE    VERSION
test-1.novalocal   Ready    control-plane   2m5s   v1.26.8
test2.novalocal    Ready    control-plane   62s    v1.26.8
[root@lcx-test-1 ~]# kubeadm certs check-expiration
[check-expiration] Reading configuration from the cluster...
[check-expiration] FYI: You can look at this config file with 'kubectl -n kube-system get cm kubeadm-config -o yaml'
W0710 18:10:37.225578   20471 utils.go:69] The recommended value for "healthzBindAddress" in "KubeletConfiguration" is: 127.0.0.1; the provided value is: 0.0.0.0

CERTIFICATE                EXPIRES                  RESIDUAL TIME   CERTIFICATE AUTHORITY   EXTERNALLY MANAGED
admin.conf                 Jun 16, 2124 10:07 UTC   99y             ca                      no      
apiserver                  Jun 16, 2124 10:07 UTC   99y             ca                      no      
apiserver-etcd-client      Jun 16, 2124 10:07 UTC   99y             etcd-ca                 no      
apiserver-kubelet-client   Jun 16, 2124 10:07 UTC   99y             ca                      no      
controller-manager.conf    Jun 16, 2124 10:07 UTC   99y             ca                      no      
etcd-healthcheck-client    Jun 16, 2124 10:07 UTC   99y             etcd-ca                 no      
etcd-peer                  Jun 16, 2124 10:07 UTC   99y             etcd-ca                 no      
etcd-server                Jun 16, 2124 10:07 UTC   99y             etcd-ca                 no      
front-proxy-client         Jun 16, 2124 10:07 UTC   99y             front-proxy-ca          no      
scheduler.conf             Jun 16, 2124 10:07 UTC   99y             ca                      no      

CERTIFICATE AUTHORITY   EXPIRES                  RESIDUAL TIME   EXTERNALLY MANAGED
ca                      Jun 16, 2124 10:07 UTC   99y             no      
etcd-ca                 Jun 16, 2124 10:07 UTC   99y             no      
front-proxy-ca          Jun 16, 2124 10:07 UTC   99y   

```
After upgrade
```
# kubectl get nodes
NAME                   STATUS   ROLES           AGE     VERSION
test-1.novalocal   Ready    control-plane   10m     v1.27.11
test2.novalocal    Ready    control-plane   9m49s   v1.27.11
[root@lcx-test-1 ~]# kubeadm certs check-expiration
[check-expiration] Reading configuration from the cluster...
[check-expiration] FYI: You can look at this config file with 'kubectl -n kube-system get cm kubeadm-config -o yaml'

CERTIFICATE                EXPIRES                  RESIDUAL TIME   CERTIFICATE AUTHORITY   EXTERNALLY MANAGED
admin.conf                 Jun 16, 2124 10:07 UTC   99y             ca                      no      
apiserver                  Jun 16, 2124 10:07 UTC   99y             ca                      no      
apiserver-etcd-client      Jun 16, 2124 10:07 UTC   99y             etcd-ca                 no      
apiserver-kubelet-client   Jun 16, 2124 10:07 UTC   99y             ca                      no      
controller-manager.conf    Jun 16, 2124 10:07 UTC   99y             ca                      no      
etcd-healthcheck-client    Jun 16, 2124 10:07 UTC   99y             etcd-ca                 no      
etcd-peer                  Jun 16, 2124 10:07 UTC   99y             etcd-ca                 no      
etcd-server                Jun 16, 2124 10:07 UTC   99y             etcd-ca                 no      
front-proxy-client         Jun 16, 2124 10:07 UTC   99y             front-proxy-ca          no      
scheduler.conf             Jun 16, 2124 10:07 UTC   99y             ca                      no      

CERTIFICATE AUTHORITY   EXPIRES                  RESIDUAL TIME   EXTERNALLY MANAGED
ca                      Jun 16, 2124 10:07 UTC   99y             no      
etcd-ca                 Jun 16, 2124 10:07 UTC   99y             no      
front-proxy-ca          Jun 16, 2124 10:07 UTC   99y             no  
```


