### PR TITLE
feat: push image to acr

### DIFF
--- a/.github/workflows/cloud-release.yml
+++ b/.github/workflows/cloud-release.yml
@@ -1,16 +1,27 @@
 name: Release Cloud
 
 on:
-  release:
-    types: [ published ]
+  workflow_call:
+    inputs:
+      tag:
+        description: "Tag for manual release"
+        required: false
+        default: ""
+        type: string
+      build_offline_tar_only:
+        description: "Build offline tar only"
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag for manual release'
+        description: "Tag for manual release"
         required: false
-        default: ''
+        default: ""
+        type: string
       build_offline_tar_only:
-        description: 'Build offline tar only'
+        description: "Build offline tar only"
         required: false
         default: false
         type: boolean
@@ -27,33 +38,33 @@ jobs:
       artifact_name: sealos-cloud-release
 
   release-controllers:
-    if: ${{ github.event.inputs.build_offline_tar_only == false }}
+    if: ${{ inputs.build_offline_tar_only == false }}
     uses: ./.github/workflows/controllers.yml
     with:
       push_image: true
-      push_image_tag: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+      push_image_tag: ${{inputs.tag }}
     secrets: inherit
 
   release-frontends:
-    if: ${{ github.event.inputs.build_offline_tar_only == false }}
+    if: ${{ inputs.build_offline_tar_only == false }}
     uses: ./.github/workflows/frontends.yml
     with:
       push_image: true
-      push_image_tag: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+      push_image_tag: ${{ inputs.tag }}
     secrets: inherit
 
   release-service:
-    if: ${{ github.event.inputs.build_offline_tar_only == false }}
+    if: ${{ inputs.build_offline_tar_only == false }}
     needs:
       - save-sealos
     uses: ./.github/workflows/services.yml
     with:
       push_image: true
-      push_image_tag: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+      push_image_tag: ${{ inputs.tag }}
     secrets: inherit
 
   release-cloud:
-    if: ${{ github.event.inputs.build_offline_tar_only == false }}
+    if: ${{ inputs.build_offline_tar_only == false }}
     needs:
       - save-sealos
       - release-controllers
@@ -62,8 +73,8 @@ jobs:
     uses: ./.github/workflows/cloud.yml
     with:
       push_image: true
-      push_image_tag: ${{ github.event.inputs.tag || github.event.release.tag_name }}
-      build_from: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+      push_image_tag: ${{ inputs.tag }}
+      build_from: ${{ inputs.tag }}
     secrets: inherit
 
   release-amd-offline-tar:
@@ -71,7 +82,7 @@ jobs:
       - release-cloud
     runs-on: self-hosted
     env:
-      RELEASE_TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+      RELEASE_TAG: ${{ inputs.tag }}
       OSS_BUCKET: ${{ secrets.OSS_BUCKET }}
     steps:
       - name: Checkout
@@ -110,7 +121,7 @@ jobs:
       - release-cloud
     runs-on: self-hosted
     env:
-      RELEASE_TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+      RELEASE_TAG: ${{ inputs.tag }}
       OSS_BUCKET: ${{ secrets.OSS_BUCKET }}
     steps:
       - name: Checkout

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -4,46 +4,46 @@ on:
   workflow_call:
     inputs:
       push_image:
-        description: 'Push image'
+        description: "Push image"
         required: false
         type: boolean
         default: false
       push_image_tag:
-        description: 'Push all-in-one image tag, default is latest'
-        default: 'latest'
+        description: "Push all-in-one image tag, default is latest"
+        default: "latest"
         required: false
         type: string
       build_from:
-        description: 'Build all-in-one image from components image tag, default is latest'
-        default: 'latest'
+        description: "Build all-in-one image from components image tag, default is latest"
+        default: "latest"
         required: false
         type: string
   workflow_dispatch:
     inputs:
       push_image:
-        description: 'Push image'
+        description: "Push image"
         required: false
         type: boolean
         default: false
       push_image_tag:
-        description: 'Push all-in-one image tag, default is latest'
-        default: 'latest'
+        description: "Push all-in-one image tag, default is latest"
+        default: "latest"
         required: false
         type: string
       build_from:
-        description: 'Build all-in-one image from components image tag, default is latest'
-        default: 'latest'
+        description: "Build all-in-one image from components image tag, default is latest"
+        default: "latest"
         required: false
         type: string
   push:
-    branches: [ "main" ]
+    branches: ["main"]
     paths:
       - "deploy/cloud/**"
       - ".github/workflows/cloud.yml"
       - "!**/*.md"
       - "!**/*.yaml"
   pull_request:
-    branches: [ "*" ]
+    branches: ["*"]
     paths:
       - "deploy/cloud/**"
       - ".github/workflows/cloud.yml"
@@ -54,6 +54,8 @@ env:
   # Common versions
   GO_VERSION: "1.20"
   DEFAULT_OWNER: "labring"
+  ALIYUN_REGISTRY: ${{ secrets.ALIYUN_REGISTRY }}
+  ALIYUN_REPO_PREFIX: ${{ secrets.ALIYUN_REPO_PREFIX && secrets.ALIYUN_REPO_PREFIX || secrets.ALIYUN_USERNAME && format('{0}/{1}', secrets.ALIYUN_REGISTRY, secrets.ALIYUN_USERNAME) || '' }}
 
 jobs:
   save-sealos:
@@ -93,6 +95,9 @@ jobs:
         run: |
           bash scripts/resolve-tag-image.sh "$PUSH_IMAGE" "$IS_TAG" "$PUSH_IMAGE_TAG"
           echo "repo=ghcr.io/${REPO_OWNER}/sealos-cloud" >> $GITHUB_OUTPUT
+          if [[ -n "${{ env.ALIYUN_REPO_PREFIX }}" ]]; then
+            echo "aliyun_repo=${{ env.ALIYUN_REPO_PREFIX }}/sealos-cloud" >> $GITHUB_OUTPUT
+          fi
       - name: Download sealos
         uses: actions/download-artifact@v4
         with:
@@ -110,9 +115,17 @@ jobs:
         # if push to master, then login to ghcr.io
         env:
           REPOSITORY_OWNER: ${{ github.repository_owner }}
-          GH_PAT: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           sudo sealos login -u "${REPOSITORY_OWNER}" -p "${GH_PAT}" --debug ghcr.io
+
+      - name: Sealos login to Aliyun Registry
+        if: ${{ env.ALIYUN_REGISTRY }}
+        env:
+          ALIYUN_USERNAME: ${{ secrets.ALIYUN_USERNAME }}
+          ALIYUN_PASSWORD: ${{ secrets.ALIYUN_PASSWORD }}
+        run: |
+          sudo sealos login -u "$ALIYUN_USERNAME" -p "$ALIYUN_PASSWORD" --debug ${{ env.ALIYUN_REGISTRY }}
 
       - name: Build sealos cloud cluster image
         working-directory: deploy/cloud
