### PR TITLE
Add support for Bing Ads

### DIFF
--- a/frontend/desktop/src/api/auth.ts
+++ b/frontend/desktop/src/api/auth.ts
@@ -6,6 +6,7 @@ import { RegionResourceType } from '@/services/backend/svc/checkResource';
 import request from '@/services/request';
 import useSessionStore from '@/stores/session';
 import { ApiResp, Region } from '@/types';
+import { AdClickData } from '@/types/adClick';
 import { BIND_STATUS } from '@/types/response/bind';
 import { RESOURCE_STATUS } from '@/types/response/checkResource';
 import { DELETE_USER_STATUS } from '@/types/response/deleteUser';
@@ -35,7 +36,7 @@ export const _passwordLoginRequest =
           password: string;
           inviterId: string | null | undefined;
           semData: SemData | null | undefined;
-          bdVid: string | null | undefined;
+          adClickData: AdClickData | null | undefined;
         }
       | {
           user: string;
@@ -122,7 +123,7 @@ export const _getNewSmsCodeRequest =
 export const _oauthProviderSignIn =
   (request: AxiosInstance) =>
   (provider: ProviderType) =>
-  (data: { code: string; inviterId?: string; semData?: SemData; bdVid?: string }) =>
+  (data: { code: string; inviterId?: string; semData?: SemData; adClickData?: AdClickData }) =>
     request.post<
       typeof data,
       ApiResp<{

--- a/frontend/desktop/src/api/platform.ts
+++ b/frontend/desktop/src/api/platform.ts
@@ -8,18 +8,19 @@ import {
   CommonClientConfigType,
   TNotification
 } from '@/types';
+import { AdClickData } from '@/types/adClick';
 import { UserTask } from '@/types/task';
 
-// handle baidu
-export const uploadConvertData = ({ newType, bdVid }: { newType: number[]; bdVid?: string }) => {
+/**
+ * Upload advertisement conversion data to the platform.
+ * @param data - The ad click data to be uploaded.
+ */
+export const uploadConvertData = (data: AdClickData) => {
   const baseurl = `http://${process.env.HOSTNAME || 'localhost'}:${process.env.PORT || 3000}`;
   const defaultUrl = 'https://ads.sealos.run';
-  if (!bdVid) {
-    return Promise.reject('upload convert data params error');
-  }
+
   return request.post(`${baseurl}/api/platform/uploadData`, {
-    newType,
-    bd_vid: bdVid,
+    data,
     main_url: defaultUrl
   });
 };

--- a/frontend/desktop/src/api/platform.ts
+++ b/frontend/desktop/src/api/platform.ts
@@ -17,11 +17,9 @@ import { UserTask } from '@/types/task';
  */
 export const uploadConvertData = (data: AdClickData) => {
   const baseurl = `http://${process.env.HOSTNAME || 'localhost'}:${process.env.PORT || 3000}`;
-  const defaultUrl = 'https://ads.sealos.run';
 
   return request.post(`${baseurl}/api/platform/uploadData`, {
-    data,
-    main_url: defaultUrl
+    data
   });
 };
 

--- a/frontend/desktop/src/components/signin/auth/usePassword.tsx
+++ b/frontend/desktop/src/components/signin/auth/usePassword.tsx
@@ -8,7 +8,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { jwtDecode } from 'jwt-decode';
 import { AccessTokenPayload } from '@/types/token';
-import { getBaiduId, getInviterId, getUserSemData, sessionConfig } from '@/utils/sessionConfig';
+import { getAdClickData, getInviterId, getUserSemData, sessionConfig } from '@/utils/sessionConfig';
 import { I18nCommonKey } from '@/types/i18next';
 import { SemData } from '@/types/sem';
 
@@ -47,7 +47,7 @@ export default function usePassword({
           try {
             setIsLoading(true);
             const inviterId = getInviterId();
-            const bdVid = getBaiduId();
+            const adClickData = getAdClickData();
             const semData: SemData | null = getUserSemData();
 
             const result = await passwordExistRequest({ user: data.username });
@@ -58,7 +58,7 @@ export default function usePassword({
                 password: data.password,
                 inviterId,
                 semData,
-                bdVid
+                adClickData
               });
               if (!!result?.data) {
                 await sessionConfig(result.data);
@@ -77,7 +77,7 @@ export default function usePassword({
                     password: data.password,
                     inviterId,
                     semData,
-                    bdVid
+                    adClickData
                   });
                   if (!!regionResult?.data) {
                     setToken(regionResult.data.token);

--- a/frontend/desktop/src/components/signin/auth/useSms.tsx
+++ b/frontend/desktop/src/components/signin/auth/useSms.tsx
@@ -16,7 +16,7 @@ import { useRouter } from 'next/router';
 import { MouseEvent, MouseEventHandler, useCallback, useEffect, useRef, useState } from 'react';
 import { get, useForm } from 'react-hook-form';
 import { getRegionToken } from '@/api/auth';
-import { getBaiduId, getInviterId, getUserSemData, sessionConfig } from '@/utils/sessionConfig';
+import { getAdClickData, getInviterId, getUserSemData, sessionConfig } from '@/utils/sessionConfig';
 import { I18nCommonKey } from '@/types/i18next';
 import { useConfigStore } from '@/stores/config';
 import useSmsStateStore from '@/stores/captcha';
@@ -59,7 +59,7 @@ export default function useSms({
               code: data.verifyCode,
               inviterId: data?.inviterId || getInviterId(),
               semData: getUserSemData(),
-              bdVid: getBaiduId()
+              adClickData: getAdClickData()
             }
           );
           const globalToken = result1?.data?.token;

--- a/frontend/desktop/src/components/v2/PhoneCheck.tsx
+++ b/frontend/desktop/src/components/v2/PhoneCheck.tsx
@@ -23,7 +23,7 @@ import useSessionStore from '@/stores/session';
 import { useMutation } from '@tanstack/react-query';
 import request from '@/services/request';
 import { ApiResp } from '@/types';
-import { getBaiduId, getInviterId, getUserSemData, sessionConfig } from '@/utils/sessionConfig';
+import { getAdClickData, getInviterId, getUserSemData, sessionConfig } from '@/utils/sessionConfig';
 import { HiddenCaptchaComponent, TCaptchaInstance } from '../signin/Captcha';
 import { useConfigStore } from '@/stores/config';
 import useCustomError from '../signin/auth/useCustomError';
@@ -64,7 +64,7 @@ export default function PhoneCheckComponent() {
         code: data.code,
         inviterId: getInviterId(),
         semData: getUserSemData(),
-        bdVid: getBaiduId()
+        adClickData: getAdClickData()
       }),
     async onSuccess(result) {
       const globalToken = result.data?.token;

--- a/frontend/desktop/src/pages/api/auth/oauth/github/index.ts
+++ b/frontend/desktop/src/pages/api/auth/oauth/github/index.ts
@@ -14,7 +14,7 @@ export default ErrorHandler(async function handler(req: NextApiRequest, res: Nex
   if (!enableGithub()) {
     throw new Error('github clinet is not defined');
   }
-  await OauthCodeFilter(req, res, async ({ code, inviterId, semData, bdVid }) => {
+  await OauthCodeFilter(req, res, async ({ code, inviterId, semData, adClickData }) => {
     await githubOAuthEnvFilter()(async ({ clientID, clientSecret }) => {
       await githubOAuthGuard(
         clientID,
@@ -41,7 +41,7 @@ export default ErrorHandler(async function handler(req: NextApiRequest, res: Nex
           email,
           inviterId,
           semData,
-          bdVid,
+          adClickData,
           providerType: 'GITHUB'
         })(req, res);
       });

--- a/frontend/desktop/src/pages/api/auth/oauth/google/index.ts
+++ b/frontend/desktop/src/pages/api/auth/oauth/google/index.ts
@@ -15,7 +15,7 @@ export default ErrorHandler(async function handler(req: NextApiRequest, res: Nex
   await OauthCodeFilter(
     req,
     res,
-    async ({ code, inviterId, semData, bdVid }) =>
+    async ({ code, inviterId, semData, adClickData }) =>
       await googleOAuthEnvFilter()(async ({ clientID, clientSecret, callbackURL }) => {
         await googleOAuthGuard(
           clientID,
@@ -41,7 +41,7 @@ export default ErrorHandler(async function handler(req: NextApiRequest, res: Nex
             email,
             inviterId,
             semData,
-            bdVid,
+            adClickData,
             providerType: 'GOOGLE'
           })(req, res);
         });

--- a/frontend/desktop/src/pages/api/auth/oauth/oauth2/index.ts
+++ b/frontend/desktop/src/pages/api/auth/oauth/oauth2/index.ts
@@ -18,7 +18,7 @@ export default ErrorHandler(async function handler(req: NextApiRequest, res: Nex
   if (!enableOAuth2() || !redirectUrl) {
     throw new Error('District related env');
   }
-  const { code, inviterId, semData, bdVid } = req.body;
+  const { code, inviterId, semData, adClickData } = req.body;
   const url = `${tokenUrl}`;
   const oauth2Data = (await (
     await fetch(url, {
@@ -69,7 +69,7 @@ export default ErrorHandler(async function handler(req: NextApiRequest, res: Nex
     name,
     inviterId,
     semData,
-    bdVid
+    adClickData
   });
 
   if (data?.isRestricted) {

--- a/frontend/desktop/src/pages/api/auth/oauth/wechat/index.ts
+++ b/frontend/desktop/src/pages/api/auth/oauth/wechat/index.ts
@@ -15,7 +15,7 @@ export default ErrorHandler(async function handler(req: NextApiRequest, res: Nex
   if (!enableWechat()) {
     throw new Error('wechat clinet is not defined');
   }
-  await OauthCodeFilter(req, res, async ({ code, inviterId, semData, bdVid }) => {
+  await OauthCodeFilter(req, res, async ({ code, inviterId, semData, adClickData }) => {
     await wechatOAuthEnvFilter()(async ({ clientID, clientSecret }) => {
       await wechatOAuthGuard(
         clientID,
@@ -31,7 +31,7 @@ export default ErrorHandler(async function handler(req: NextApiRequest, res: Nex
           name,
           inviterId,
           semData,
-          bdVid,
+          adClickData,
           providerType: 'WECHAT'
         })(req, res);
       });

--- a/frontend/desktop/src/pages/api/auth/password/index.ts
+++ b/frontend/desktop/src/pages/api/auth/password/index.ts
@@ -9,7 +9,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     if (!enablePassword()) {
       throw new Error('PASSWORD_SALT is not defined');
     }
-    const { user: name, password, inviterId, semData, bdVid } = req.body;
+    const { user: name, password, inviterId, semData, adClickData } = req.body;
     if (!strongPassword(password)) {
       return jsonRes(res, {
         message:
@@ -25,7 +25,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       name,
       inviterId,
       semData,
-      bdVid
+      adClickData
     });
 
     if (data?.isRestricted) {

--- a/frontend/desktop/src/pages/api/auth/phone/verify.ts
+++ b/frontend/desktop/src/pages/api/auth/phone/verify.ts
@@ -13,7 +13,7 @@ export default ErrorHandler(async function handler(req: NextApiRequest, res: Nex
     await filterPhoneVerifyParams(
       req,
       res,
-      async ({ phoneNumbers, code, inviterId, semData, bdVid }) => {
+      async ({ phoneNumbers, code, inviterId, semData, adClickData }) => {
         await verifyCodeGuard(
           phoneNumbers,
           code,
@@ -25,7 +25,7 @@ export default ErrorHandler(async function handler(req: NextApiRequest, res: Nex
             providerId: phoneInfo.id,
             name: phoneInfo.id,
             semData,
-            bdVid,
+            adClickData,
             inviterId,
             providerType: 'PHONE'
           })(req, res);

--- a/frontend/desktop/src/pages/api/platform/uploadData.ts
+++ b/frontend/desktop/src/pages/api/platform/uploadData.ts
@@ -5,9 +5,8 @@ import { BingAdApiClient } from '@/services/backend/bingAdApiClient';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
-    const { data, main_url } = req.body as {
+    const { data } = req.body as {
       data: AdClickData;
-      main_url: string;
     };
 
     if (data.source === 'Baidu') {
@@ -19,11 +18,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         });
       }
 
+      const mainUrl = 'https://ads.sealos.run';
+
       const url = 'https://ocpc.baidu.com/ocpcapi/api/uploadConvertData';
       const uploadBody = {
         token: BD_TOKEN,
         conversionTypes: data.additionalData.newType.map((item) => ({
-          logidUrl: `${main_url}?bd_vid=${data.clickId}`,
+          logidUrl: `${mainUrl}?bd_vid=${data.clickId}`,
           newType: item
         }))
       };
@@ -38,7 +39,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         })
       ).json();
 
-      console.log('upload baidu ad click data:', data, 'result:', result);
+      console.log('Uploaded baidu AD click data:', data, '\nResult:', result);
 
       return jsonRes(res, {
         data: result
@@ -63,12 +64,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         );
       }
 
-      // Initialized above, it's safe to assert its existence
-      const result = await global.bingAdApiClient!.applyOfflineConversion({
+      const result = await global.bingAdApiClient.applyOfflineConversion({
         name: global.AppConfig.desktop.auth.bingAd.conversionName,
         time: new Date(data.additionalData.timestamp),
         clickId: data.clickId
       });
+
+      console.log('Uploaded Bing AD click data:', data, '\nResult:', result);
 
       return jsonRes(res, {
         data: result

--- a/frontend/desktop/src/pages/api/platform/uploadData.ts
+++ b/frontend/desktop/src/pages/api/platform/uploadData.ts
@@ -44,7 +44,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         data: result
       });
     } else if (data.source === 'Bing') {
-      if (global.AppConfig.desktop.auth.bingAd.enabled === false) {
+      if (!global.AppConfig.desktop.auth.bingAd) {
         return jsonRes(res, {
           data: 'Bing Ads API is not enabled.'
         });

--- a/frontend/desktop/src/pages/api/platform/uploadData.ts
+++ b/frontend/desktop/src/pages/api/platform/uploadData.ts
@@ -1,46 +1,55 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { jsonRes } from '@/services/backend/response';
+import { AdClickData } from '@/types/adClick';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
-    const { newType, bd_vid, main_url } = req.body as {
-      newType: number[];
-      bd_vid: string;
+    const { data, main_url } = req.body as {
+      data: AdClickData;
       main_url: string;
     };
-    const BD_TOKEN = global.AppConfig?.desktop.auth?.baiduToken;
 
-    if (!BD_TOKEN || !bd_vid) {
+    if (data.source === 'Baidu') {
+      const BD_TOKEN = global.AppConfig?.desktop.auth?.baiduToken;
+      if (!BD_TOKEN) {
+        return jsonRes(res, {
+          data: 'Parameter error',
+          code: 400
+        });
+      }
+
+      const url = 'https://ocpc.baidu.com/ocpcapi/api/uploadConvertData';
+      const uploadBody = {
+        token: BD_TOKEN,
+        conversionTypes: data.additionalData.newType.map((item) => ({
+          logidUrl: `${main_url}?bd_vid=${data.clickId}`,
+          newType: item
+        }))
+      };
+
+      const result = await (
+        await fetch(url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify(uploadBody)
+        })
+      ).json();
+
+      console.log('upload baidu ad click data:', data, 'result:', result);
+
       return jsonRes(res, {
-        data: 'Parameter error',
-        code: 400
+        data: result
       });
     }
 
-    const url = 'https://ocpc.baidu.com/ocpcapi/api/uploadConvertData';
-    const logidUrl = `${main_url}?bd_vid=${bd_vid}`;
-
-    const data = {
-      token: BD_TOKEN,
-      conversionTypes: newType.map((item) => ({ logidUrl: logidUrl, newType: item }))
-    };
-
-    const result = await (
-      await fetch(url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(data)
-      })
-    ).json();
-
-    console.log('upload data:', data, 'result:', result);
     jsonRes(res, {
-      data: result
+      data: 'Unsupported AD source.',
+      code: 400
     });
   } catch (error) {
-    console.log('upload data error', error);
+    console.log('upload ad click data error', error);
     jsonRes(res, { code: 500, data: error });
   }
 }

--- a/frontend/desktop/src/pages/callback.tsx
+++ b/frontend/desktop/src/pages/callback.tsx
@@ -5,7 +5,7 @@ import { ApiResp } from '@/types';
 import { Flex, Spinner } from '@chakra-ui/react';
 import { isString } from 'lodash';
 import { bindRequest, getRegionToken, signInRequest, unBindRequest } from '@/api/auth';
-import { getBaiduId, getInviterId, getUserSemData, sessionConfig } from '@/utils/sessionConfig';
+import { getAdClickData, getInviterId, getUserSemData, sessionConfig } from '@/utils/sessionConfig';
 import useCallbackStore, { MergeUserStatus } from '@/stores/callback';
 import { ProviderType } from 'prisma/global/generated/client';
 import request from '@/services/request';
@@ -66,7 +66,7 @@ export default function Callback() {
               code,
               inviterId: getInviterId() ?? undefined,
               semData: getUserSemData() ?? undefined,
-              bdVid: getBaiduId() ?? undefined
+              adClickData: getAdClickData() ?? undefined
             });
             setProvider();
             if (data.code === 200 && data.data?.token) {

--- a/frontend/desktop/src/pages/index.tsx
+++ b/frontend/desktop/src/pages/index.tsx
@@ -10,7 +10,7 @@ import { SemData } from '@/types/sem';
 import { NSType } from '@/types/team';
 import { AccessTokenPayload } from '@/types/token';
 import { parseOpenappQuery } from '@/utils/format';
-import { sessionConfig, setBaiduId, setInviterId, setUserSemData } from '@/utils/sessionConfig';
+import { sessionConfig, setAdClickData, setInviterId, setUserSemData } from '@/utils/sessionConfig';
 import { switchKubeconfigNamespace } from '@/utils/switchKubeconfigNamespace';
 import { compareFirstLanguages } from '@/utils/tools';
 import { Box, useColorMode } from '@chakra-ui/react';
@@ -187,22 +187,31 @@ export default function Home({ sealos_cloud_domain }: { sealos_cloud_domain: str
     swtichWorksapceMutation.mutate(workspaceUid);
   }, [session?.user?.ns_uid, workspaces]);
 
-  // handle baidu
+  // handle page views from ad clicks
   useEffect(() => {
-    const { bd_vid, s, k } = router.query;
+    const { bd_vid, msclkid } = router.query;
+    // Baidu click data
     if (bd_vid) {
-      setBaiduId(bd_vid as string);
-    }
+      setAdClickData({
+        source: 'Baidu',
+        clickId: bd_vid as string,
+        additionalData: {
+          newType: [3]
+        }
+      });
 
-    // handle new user sem source
-    const semData: SemData = { channel: '' };
-    if (s) {
-      semData.channel = s as string;
+      // Baidu SEM data
+      const { s, k } = router.query;
+      // handle new user sem source
+      const semData: SemData = { channel: '' };
+      if (s) {
+        semData.channel = s as string;
+      }
+      if (k) {
+        semData.additionalInfo = { semKeyword: k as string };
+      }
+      setUserSemData(semData);
     }
-    if (k) {
-      semData.additionalInfo = { semKeyword: k as string };
-    }
-    setUserSemData(semData);
   }, []);
 
   // handle workspaceInvite

--- a/frontend/desktop/src/pages/index.tsx
+++ b/frontend/desktop/src/pages/index.tsx
@@ -211,6 +211,15 @@ export default function Home({ sealos_cloud_domain }: { sealos_cloud_domain: str
         semData.additionalInfo = { semKeyword: k as string };
       }
       setUserSemData(semData);
+    } else if (msclkid) {
+      // Bing click data
+      setAdClickData({
+        source: 'Bing',
+        clickId: msclkid as string,
+        additionalData: {
+          timestamp: Date.now()
+        }
+      });
     }
   }, []);
 

--- a/frontend/desktop/src/services/backend/bingAdApiClient.ts
+++ b/frontend/desktop/src/services/backend/bingAdApiClient.ts
@@ -1,0 +1,114 @@
+export class BingAdApiClient {
+  private bearerToken: {
+    accessToken: string;
+    refreshToken: string;
+    expiresAt: number;
+  } | null = null;
+
+  constructor(
+    private tenant: string,
+    private clientId: string,
+    private clientSecret: string,
+    private initialRefreshToken: string,
+    private developerToken: string,
+    private customerId: number,
+    private customerAccountId: number,
+    private conversionName: string
+  ) {
+    console.log('BingAdApiClient initialized with conversion:', conversionName);
+  }
+
+  public async refreshBearerToken() {
+    console.log('Refreshing Bing Ads API bearer token...');
+
+    const refreshToken = this.bearerToken?.refreshToken ?? this.initialRefreshToken;
+    const scope = 'https://ads.microsoft.com/msads.manage offline_access';
+
+    const tokenEndpoint = `https://login.microsoftonline.com/${this.tenant}/oauth2/v2.0/token`;
+
+    const body = new URLSearchParams({
+      client_id: this.clientId,
+      scope,
+      client_secret: this.clientSecret,
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken
+    }).toString();
+
+    const resp = (await (
+      await fetch(tokenEndpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body
+      })
+    ).json()) as
+      | {
+          access_token: string;
+          refresh_token: string;
+          expires_in: number;
+        }
+      | {
+          error: string;
+          error_description: string;
+          error_codes: number[];
+        };
+
+    if ('error' in resp) {
+      throw new Error(
+        `Failed to refresh Bing Ads API token: ${resp.error} - ${resp.error_description}`
+      );
+    }
+
+    this.bearerToken = {
+      accessToken: resp.access_token,
+      refreshToken: resp.refresh_token,
+      expiresAt: Date.now() + resp.expires_in * 1000
+    };
+  }
+
+  public async applyOfflineConversion(conversion: { name: string; time: Date; clickId: string }) {
+    // Refresh the token if it's not set or about to expire (20 minutes before expiration)
+    if (!this.bearerToken || Date.now() >= this.bearerToken.expiresAt - 20 * 60 * 1000) {
+      await this.refreshBearerToken();
+    }
+
+    const endpoint =
+      'https://campaign.api.bingads.microsoft.com/CampaignManagement/v13/OfflineConversions/Apply';
+
+    const body = {
+      OfflineConversions: [
+        {
+          ConversionName: this.conversionName,
+          ConversionTime: conversion.time.toISOString(),
+          MicrosoftClickId: conversion.clickId
+        }
+      ]
+    };
+
+    const resp = (await (
+      await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.bearerToken!.accessToken}`,
+          DeveloperToken: this.developerToken,
+          CustomerId: this.customerId.toString(),
+          CustomerAccountId: this.customerAccountId.toString()
+        },
+        body: JSON.stringify(body)
+      })
+    ).json()) as
+      | { PartialErrors: Array<{ Code: number; Message: string; ErrorCode: string }> }
+      | { Errors: Array<{ Code: number; Message: string; ErrorCode: string }> };
+
+    if ('Errors' in resp) {
+      throw new Error(
+        `Failed to apply Bing AD offline conversion: ` +
+          resp.Errors.map((e) => `${e.Code}: ${e.Message}`).join('\n')
+      );
+    }
+
+    return resp;
+  }
+}

--- a/frontend/desktop/src/services/backend/globalAuth.ts
+++ b/frontend/desktop/src/services/backend/globalAuth.ts
@@ -16,6 +16,7 @@ import { enableSignUp, enableTracking, getRegionUid, getVersion } from '../enabl
 import { trackSignUp } from './tracking';
 import { emit } from 'process';
 import { addOauthProvider, bindEmailSvc } from './svc/bindProvider';
+import { AdClickData } from '@/types/adClick';
 
 type TransactionClient = Omit<
   PrismaClient,
@@ -375,7 +376,7 @@ export const getGlobalToken = async ({
   password,
   inviterId,
   semData,
-  bdVid
+  adClickData
 }: {
   provider: ProviderType;
   providerId: string;
@@ -385,7 +386,7 @@ export const getGlobalToken = async ({
   password?: string;
   inviterId?: string;
   semData?: SemData;
-  bdVid?: string;
+  adClickData?: AdClickData;
 }) => {
   let user: User | null = null;
 
@@ -500,8 +501,8 @@ export const getGlobalToken = async ({
             signResult: result
           });
         }
-        if (bdVid) {
-          await uploadConvertData({ newType: [3], bdVid })
+        if (adClickData) {
+          await uploadConvertData(adClickData)
             .then((res) => {
               console.log(res);
             })

--- a/frontend/desktop/src/services/backend/globalAuth.ts
+++ b/frontend/desktop/src/services/backend/globalAuth.ts
@@ -502,13 +502,7 @@ export const getGlobalToken = async ({
           });
         }
         if (adClickData) {
-          await uploadConvertData(adClickData)
-            .then((res) => {
-              console.log(res);
-            })
-            .catch((err) => {
-              console.log(err);
-            });
+          await uploadConvertData(adClickData);
         }
         if (enableTracking()) {
           await trackSignUp({

--- a/frontend/desktop/src/services/backend/middleware/oauth.ts
+++ b/frontend/desktop/src/services/backend/middleware/oauth.ts
@@ -12,17 +12,23 @@ import { BIND_STATUS } from '@/types/response/bind';
 import { UNBIND_STATUS } from '@/types/response/unbind';
 import { SemData } from '@/types/sem';
 import axios from 'axios';
+import { AdClickData } from '@/types/adClick';
 
 export const OauthCodeFilter = async (
   req: NextApiRequest,
   res: NextApiResponse,
-  next: (data: { code: string; inviterId?: string; semData?: SemData; bdVid?: string }) => void
+  next: (data: {
+    code: string;
+    inviterId?: string;
+    semData?: SemData;
+    adClickData?: AdClickData;
+  }) => void
 ) => {
-  const { code, inviterId, semData, bdVid } = req.body as {
+  const { code, inviterId, semData, adClickData } = req.body as {
     code?: string;
     inviterId?: string;
     semData?: SemData;
-    bdVid?: string;
+    adClickData?: AdClickData;
   };
   if (!code) {
     return jsonRes(res, {
@@ -36,7 +42,7 @@ export const OauthCodeFilter = async (
       code,
       inviterId,
       semData,
-      bdVid
+      adClickData
     })
   );
 };

--- a/frontend/desktop/src/services/backend/middleware/sms.ts
+++ b/frontend/desktop/src/services/backend/middleware/sms.ts
@@ -15,6 +15,7 @@ import { captchaReq } from '../sms';
 import { isDisposableEmail } from 'disposable-email-domains-js';
 import { createMiddleware } from '@/utils/factory';
 import { HttpStatusCode } from 'axios';
+import { AdClickData } from '@/types/adClick';
 
 export const filterPhoneParams = async (
   req: NextApiRequest,
@@ -50,15 +51,15 @@ export const filterPhoneVerifyParams = (
     code: string;
     inviterId?: string;
     semData?: SemData;
-    bdVid?: string;
+    adClickData?: AdClickData;
   }) => void
 ) =>
   filterPhoneParams(req, res, async (data) => {
-    const { code, inviterId, semData, bdVid } = req.body as {
+    const { code, inviterId, semData, adClickData } = req.body as {
       code?: string;
       inviterId?: string;
       semData?: SemData;
-      bdVid?: string;
+      adClickData?: AdClickData;
     };
     if (!code)
       return jsonRes(res, {
@@ -72,7 +73,7 @@ export const filterPhoneVerifyParams = (
         code,
         inviterId,
         semData,
-        bdVid
+        adClickData
       })
     );
   });

--- a/frontend/desktop/src/services/backend/svc/access.ts
+++ b/frontend/desktop/src/services/backend/svc/access.ts
@@ -5,6 +5,7 @@ import { globalPrisma } from '../db/init';
 import { getGlobalToken } from '../globalAuth';
 import { jsonRes } from '../response';
 import { createMiddleware } from '@/utils/factory';
+import { AdClickData } from '@/types/adClick';
 type AuthContext = {
   avatar_url: string;
   providerId: string;
@@ -14,7 +15,7 @@ type AuthContext = {
   password?: string;
   inviterId?: string;
   semData?: SemData;
-  bdVid?: string;
+  adClickData?: AdClickData;
 };
 export const getGlobalTokenSvc = createMiddleware<AuthContext, unknown>(
   async ({ req, res, next, ctx }) => {
@@ -27,7 +28,7 @@ export const getGlobalTokenSvc = createMiddleware<AuthContext, unknown>(
       inviterId: ctx.inviterId,
       password: ctx.password,
       semData: ctx.semData,
-      bdVid: ctx.bdVid
+      adClickData: ctx.adClickData
     });
 
     if (data?.isRestricted) {

--- a/frontend/desktop/src/types/adClick.ts
+++ b/frontend/desktop/src/types/adClick.ts
@@ -1,0 +1,16 @@
+export type AdClickData = {
+  clickId: string;
+} & (
+  | {
+      source: 'Baidu';
+      additionalData: {
+        newType: number[];
+      };
+    }
+  | {
+      source: 'Bing';
+      additionalData: {
+        timestamp: number;
+      };
+    }
+);

--- a/frontend/desktop/src/types/index.ts
+++ b/frontend/desktop/src/types/index.ts
@@ -4,6 +4,7 @@ import { type MongoClient } from 'mongodb';
 import { Transporter } from 'nodemailer';
 import SMTPPool from 'nodemailer/lib/smtp-pool';
 import { type AppConfigType } from './system';
+import { BingAdApiClient } from '@/services/backend/bingAdApiClient';
 export * from './api';
 export * from './app';
 export * from './crd';
@@ -26,4 +27,5 @@ declare global {
   var nodemailer: Transporter<SMTPPool.SentMessageInfo> | undefined;
   var umami: Umami | undefined;
   var dataLayer: { push: Function } | null;
+  var bingAdApiClient: BingAdApiClient | null;
 }

--- a/frontend/desktop/src/types/system.ts
+++ b/frontend/desktop/src/types/system.ts
@@ -90,8 +90,7 @@ export type AuthConfigType = {
   callbackURL: string;
   signUpEnabled?: boolean;
   baiduToken?: string;
-  bingAd: {
-    enabled: boolean;
+  bingAd?: {
     tenant: string;
     clientId: string;
     clientSecret: string;
@@ -201,6 +200,7 @@ export type AuthClientConfigType = {
     AuthConfigType,
     [
       'baiduToken',
+      'bingAd',
       'signUpEnabled',
       'invite.lafSecretKey',
       'invite.lafBaseURL',

--- a/frontend/desktop/src/types/system.ts
+++ b/frontend/desktop/src/types/system.ts
@@ -90,6 +90,17 @@ export type AuthConfigType = {
   callbackURL: string;
   signUpEnabled?: boolean;
   baiduToken?: string;
+  bingAd: {
+    enabled: boolean;
+    tenant: string;
+    clientId: string;
+    clientSecret: string;
+    refreshToken: string;
+    developerToken: string;
+    customerId: number;
+    customerAccountId: number;
+    conversionName: string;
+  };
   hasBaiduToken?: boolean;
   jwt: JwtConfigType;
   billingUrl?: string;

--- a/frontend/desktop/src/utils/sessionConfig.ts
+++ b/frontend/desktop/src/utils/sessionConfig.ts
@@ -3,6 +3,7 @@ import { jwtDecode } from 'jwt-decode';
 import { AccessTokenPayload } from '@/types/token';
 import useSessionStore from '@/stores/session';
 import { SemData } from '@/types/sem';
+import { AdClickData } from '@/types/adClick';
 
 export const sessionConfig = async ({
   token,
@@ -52,6 +53,15 @@ export const setUserSemData = (data: SemData): void => {
   localStorage.setItem('sealos_sem', JSON.stringify(data));
 };
 
-export const getBaiduId = () => localStorage.getItem('bd_vid');
+export const getAdClickData = (): AdClickData | null => {
+  const adClickString = localStorage.getItem('ad_click');
+  if (adClickString) {
+    return JSON.parse(adClickString);
+  }
 
-export const setBaiduId = (id: string) => localStorage.setItem('bd_vid', id);
+  return null;
+};
+
+export const setAdClickData = (data: AdClickData) => {
+  localStorage.setItem('ad_click', JSON.stringify(data));
+};


### PR DESCRIPTION
Added support for Bing Ads.

A `BingAdApiClient` instance is created and mounted to the `global` object when the first Bing AD conversion is being uploaded.

The following config entries is required for using Bing AD service:
```plaintext
desktop.auth.bingAd.tenant
desktop.auth.bingAd.clientId
desktop.auth.bingAd.clientSecret
desktop.auth.bingAd.refreshToken
desktop.auth.bingAd.developerToken
desktop.auth.bingAd.customerId
desktop.auth.bingAd.customerAccountId
desktop.auth.bingAd.conversionName
```

New access tokens will be obtained if its lifetime is less than 20 minutes. The lifetime check happens before API calls only.