### PR TITLE
ci: update `upload-artifact` and `download-artifact` actions to v4

### DIFF
--- a/.github/workflows/ci-patch-image.yml
+++ b/.github/workflows/ci-patch-image.yml
@@ -70,13 +70,13 @@ jobs:
           password: ${{ secrets.GH_PAT }}
 
       - name: Download sealos
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sealos-amd64
           path: docker/sealos/bin/sealos-amd64
 
       - name: Download sealos
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sealos-arm64
           path: docker/sealos/bin/sealos-arm64
@@ -146,7 +146,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Download sealos
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sealos
           path: /tmp/
@@ -159,12 +159,12 @@ jobs:
         uses: rlespinasse/git-commit-data-action@v1
 
       - name: Download amd64 patch image tar
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: patch-image-amd64.tar
           path: /tmp/sealos/images/
       - name: Download arm64 patch image tar
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: patch-image-arm64.tar
           path: /tmp/sealos/images/

--- a/.github/workflows/cloud-release.yml
+++ b/.github/workflows/cloud-release.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Download sealos
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sealos
           path: /tmp/
@@ -114,7 +114,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Download sealos
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sealos
           path: /tmp/

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -85,7 +85,7 @@ jobs:
           bash ./scripts/resolve-tag-image.sh "${{ inputs.push_image }}" "${{ steps.check_tag.outputs.isTag }}"  "${{ inputs.push_image_tag }}"     
           echo repo=ghcr.io/${{ github.repository_owner }}/sealos-cloud >> $GITHUB_OUTPUT
       - name: Download sealos
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sealos
           path: /tmp/

--- a/.github/workflows/controllers.yml
+++ b/.github/workflows/controllers.yml
@@ -231,7 +231,7 @@ jobs:
           echo latest_cluster_image=ghcr.io/${{ github.repository_owner }}/sealos-cloud-${{ matrix.module.name }}-controller:latest >> $GITHUB_OUTPUT
 
       - name: Download sealos
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sealos
           path: /tmp/

--- a/.github/workflows/e2e_k3s_multi_node.yml
+++ b/.github/workflows/e2e_k3s_multi_node.yml
@@ -35,12 +35,12 @@ jobs:
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
       - name: Download sealos binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sealos-${{ matrix.arch }}
           path: /tmp/sealos/bin/
       - name: Download sealos
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sealos-amd64
           path: /tmp/verify/
@@ -49,12 +49,12 @@ jobs:
           sudo chmod a+x /tmp/verify/sealos
           sudo /tmp/verify/sealos version
       - name: Download patch image tar
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: patch-image-${{ matrix.arch }}.tar
           path: /tmp/sealos/images/
       - name: Download e2e test
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: e2e.test
           path: /tmp/

--- a/.github/workflows/e2e_k8s_multi_node.yml
+++ b/.github/workflows/e2e_k8s_multi_node.yml
@@ -35,12 +35,12 @@ jobs:
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
       - name: Download sealos binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sealos-${{ matrix.arch }}
           path: /tmp/sealos/bin/
       - name: Download sealos
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sealos-amd64
           path: /tmp/verify/
@@ -49,12 +49,12 @@ jobs:
           sudo chmod a+x /tmp/verify/sealos
           sudo /tmp/verify/sealos version
       - name: Download patch image tar
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: patch-image-${{ matrix.arch }}.tar
           path: /tmp/sealos/images/
       - name: Download e2e test
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: e2e.test
           path: /tmp/

--- a/.github/workflows/e2e_test_core.yml
+++ b/.github/workflows/e2e_test_core.yml
@@ -63,22 +63,22 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Download image-cri-shim
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: image-cri-shim-amd64
           path: /tmp/
       - name: Download sealctl
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sealctl-amd64
           path: /tmp/
       - name: Download sealos
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sealos-amd64
           path: /tmp/
       - name: Download e2e test
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: e2e.test
           path: /tmp/

