### PR TITLE
opt: remove --masters and --nodes options for reset

### DIFF
--- a/cmd/sealos/cmd/reset.go
+++ b/cmd/sealos/cmd/reset.go
@@ -31,8 +31,8 @@ reset you current cluster:
 
 func newResetCmd() *cobra.Command {
 	resetArgs := &apply.ResetArgs{
-		Cluster: &apply.Cluster{},
-		SSH:     &apply.SSH{},
+		ClusterName: &apply.ClusterName{},
+		SSH:         &apply.SSH{},
 	}
 
 	var resetCmd = &cobra.Command{

--- a/pkg/apply/args.go
+++ b/pkg/apply/args.go
@@ -37,6 +37,14 @@ func (c *Cluster) RegisterFlags(fs *pflag.FlagSet, verb, action string) {
 	fs.StringVar(&c.ClusterName, "cluster", "default", fmt.Sprintf("name of cluster to applied %s action", action))
 }
 
+type ClusterName struct {
+	ClusterName string
+}
+
+func (c *ClusterName) RegisterFlags(fs *pflag.FlagSet, verb, action string) {
+	fs.StringVar(&c.ClusterName, "cluster", "default", fmt.Sprintf("name of cluster to applied %s action", action))
+}
+
 type SSH struct {
 	User       string
 	Password   string
@@ -85,12 +93,12 @@ func (arg *Args) RegisterFlags(fs *pflag.FlagSet) {
 }
 
 type ResetArgs struct {
-	*Cluster
+	*ClusterName
 	*SSH
 }
 
 func (arg *ResetArgs) RegisterFlags(fs *pflag.FlagSet) {
-	arg.Cluster.RegisterFlags(fs, "be reset", "reset")
+	arg.ClusterName.RegisterFlags(fs, "be reset", "reset")
 	arg.SSH.RegisterFlags(fs)
 }
 

--- a/pkg/apply/args.go
+++ b/pkg/apply/args.go
@@ -41,7 +41,7 @@ type ClusterName struct {
 	ClusterName string
 }
 
-func (c *ClusterName) RegisterFlags(fs *pflag.FlagSet, verb, action string) {
+func (c *ClusterName) RegisterFlags(fs *pflag.FlagSet, _, action string) {
 	fs.StringVar(&c.ClusterName, "cluster", "default", fmt.Sprintf("name of cluster to applied %s action", action))
 }
 

--- a/pkg/apply/args_test.go
+++ b/pkg/apply/args_test.go
@@ -175,16 +175,16 @@ func TestParseResetArgsFlagsCorrect(t *testing.T) {
 	}{
 		{
 			[]string{
-				"--masters", "10.74.22.22:22", "--nodes", "10.74.22.44:22", "--cluster", "default",
+				"--cluster", "default",
 				"-u", "root", "-p", "s3cret", "--port", "2222",
 			},
 			&ResetArgs{
-				Cluster: &Cluster{},
-				SSH:     &SSH{},
+				ClusterName: &ClusterName{},
+				SSH:         &SSH{},
 			},
 			&ResetArgs{
-				Cluster: &Cluster{Masters: "10.74.22.22:22", Nodes: "10.74.22.44:22", ClusterName: "default"},
-				SSH:     &SSH{User: "root", Password: "s3cret", Port: 2222, Pk: path.Join(constants.GetHomeDir(), ".ssh", "id_rsa")},
+				ClusterName: &ClusterName{ClusterName: "default"},
+				SSH:         &SSH{User: "root", Password: "s3cret", Port: 2222, Pk: path.Join(constants.GetHomeDir(), ".ssh", "id_rsa")},
 			},
 		},
 	}

--- a/pkg/apply/reset.go
+++ b/pkg/apply/reset.go
@@ -23,15 +23,12 @@ import (
 	"github.com/labring/sealos/pkg/apply/applydrivers"
 	"github.com/labring/sealos/pkg/clusterfile"
 	"github.com/labring/sealos/pkg/constants"
-	"github.com/labring/sealos/pkg/exec"
 	"github.com/labring/sealos/pkg/ssh"
-	v2 "github.com/labring/sealos/pkg/types/v1beta1"
 	"github.com/labring/sealos/pkg/utils/logger"
-	stringsutil "github.com/labring/sealos/pkg/utils/strings"
 )
 
 func NewApplierFromResetArgs(cmd *cobra.Command, args *ResetArgs) (applydrivers.Interface, error) {
-	clusterPath := constants.Clusterfile(args.ClusterName)
+	clusterPath := constants.Clusterfile(args.ClusterName.ClusterName)
 	cf := clusterfile.NewClusterFile(clusterPath)
 	err := cf.Process()
 	// incase we want to reset force
@@ -40,7 +37,7 @@ func NewApplierFromResetArgs(cmd *cobra.Command, args *ResetArgs) (applydrivers.
 	}
 	cluster := cf.GetCluster()
 	if cluster == nil {
-		cluster = initCluster(args.ClusterName)
+		return nil, errors.New("clusterfile must exist")
 	}
 	c := &ClusterArgs{
 		clusterName: cluster.Name,
@@ -53,36 +50,19 @@ func NewApplierFromResetArgs(cmd *cobra.Command, args *ResetArgs) (applydrivers.
 }
 
 func (r *ClusterArgs) resetArgs(cmd *cobra.Command, args *ResetArgs) error {
-	if args.Cluster.ClusterName == "" {
+	if args.ClusterName.ClusterName == "" {
 		return fmt.Errorf("cluster name can not be empty")
-	}
-	if err := PreProcessIPList(args.Cluster); err != nil {
-		return err
 	}
 	override := getSSHFromCommand(cmd)
 	if override != nil {
 		ssh.OverSSHConfig(&r.cluster.Spec.SSH, override)
 	}
 
-	if len(args.Cluster.Masters) > 0 {
-		masters := stringsutil.FilterNonEmptyFromString(args.Cluster.Masters, ",")
-		nodes := stringsutil.FilterNonEmptyFromString(args.Cluster.Nodes, ",")
-		r.hosts = []v2.Host{}
-
-		sshClient := ssh.NewCacheClientFromCluster(r.cluster, true)
-		execer, err := exec.New(sshClient)
-		if err != nil {
-			return err
-		}
-		r.setHostWithIpsPort(masters, []string{v2.MASTER, GetHostArch(execer, masters[0])})
-		if len(nodes) > 0 {
-			r.setHostWithIpsPort(nodes, []string{v2.NODE, GetHostArch(execer, nodes[0])})
-		}
-		r.cluster.Spec.Hosts = r.hosts
+	if r.cluster.ObjectMeta.CreationTimestamp.IsZero() {
+		return errors.New("creation time must be specified in clusterfile")
 	}
-
-	if r.cluster.ObjectMeta.CreationTimestamp.IsZero() && len(r.cluster.Spec.Hosts) == 0 {
-		return errors.New("must specified '--masters' or '--nodes' when clusterfile is not exists")
+	if len(r.cluster.Spec.Hosts) == 0 {
+		return errors.New("host must not be empty in clusterfile")
 	}
 	logger.Debug("cluster info: %v", r.cluster)
 	return nil

--- a/pkg/apply/reset_test.go
+++ b/pkg/apply/reset_test.go
@@ -51,7 +51,7 @@ func TestNewApplierFromResetArgs(t *testing.T) {
 					SSH: &SSH{},
 				},
 			},
-			wantErr: false,
+			wantErr: true, // clusterfile must exist
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/apply/reset_test.go
+++ b/pkg/apply/reset_test.go
@@ -35,22 +35,8 @@ func TestNewApplierFromResetArgs(t *testing.T) {
 			name: "error",
 			args: args{
 				args: &ResetArgs{
-					Cluster: &Cluster{},
-					SSH:     &SSH{},
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "error duplicate",
-			args: args{
-				args: &ResetArgs{
-					Cluster: &Cluster{
-						Masters:     "192.158.1.1",
-						Nodes:       "192.158.1.1",
-						ClusterName: "default",
-					},
-					SSH: &SSH{},
+					ClusterName: &ClusterName{},
+					SSH:         &SSH{},
 				},
 			},
 			wantErr: true,
@@ -59,9 +45,7 @@ func TestNewApplierFromResetArgs(t *testing.T) {
 			name: "success",
 			args: args{
 				args: &ResetArgs{
-					Cluster: &Cluster{
-						Masters:     "192.158.1.1",
-						Nodes:       "192.158.1.2",
+					ClusterName: &ClusterName{
 						ClusterName: "default",
 					},
 					SSH: &SSH{},


### PR DESCRIPTION
Remove --masters and --nodes options for command `sealos reset`.

There is no need to provide the masters and nodes options to the `reset` command, because even if you specify master or node, the `reset` command will still reset all hosts in the entire cluster.

At the same time, it is necessary to force a check on whether the Clusterfile exists. When it does not exist, an error is reported and the  process exits.