@@ -120,12 +133,14 @@ jobs:
           BUILD_FROM: ${{ inputs.build_from }}
           REPOSITORY_OWNER: ${{ github.repository_owner }}
           REPO: ${{ steps.prepare.outputs.repo }}
+          ALIYUN_REPO: ${{ steps.prepare.outputs.aliyun_repo }}
           TAG_NAME: ${{ steps.prepare.outputs.tag_name }}
         run: |
           [ -z "${BUILD_FROM}" ] && BuildFromTag="latest" || BuildFromTag="${BUILD_FROM}"; echo "BuildFromTag=${BuildFromTag}"
           sed -i "s#labring#${REPOSITORY_OWNER}#g" init.sh
           sed -i "s#latest#${BuildFromTag}#g" init.sh
 
+          # Build for GHCR
           sudo bash init.sh amd64 
           sudo sealos build -t "${REPO}:${TAG_NAME}-amd64" --platform linux/amd64 -f Kubefile
           sudo sealos build -t "${REPO}:latest-amd64" --platform linux/amd64 -f Kubefile
@@ -138,16 +153,44 @@ jobs:
           sudo sealos build -t "${REPO}:${TAG_NAME}-arm64" --platform linux/arm64 -f Kubefile
           sudo sealos build -t "${REPO}:latest-arm64" --platform linux/arm64 -f Kubefile
 
+          # Build for Aliyun if enabled
+          if [[ -n "${ALIYUN_REPO}" ]]; then
+            # delete old registry cache
+            sudo rm -rf registry
+            sudo rm -rf tars
+            
+            sudo bash init.sh amd64 
+            sudo sealos build -t "${ALIYUN_REPO}:${TAG_NAME}-amd64" --platform linux/amd64 -f Kubefile
+            sudo sealos build -t "${ALIYUN_REPO}:latest-amd64" --platform linux/amd64 -f Kubefile
+
+            # delete old registry cache
+            sudo rm -rf registry
+            sudo rm -rf tars
+
+            sudo bash init.sh arm64 
+            sudo sealos build -t "${ALIYUN_REPO}:${TAG_NAME}-arm64" --platform linux/arm64 -f Kubefile
+            sudo sealos build -t "${ALIYUN_REPO}:latest-arm64" --platform linux/arm64 -f Kubefile
+          fi
+
       - name: Manifest Cluster Images
         # if push to master, then patch images to ghcr.io
         env:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ steps.prepare.outputs.repo }}
+          ALIYUN_REPO: ${{ steps.prepare.outputs.aliyun_repo }}
           TAG_NAME: ${{ steps.prepare.outputs.tag_name }}
         run: |
           sudo sealos images
+
+          # Create manifests for GHCR
           bash scripts/manifest-cluster-images.sh "$REPO:$TAG_NAME"
           bash scripts/manifest-cluster-images.sh "$REPO:latest"
+
+          # Create manifests for Aliyun if enabled
+          if [[ -n "${ALIYUN_REPO}" ]]; then
+            bash scripts/manifest-cluster-images.sh "$ALIYUN_REPO:$TAG_NAME"
+            bash scripts/manifest-cluster-images.sh "$ALIYUN_REPO:latest"
+          fi
 
       # todo: build multi-arch images
 

--- a/.github/workflows/controllers.yml
+++ b/.github/workflows/controllers.yml
@@ -204,6 +204,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=${{ steps.prepare.outputs.tag_name }},enable=true
+            type=ref,event=tag
             type=sha
 
       - name: build (and publish) ${{ matrix.module.name }} main image

--- a/.github/workflows/controllers.yml
+++ b/.github/workflows/controllers.yml
@@ -206,6 +206,8 @@ jobs:
             type=raw,value=${{ steps.prepare.outputs.tag_name }},enable=true
             type=ref,event=tag
             type=sha
+        env:
+          DOCKER_METADATA_SHORT_SHA_LENGTH: 9
 
       - name: build (and publish) ${{ matrix.module.name }} main image
         uses: docker/build-push-action@v6

--- a/.github/workflows/controllers.yml
+++ b/.github/workflows/controllers.yml
@@ -28,14 +28,14 @@ on:
         required: false
         type: string
   push:
-    branches: [ "main" ]
+    branches: ["main"]
     paths:
       - "controllers/**"
       - ".github/workflows/controllers.yml"
       - "!**/*.md"
       - "!**/*.yaml"
   pull_request:
-    branches: [ "*" ]
+    branches: ["*"]
     paths:
       - "controllers/**"
       - ".github/workflows/controllers.yml"
@@ -48,6 +48,9 @@ env:
   DEFAULT_OWNER: "labring"
   CRYPTOKEY: ${{ secrets.CONTROLLER_BUILD_CRYPTOKEY }}
   LICENSE_KEY: ${{ secrets.LICENSE_KEY }}
+  ALIYUN_REGISTRY: ${{ secrets.ALIYUN_REGISTRY }}
+  ALIYUN_REPO_PREFIX: ${{ secrets.ALIYUN_REPO_PREFIX && secrets.ALIYUN_REPO_PREFIX || secrets.ALIYUN_USERNAME && format('{0}/{1}', secrets.ALIYUN_REGISTRY, secrets.ALIYUN_USERNAME) || '' }}
+
 jobs:
   resolve-modules:
     runs-on: ubuntu-24.04
@@ -63,7 +66,7 @@ jobs:
 
   golangci-lint:
     if: ${{ github.event_name }} == 'push' || ${{ github.event_name }} == 'pull_request'
-    needs: [ resolve-modules ]
+    needs: [resolve-modules]
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -103,7 +106,7 @@ jobs:
           - { name: job-heartbeat, path: job/heartbeat }
           - { name: resources, path: resources }
           - { name: node, path: node }
-          - { name: devbox, path: devbox}
+          - { name: devbox, path: devbox }
           - { name: objectstorage, path: objectstorage }
     steps:
       - name: Checkout
@@ -162,6 +165,9 @@ jobs:
         run: |
           bash scripts/resolve-tag-image.sh "$PUSH_IMAGE" "$IS_TAG" "$PUSH_IMAGE_TAG"
           echo "docker_repo=ghcr.io/${REPO_OWNER}/sealos-${MODULE_NAME}-controller" >> $GITHUB_OUTPUT
+          if [[ -n "${{ env.ALIYUN_REPO_PREFIX }}" ]]; then
+            echo "aliyun_docker_repo=${{ env.ALIYUN_REPO_PREFIX }}/sealos-${MODULE_NAME}-controller" >> $GITHUB_OUTPUT
+          fi
 
       - # Add support for more platforms with QEMU (optional)
         # https://github.com/docker/setup-qemu-action
