### PR TITLE
chore: remove typecheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,6 @@ linters:
     - misspell
     - whitespace
     - ineffassign
-    - typecheck
     - errcheck
     - govet
     - staticcheck


### PR DESCRIPTION
This PR removes redundant `typecheck` from the `linters.enable` list.

`typecheck` is not a linter and it doesn't perform any analysis. It's just a way to identify, parse, and display compiling errors and some linter errors.

More info:

- https://golangci-lint.run/welcome/faq/#why-do-you-have-typecheck-errors
- https://golangci-lint.run/welcome/faq/#why-is-it-not-possible-to-skipignore-typecheck-errors