### PR TITLE
fix(main): validate kubeadm config files before pulling images

### DIFF
--- a/.github/workflows/e2e_test_core.yml
+++ b/.github/workflows/e2e_test_core.yml
@@ -52,6 +52,10 @@ jobs:
             E2E_sealos_runtime_version_126_test,
             E2E_sealos_runtime_version_127_test,
             E2E_sealos_runtime_version_128_test,
+            E2E_sealos_runtime_version_129_test,
+            E2E_sealos_runtime_version_130_test,
+            E2E_sealos_runtime_version_131_test,
+            E2E_sealos_runtime_version_132_test,
             E2E_sealos_runtime_version_docker_122_test,
             E2E_sealos_runtime_version_docker_123_test,
             E2E_sealos_runtime_version_docker_124_test,
@@ -59,6 +63,10 @@ jobs:
             E2E_sealos_runtime_version_docker_126_test,
             E2E_sealos_runtime_version_docker_127_test,
             E2E_sealos_runtime_version_docker_128_test
+            E2E_sealos_runtime_version_docker_129_test,
+            E2E_sealos_runtime_version_docker_130_test,
+            E2E_sealos_runtime_version_docker_131_test,
+            E2E_sealos_runtime_version_docker_132_test,
           ]
     runs-on: ubuntu-24.04
     steps:

--- a/lifecycle/pkg/runtime/kubernetes/master.go
+++ b/lifecycle/pkg/runtime/kubernetes/master.go
@@ -18,11 +18,17 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strings"
+
+	"github.com/labring/sreg/pkg/registry/crane"
+	"k8s.io/apimachinery/pkg/util/json"
+
+	"github.com/labring/sealos/pkg/registry/helpers"
 
 	"github.com/labring/sealos/pkg/ssh"
 	"github.com/labring/sealos/pkg/utils/file"
 	"github.com/labring/sealos/pkg/utils/logger"
-	"github.com/labring/sealos/pkg/utils/strings"
+	str2 "github.com/labring/sealos/pkg/utils/strings"
 
 	"golang.org/x/sync/errgroup"
 )
