### PR TITLE
fix(aiproxy): fix kc auth

### DIFF
--- a/frontend/providers/aiproxy/.env.template
+++ b/frontend/providers/aiproxy/.env.template
@@ -10,4 +10,9 @@ DOC_URL=
 IS_INVITATION_ACTIVE=true
 INVITATION_URL=
 
+# for dev
+NODE_ENV=
+NEXT_PUBLIC_MOCK_USER=
+
+
 # NEXT_PUBLIC_CUSTOM_SCRIPTS='[{"src": "http://www.example.com/example.js"}]'

--- a/frontend/providers/aiproxy/utils/backend/check-kc.ts
+++ b/frontend/providers/aiproxy/utils/backend/check-kc.ts
@@ -113,11 +113,11 @@ export async function verifyK8sConfigAsync(kc: k8s.KubeConfig): Promise<boolean>
       return true
     } catch (error: any) {
       if (error.code === 403) {
-        console.error(`用户没有命名空间 ${namespace} 的访问权限`)
+        console.error('用户没有命名空间 ' + namespace + ' 的访问权限')
         return false
       }
 
-      console.error(`验证命名空间 ${namespace} 权限时出错:`, error)
+      console.error('验证命名空间 ' + namespace + ' 权限时出错:', error)
       return false
     }
   } catch (error) {

--- a/frontend/providers/aiproxy/utils/backend/check-kc.ts
+++ b/frontend/providers/aiproxy/utils/backend/check-kc.ts
@@ -113,11 +113,11 @@ export async function verifyK8sConfigAsync(kc: k8s.KubeConfig): Promise<boolean>
       return true
     } catch (error: any) {
       if (error.code === 403) {
-        console.error('用户没有命名空间 ' + namespace + ' 的访问权限')
+        console.error('用户没有命名空间 %s 的访问权限', namespace)
         return false
       }
 
-      console.error('验证命名空间 ' + namespace + ' 权限时出错:', error)
+      console.error('验证命名空间权限时出错: %s', namespace, error)
       return false
     }
   } catch (error) {

--- a/frontend/providers/aiproxy/utils/backend/check-kc.ts
+++ b/frontend/providers/aiproxy/utils/backend/check-kc.ts
@@ -1,6 +1,22 @@
 import * as k8s from '@kubernetes/client-node'
 
 /**
+ * 从 KubeConfig 字符串中获取命名空间
+ * @param configStr - KubeConfig 配置字符串
+ * @returns 返回配置中的命名空间，如果解析失败则报错
+ */
+export function getNamespaceFromKubeConfigString(configStr: string): string {
+  try {
+    const kc = new k8s.KubeConfig()
+    kc.loadFromString(configStr)
+    return getNamespaceFromKubeConfig(kc)
+  } catch (error) {
+    console.error('解析 KubeConfig 字符串失败:', error)
+    throw new Error('解析 KubeConfig 获取命名空间失败')
+  }
+}
+
+/**
  * 从 KubeConfig 对象中获取当前上下文的命名空间
  * @param kc - KubeConfig 对象
  * @returns 返回当前上下文中设置的命名空间，如果未设置则报错"
@@ -27,31 +43,24 @@ export function getNamespaceFromKubeConfig(kc: k8s.KubeConfig): string {
 }
 
 /**
- * 从 KubeConfig 字符串中获取命名空间
- * @param configStr - KubeConfig 配置字符串
- * @returns 返回配置中的命名空间，如果解析失败则返回 "default"
- */
-export function getNamespaceFromKubeConfigString(configStr: string): string {
-  try {
-    const kc = new k8s.KubeConfig()
-    kc.loadFromString(configStr)
-    return getNamespaceFromKubeConfig(kc)
-  } catch (error) {
-    console.error('解析 KubeConfig 字符串失败:', error)
-    throw new Error('解析 KubeConfig 获取命名空间失败')
-  }
-}
-
-/**
- * 验证 KubeConfig 对象是否为本集群签发
+ * 验证 KubeConfig 对象是否为本集群签发且具有配置中命名空间的权限
  * @param kc - 要验证的 KubeConfig 对象
- * @returns 返回一个布尔值，表示是否为本集群签发
+ * @returns 返回一个布尔值，表示是否为本集群签发且具有该命名空间的权限
  */
 export async function verifyK8sConfigAsync(kc: k8s.KubeConfig): Promise<boolean> {
   try {
     // 获取当前集群信息
     const cluster = kc.getCurrentCluster()
     if (!cluster) {
+      return false
+    }
+
+    // 获取KubeConfig中的命名空间
+    let namespace: string
+    try {
+      namespace = getNamespaceFromKubeConfig(kc)
+    } catch (error) {
+      console.error('获取命名空间失败:', error)
       return false
     }
 
@@ -76,17 +85,39 @@ export async function verifyK8sConfigAsync(kc: k8s.KubeConfig): Promise<boolean>
     verificationKc.contexts = kc.contexts
     verificationKc.setCurrentContext(kc.getCurrentContext() || '')
 
-    // 使用修改后的配置尝试访问 API 服务器的版本端点
+    // 1. 首先验证集群连接
     const k8sApi = verificationKc.makeApiClient(k8s.VersionApi)
-
     try {
       // 尝试获取 API 服务器版本信息
-      const response = await k8sApi.getCode()
-      // 如果请求成功，说明配置有效且为本集群签发
-      return true
+      await k8sApi.getCode()
     } catch (error) {
-      // 如果请求失败，可能是由于配置无效或不是本集群签发的
-      console.error('验证 KubeConfig 失败:', error)
+      console.error('验证 KubeConfig 集群连接失败:', error)
+      return false
+    }
+
+    // 2. 验证对配置中指定命名空间的访问权限
+    try {
+      // 创建命名空间 API 客户端
+      const coreV1Api = verificationKc.makeApiClient(k8s.CoreV1Api)
+
+      // 构建请求参数对象
+      const params: k8s.CoreV1ApiListNamespacedPodRequest = {
+        namespace: namespace,
+        limit: 1
+      }
+
+      // 尝试获取指定命名空间中的 Pod 列表，这需要对该命名空间的 list pods 权限
+      await coreV1Api.listNamespacedPod(params)
+
+      // 如果成功获取 Pod 列表，则表示有权限访问该命名空间
+      return true
+    } catch (error: any) {
+      if (error.code === 403) {
+        console.error(`用户没有命名空间 ${namespace} 的访问权限`)
+        return false
+      }
+
+      console.error(`验证命名空间 ${namespace} 权限时出错:`, error)
       return false
     }
   } catch (error) {

--- a/frontend/providers/objectstorage/src/pages/api/site/openHost.ts
+++ b/frontend/providers/objectstorage/src/pages/api/site/openHost.ts
@@ -9,12 +9,13 @@ import { checkSealosUserIsRealName } from '@/utils/isRealName';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
   try {
-    const token = req.headers.authorization;
-    if (!token) {
+    const appToken = req.headers['app-token'];
+
+    if (!appToken) {
       return jsonRes(res, { code: 403, error: 'no authorization' });
     }
 
-    const isRealName = await checkSealosUserIsRealName(token);
+    const isRealName = await checkSealosUserIsRealName(appToken as string);
     if (!isRealName) {
       return jsonRes(res, { code: 403, error: 'userNotRealName' });
     }

--- a/frontend/providers/objectstorage/src/services/request.ts
+++ b/frontend/providers/objectstorage/src/services/request.ts
@@ -6,7 +6,7 @@ import axios, {
 } from 'axios';
 import type { ApiResp } from './kubernet';
 import { isApiResp } from './kubernet';
-import { getUserKubeConfig } from '@/utils/user';
+import { getAppToken, getUserKubeConfig } from '@/utils/user';
 export const appLanuchPadClient = axios.create({
   baseURL: process.env.APP_LAUNCHPAD_URL,
   timeout: 60000
@@ -29,6 +29,7 @@ request.interceptors.request.use(
     const kc = getUserKubeConfig();
     //获取token，并将其添加至请求头中
     _headers['Authorization'] = encodeURIComponent(kc);
+    _headers['app-token'] = getAppToken();
     if (!config.headers || config.headers['Content-Type'] === '') {
       _headers['Content-Type'] = 'application/json';
     }

--- a/frontend/providers/objectstorage/src/utils/user.ts
+++ b/frontend/providers/objectstorage/src/utils/user.ts
@@ -23,6 +23,8 @@ export const getUserKubeConfig = () =>
   //   ? process.env.NEXT_PUBLIC_MOCK_USER
   useSessionStore.getState().session?.kubeconfig || '';
 
+export const getAppToken = () => useSessionStore.getState().session?.token || '';
+
 export const getUserNamespace = () => {
   const kubeConfig = getUserKubeConfig();
   const json = yaml.load(kubeConfig) as KC;


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Enhances Kubernetes authentication in aiproxy by adding namespace permission verification to ensure users have proper access rights.

- Modified `verifyK8sConfigAsync` in `utils/backend/check-kc.ts` to verify both cluster connectivity and namespace-specific permissions.
- Improved error handling with more specific error messages for different authentication failure scenarios.
- Reorganized code structure by moving the `getNamespaceFromKubeConfigString` function to the top of the file for better readability.
- Added development environment variables in `.env.template` to support testing and development workflows.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
