### PR TITLE
Fix the CI labeler to correctly tag PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,7 @@
 #Usage in github: https://github.com/actions/labeler
 
 area/command:
-  - any: [ 'cmd/**/*' ]
+  - any: [ 'lifecycle/cmd/**/*' ]
 
 kind/documentation:
   - any: [ 'docs/**/*' ]
@@ -11,62 +11,58 @@ area/qa:
 
 area/test:
   - '**/*_test.go'
-  - 'test/**/*'
+  - 'lifecycle/test/**/*'
 
 area/buildah:
-  - any: [ 'pkg/buildah/**/*' ]
+  - any: [ 'lifecycle/pkg/buildah/**/*' ]
 
 area/imageCRIShim:
-  - any: [ 'staging/src/github.com/labring/image-cri-shim/**/*' ]
+  - any: [ 'lifecycle/staging/src/github.com/labring/image-cri-shim/**/*' ]
 
 area/lvscare:
-  - any: [ 'staging/src/github.com/labring/lvscare/**/*' ]
+  - any: [ 'lifecycle/staging/src/github.com/labring/lvscare/**/*' ]
 
 area/bootstrap:
-  - any: [ 'pkg/bootstrap/**/*' ]
+  - any: [ 'lifecycle/pkg/bootstrap/**/*' ]
 
 area/clusterfile:
-  - any: [ 'pkg/clusterfile/**/*' ]
+  - any: [ 'lifecycle/pkg/clusterfile/**/*' ]
 
 area/config:
-  - any: [ 'pkg/config/**/*' ]
-  - any: [ 'pkg/env/**/*' ]
-  - any: [ 'pkg/template/**/*' ]
+  - any: [ 'lifecycle/pkg/config/**/*' ]
+  - any: [ 'lifecycle/pkg/env/**/*' ]
+  - any: [ 'lifecycle/pkg/template/**/*' ]
 
 area/guest:
-  - any: [ 'pkg/guest/**/*' ]
+  - any: [ 'lifecycle/pkg/guest/**/*' ]
 
 area/env:
-  - any: [ 'pkg/system/**/*' ]
+  - any: [ 'lifecycle/pkg/system/**/*' ]
 
 area/filesystem:
-  - any: [ 'pkg/filesystem/**/*' ]
-
-area/build:
-  - any: [ 'pkg/buildimage/**/*' ]
+  - any: [ 'lifecycle/pkg/filesystem/**/*' ]
 
 area/apply:
-  - any: [ 'pkg/apply/**/*' ]
+  - any: [ 'lifecycle/pkg/apply/**/*' ]
 
 area/check:
-  - any: [ 'pkg/checker/**/*' ]
+  - any: [ 'lifecycle/pkg/checker/**/*' ]
 
 area/ipvs:
-  - any: [ 'pkg/ipvs/**/*' ]
+  - any: [ 'lifecycle/pkg/ipvs/**/*' ]
 
 area/ssh:
-  - any: [ 'pkg/ssh/**/*' ]
-  - any: [ 'pkg/remote/**/*' ]
+  - any: [ 'lifecycle/pkg/ssh/**/*' ]
 
 area/registry:
-  - any: [ 'pkg/registry/**/*' ]
+  - any: [ 'lifecycle/pkg/registry/**/*' ]
 
 area/runtime:
-  - any: [ 'pkg/runtime/**/*' ]
+  - any: [ 'lifecycle/pkg/runtime/**/*' ]
 
 area/api:
-  - any: [ 'pkg/types/**/*']
-  - any: [ '**/*_types.go' ]
+  - any: [ 'lifecycle/pkg/types/**/*']
+  - any: [ 'lifecycle/**/*_types.go' ]
 
 area/cloud:
   - any: [ 'controllers/**/*' ]
@@ -75,8 +71,8 @@ area/cloud:
   - any: ['docs/4.0/i18n/zh-Hans/**', '!docs/4.0/i18n/zh-Hans/lifecycle-management/**']
 
 area/lifecycle-management:
-  - any: [ 'pkg/**/*' ]
-  - any: [ 'staging/**/*' ]
+  - any: [ 'lifecycle/pkg/**/*' ]
+  - any: [ 'lifecycle/staging/**/*' ]
   - any: [ 'docs/4.0/docs/lifecycle-management/**/*' ]
   - any: [ 'docs/4.0/i18n/zh-Hans/lifecycle-management/**/*' ]
 
@@ -86,11 +82,12 @@ area/frontend:
 
 area/ci:
   - 'scripts/**/*'
-  - 'docker/**/*'
+  - 'lifecycle/scripts/**/*'
+  - 'lifecycle/docker/**/*'
   - 'deploy/**/*'
   - '.golangci.yml'
-  - '.goreleaser.yml'
-  - 'Makefile'
+  - 'lifecycle/.goreleaser.yml'
+  - 'lifecycle/Makefile'
 
 area/workflow:
   - any: [ '.github/**/*' ]


### PR DESCRIPTION
Due to the move of the lifecycle directory, the CI labeler needs to be updated.