@@ -178,13 +184,23 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Login to Aliyun Registry
+        uses: docker/login-action@v3
+        if: ${{ ((github.event_name == 'push') ||(github.event_name == 'create') || (inputs.push_image == true)) && env.ALIYUN_REGISTRY }}
+        with:
+          registry: ${{ env.ALIYUN_REGISTRY }}
+          username: ${{ secrets.ALIYUN_USERNAME }}
+          password: ${{ secrets.ALIYUN_PASSWORD }}
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/${{ github.repository_owner }}/sealos-${{ matrix.module.name }}-controller
+            ${{ steps.prepare.outputs.docker_repo }}
+            ${{ steps.prepare.outputs.aliyun_docker_repo }}
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=${{ steps.prepare.outputs.tag_name }},enable=true
@@ -199,10 +215,12 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
+
   save-sealos:
     uses: ./.github/workflows/import-save-sealos.yml
     with:
       artifact_name: sealos-controllers
+
   build-cluster-image:
     if: ${{ (github.event_name == 'push') ||(github.event_name == 'create') || (inputs.push_image == true)  }}
     needs:
@@ -261,6 +279,12 @@ jobs:
           echo "cluster_image=ghcr.io/${REPO_OWNER}/sealos-cloud-${MODULE_NAME}-controller:$tag_name" >> $GITHUB_OUTPUT
           echo "latest_cluster_image=ghcr.io/${REPO_OWNER}/sealos-cloud-${MODULE_NAME}-controller:latest" >> $GITHUB_OUTPUT
 
+          if [[ -n "${{ env.ALIYUN_REPO_PREFIX }}" ]]; then
+            echo "aliyun_cluster_repo=${{ env.ALIYUN_REPO_PREFIX }}/sealos-cloud-${MODULE_NAME}-controller" >> $GITHUB_OUTPUT
+            echo "aliyun_cluster_image=${{ env.ALIYUN_REPO_PREFIX }}/sealos-cloud-${MODULE_NAME}-controller:$tag_name" >> $GITHUB_OUTPUT
+            echo "aliyun_latest_cluster_image=${{ env.ALIYUN_REPO_PREFIX }}/sealos-cloud-${MODULE_NAME}-controller:latest" >> $GITHUB_OUTPUT
+          fi
+
       - name: Download sealos
         uses: actions/download-artifact@v4
         with:
@@ -286,16 +310,27 @@ jobs:
         # if push to master, then login to ghcr.io
         env:
           REPOSITORY_OWNER: ${{ github.repository_owner }}
-          GH_PAT: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           sudo sealos login -u "${REPOSITORY_OWNER}" -p "${GH_PAT}" --debug ghcr.io
+
+      - name: Sealos login to Aliyun Registry
+        if: ${{ env.ALIYUN_REGISTRY }}
+        env:
+          ALIYUN_USERNAME: ${{ secrets.ALIYUN_USERNAME }}
+          ALIYUN_PASSWORD: ${{ secrets.ALIYUN_PASSWORD }}
+        run: |
+          sudo sealos login -u "$ALIYUN_USERNAME" -p "$ALIYUN_PASSWORD" --debug ${{ env.ALIYUN_REGISTRY }}
 
       - name: Build ${{ matrix.module.name }}-controller cluster image
         working-directory: controllers/${{ matrix.module.path }}/deploy
         env:
           CLUSTER_IMAGE: ${{ steps.prepare.outputs.cluster_image }}
           LATEST_CLUSTER_IMAGE: ${{ steps.prepare.outputs.latest_cluster_image }}
+          ALIYUN_CLUSTER_IMAGE: ${{ steps.prepare.outputs.aliyun_cluster_image }}
+          ALIYUN_LATEST_CLUSTER_IMAGE: ${{ steps.prepare.outputs.aliyun_latest_cluster_image }}
         run: |
+          # Build for GHCR
           sudo sealos build -t "${CLUSTER_IMAGE}-amd64" --platform linux/amd64 -f Kubefile
           sudo sealos build -t "${LATEST_CLUSTER_IMAGE}-amd64" --platform linux/amd64 -f Kubefile
           # delete old registry cache
@@ -303,16 +338,33 @@ jobs:
           sudo sealos build -t "${CLUSTER_IMAGE}-arm64" --platform linux/arm64 -f Kubefile
           sudo sealos build -t "${LATEST_CLUSTER_IMAGE}-arm64" --platform linux/arm64 -f Kubefile
 
+          # Build for Aliyun if enabled
+          if [[ -n "${ALIYUN_CLUSTER_IMAGE}" ]]; then
+            sudo rm -rf registry
+            sudo sealos build -t "${ALIYUN_CLUSTER_IMAGE}-amd64" --platform linux/amd64 -f Kubefile
+            sudo sealos build -t "${ALIYUN_LATEST_CLUSTER_IMAGE}-amd64" --platform linux/amd64 -f Kubefile
+            sudo rm -rf registry
+            sudo sealos build -t "${ALIYUN_CLUSTER_IMAGE}-arm64" --platform linux/arm64 -f Kubefile
+            sudo sealos build -t "${ALIYUN_LATEST_CLUSTER_IMAGE}-arm64" --platform linux/arm64 -f Kubefile
+          fi
+
       - name: Manifest Cluster Images
         # if push to master, then patch images to ghcr.io
         env:
           OWNER: ${{ github.repository_owner }}
           CLUSTER_IMAGE: ${{ steps.prepare.outputs.cluster_image }}
           LATEST_CLUSTER_IMAGE: ${{ steps.prepare.outputs.latest_cluster_image }}
+          ALIYUN_CLUSTER_IMAGE: ${{ steps.prepare.outputs.aliyun_cluster_image }}
+          ALIYUN_LATEST_CLUSTER_IMAGE: ${{ steps.prepare.outputs.aliyun_latest_cluster_image }}
         run: |
           sudo sealos images
           bash scripts/manifest-cluster-images.sh "$CLUSTER_IMAGE"
           bash scripts/manifest-cluster-images.sh "$LATEST_CLUSTER_IMAGE"
+
+          if [[ -n "${ALIYUN_CLUSTER_IMAGE}" ]]; then
+            bash scripts/manifest-cluster-images.sh "$ALIYUN_CLUSTER_IMAGE"
+            bash scripts/manifest-cluster-images.sh "$ALIYUN_LATEST_CLUSTER_IMAGE"
+          fi
 
       - name: Renew issue and Sync Images for ${{ steps.prepare.outputs.cluster_image }}
         uses: labring/gh-rebot@v0.0.6
@@ -320,7 +372,7 @@ jobs:
         with:
           version: v0.0.8-rc1
         env:
