### PR TITLE
fix(devbox): devboxList large amounts cause show bug in firefox

### DIFF
--- a/frontend/providers/devbox/components/AdvancedTable.tsx
+++ b/frontend/providers/devbox/components/AdvancedTable.tsx
@@ -43,7 +43,7 @@ export const AdvancedTable = ({ columns, data, itemClass = '' }: Props) => {
         <Grid
           templateColumns={`repeat(${columns.length},1fr)`}
           overflowX={'auto'}
-          minH={'fit-content'}
+          minH={'70px'}
           key={index1}
           bg={'white'}
           _hover={{


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->

fit-content is not well supported in firefox and safari,so change to static px.