@@ -48,30 +54,41 @@ func (k *KubeadmRuntime) imagePull(hostAndPort, version string) error {
 	if version == "" {
 		version = k.getKubeVersion()
 	}
-	initConfigPath := k.getInitMasterKubeadmConfigFilePath()
-	joinMasterConfigPath := path.Join(k.pathResolver.ConfigsPath(), defaultJoinMasterKubeadmFileName)
-	joinNodeConfigPath := path.Join(k.pathResolver.ConfigsPath(), defaultJoinNodeKubeadmFileName)
-	updateClusterConfigPath := path.Join(k.pathResolver.ConfigsPath(), defaultUpdateKubeadmFileName)
-	if !file.IsExist(initConfigPath) && !file.IsExist(joinMasterConfigPath) && !file.IsExist(joinNodeConfigPath) && !file.IsExist(updateClusterConfigPath) {
-		return fmt.Errorf("kubeadm config files not found, please check if the kubeadm configs are generated")
+	type Images struct {
+		Images []string `json:"images"`
 	}
-	configFiles := []string{
-		initConfigPath,
-		joinMasterConfigPath,
-		joinNodeConfigPath,
-		updateClusterConfigPath,
+	imageList := fmt.Sprintf("kubeadm config images list --kubernetes-version %s -o json 2>/dev/null", version)
+	listJson, err := k.sshCmdToString(hostAndPort, imageList)
+	if err != nil {
+		return fmt.Errorf("get kubeadm images list failed, error: %s", err.Error())
 	}
-	var configFlag string
-	for _, configFile := range configFiles {
-		if file.IsExist(configFile) {
-			configFlag = fmt.Sprintf("--config %s ", configFile)
+	var images Images
+	if err = json.Unmarshal([]byte(listJson), &images); err != nil {
+		return fmt.Errorf("unmarshal kubeadm images list failed, json: %s, error: %s", listJson, err.Error())
+	}
+	var newImageList []string
+	registry := helpers.GetRegistryInfo(k.execer, k.pathResolver.RootFSPath(), k.cluster.GetRegistryIPAndPort())
+	for _, image := range images.Images {
+		image = strings.TrimSpace(image)
+		if image == "" {
+			continue
+		}
+		regAddr := crane.GetRegistryDomain(image)
+		if regAddr != "" {
+			image = strings.Replace(image, regAddr, fmt.Sprintf("%s:%s", registry.Domain, registry.Port), 1)
+			newImageList = append(newImageList, image)
 		}
 	}
-	imagePull := fmt.Sprintf("kubeadm config images pull %s  --kubernetes-version %s %s", configFlag, version, vlogToStr(k.klogLevel))
-	err := k.sshCmdAsync(hostAndPort, imagePull)
-	if err != nil {
-		return fmt.Errorf("master pull image failed, error: %s", err.Error())
+	logger.Info("start to pull images: %s", strings.Join(newImageList, ", "))
+
+	for _, image := range newImageList {
+		imagePullCmd := fmt.Sprintf("crictl pull %s", image)
+		if err := k.sshCmdAsync(hostAndPort, imagePullCmd); err != nil {
+			return fmt.Errorf("pull image %s failed, error: %s", image, err.Error())
+		}
+		logger.Info("succeeded in pulling image %s", image)
 	}
+
 	return nil
 }
 
@@ -174,7 +191,7 @@ func (k *KubeadmRuntime) joinMasters(masters []string) error {
 }
 
 func (k *KubeadmRuntime) SyncNodeIPVS(mastersIPList, nodeIPList []string) error {
-	return k.syncNodeIPVSYaml(strings.RemoveDuplicate(mastersIPList), nodeIPList)
+	return k.syncNodeIPVSYaml(str2.RemoveDuplicate(mastersIPList), nodeIPList)
 }
 
 func (k *KubeadmRuntime) deleteMasters(masters []string) error {
@@ -200,7 +217,7 @@ func (k *KubeadmRuntime) deleteMasters(masters []string) error {
 func (k *KubeadmRuntime) deleteMaster(master string) error {
 	return k.resetNode(master, func() {
 		//remove master
-		masterIPs := strings.RemoveFromSlice(k.getMasterIPList(), master)
+		masterIPs := str2.RemoveFromSlice(k.getMasterIPList(), master)
 		if len(masterIPs) > 0 {
 			// TODO: do we need draining first?
 			if err := k.removeNode(master); err != nil {

--- a/lifecycle/test/e2e/k8s_129_test.go
+++ b/lifecycle/test/e2e/k8s_129_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2023 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/labring/sealos/test/e2e/suites/operators"
+	"github.com/labring/sealos/test/e2e/testhelper/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("E2E_sealos_runtime_version_129_test", func() {
+	var (
+		fakeClient *operators.FakeClient
+		err        error
+	)
+	fakeClient = operators.NewFakeClient("")
+
+	Context("sealos run for many version", func() {
+		It("sealos apply single by containerd v1.29.0", func() {
+			images := []string{"labring/kubernetes:v1.29.0"}
+			defer func() {
+				err = fakeClient.Cluster.Reset()
+				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))
+			}()
+			err = fakeClient.Cluster.Run(images...)
+			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+			err = checkVersionImageList(fakeClient)
+			utils.CheckErr(err, fmt.Sprintf("failed to check version image list: %v", err))
+		})
+	})
+
+})

--- a/lifecycle/test/e2e/k8s_130_test.go
+++ b/lifecycle/test/e2e/k8s_130_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2023 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/labring/sealos/test/e2e/suites/operators"
+	"github.com/labring/sealos/test/e2e/testhelper/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("E2E_sealos_runtime_version_130_test", func() {
+	var (
+		fakeClient *operators.FakeClient
+		err        error
+	)
+	fakeClient = operators.NewFakeClient("")
+
+	Context("sealos run for many version", func() {
+		It("sealos apply single by containerd v1.30.0", func() {
+			images := []string{"labring/kubernetes:v1.30.0"}
+			defer func() {
+				err = fakeClient.Cluster.Reset()
+				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))
+			}()
+			err = fakeClient.Cluster.Run(images...)
+			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+			err = checkVersionImageList(fakeClient)
+			utils.CheckErr(err, fmt.Sprintf("failed to check version image list: %v", err))
+		})
+	})
+
+})

--- a/lifecycle/test/e2e/k8s_131_test.go
+++ b/lifecycle/test/e2e/k8s_131_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2023 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/labring/sealos/test/e2e/suites/operators"
+	"github.com/labring/sealos/test/e2e/testhelper/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("E2E_sealos_runtime_version_131_test", func() {
+	var (
+		fakeClient *operators.FakeClient
+		err        error
+	)
+	fakeClient = operators.NewFakeClient("")
+
+	Context("sealos run for many version", func() {
+		It("sealos apply single by containerd v1.31.0", func() {
+			images := []string{"labring/kubernetes:v1.31.0"}
+			defer func() {
+				err = fakeClient.Cluster.Reset()
+				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))
+			}()
+			err = fakeClient.Cluster.Run(images...)
+			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+			err = checkVersionImageList(fakeClient)
+			utils.CheckErr(err, fmt.Sprintf("failed to check version image list: %v", err))
+		})
+	})
+
+})