-          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GH_TOKEN: "${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}"
           SEALOS_TYPE: "issue_renew"
           SEALOS_ISSUE_TITLE: "[DaylyReport] Auto build for sealos"
           SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"
@@ -335,7 +387,7 @@ jobs:
         with:
           version: v0.0.8-rc1
         env:
-          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GH_TOKEN: "${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}"
           SEALOS_TYPE: "issue_renew"
           SEALOS_ISSUE_TITLE: "[DaylyReport] Auto build for sealos"
           SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"

--- a/.github/workflows/controllers.yml
+++ b/.github/workflows/controllers.yml
@@ -204,6 +204,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=${{ steps.prepare.outputs.tag_name }},enable=true
+            type=sha
 
       - name: build (and publish) ${{ matrix.module.name }} main image
         uses: docker/build-push-action@v6
@@ -372,7 +373,7 @@ jobs:
         with:
           version: v0.0.8-rc1
         env:
-          GH_TOKEN: "${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}"
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           SEALOS_TYPE: "issue_renew"
           SEALOS_ISSUE_TITLE: "[DaylyReport] Auto build for sealos"
           SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"
@@ -387,7 +388,7 @@ jobs:
         with:
           version: v0.0.8-rc1
         env:
-          GH_TOKEN: "${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}"
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           SEALOS_TYPE: "issue_renew"
           SEALOS_ISSUE_TITLE: "[DaylyReport] Auto build for sealos"
           SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -22,6 +22,8 @@ env:
   # Common versions
   GO_VERSION: "1.20"
   DEFAULT_OWNER: "labring"
+  ALIYUN_REGISTRY: ${{ secrets.ALIYUN_REGISTRY }}
+  ALIYUN_REPO_PREFIX: ${{ secrets.ALIYUN_REPO_PREFIX && secrets.ALIYUN_REPO_PREFIX || secrets.ALIYUN_USERNAME && format('{0}/{1}', secrets.ALIYUN_REGISTRY, secrets.ALIYUN_USERNAME) || '' }}
 
 jobs:
   image-build:
@@ -50,6 +52,9 @@ jobs:
           MODULE_NAME=$(basename "$MODULE_INPUT")
           echo "MODULE_NAME=${MODULE_NAME}" >> $GITHUB_ENV
           echo "GHCR_REPO=ghcr.io/${REPOSITORY_OWNER}/sealos-${MODULE_NAME}-frontend" >> $GITHUB_ENV
+          if [[ -n "${{ env.ALIYUN_REPO_PREFIX }}" ]]; then
+            echo "ALIYUN_REPO=${{ env.ALIYUN_REPO_PREFIX }}/sealos-${MODULE_NAME}-frontend" >> $GITHUB_ENV
+          fi
 
       - name: Docker meta
         id: meta
@@ -57,6 +62,7 @@ jobs:
         with:
           images: |
             ${{ env.GHCR_REPO }}
