### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,202 +1,46 @@
+Sealos Commercial Use License v1.0
 
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+(Modified from Apache License 2.0)
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+1. Definitions
 
-   1. Definitions.
+"Licensor": The copyright owner(s) of the Sealos project.
+"Commercial Service": Any service provided to third parties (paid or free) using Sealos source code or derivatives, including public/private cloud offerings.
+"Internal Use": Deployment within an entity’s internal operations without serving third parties.
+2. Grant of License
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+Subject to this license’s terms, Licensor grants You a perpetual, worldwide, non-exclusive, non-transferable, royalty-free license to:
+(a) Use, reproduce, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software;
+(b) Grant sublicenses only for Internal Use or non-Commercial Service purposes.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+3. Commercial Service Restriction
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+3.1 Authorization Requirement
+Any entity utilizing the Software (source code or derivatives) to provide a Commercial Service must obtain explicit written permission from the Licensor.
+3.2 Exemptions
+No additional authorization is required for:
+(a) Internal Use by any entity;
+(b) Non-commercial use by individuals;
+(c) Distribution complying with Apache License 2.0 (where no Commercial Service is involved).
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+4. Trademarks and Attribution
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+(a) Use of "Sealos" or related trademarks requires separate written consent from the Licensor.
+(b) All redistributions must retain original copyright/license notices.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+5. Disclaimer of Warranty (Apache 2.0 Clause)
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+Unless required by applicable law, the Software is provided "AS IS", WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+6. Limitation of Liability (Apache 2.0 Clause)
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+Licensor shall not be liable for any indirect, incidental, or consequential damages arising from use of the Software.
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+7. Conflict Resolution
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+(a) If Section 3 (Commercial Service Restriction) conflicts with other terms, Section 3 shall prevail.
+(b) For all other conflicts, original Apache License 2.0 terms govern.
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+8. Termination
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Breach of Section 3 automatically terminates all rights granted under this license.

--- a/LICENSE
+++ b/LICENSE
@@ -1,46 +1,70 @@
-Sealos Commercial Use License v1.0
 
+Sealos Commercial Use License v1.0
 (Modified from Apache License 2.0)
 
 1. Definitions
 
 "Licensor": The copyright owner(s) of the Sealos project.
-"Commercial Service": Any service provided to third parties (paid or free) using Sealos source code or derivatives, including public/private cloud offerings.
-"Internal Use": Deployment within an entity’s internal operations without serving third parties.
+"Commercial Service": Any service provided to third parties (paid or free) using Sealos source code or derivatives, including public clouds, private clouds, or managed services.
+"Internal Use": Deployment within an entity's operations without serving external third parties.
+"You": The licensee exercising rights under this License.
 2. Grant of License
 
-Subject to this license’s terms, Licensor grants You a perpetual, worldwide, non-exclusive, non-transferable, royalty-free license to:
+Subject to this License, Licensor grants You a perpetual, worldwide, non-exclusive, non-transferable, royalty-free license to:
 (a) Use, reproduce, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software;
-(b) Grant sublicenses only for Internal Use or non-Commercial Service purposes.
+(b) Grant sublicenses only for Internal Use or non-Commercial Service purposes;
+(c) Make, use, offer to sell, sell, import, and otherwise transfer the Work.
 
 3. Commercial Service Restriction
 
 3.1 Authorization Requirement
-Any entity utilizing the Software (source code or derivatives) to provide a Commercial Service must obtain explicit written permission from the Licensor.
+Any entity using the Software (source code or derivatives) to provide Commercial Service must obtain explicit written permission from Licensor.
 3.2 Exemptions
 No additional authorization is required for:
 (a) Internal Use by any entity;
 (b) Non-commercial use by individuals;
-(c) Distribution complying with Apache License 2.0 (where no Commercial Service is involved).
+(c) Distribution complying with Apache License 2.0 terms (where no Commercial Service is involved).
 
-4. Trademarks and Attribution
+4. Redistribution
 
-(a) Use of "Sealos" or related trademarks requires separate written consent from the Licensor.
-(b) All redistributions must retain original copyright/license notices.
+You may reproduce and distribute copies of the Software or derivative works thereof in any medium, provided that:
+(a) You give all recipients a copy of this License;
+(b) You retain all copyright/patent/trademark/disclaimer notices;
+(c) You must cause any modified files to carry prominent notices stating You changed the files;
+(d) All derivative works must include the full text of this License.
 
-5. Disclaimer of Warranty (Apache 2.0 Clause)
+5. Submission of Contributions
 
-Unless required by applicable law, the Software is provided "AS IS", WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+Unless You explicitly state otherwise, any Contribution submitted for inclusion in the Software by You shall be under the terms of this License.
 
-6. Limitation of Liability (Apache 2.0 Clause)
+6. Trademarks
 
-Licensor shall not be liable for any indirect, incidental, or consequential damages arising from use of the Software.
+6.1 This License does not grant permission to use the trade names, trademarks, service marks, or product names of Licensor, except as required for reasonable and customary use in describing the origin of the Software.
+6.2 Use of "Sealos" or related trademarks in connection with Commercial Services requires separate written consent from Licensor.
 
-7. Conflict Resolution
+7. Disclaimer of Warranty
+
+Unless required by applicable law or agreed to in writing, Licensor provides the Software (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Software and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability
+
+In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Software (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Conflict Resolution
 
 (a) If Section 3 (Commercial Service Restriction) conflicts with other terms, Section 3 shall prevail.
 (b) For all other conflicts, original Apache License 2.0 terms govern.
 
-8. Termination
+10. Termination
 
-Breach of Section 3 automatically terminates all rights granted under this license.
+(a) Breach of Section 3 automatically terminates all rights granted under this License.
+(b) Patent litigation against any entity alleging infringement by the Software terminates all patent licenses granted under this License.
+
+11. Additional Provisions
+
+11.1 Jurisdiction
+This License shall be governed by the laws of [Specify Jurisdiction, e.g., "the People's Republic of China"], excluding its conflict-of-law provisions.
+11.2 Audit Rights
+Licensees providing Commercial Services shall maintain accurate usage records and make them available for verification by Licensor upon request.
+11.3 Severability
+If any provision is held unenforceable, the remaining provisions remain in full force.


### PR DESCRIPTION
This pull request replaces the Apache License 2.0 with the Sealos Commercial Use License v1.0 in the `LICENSE` file. The new license introduces specific terms for commercial use, internal use, and redistribution, while retaining some elements of the original Apache License.

### Key Changes:

#### License Update:
* The `LICENSE` file now uses the Sealos Commercial Use License v1.0, which is modified from the Apache License 2.0. The new license includes additional provisions for commercial services, internal use, and trademark usage.

#### Commercial Use Restrictions:
* Entities providing commercial services using the software or its derivatives must obtain explicit written permission from the Licensor. Exemptions are provided for internal use, non-commercial use, and Apache License-compliant distribution when no commercial service is involved.

#### Additional Provisions:
* Introduced specific clauses for conflict resolution, termination upon breach of commercial use terms, jurisdiction, audit rights for commercial services, and severability of license terms.
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
