### PR TITLE
fix: failed to delete node by apply

### DIFF
--- a/pkg/apply/applydrivers/apply_drivers_default.go
+++ b/pkg/apply/applydrivers/apply_drivers_default.go
@@ -228,7 +228,10 @@ func (c *Applier) scaleCluster(mj, md, nj, nd []string) error {
 	logger.Info("start to scale this cluster")
 	logger.Debug("current cluster: master %s, worker %s", c.ClusterCurrent.GetMasterIPAndPortList(), c.ClusterCurrent.GetNodeIPAndPortList())
 	logger.Debug("desired cluster: master %s, worker %s", c.ClusterDesired.GetMasterIPAndPortList(), c.ClusterDesired.GetNodeIPAndPortList())
-	scaleProcessor, err := processor.NewScaleProcessor(c.ClusterFile, c.ClusterDesired.Name, c.ClusterDesired.Spec.Image, mj, md, nj, nd)
+	
+	localpath := constants.Clusterfile(c.ClusterDesired.Name)
+	cf := clusterfile.NewClusterFile(localpath)
+	scaleProcessor, err := processor.NewScaleProcessor(cf, c.ClusterDesired.Name, c.ClusterDesired.Spec.Image, mj, md, nj, nd)
 	if err != nil {
 		return err
 	}

--- a/pkg/apply/applydrivers/apply_drivers_default.go
+++ b/pkg/apply/applydrivers/apply_drivers_default.go
@@ -228,7 +228,7 @@ func (c *Applier) scaleCluster(mj, md, nj, nd []string) error {
 	logger.Info("start to scale this cluster")
 	logger.Debug("current cluster: master %s, worker %s", c.ClusterCurrent.GetMasterIPAndPortList(), c.ClusterCurrent.GetNodeIPAndPortList())
 	logger.Debug("desired cluster: master %s, worker %s", c.ClusterDesired.GetMasterIPAndPortList(), c.ClusterDesired.GetNodeIPAndPortList())
-	
+
 	localpath := constants.Clusterfile(c.ClusterDesired.Name)
 	cf := clusterfile.NewClusterFile(localpath)
 	scaleProcessor, err := processor.NewScaleProcessor(cf, c.ClusterDesired.Name, c.ClusterDesired.Spec.Image, mj, md, nj, nd)


### PR DESCRIPTION
fix #4869 

when delete node via `seaos apply -f Clusterfile`, the target node will not exist in the Clusterfile, in that case, if the node has a different passwd with other nodes, the scale down process will failed.

my solution is passing the 'current' clusterfile when `NewScaleProcessor`, it will not affect the `sealos add` and `sealos delete` because the `add` and `delete` processes pass current clusterfile originally. It will only affect the `sealos apply` when it comes scale process.
