### PR TITLE
feat(desktop): handle sem params on signin page

### DIFF
--- a/frontend/desktop/src/hooks/useSemParams.ts
+++ b/frontend/desktop/src/hooks/useSemParams.ts
@@ -1,0 +1,54 @@
+import { AdClickData } from '@/types/adClick';
+import { SemData } from '@/types/sem';
+import { useRouter } from 'next/router';
+
+type SemParams = {
+  adClickData?: AdClickData;
+  semData?: SemData;
+};
+
+export function useSemParams(): SemParams {
+  const router = useRouter();
+
+  // handle page views from ad clicks
+  const { bd_vid, msclkid } = router.query;
+  let adClickData: AdClickData | undefined = undefined;
+
+  // Baidu click data
+  if (bd_vid) {
+    adClickData = {
+      source: 'Baidu',
+      clickId: bd_vid as string,
+      additionalData: {
+        newType: [3]
+      }
+    };
+  } else if (msclkid) {
+    // Bing click data
+    adClickData = {
+      source: 'Bing',
+      clickId: msclkid as string,
+      additionalData: {
+        timestamp: Date.now()
+      }
+    };
+  }
+
+  // handle new user sem source
+  const { search, s, k } = router.query;
+  const semData: SemData = { channel: '', additionalInfo: {} };
+  if (search) {
+    semData.additionalInfo.searchEngine = search as string;
+  }
+  if (s) {
+    semData.channel = s as string;
+  }
+  if (k) {
+    semData.additionalInfo.semKeyword = k as string;
+  }
+
+  return {
+    adClickData,
+    semData
+  };
+}

--- a/frontend/desktop/src/pages/index.tsx
+++ b/frontend/desktop/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import { nsListRequest, switchRequest } from '@/api/namespace';
 import DesktopContent from '@/components/desktop_content';
 import { trackEventName } from '@/constants/account';
+import { useSemParams } from '@/hooks/useSemParams';
 import useAppStore from '@/stores/app';
 import useCallbackStore from '@/stores/callback';
 import { useConfigStore } from '@/stores/config';
@@ -187,45 +188,17 @@ export default function Home({ sealos_cloud_domain }: { sealos_cloud_domain: str
     swtichWorksapceMutation.mutate(workspaceUid);
   }, [session?.user?.ns_uid, workspaces]);
 
-  // handle page views from ad clicks
+  // Grab params from ad clicks and store in local storage
+  const { adClickData, semData } = useSemParams();
   useEffect(() => {
-    const { bd_vid, msclkid } = router.query;
-
-    // Baidu click data
-    if (bd_vid) {
-      setAdClickData({
-        source: 'Baidu',
-        clickId: bd_vid as string,
-        additionalData: {
-          newType: [3]
-        }
-      });
-    } else if (msclkid) {
-      // Bing click data
-      setAdClickData({
-        source: 'Bing',
-        clickId: msclkid as string,
-        additionalData: {
-          timestamp: Date.now()
-        }
-      });
+    if (adClickData) {
+      setAdClickData(adClickData);
     }
 
-    // handle new user sem source
-    const { search, s, k } = router.query;
-    const semData: SemData = { channel: '', additionalInfo: {} };
-    if (search) {
-      semData.additionalInfo.searchEngine = search as string;
+    if (semData) {
+      setUserSemData(semData);
     }
-    if (s) {
-      semData.channel = s as string;
-    }
-    if (k) {
-      semData.additionalInfo.semKeyword = k as string;
-    }
-
-    setUserSemData(semData);
-  }, []);
+  });
 
   // handle workspaceInvite
   useEffect(() => {

--- a/frontend/desktop/src/pages/signin.tsx
+++ b/frontend/desktop/src/pages/signin.tsx
@@ -12,6 +12,8 @@ import useScriptStore from '@/stores/script';
 import SignLayout from '@/components/v2/SignLayout';
 import LangSelectSimple from '@/components/LangSelect/simple';
 import SigninComponent from '@/components/v2/Sign';
+import { useSemParams } from '@/hooks/useSemParams';
+import { setAdClickData, setUserSemData } from '@/utils/sessionConfig';
 
 export default function SigninPage() {
   const { layoutConfig, authConfig } = useConfigStore();
@@ -24,6 +26,18 @@ export default function SigninPage() {
       window.location.replace(url);
     }
   }, []);
+
+  // Grab params from ad clicks and store in local storage
+  const { adClickData, semData } = useSemParams();
+  useEffect(() => {
+    if (adClickData) {
+      setAdClickData(adClickData);
+    }
+
+    if (semData) {
+      setUserSemData(semData);
+    }
+  });
 
   return (
     <Box>


### PR DESCRIPTION
Our marketing landing page redirects user to `/signin`, so we need to handle SEM params there.