--- a/.github/workflows/e2e_test_core_k3s.yml
+++ b/.github/workflows/e2e_test_core_k3s.yml
@@ -37,22 +37,22 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Download image-cri-shim
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: image-cri-shim-amd64
           path: /tmp/
       - name: Download sealctl
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sealctl-amd64
           path: /tmp/
       - name: Download sealos
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sealos-amd64
           path: /tmp/
       - name: Download e2e test
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: e2e.test
           path: /tmp/

--- a/.github/workflows/e2e_test_image_cri_shim.yml
+++ b/.github/workflows/e2e_test_image_cri_shim.yml
@@ -31,12 +31,12 @@ jobs:
       - name: Install Dependencies
         run: sudo apt update && sudo apt install -y libgpgme-dev libbtrfs-dev libdevmapper-dev
       - name: Download image-cri-shim
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: image-cri-shim-amd64
           path: /tmp/
       - name: Download sealos
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sealos-amd64
           path: /tmp/
@@ -46,7 +46,7 @@ jobs:
           sudo mv /tmp/sealos /usr/bin/
           sudo sealos version
       - name: Download e2e test
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: e2e.test
           path: /tmp/

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -203,7 +203,7 @@ jobs:
           echo latest_cluster_image=ghcr.io/${{ github.repository_owner }}/sealos-cloud-${{ env.MODULE_NAME }}-frontend:latest >> $GITHUB_OUTPUT
 
       - name: Download sealos
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sealos
           path: /tmp/

--- a/.github/workflows/import-patch-image.yml
+++ b/.github/workflows/import-patch-image.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           make build BINS=${{ matrix.binary }} PLATFORM=linux_${{ matrix.arch }}
       - name: Save Binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.binary }}-${{ matrix.arch }}
           path: bin/linux_${{ matrix.arch}}/${{ matrix.binary }}
@@ -123,7 +123,7 @@ jobs:
           go install github.com/onsi/ginkgo/v2/ginkgo
           cd test/e2e && ginkgo build .
       - name: Save E2e Test
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: e2e.test
           path: test/e2e/e2e.test
@@ -152,25 +152,25 @@ jobs:
         uses: rlespinasse/git-commit-data-action@v1
 
       - name: Download lvscare
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: lvscare-${{ matrix.arch }}
           path: docker/lvscare
 
       - name: Download sealctl
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sealctl-${{ matrix.arch }}
           path: docker/patch
 
       - name: Download image-cri-shim
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: image-cri-shim-${{ matrix.arch }}
           path: docker/patch
 
       - name: Download sealos
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sealos-${{ matrix.arch }}
           path: docker/sealos
@@ -203,7 +203,7 @@ jobs:
           OWNER: ${{ github.repository_owner }}
 
       - name: Upload Cluster Images
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: patch-image-${{ matrix.arch }}.tar
           path: patch-${{ matrix.arch }}.tar

--- a/.github/workflows/import-save-sealos.yml
+++ b/.github/workflows/import-save-sealos.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           sealosVersion: "4.1.7"
       - name: Save Binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sealos
           path: /usr/bin/sealos

--- a/.github/workflows/objectstorage.yaml
+++ b/.github/workflows/objectstorage.yaml
@@ -85,7 +85,7 @@ jobs:
           bash ./scripts/resolve-tag-image.sh "${{ inputs.push_image }}" "${{ steps.check_tag.outputs.isTag }}"  "${{ inputs.push_image_tag }}"     
           echo repo=ghcr.io/${{ github.repository_owner }}/sealos-cloud-objectstorage >> $GITHUB_OUTPUT
       - name: Download sealos
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sealos
           path: /tmp/

--- a/.github/workflows/services.yml
+++ b/.github/workflows/services.yml
@@ -208,7 +208,7 @@ jobs:
           echo cluster_repo=ghcr.io/${{ github.repository_owner }}/sealos-cloud-${{ matrix.module }}-service >> $GITHUB_OUTPUT
 
       - name: Download sealos
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: sealos
           path: /tmp/


### PR DESCRIPTION
v3 of `actions/upload-artifact` and `actions/download-artifact` will be fully deprecated by **30 January 2025**. Jobs that are scheduled to run during the brownout periods will also fail. See:

1. https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
2. https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/