--- a/lifecycle/test/e2e/k8s_132_test.go
+++ b/lifecycle/test/e2e/k8s_132_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2023 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/labring/sealos/test/e2e/suites/operators"
+	"github.com/labring/sealos/test/e2e/testhelper/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("E2E_sealos_runtime_version_132_test", func() {
+	var (
+		fakeClient *operators.FakeClient
+		err        error
+	)
+	fakeClient = operators.NewFakeClient("")
+
+	Context("sealos run for many version", func() {
+		It("sealos apply single by containerd v1.32.0", func() {
+			images := []string{"labring/kubernetes:v1.32.0"}
+			defer func() {
+				err = fakeClient.Cluster.Reset()
+				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))
+			}()
+			err = fakeClient.Cluster.Run(images...)
+			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+			err = checkVersionImageList(fakeClient)
+			utils.CheckErr(err, fmt.Sprintf("failed to check version image list: %v", err))
+		})
+	})
+
+})

--- a/lifecycle/test/e2e/k8s_docker_129_test.go
+++ b/lifecycle/test/e2e/k8s_docker_129_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2023 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/labring/sealos/test/e2e/suites/operators"
+	"github.com/labring/sealos/test/e2e/testhelper/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("E2E_sealos_runtime_version_docker_129_test", func() {
+	var (
+		fakeClient *operators.FakeClient
+		err        error
+	)
+	fakeClient = operators.NewFakeClient("")
+
+	Context("sealos run for many version", func() {
+		It("sealos apply single by docker v1.29.0", func() {
+			images := []string{"labring/kubernetes-docker:v1.29.0"}
+			defer func() {
+				err = fakeClient.Cluster.Reset()
+				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))
+			}()
+			err = fakeClient.Cluster.Run(images...)
+			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+			err = checkVersionImageList(fakeClient)
+			utils.CheckErr(err, fmt.Sprintf("failed to check version image list: %v", err))
+		})
+	})
+
+})

--- a/lifecycle/test/e2e/k8s_docker_130_test.go
+++ b/lifecycle/test/e2e/k8s_docker_130_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2023 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/labring/sealos/test/e2e/suites/operators"
+	"github.com/labring/sealos/test/e2e/testhelper/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("E2E_sealos_runtime_version_docker_130_test", func() {
+	var (
+		fakeClient *operators.FakeClient
+		err        error
+	)
+	fakeClient = operators.NewFakeClient("")
+
+	Context("sealos run for many version", func() {
+		It("sealos apply single by docker v1.30.0", func() {
+			images := []string{"labring/kubernetes-docker:v1.30.0"}
+			defer func() {
+				err = fakeClient.Cluster.Reset()
+				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))
+			}()
+			err = fakeClient.Cluster.Run(images...)
+			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+			err = checkVersionImageList(fakeClient)
+			utils.CheckErr(err, fmt.Sprintf("failed to check version image list: %v", err))
+		})
+	})
+
+})

--- a/lifecycle/test/e2e/k8s_docker_131_test.go
+++ b/lifecycle/test/e2e/k8s_docker_131_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2023 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/labring/sealos/test/e2e/suites/operators"
+	"github.com/labring/sealos/test/e2e/testhelper/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("E2E_sealos_runtime_version_docker_131_test", func() {
+	var (
+		fakeClient *operators.FakeClient
+		err        error
+	)
+	fakeClient = operators.NewFakeClient("")
+
+	Context("sealos run for many version", func() {
+		It("sealos apply single by docker v1.31.0", func() {
+			images := []string{"labring/kubernetes-docker:v1.31.0"}
+			defer func() {
+				err = fakeClient.Cluster.Reset()
+				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))
+			}()
+			err = fakeClient.Cluster.Run(images...)
+			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+			err = checkVersionImageList(fakeClient)
+			utils.CheckErr(err, fmt.Sprintf("failed to check version image list: %v", err))
+		})
+	})
+
+})

