### PR TITLE
chore: update license to Sealos Commercial Use License v1.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,6 +213,10 @@ Here are some dependents with specific version:
 
 When you develop the sealos project at the local environment, you should use subcommands of Makefile to help yourself to check and build the latest version of sealos. For the convenience of developers, we use the docker to build sealos. It can reduce problems of the developing environment.
 
+### License
+
+By submitting a pull request, you agree to license your contributions under the [Sealos Commercial Use License v1.0](LICENSE.md)
+
 ### Docs Contribution
 
 #### Structure and Repo

--- a/README.md
+++ b/README.md
@@ -167,3 +167,8 @@ Have a look through [existing issues](https://github.com/labring/sealos/issues?q
 <!-- ## License -->
 
 <!-- [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Flabring%2Fsealos.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Flabring%2Fsealos?ref=badge_large) -->
+
+## License
+
+> ⚠️ **License Change Alert**  
+> As of 2025-08-01, Sealos adopts the **[Sealos Commercial Use License v1.0](LICENSE.md)**.This change aims to better support the sustainable development of the project while safeguarding the rights and interests of community users.

--- a/README_zh.md
+++ b/README_zh.md
@@ -113,3 +113,8 @@ Sealos 维护了一个[公开的发展路线图](https://github.com/orgs/labring
 <!-- ## License -->
 
 <!-- [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Flabring%2Fsealos.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Flabring%2Fsealos?ref=badge_large) -->
+
+## 📢 **许可证**
+
+> ⚠️ **重要许可证变更通知**  
+> 自 **2025年8月1日**起，Sealos 项目正式采用 **[Sealos 商业使用许可证 v1.0](LICENSE.md)**。本次变更旨在更好地支持项目的可持续发展，同时保障社区用户的权益。

--- a/lifecycle/scripts/template/LICENSE
+++ b/lifecycle/scripts/template/LICENSE
@@ -1,13 +1,7 @@
 Copyright © {{.Year}} {{.Holder}}
 
-Licensed under the Apache License, Version 2.0 (the "License");
+Licensed under the Sealos Commercial Use License v1.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+    https://github.com/labring/sealos/blob/main/LICENSE.md

--- a/lifecycle/scripts/template/boilerplate.go.txt
+++ b/lifecycle/scripts/template/boilerplate.go.txt
@@ -1,13 +1,8 @@
 // Copyright © 2022 sealos.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
+// Licensed under the Sealos Commercial Use License v1.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://github.com/labring/sealos/blob/main/LICENSE.md
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.


### PR DESCRIPTION
This pull request introduces significant changes to the licensing model for the Sealos project, transitioning from the Apache License 2.0 to the Sealos Commercial Use License v1.0. The changes include updates to documentation, license templates, and contributor agreements to reflect this new licensing model.

### Licensing Model Transition:

* [`COMMERCIAL_USE.md`](diffhunk://#diff-84ce09d94c3b3dea651e6499b4103373c59095127faf7593a434104aba039d5cR1-R6): Added a new section detailing the requirements for using Sealos under the Sealos Commercial Use License v1.0, including obtaining written permission, contacting legal@sealos.io, and displaying a valid license certificate in the service UI.
* [`lifecycle/scripts/template/LICENSE`](diffhunk://#diff-d481515be8db8127db752e3d44cc0334fba1ddcbb87cf468dcb71e7c5aa566fdL3-R7): Replaced the Apache License 2.0 text with the Sealos Commercial Use License v1.0, updating the license URL to point to the project's GitHub repository.
* [`lifecycle/scripts/template/boilerplate.go.txt`](diffhunk://#diff-fafcf4cf5ae40172e7e477fbceb9cb97000ef89436af79e46114ab929031ce5cL3-L13): Updated the license header in the boilerplate file to reflect the Sealos Commercial Use License v1.0, removing the Apache License 2.0 disclaimers.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R166-R170): Added a "License" section with a notification about the license change effective August 1, 2025, explaining the rationale for the transition.
* [`README_zh.md`](diffhunk://#diff-bc53aca037f8d406f619f15cf2c5c905a7a61f81f89cab98dd52f7ff65725f6eR112-R116): Added a corresponding "许可证" section in Chinese, notifying users of the license change and its effective date.
* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R216-R219): Included a new "License" subsection clarifying that all contributions are licensed under the Sealos Commercial Use License v1.0.

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
