### PR TITLE
fix(desktop): gtm signup event not fired in phone check process

### DIFF
--- a/frontend/desktop/src/components/v2/EmailCheck.tsx
+++ b/frontend/desktop/src/components/v2/EmailCheck.tsx
@@ -75,19 +75,18 @@ export default function EmailCheckComponent() {
       const globalToken = result.data?.token;
       if (!globalToken) throw Error();
       setToken(globalToken);
-      const method = 'email';
       if (result.data?.needInit) {
         gtmLoginSuccess({
           user_type: 'new',
-          method
+          method: 'email'
         });
         await router.push('/workspace');
       } else {
         const regionTokenRes = await getRegionToken();
         if (regionTokenRes?.data) {
           gtmLoginSuccess({
-            user_type: 'returning',
-            method
+            user_type: 'existing',
+            method: 'email'
           });
           await sessionConfig(regionTokenRes.data);
           await router.replace('/');

--- a/frontend/desktop/src/components/v2/PhoneCheck.tsx
+++ b/frontend/desktop/src/components/v2/PhoneCheck.tsx
@@ -28,6 +28,7 @@ import { HiddenCaptchaComponent, TCaptchaInstance } from '../signin/Captcha';
 import { useConfigStore } from '@/stores/config';
 import useCustomError from '../signin/auth/useCustomError';
 import useScriptStore from '@/stores/script';
+import { gtmLoginSuccess } from '@/utils/gtm';
 
 export default function PhoneCheckComponent() {
   const router = useRouter();
@@ -160,8 +161,16 @@ export default function PhoneCheckComponent() {
       if (!globalToken) throw Error();
       setToken(globalToken);
       if (result.data?.needInit) {
+        gtmLoginSuccess({
+          user_type: 'new',
+          method: 'phone'
+        });
         await router.push('/workspace');
       } else {
+        gtmLoginSuccess({
+          user_type: 'existing',
+          method: 'phone'
+        });
         const regionTokenRes = await getRegionToken();
         if (regionTokenRes?.data) {
           await sessionConfig(regionTokenRes.data);

--- a/frontend/desktop/src/pages/callback.tsx
+++ b/frontend/desktop/src/pages/callback.tsx
@@ -73,20 +73,20 @@ export default function Callback() {
               const token = data.data?.token;
               setToken(token);
               const needInit = data.data.needInit;
-              const method =
-                provider === 'GITHUB' ? 'github' : provider === 'GOOGLE' ? 'gmail' : 'unknown';
 
               if (needInit) {
                 gtmLoginSuccess({
                   user_type: 'new',
-                  method
+                  method: 'oauth2',
+                  oauth2Provider: provider
                 });
                 await router.push('/workspace');
                 return;
               }
               gtmLoginSuccess({
-                user_type: 'returning',
-                method
+                user_type: 'existing',
+                method: 'oauth2',
+                oauth2Provider: provider
               });
               const regionTokenRes = await getRegionToken();
               if (regionTokenRes?.data) {

--- a/frontend/desktop/src/utils/gtm.ts
+++ b/frontend/desktop/src/utils/gtm.ts
@@ -6,14 +6,17 @@ export const gtmLoginStart = () =>
   });
 export const gtmLoginSuccess = ({
   method,
+  oauth2Provider,
   user_type
 }: {
-  method: 'email' | 'gmail' | 'github' | 'unknown';
-  user_type: 'new' | 'returning';
+  method: 'phone' | 'email' | 'oauth2';
+  oauth2Provider?: string;
+  user_type: 'new' | 'existing';
 }) =>
   window?.dataLayer?.push({
     event: 'login_success',
     method,
+    oauth2_provider: oauth2Provider,
     user_type,
     module: 'auth',
     context: 'app'


### PR DESCRIPTION
`signin_success` event:

```ts
{
  event: 'login_success';
  method: 'phone' | 'email' | 'oauth2';
  oauth2Provider?: string;
  user_type: 'new' | 'existing';
  module: 'auth';
  context: 'app';
}
```