### PR TITLE
fix: 文档字段描述有误

### DIFF
--- a/docs/4.0/docs/self-hosting/lifecycle-management/advanced-guide/image-build-standardized.md
+++ b/docs/4.0/docs/self-hosting/lifecycle-management/advanced-guide/image-build-standardized.md
@@ -88,7 +88,7 @@ Descriptions of each parameter:
   - defaultVIP: Default VIP address.
   - disableApparmor: Whether to disable apparmor (containerd has this issue).
   - registryConfig: Configuration directory of the container image registry.
-  - registryData: Data directory for the container image registry (The configuration itself has no practical meaning. because the directory is mounted and it's actually stored in `/var/lib/sealos`).
+  - registryData: Data directory of the container image registry (The configuration itself has no practical meaning. because the directory is mounted and it's actually stored in `/var/lib/sealos`).
   - registryDomain: Default domain of the container image registry.
   - registryPassword: Default Password of the container image registry.
   - registryPort: Default port number of the container image registry.

--- a/docs/4.0/docs/self-hosting/lifecycle-management/advanced-guide/image-build-standardized.md
+++ b/docs/4.0/docs/self-hosting/lifecycle-management/advanced-guide/image-build-standardized.md
@@ -91,7 +91,7 @@ Descriptions of each parameter:
   - registryData: Data directory of the container image repository (because it's the directory that has been mounted, this configuration actually has no practical significance, it's actually stored under /var/lib/sealos).
   - registryDomain: The default domain of the image repository.
   - registryPassword: The password of the default image repository.
-  - registryPort: The password of the default image repository.
+  - registryPort: The port of the default image repository.
   - registryUsername: The account of the default image repository.
   - sandboxImage: Default sandbox_image for cri to start. (No need to write repo, just need to write image name, eg: pasue:3.7).
 - `COPY`: The `COPY` directive copies new files or directories from `<src>` and adds them to the file system path `<dest>` on the container. (**Note that the registry directory needs to be copied, otherwise the cluster has no container images**)

--- a/docs/4.0/docs/self-hosting/lifecycle-management/advanced-guide/image-build-standardized.md
+++ b/docs/4.0/docs/self-hosting/lifecycle-management/advanced-guide/image-build-standardized.md
@@ -87,12 +87,12 @@ Descriptions of each parameter:
   - criData: Data directory of cri.
   - defaultVIP: Default VIP address.
   - disableApparmor: Whether to disable apparmor (containerd has this issue).
-  - registryConfig: Configuration directory of the container image repository.
-  - registryData: Data directory of the container image repository (because it's the directory that has been mounted, this configuration actually has no practical significance, it's actually stored under /var/lib/sealos).
-  - registryDomain: The default domain of the image repository.
-  - registryPassword: The password of the default image repository.
-  - registryPort: The port of default container image registry.
-  - registryUsername: The account of the default image repository.
+  - registryConfig: Configuration directory of the container image registry.
+  - registryData: Data directory for the container image registry (The configuration itself has no practical meaning. because the directory is mounted and it's actually stored in `/var/lib/sealos`).
+  - registryDomain: Default domain of the container image registry.
+  - registryPassword: Default Password of the container image registry.
+  - registryPort: Default port number of the container image registry.
+  - registryUsername: Default username of the default container image registry.
   - sandboxImage: Default sandbox_image for cri to start. (No need to write repo, just need to write image name, eg: pasue:3.7).
 - `COPY`: The `COPY` directive copies new files or directories from `<src>` and adds them to the file system path `<dest>` on the container. (**Note that the registry directory needs to be copied, otherwise the cluster has no container images**)
 - `ENTRYPOINT`: This directive is used to set the startup command for the image. When the image starts, this command will be executed.

--- a/docs/4.0/docs/self-hosting/lifecycle-management/advanced-guide/image-build-standardized.md
+++ b/docs/4.0/docs/self-hosting/lifecycle-management/advanced-guide/image-build-standardized.md
@@ -92,7 +92,7 @@ Descriptions of each parameter:
   - registryDomain: Default domain of the container image registry.
   - registryPassword: Default Password of the container image registry.
   - registryPort: Default port number of the container image registry.
-  - registryUsername: Default username of the default container image registry.
+  - registryUsername: Default username of the container image registry.
   - sandboxImage: Default sandbox_image for cri to start. (No need to write repo, just need to write image name, eg: pasue:3.7).
 - `COPY`: The `COPY` directive copies new files or directories from `<src>` and adds them to the file system path `<dest>` on the container. (**Note that the registry directory needs to be copied, otherwise the cluster has no container images**)
 - `ENTRYPOINT`: This directive is used to set the startup command for the image. When the image starts, this command will be executed.

--- a/docs/4.0/docs/self-hosting/lifecycle-management/advanced-guide/image-build-standardized.md
+++ b/docs/4.0/docs/self-hosting/lifecycle-management/advanced-guide/image-build-standardized.md
@@ -91,7 +91,7 @@ Descriptions of each parameter:
   - registryData: Data directory of the container image repository (because it's the directory that has been mounted, this configuration actually has no practical significance, it's actually stored under /var/lib/sealos).
   - registryDomain: The default domain of the image repository.
   - registryPassword: The password of the default image repository.
-  - registryPort: The port of the default image repository.
+  - registryPort: The port of default container image registry.
   - registryUsername: The account of the default image repository.
   - sandboxImage: Default sandbox_image for cri to start. (No need to write repo, just need to write image name, eg: pasue:3.7).
 - `COPY`: The `COPY` directive copies new files or directories from `<src>` and adds them to the file system path `<dest>` on the container. (**Note that the registry directory needs to be copied, otherwise the cluster has no container images**)

--- a/docs/4.0/i18n/zh-Hans/self-hosting/lifecycle-management/advanced-guide/image-build-standardized.md
+++ b/docs/4.0/i18n/zh-Hans/self-hosting/lifecycle-management/advanced-guide/image-build-standardized.md
@@ -93,7 +93,7 @@ CMD ["kubectl apply -f manifests/custom-resources.yaml"]
   - registryData: 容器镜像仓库的数据目录（因为是目录进行了挂载，其实这个配置没有实际意义，它实际还是存储在/var/lib/sealos下面）
   - registryDomain: 默认镜像仓库的域名
   - registryPassword: 默认镜像仓库的密码
-  - registryPort:  默认镜像仓库的密码
+  - registryPort:  默认镜像仓库的端口
   - registryUsername: 默认镜像仓库的账户
   - sandboxImage: 默认cri启动的sandbox_image。（无需写repo只需要写镜像名称，eg: pasue:3.7）
 - `COPY`：`COPY`指令从`<src>`复制新的文件或目录，并将它们添加到容器的文件系统路径`<dest>`上。(**注意，需要把registry目录进行拷贝，否则集群没有容器镜像**)

--- a/docs/5.0/docs/developer-guide/lifecycle-management/advanced-guide/image-build-standardized.md
+++ b/docs/5.0/docs/developer-guide/lifecycle-management/advanced-guide/image-build-standardized.md
@@ -113,7 +113,7 @@ Descriptions of each parameter:
       this configuration actually has no practical significance, it's actually stored under /var/lib/sealos).
     - registryDomain: The default domain of the image repository.
     - registryPassword: The password of the default image repository.
-    - registryPort: The password of the default image repository.
+    - registryPort: The port of the default image repository.
     - registryUsername: The account of the default image repository.
     - sandboxImage: Default sandbox_image for cri to start. (No need to write repo, just need to write image name, eg:
       pasue:3.7).

--- a/docs/5.0/docs/developer-guide/lifecycle-management/advanced-guide/image-build-standardized.md
+++ b/docs/5.0/docs/developer-guide/lifecycle-management/advanced-guide/image-build-standardized.md
@@ -114,7 +114,7 @@ Descriptions of each parameter:
     - registryDomain: Default domain of the container image registry.
     - registryPassword: Default Password of the container image registry.
     - registryPort: Default port number of the container image registry.
-    - registryUsername: Default username of the default container image registry.
+    - registryUsername: Default username of the container image registry.
     - sandboxImage: Default sandbox_image for cri to start. (No need to write repo, just need to write image name, eg:
       pasue:3.7).
 - `COPY`: The `COPY` directive copies new files or directories from `<src>` and adds them to the file system path

--- a/docs/5.0/docs/developer-guide/lifecycle-management/advanced-guide/image-build-standardized.md
+++ b/docs/5.0/docs/developer-guide/lifecycle-management/advanced-guide/image-build-standardized.md
@@ -108,13 +108,13 @@ Descriptions of each parameter:
     - criData: Data directory of cri.
     - defaultVIP: Default VIP address.
     - disableApparmor: Whether to disable apparmor (containerd has this issue).
-    - registryConfig: Configuration directory of the container image repository.
-    - registryData: Data directory of the container image repository (because it's the directory that has been mounted,
-      this configuration actually has no practical significance, it's actually stored under /var/lib/sealos).
-    - registryDomain: The default domain of the image repository.
-    - registryPassword: The password of the default image repository.
-    - registryPort: The port of default container image registry.
-    - registryUsername: The account of the default image repository.
+    - registryConfig: Configuration directory of the container image registry.
+    - registryData: Data directory of the container image registry (The configuration itself has no practical meaning.
+      because the directory is mounted and it's actually stored in `/var/lib/sealos`).
+    - registryDomain: Default domain of the container image registry.
+    - registryPassword: Default Password of the container image registry.
+    - registryPort: Default port number of the container image registry.
+    - registryUsername: Default username of the default container image registry.
     - sandboxImage: Default sandbox_image for cri to start. (No need to write repo, just need to write image name, eg:
       pasue:3.7).
 - `COPY`: The `COPY` directive copies new files or directories from `<src>` and adds them to the file system path

--- a/docs/5.0/docs/developer-guide/lifecycle-management/advanced-guide/image-build-standardized.md
+++ b/docs/5.0/docs/developer-guide/lifecycle-management/advanced-guide/image-build-standardized.md
@@ -113,7 +113,7 @@ Descriptions of each parameter:
       this configuration actually has no practical significance, it's actually stored under /var/lib/sealos).
     - registryDomain: The default domain of the image repository.
     - registryPassword: The password of the default image repository.
-    - registryPort: The port of the default image repository.
+    - registryPort: The port of default container image registry.
     - registryUsername: The account of the default image repository.
     - sandboxImage: Default sandbox_image for cri to start. (No need to write repo, just need to write image name, eg:
       pasue:3.7).

--- a/docs/5.0/i18n/zh-Hans/developer-guide/lifecycle-management/advanced-guide/image-build-standardized.md
+++ b/docs/5.0/i18n/zh-Hans/developer-guide/lifecycle-management/advanced-guide/image-build-standardized.md
@@ -95,7 +95,7 @@ CMD ["kubectl apply -f manifests/custom-resources.yaml"]
   - registryData: 容器镜像仓库的数据目录（因为是目录进行了挂载，其实这个配置没有实际意义，它实际还是存储在/var/lib/sealos下面）
   - registryDomain: 默认镜像仓库的域名
   - registryPassword: 默认镜像仓库的密码
-  - registryPort:  默认镜像仓库的密码
+  - registryPort:  默认镜像仓库的端口
   - registryUsername: 默认镜像仓库的账户
   - sandboxImage: 默认cri启动的sandbox_image。（无需写repo只需要写镜像名称，eg: pasue:3.7）
 - `COPY`：`COPY`指令从`<src>`复制新的文件或目录，并将它们添加到容器的文件系统路径`<dest>`上。(**注意，需要把registry目录进行拷贝，否则集群没有容器镜像**)


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
文档中registryPort字段应为：“默认镜像仓库的端口”，不应该是“默认镜像仓库的密码”