### PR TITLE
Update install-tailchat.md

### DIFF
--- a/docs/5.0/docs/quick-start/examples/social-communication/install-tailchat.md
+++ b/docs/5.0/docs/quick-start/examples/social-communication/install-tailchat.md
@@ -51,8 +51,8 @@ Next, we will create Minio, an open-source object storage service. We can also q
 The image used is `minio/minio`. Note that we need to make some adjustments:
 
 - Expose port: 9000
-- Change the run command to: `minio`
-- Change the command parameters to: `server /data`
+- Change the run command to: `minio server`
+- Change the command parameters to: `/data`
 - Set environment variables:
     - MINIO_ROOT_USER: tailchat
     - MINIO_ROOT_PASSWORD: com.msgbyte.tailchat


### PR DESCRIPTION
error:
‘server /data’ is not a minio sub-command. See ‘minio --help’. see below:
https://github.com/jgoerner/beyond-jupyter/issues/3

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
