### PR TITLE
Introducing Sealos Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A Cloud Operating System designed for managing cloud-native applications
 [![codecov](https://codecov.io/gh/labring/sealos/branch/main/graph/badge.svg?token=e41ZDcj06N)](https://codecov.io/gh/labring/sealos)
 [![Website](https://img.shields.io/website?url=https%3A%2F%2Fpostwoman.io&logo=Postwoman)](https://sealos.io)
 [![OSCS Status](https://www.oscs1024.com/platform/badge/labring/sealos.svg?size=small)](https://www.oscs1024.com/repo/labring/sealos?ref=badge_small)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Sealos%20Guru-006BFF)](https://gurubase.io/g/sealos)
 
 <br />
 


### PR DESCRIPTION
Hello team,

We are the maintainers of [Anteon](https://github.com/getanteon/anteon). Recently, we created Gurubase.io with the mission of building a centralized, open-source, tool-focused knowledge base. Each "guru" in Gurubase is equipped with custom knowledge to answer user questions based on data related to the respective tool.

We’re excited to let you know that [Sealos Guru](https://gurubase.io/g/sealos) has been manually added to Gurubase. Sealos Guru uses the data from this repo and data from the [docs](https://sealos.io/) to answer questions by leveraging the LLM.

This PR introduces the "Sealos Guru", showcasing that Sealos now has an AI assistant available to help users with their questions. We’d love to hear your feedback on this contribution.

You also have the option to maintain the "Sealos Guru" by following the instructions in the [Gurubase Repo](https://github.com/getanteon/gurubase?tab=readme-ov-file#how-to-claim-a-guru) and to add an ASK AI widget to the Sealos documentation website as detailed [here](https://github.com/getanteon/gurubase?tab=readme-ov-file#widget).

If you’d prefer us to disable Sealos Guru in Gurubase, just let us know that's totally fine.
