### PR TITLE
add simple health check for account svc

### DIFF
--- a/service/account/deploy/manifests/deploy.yaml.tmpl
+++ b/service/account/deploy/manifests/deploy.yaml.tmpl
@@ -66,6 +66,13 @@ spec:
               memory: 256Mi
           ports:
             - containerPort: 2333
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 2333
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            failureThreshold: 6
           imagePullPolicy: Always
           volumeMounts:
           - mountPath: /config/config.json

--- a/service/account/router/router.go
+++ b/service/account/router/router.go
@@ -80,6 +80,9 @@ func RegisterPayRouter() {
 	//POST(helper.AdminActiveBilling, api.AdminActiveBilling)
 	docs.SwaggerInfo.Host = env.GetEnvWithDefault("SWAGGER_HOST", "localhost:2333")
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerfiles.Handler))
+	router.GET("/health", func(c *gin.Context) {
+		c.JSON(200, gin.H{"status": "healthy"})
+	})
 
 	// Create a buffered channel interrupt and use the signal.
 	rootCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Adds a health check endpoint to the account service and configures a Kubernetes readiness probe to monitor service availability.

- Added a `/health` endpoint in `service/account/router/router.go` that returns a 200 status code with a "healthy" status message.
- Configured a Kubernetes readiness probe in `service/account/deploy/manifests/deploy.yaml.tmpl` that checks the health endpoint every 5 seconds.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