+            ${{ env.ALIYUN_REPO }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -69,6 +75,14 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Aliyun Registry
+        if: ${{ inputs.push_image && env.ALIYUN_REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.ALIYUN_REGISTRY }}
+          username: ${{ secrets.ALIYUN_USERNAME }}
+          password: ${{ secrets.ALIYUN_PASSWORD }}
+
       - name: Build
         id: build
         uses: docker/build-push-action@v6
@@ -80,7 +94,7 @@ jobs:
             name=${{ env.MODULE_NAME }}
             path=${{ inputs.module }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,"name=${{ env.GHCR_REPO }}",name-canonical=true,push-by-digest=${{ inputs.push_image }},push=${{ inputs.push_image }}
+          outputs: type=image,"name=${{ env.GHCR_REPO }}${{ env.ALIYUN_REPO && format(',{0}', env.ALIYUN_REPO) || '' }}",name-canonical=true,push-by-digest=${{ inputs.push_image }},push=${{ inputs.push_image }}
 
       - name: Export digest
         env:
@@ -119,6 +133,14 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Aliyun Registry
+        if: ${{ env.ALIYUN_REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.ALIYUN_REGISTRY }}
+          username: ${{ secrets.ALIYUN_USERNAME }}
+          password: ${{ secrets.ALIYUN_PASSWORD }}
+
       - name: Extract module name
         id: module_name
         env:
@@ -128,6 +150,9 @@ jobs:
           MODULE_NAME=$(basename "$MODULE_INPUT")
           echo "MODULE_NAME=${MODULE_NAME}" >> $GITHUB_ENV
           echo "GHCR_REPO=ghcr.io/${REPOSITORY_OWNER}/sealos-${MODULE_NAME}-frontend" >> $GITHUB_ENV
+          if [[ -n "${{ env.ALIYUN_REPO_PREFIX }}" ]]; then
+            echo "ALIYUN_REPO=${{ env.ALIYUN_REPO_PREFIX }}/sealos-${MODULE_NAME}-frontend" >> $GITHUB_ENV
+          fi
 
       - name: Download digests
         uses: actions/download-artifact@v4
@@ -138,6 +163,7 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Expose git commit data
         uses: rlespinasse/git-commit-data-action@v1
 
@@ -167,19 +193,23 @@ jobs:
         with:
           images: |
             ${{ env.GHCR_REPO }}
+            ${{ env.ALIYUN_REPO }}
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=${{ steps.prepare.outputs.tag_name }},enable=true
             type=sha
 
-      - name: Create manifest list and push
+      - name: Create manifest list and push to GHCR
         working-directory: ${{ runner.temp }}/digests
         env:
           TEMP_DIR: ${{ runner.temp }}
           GHCR_REPO: ${{ env.GHCR_REPO }}
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf "${GHCR_REPO}@sha256:%s " *)
+          for TAG in $DOCKER_METADATA_OUTPUT_TAGS; do
+            docker buildx imagetools create -t $TAG \
+              $(printf "${GHCR_REPO}@sha256:%s " *)
+            sleep 5
+          done
 
       - name: Inspect image
         env:
@@ -201,6 +231,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Extract module name
         id: module_name
         env:
@@ -211,6 +242,7 @@ jobs:
 
       - name: Expose git commit data
         uses: rlespinasse/git-commit-data-action@v1
+
       - name: Check if tag
         id: check_tag
         env:
@@ -240,6 +272,12 @@ jobs:
           echo "cluster_image=ghcr.io/${REPO_OWNER}/sealos-cloud-${MODULE_NAME}-frontend:${tag_name}" >> $GITHUB_OUTPUT
           echo "latest_cluster_image=ghcr.io/${REPO_OWNER}/sealos-cloud-${MODULE_NAME}-frontend:latest" >> $GITHUB_OUTPUT
 
+          if [[ -n "${{ env.ALIYUN_REPO_PREFIX }}" ]]; then
+            echo "aliyun_cluster_repo=${{ env.ALIYUN_REPO_PREFIX }}/sealos-cloud-${MODULE_NAME}-frontend" >> $GITHUB_OUTPUT
+            echo "aliyun_cluster_image=${{ env.ALIYUN_REPO_PREFIX }}/sealos-cloud-${MODULE_NAME}-frontend:${tag_name}" >> $GITHUB_OUTPUT
+            echo "aliyun_latest_cluster_image=${{ env.ALIYUN_REPO_PREFIX }}/sealos-cloud-${MODULE_NAME}-frontend:latest" >> $GITHUB_OUTPUT
+          fi
+
       - name: Download sealos
         uses: actions/download-artifact@v4
         with:
@@ -259,6 +297,14 @@ jobs:
         run: |
           sudo sealos login -u "$REPOSITORY_OWNER" -p "$GH_PAT" --debug ghcr.io
 
+      - name: Sealos login to Aliyun Registry
+        if: ${{ env.ALIYUN_REGISTRY }}
+        env:
+          ALIYUN_USERNAME: ${{ secrets.ALIYUN_USERNAME }}
+          ALIYUN_PASSWORD: ${{ secrets.ALIYUN_PASSWORD }}
+        run: |
+          sudo sealos login -u "$ALIYUN_USERNAME" -p "$ALIYUN_PASSWORD" --debug ${{ env.ALIYUN_REGISTRY }}
+
       - name: Build ${{ env.MODULE_NAME }}-frontend cluster image
         working-directory: frontend/${{ inputs.module }}/deploy
         env:
@@ -268,8 +314,12 @@ jobs:
           NEW_DOCKER_IMAGE: ${{ steps.prepare.outputs.new_docker_image }}
           CLUSTER_IMAGE: ${{ steps.prepare.outputs.cluster_image }}
           LATEST_CLUSTER_IMAGE: ${{ steps.prepare.outputs.latest_cluster_image }}
+          ALIYUN_CLUSTER_IMAGE: ${{ steps.prepare.outputs.aliyun_cluster_image }}
+          ALIYUN_LATEST_CLUSTER_IMAGE: ${{ steps.prepare.outputs.aliyun_latest_cluster_image }}
         run: |
           sudo sed -i "s;${OLD_DOCKER_IMAGE};${NEW_DOCKER_IMAGE};" manifests/*
+
+          # Build for GHCR
           sudo sealos build -t "${CLUSTER_IMAGE}-amd64" --platform linux/amd64 -f Kubefile
           sudo sealos build -t "${LATEST_CLUSTER_IMAGE}-amd64" --platform linux/amd64 -f Kubefile
           # delete old registry cache
@@ -277,15 +327,32 @@ jobs:
           sudo sealos build -t "${CLUSTER_IMAGE}-arm64" --platform linux/arm64 -f Kubefile
           sudo sealos build -t "${LATEST_CLUSTER_IMAGE}-arm64" --platform linux/arm64 -f Kubefile
 
-      - name: Manifest Cluster Images'
+          # Build for Aliyun if enabled
+          if [[ -n "${ALIYUN_CLUSTER_IMAGE}" ]]; then
+            sudo rm -rf registry
+            sudo sealos build -t "${ALIYUN_CLUSTER_IMAGE}-amd64" --platform linux/amd64 -f Kubefile
+            sudo sealos build -t "${ALIYUN_LATEST_CLUSTER_IMAGE}-amd64" --platform linux/amd64 -f Kubefile
+            sudo rm -rf registry
+            sudo sealos build -t "${ALIYUN_CLUSTER_IMAGE}-arm64" --platform linux/arm64 -f Kubefile
+            sudo sealos build -t "${ALIYUN_LATEST_CLUSTER_IMAGE}-arm64" --platform linux/arm64 -f Kubefile
+          fi
+
+      - name: Manifest Cluster Images
         env:
           OWNER: ${{ github.repository_owner }}
           CLUSTER_IMAGE: ${{ steps.prepare.outputs.cluster_image }}
           LATEST_CLUSTER_IMAGE: ${{ steps.prepare.outputs.latest_cluster_image }}
+          ALIYUN_CLUSTER_IMAGE: ${{ steps.prepare.outputs.aliyun_cluster_image }}
+          ALIYUN_LATEST_CLUSTER_IMAGE: ${{ steps.prepare.outputs.aliyun_latest_cluster_image }}
         run: |
           sudo sealos images
           bash scripts/manifest-cluster-images.sh "$CLUSTER_IMAGE"
           bash scripts/manifest-cluster-images.sh "$LATEST_CLUSTER_IMAGE"
+
+          if [[ -n "${ALIYUN_CLUSTER_IMAGE}" ]]; then
+            bash scripts/manifest-cluster-images.sh "$ALIYUN_CLUSTER_IMAGE"
+            bash scripts/manifest-cluster-images.sh "$ALIYUN_LATEST_CLUSTER_IMAGE"
+          fi
 
       - name: Renew issue and Sync Images for ${{ steps.prepare.outputs.cluster_image }}
         uses: labring/gh-rebot@v0.0.6

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -197,6 +197,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=${{ steps.prepare.outputs.tag_name }},enable=true
+            type=ref,event=tag
             type=sha
 
       - name: Create manifest list and push to GHCR

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Login to Aliyun Registry
         if: ${{ inputs.push_image && env.ALIYUN_REGISTRY }}
@@ -131,7 +131,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Login to Aliyun Registry
         if: ${{ env.ALIYUN_REGISTRY }}
@@ -293,7 +293,7 @@ jobs:
       - name: Sealos login to ghcr.io
         env:
           REPOSITORY_OWNER: ${{ github.repository_owner }}
-          GH_PAT: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           sudo sealos login -u "$REPOSITORY_OWNER" -p "$GH_PAT" --debug ghcr.io
 
@@ -360,7 +360,7 @@ jobs:
         with:
           version: v0.0.8-rc1
         env:
-          GH_TOKEN: "${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}"
+          GH_TOKEN: "${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}"
           SEALOS_TYPE: "issue_renew"
           SEALOS_ISSUE_TITLE: "[DaylyReport] Auto build for sealos"
           SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"
@@ -375,7 +375,7 @@ jobs:
         with:
           version: v0.0.8-rc1
         env:
-          GH_TOKEN: "${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}"
+          GH_TOKEN: "${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}"
           SEALOS_TYPE: "issue_renew"
           SEALOS_ISSUE_TITLE: "[DaylyReport] Auto build for sealos"
           SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -202,7 +202,7 @@ jobs:
         env:
           DOCKER_METADATA_SHORT_SHA_LENGTH: 9
 
-      - name: Create manifest list and push to GHCR
+      - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         env:
           TEMP_DIR: ${{ runner.temp }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -199,6 +199,8 @@ jobs:
             type=raw,value=${{ steps.prepare.outputs.tag_name }},enable=true
             type=ref,event=tag
             type=sha
+        env:
+          DOCKER_METADATA_SHORT_SHA_LENGTH: 9
 
       - name: Create manifest list and push to GHCR
         working-directory: ${{ runner.temp }}/digests

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -360,7 +360,7 @@ jobs:
         with:
           version: v0.0.8-rc1
         env:
-          GH_TOKEN: "${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}"
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           SEALOS_TYPE: "issue_renew"
           SEALOS_ISSUE_TITLE: "[DaylyReport] Auto build for sealos"
           SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"
@@ -375,7 +375,7 @@ jobs:
         with:
           version: v0.0.8-rc1
         env:
-          GH_TOKEN: "${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}"
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           SEALOS_TYPE: "issue_renew"
           SEALOS_ISSUE_TITLE: "[DaylyReport] Auto build for sealos"
           SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Login to Aliyun Registry
         if: ${{ inputs.push_image && env.ALIYUN_REGISTRY }}
@@ -131,7 +131,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Login to Aliyun Registry
         if: ${{ env.ALIYUN_REGISTRY }}
@@ -293,7 +293,7 @@ jobs:
       - name: Sealos login to ghcr.io
         env:
           REPOSITORY_OWNER: ${{ github.repository_owner }}
-          GH_PAT: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           sudo sealos login -u "$REPOSITORY_OWNER" -p "$GH_PAT" --debug ghcr.io
 
@@ -360,7 +360,7 @@ jobs:
         with:
           version: v0.0.8-rc1
         env:
-          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GH_TOKEN: "${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}"
           SEALOS_TYPE: "issue_renew"
           SEALOS_ISSUE_TITLE: "[DaylyReport] Auto build for sealos"
           SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"
@@ -375,7 +375,7 @@ jobs:
         with:
           version: v0.0.8-rc1
         env:
-          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GH_TOKEN: "${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}"
           SEALOS_TYPE: "issue_renew"
           SEALOS_ISSUE_TITLE: "[DaylyReport] Auto build for sealos"
           SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
   goreleaser:
     runs-on: ubuntu-24.04
     permissions:
+      contents: write
       packages: write
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
     needs:
       - goreleaser
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ env:
 
 on:
   workflow_dispatch:
-
   push:
     tags:
       - "*"
@@ -120,10 +119,10 @@ jobs:
         run: ./scripts/changelog.sh "${REPOSITORY}"
       - uses: peter-evans/create-pull-request@v5
         with:
-          title: 'docs: Automated Changelog Update for ${{steps.get-current-tag.outputs.tag }}'
+          title: "docs: Automated Changelog Update for ${{steps.get-current-tag.outputs.tag }}"
           body: |
             copilot:all
-            
+
             Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
           commit-message: |
             🤖 add release changelog using rebot.
@@ -134,3 +133,16 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           committer: sealos-release-robot <sealos-release-robot@sealos.io>
           author: sealos-release-robot <sealos-release-robot@sealos.io>
+
+  cloud-release:
+    uses: ./.github/workflows/cloud-release.yml
+    needs:
+      - goreleaser
+      - sync
+    permissions:
+      contents: read
+      packages: write
+    secrets: inherit
+    with:
+      tag: ${{ github.ref_name }}
+      build_offline_tar_only: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,6 @@ jobs:
             libbtrfs-dev libgpgme-dev libdevmapper-dev \
             qemu-user-static binfmt-support
 
-      - name: Copy License to lifecycle
-        run: |
-          cp LICENSE* ./lifecycle/
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,10 @@ jobs:
             libbtrfs-dev libgpgme-dev libdevmapper-dev \
             qemu-user-static binfmt-support
 
+      - name: Copy License to lifecycle
+        run: |
+          cp LICENSE* ./lifecycle/
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,5 @@ jobs:
           signoff: true
           delete-branch: true
           token: ${{ secrets.GITHUB_TOKEN }}
-          reviewers: cuisongliu
           committer: sealos-release-robot <sealos-release-robot@sealos.io>
           author: sealos-release-robot <sealos-release-robot@sealos.io>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-24.04
+    permissions:
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -53,6 +55,9 @@ jobs:
     runs-on: ubuntu-24.04
     needs:
       - goreleaser
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -95,6 +100,9 @@ jobs:
     runs-on: ubuntu-24.04
     needs:
       - goreleaser
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/services.yml
+++ b/.github/workflows/services.yml
@@ -197,6 +197,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=${{ steps.prepare.outputs.tag_name }},enable=true
+            type=ref,event=tag
             type=sha
 
       - name: build (and publish) ${{ matrix.module }} main image

--- a/.github/workflows/services.yml
+++ b/.github/workflows/services.yml
@@ -192,11 +192,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/${{ github.repository_owner }}/sealos-${{ matrix.module }}-service
+            ${{ steps.prepare.outputs.docker_repo }}
             ${{ steps.prepare.outputs.aliyun_docker_repo }}
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=${{ steps.prepare.outputs.tag_name }},enable=true
+            type=sha
 
       - name: build (and publish) ${{ matrix.module }} main image
         uses: docker/build-push-action@v6
@@ -373,7 +374,7 @@ jobs:
         with:
           version: v0.0.8-rc1
         env:
-          GH_TOKEN: "${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}"
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           SEALOS_TYPE: "issue_renew"
           SEALOS_ISSUE_TITLE: "[DaylyReport] Auto build for sealos"
           SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"
@@ -387,7 +388,7 @@ jobs:
         with:
           version: v0.0.8-rc1
         env:
-          GH_TOKEN: "${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}"
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           SEALOS_TYPE: "issue_renew"
           SEALOS_ISSUE_TITLE: "[DaylyReport] Auto build for sealos"
           SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"

--- a/.github/workflows/services.yml
+++ b/.github/workflows/services.yml
@@ -199,6 +199,8 @@ jobs:
             type=raw,value=${{ steps.prepare.outputs.tag_name }},enable=true
             type=ref,event=tag
             type=sha
+        env:
+          DOCKER_METADATA_SHORT_SHA_LENGTH: 9
 
       - name: build (and publish) ${{ matrix.module }} main image
         uses: docker/build-push-action@v6

--- a/.github/workflows/services.yml
+++ b/.github/workflows/services.yml
@@ -1,42 +1,41 @@
 name: Build Services image
 
-
 on:
   create:
     tags:
   workflow_call:
     inputs:
       push_image:
-        description: 'Push image'
+        description: "Push image"
         required: false
         type: boolean
         default: false
       push_image_tag:
-        description: 'Push image tag'
-        default: 'latest'
+        description: "Push image tag"
+        default: "latest"
         required: false
         type: string
   workflow_dispatch:
     inputs:
       push_image:
-        description: 'Push image'
+        description: "Push image"
         required: false
         type: boolean
         default: false
       push_image_tag:
-        description: 'Push image tag'
-        default: 'latest'
+        description: "Push image tag"
+        default: "latest"
         required: false
         type: string
   push:
-    branches: [ "main" ]
+    branches: ["main"]
     paths:
       - "service/**"
       - ".github/workflows/services.yml"
       - "!**/*.md"
       - "!**/*.yaml"
   pull_request:
-    branches: [ "*" ]
+    branches: ["*"]
     paths:
       - "service/**"
       - ".github/workflows/services.yml"
@@ -47,6 +46,8 @@ env:
   GO_VERSION: "1.22"
   DEFAULT_OWNER: "labring"
   CRYPTOKEY: ${{ secrets.CONTROLLER_BUILD_CRYPTOKEY }}
+  ALIYUN_REGISTRY: ${{ secrets.ALIYUN_REGISTRY }}
+  ALIYUN_REPO_PREFIX: ${{ secrets.ALIYUN_REPO_PREFIX && secrets.ALIYUN_REPO_PREFIX || secrets.ALIYUN_USERNAME && format('{0}/{1}', secrets.ALIYUN_REGISTRY, secrets.ALIYUN_USERNAME) || '' }}
 
 jobs:
   resolve-modules:
@@ -62,7 +63,7 @@ jobs:
         run: bash scripts/resolve-modules.sh ./service
 
   golangci-lint:
-    needs: [  resolve-modules ]
+    needs: [resolve-modules]
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -91,7 +92,17 @@ jobs:
     strategy:
       matrix:
         ## TODO: add more modules
-        module: [ database, pay, account, minio, launchpad, exceptionmonitor, devbox, vlogs ]
+        module:
+          [
+            database,
+            pay,
+            account,
+            minio,
+            launchpad,
+            exceptionmonitor,
+            devbox,
+            vlogs,
+          ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -147,6 +158,9 @@ jobs:
         run: |
           bash scripts/resolve-tag-image.sh "$PUSH_IMAGE" "$IS_TAG" "$PUSH_IMAGE_TAG"
           echo "docker_repo=ghcr.io/$REPO_OWNER/sealos-$MODULE-service" >> $GITHUB_OUTPUT
+          if [[ -n "${{ env.ALIYUN_REPO_PREFIX }}" ]]; then
+            echo "aliyun_docker_repo=${{ env.ALIYUN_REPO_PREFIX }}/sealos-$MODULE-service" >> $GITHUB_OUTPUT
+          fi
 
       - # Add support for more platforms with QEMU (optional)
         # https://github.com/docker/setup-qemu-action
@@ -163,7 +177,15 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Login to Aliyun Registry
+        uses: docker/login-action@v3
+        if: ${{ ((github.event_name == 'push') ||(github.event_name == 'create') || (inputs.push_image == true)) && env.ALIYUN_REGISTRY }}
+        with:
+          registry: ${{ env.ALIYUN_REGISTRY }}
+          username: ${{ secrets.ALIYUN_USERNAME }}
+          password: ${{ secrets.ALIYUN_PASSWORD }}
 
       - name: Docker meta
         id: meta
@@ -171,6 +193,7 @@ jobs:
         with:
           images: |
             ghcr.io/${{ github.repository_owner }}/sealos-${{ matrix.module }}-service
+            ${{ steps.prepare.outputs.aliyun_docker_repo }}
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=${{ steps.prepare.outputs.tag_name }},enable=true
@@ -202,7 +225,17 @@ jobs:
     strategy:
       matrix:
         ## TODO: add more modules
-        module: [ database, pay, account, minio, launchpad, exceptionmonitor, devbox, vlogs ]
+        module:
+          [
+            database,
+            pay,
+            account,
+            minio,
+            launchpad,
+            exceptionmonitor,
+            devbox,
+            vlogs,
+          ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -235,6 +268,10 @@ jobs:
           echo "new_docker_repo=ghcr.io/$REPO_OWNER/sealos-$MODULE-service" >> $GITHUB_OUTPUT
           echo "cluster_repo=ghcr.io/$REPO_OWNER/sealos-cloud-$MODULE-service" >> $GITHUB_OUTPUT
 
+          if [[ -n "${{ env.ALIYUN_REPO_PREFIX }}" ]]; then
+            echo "aliyun_cluster_repo=${{ env.ALIYUN_REPO_PREFIX }}/sealos-cloud-$MODULE-service" >> $GITHUB_OUTPUT
+          fi
+
       - name: Download sealos
         uses: actions/download-artifact@v4
         with:
@@ -250,9 +287,17 @@ jobs:
         # if push to master, then login to ghcr.io
         env:
           REPOSITORY_OWNER: ${{ github.repository_owner }}
-          GH_PAT: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           sudo sealos login -u "$REPOSITORY_OWNER" -p "$GH_PAT" --debug ghcr.io
+
+      - name: Sealos login to Aliyun Registry
+        if: ${{ env.ALIYUN_REGISTRY }}
+        env:
+          ALIYUN_USERNAME: ${{ secrets.ALIYUN_USERNAME }}
+          ALIYUN_PASSWORD: ${{ secrets.ALIYUN_PASSWORD }}
+        run: |
+          sudo sealos login -u "$ALIYUN_USERNAME" -p "$ALIYUN_PASSWORD" --debug ${{ env.ALIYUN_REGISTRY }}
 
       - name: Mutate image tag in deploy files
         working-directory: service/${{ matrix.module }}/deploy
@@ -270,26 +315,57 @@ jobs:
         env:
           MODULE: ${{ matrix.module }}
           CLUSTER_REPO: ${{ steps.prepare.outputs.cluster_repo }}
+          ALIYUN_CLUSTER_REPO: ${{ steps.prepare.outputs.aliyun_cluster_repo }}
           TAG_NAME: ${{ steps.prepare.outputs.tag_name }}
         run: |
+          # Build for GHCR
           CLUSTER_IMAGE_NAME="${CLUSTER_REPO}:${TAG_NAME}"
           sudo sealos build -t "${CLUSTER_IMAGE_NAME}-amd64" --platform linux/amd64 -f Kubefile
           sudo rm -rf registry
           sudo sealos build -t "${CLUSTER_IMAGE_NAME}-arm64" --platform linux/arm64 -f Kubefile
+
+          # Build for Aliyun if enabled
+          if [[ -n "${ALIYUN_CLUSTER_REPO}" ]]; then
+            ALIYUN_CLUSTER_IMAGE_NAME="${ALIYUN_CLUSTER_REPO}:${TAG_NAME}"
+            sudo rm -rf registry
+            sudo sealos build -t "${ALIYUN_CLUSTER_IMAGE_NAME}-amd64" --platform linux/amd64 -f Kubefile
+            sudo rm -rf registry
+            sudo sealos build -t "${ALIYUN_CLUSTER_IMAGE_NAME}-arm64" --platform linux/arm64 -f Kubefile
+          fi
+
           sudo sealos images
 
       - name: Build ${{ matrix.module }}-service cluster image for latest
         env:
           CLUSTER_REPO: ${{ steps.prepare.outputs.cluster_repo }}
+          ALIYUN_CLUSTER_REPO: ${{ steps.prepare.outputs.aliyun_cluster_repo }}
           TAG_NAME: ${{ steps.prepare.outputs.tag_name }}
         run: |
+          # Handle GHCR images
           CLUSTER_IMAGE_NAME="$CLUSTER_REPO:$TAG_NAME"
           CLUSTER_IMAGE_NAME_LATEST="$CLUSTER_REPO:latest"
           sudo sealos tag "$CLUSTER_IMAGE_NAME-amd64"  "$CLUSTER_IMAGE_NAME_LATEST-amd64"
           sudo sealos tag "$CLUSTER_IMAGE_NAME-arm64"  "$CLUSTER_IMAGE_NAME_LATEST-arm64"
+
+          # Handle Aliyun images if enabled
+          if [[ -n "${ALIYUN_CLUSTER_REPO}" ]]; then
+            ALIYUN_CLUSTER_IMAGE_NAME="$ALIYUN_CLUSTER_REPO:$TAG_NAME"
+            ALIYUN_CLUSTER_IMAGE_NAME_LATEST="$ALIYUN_CLUSTER_REPO:latest"
+            sudo sealos tag "$ALIYUN_CLUSTER_IMAGE_NAME-amd64"  "$ALIYUN_CLUSTER_IMAGE_NAME_LATEST-amd64"
+            sudo sealos tag "$ALIYUN_CLUSTER_IMAGE_NAME-arm64"  "$ALIYUN_CLUSTER_IMAGE_NAME_LATEST-arm64"
+          fi
+
           sudo sealos images
+
+          # Create manifests for GHCR
           bash scripts/manifest-cluster-images.sh "$CLUSTER_IMAGE_NAME"
           bash scripts/manifest-cluster-images.sh "$CLUSTER_IMAGE_NAME_LATEST"
+
+          # Create manifests for Aliyun if enabled
+          if [[ -n "${ALIYUN_CLUSTER_REPO}" ]]; then
+            bash scripts/manifest-cluster-images.sh "$ALIYUN_CLUSTER_IMAGE_NAME"
+            bash scripts/manifest-cluster-images.sh "$ALIYUN_CLUSTER_IMAGE_NAME_LATEST"
+          fi
 
       - name: Renew issue and Sync Images
         uses: labring/gh-rebot@v0.0.6
@@ -297,7 +373,7 @@ jobs:
         with:
           version: v0.0.8-rc1
         env:
-          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GH_TOKEN: "${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}"
           SEALOS_TYPE: "issue_renew"
           SEALOS_ISSUE_TITLE: "[DaylyReport] Auto build for sealos"
           SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"
@@ -311,7 +387,7 @@ jobs:
         with:
           version: v0.0.8-rc1
         env:
-          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GH_TOKEN: "${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}"
           SEALOS_TYPE: "issue_renew"
           SEALOS_ISSUE_TITLE: "[DaylyReport] Auto build for sealos"
           SEALOS_ISSUE_BODYFILE: "scripts/ISSUE_RENEW.md"

--- a/scripts/resolve-tag-image.sh
+++ b/scripts/resolve-tag-image.sh
@@ -1,15 +1,18 @@
 #!/bin/bash
 set -ex
-SHA_TAG=${GIT_COMMIT_SHORT_SHA}
+SHA_TAG="${GIT_COMMIT_SHORT_SHA}"
 tag_name="$SHA_TAG"
 
 push_image=${1:-false}
-release=${2:-false}
+is_tag=${2:-false}
+push_tag_name=${3}
 
-if [[ "$push_image" == true ]]; then
-  tag_name=${3:-latest}
-elif [[ "$release" == true ]]; then
+if [[ "$is_tag" == true ]]; then
   tag_name=${GITHUB_REF#refs/tags/}
+elif [[ "$push_image" == true ]]; then
+  if [[ -n "$push_tag_name" ]]; then
+    tag_name=$push_tag_name
+  fi
 fi
 
 echo "tag_name=$tag_name" >> "$GITHUB_OUTPUT"

--- a/scripts/resolve-tag-image.sh
+++ b/scripts/resolve-tag-image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -ex
-SHA_TAG="${GIT_COMMIT_SHORT_SHA}"
+SHA_TAG="sha-${GIT_COMMIT_SHORT_SHA}"
 tag_name="$SHA_TAG"
 
 push_image=${1:-false}


### PR DESCRIPTION
What Changes:
1. Added `GHCR_TOKEN` secret to enable personal repository CI to run properly. This secret should be set to a [pat](https://github.com/settings/tokens) with `write:package` permission. Note that this PAT should only be configured in the personal fork of the sealos repository, not in the organization, to avoid PAT leakage. Furthermore, this PAT is only used for logging into ghcr.io within the workflow and will not be used elsewhere, minimizing the risk of leakage
2. Fixed the issue where a fixed PR reviewer in `peter-evans/create-pull-request@v5` caused CI to fail in forked repositories 
<img width="1167" height="343" alt="image" src="https://github.com/user-attachments/assets/b7978a65-b98a-4cfe-931e-f91458bde14e" />

3. Added ACR image push support for `sealos cloud`, `controller`, `service`, and `frontend`
4. Fixed `resolve-tag-image.sh` defaulting to using sha instead of latest
5. sha tag add `sha-` prefix, and set `DOCKER_METADATA_SHORT_SHA_LENGTH` env to `9`

Secrets For Org:
```yaml
ALIYUN_REGISTRY: registry.cn-hangzhou.aliyuncs.com
ALIYUN_USERNAME: xxx
ALIYUN_PASSWORD: xxx
ALIYUN_REPO_PREFIX: registry.cn-hangzhou.aliyuncs.com/xxx
```

Secrets For Fork:
```yaml
ALIYUN_REGISTRY: registry.cn-hangzhou.aliyuncs.com
ALIYUN_USERNAME: xxx
ALIYUN_PASSWORD: xxx
ALIYUN_REPO_PREFIX: registry.cn-hangzhou.aliyuncs.com/xxx
GHCR_TOKEN: xxx
```

`GHCR_TOKEN` is a has `write:package` permission github pat