--- a/lifecycle/test/e2e/k8s_docker_132_test.go
+++ b/lifecycle/test/e2e/k8s_docker_132_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2023 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/labring/sealos/test/e2e/suites/operators"
+	"github.com/labring/sealos/test/e2e/testhelper/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("E2E_sealos_runtime_version_docker_132_test", func() {
+	var (
+		fakeClient *operators.FakeClient
+		err        error
+	)
+	fakeClient = operators.NewFakeClient("")
+
+	Context("sealos run for many version", func() {
+		It("sealos apply single by docker v1.32.0", func() {
+			images := []string{"labring/kubernetes-docker:v1.32.0"}
+			defer func() {
+				err = fakeClient.Cluster.Reset()
+				utils.CheckErr(err, fmt.Sprintf("failed to reset cluster run: %v", err))
+			}()
+			err = fakeClient.Cluster.Run(images...)
+			utils.CheckErr(err, fmt.Sprintf("failed to run images %v: %v", images, err))
+			err = checkVersionImageList(fakeClient)
+			utils.CheckErr(err, fmt.Sprintf("failed to check version image list: %v", err))
+		})
+	})
+
+})


### PR DESCRIPTION
This pull request introduces updates to the `sealos` project, including enhancements to Kubernetes image pulling logic, the addition of new E2E test cases for Kubernetes versions, and improvements to code structure. Below is a summary of the most important changes:

### Kubernetes Image Pulling Enhancements:
* Refactored the `imagePull` method in `lifecycle/pkg/runtime/kubernetes/master.go` to dynamically fetch and modify Kubernetes image lists before pulling them. This includes parsing image lists in JSON format, replacing registry domains, and using `crictl` for pulling images.
* Introduced new imports for handling JSON parsing and registry domain management, such as `k8s.io/apimachinery/pkg/util/json` and `github.com/labring/sreg/pkg/registry/crane`.

### E2E Test Additions:
* Added E2E test cases for Kubernetes versions `v1.29.0`, `v1.30.0`, `v1.31.0`, and `v1.32.0` for both `containerd` and `docker` runtimes. These tests verify cluster creation, image application, and cleanup processes. [[1]](diffhunk://#diff-9c13458ec8c519175e8739ac7db0dee134bd86e9e64ebdc2dd0f0dfec595fce7R1-R49) [[2]](diffhunk://#diff-94e0998d03ea59c8a9de979a062b11451fdd634a93a5ec5ac914eb9ce1466e9dR1-R49) [[3]](diffhunk://#diff-c02876b1e2bce93009f746afb2a2e07676d4b4c0b737465d70c7e2c27e140776R1-R49) [[4]](diffhunk://#diff-a4b0bbbafee58934a2eebaad053e9c4868edef2c3047546edd23b870ddc89ffaR1-R49) [[5]](diffhunk://#diff-a15d15f2ad3d8fa86d363592e169838f746f29f2e95290b03af1b1b085513f76R1-R49) [[6]](diffhunk://#diff-466915f63971dd7d74e390def05ea55bf6ad60ec66a8f7b56a82b32cae58f37fR1-R49) [[7]](diffhunk://#diff-7ec5ba7ccf01b95fff49a86f6b1d7d3d0b7961b9dc3ee7f0b76fac84264f8674R1-R49) [[8]](diffhunk://#diff-d5a135e392f31ce87039dc04b899bc6d6195f53936e7abff1bb004538ffa6901R1-R49)
* Updated the `.github/workflows/e2e_test_core.yml` file to include the new test cases in the CI pipeline.

### Code Structure Improvements:
* Replaced the usage of `strings` utility functions with `str2` (aliased import of `github.com/labring/sealos/pkg/utils/strings`) in `lifecycle/pkg/runtime/kubernetes/master.go` to avoid naming conflicts and improve clarity. [[1]](diffhunk://#diff-adb080595d966a280c1442130d8611e989ed3cf4546aac43fd30a1ba1d524345L158-R194) [[2]](diffhunk://#diff-adb080595d966a280c1442130d8611e989ed3cf4546aac43fd30a1ba1d524345L184-R220)

These changes enhance the functionality, test coverage, and maintainability of the `sealos` project.
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->

<img width="2898" height="412" alt="image" src="https://github.com/user-attachments/assets/fc8d1b21-4ba7-415b-8fde-3dff04060da3" />

#5653 

- [x] The new version does not support the --cri-socket parameter and needs to be adjusted using --config.
- [x] Test version 1.31+ tested.
- [x] Need to test the low version