### PR TITLE
docs: update contribution policy and guidelines in README

### DIFF
--- a/lifecycle/scripts/make-rules/license.mk
+++ b/lifecycle/scripts/make-rules/license.mk
@@ -17,7 +17,7 @@ TEMPLATE := $(ROOT_DIR)/scripts/template/LICENSE
 .PHONY: license.verify
 license.verify: tools.verify.addlicense
 	@echo "===========> Verifying the boilerplate headers for all files"
-	@$(TOOLS_DIR)/addlicense -check -ignore **/test/** -f $(TEMPLATE) $(CODE_DIRS)
+	@$(TOOLS_DIR)/addlicense -check -ignore **/test/** -ignore  **/.github/** -f $(TEMPLATE) $(CODE_DIRS)
 
 .PHONY: license.add
 license.add: tools.verify.addlicense license.controller.add

--- a/lifecycle/staging/src/github.com/labring/image-cri-shim/.github/workflows/close-pr.yml
+++ b/lifecycle/staging/src/github.com/labring/image-cri-shim/.github/workflows/close-pr.yml
@@ -1,0 +1,20 @@
+name: ❌ Close Pull Requests
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  close-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Close Pull Request
+        uses: superbrothers/close-pull-request@v3
+        with:
+          comment: "❌ PRs are not accepted in this repository."
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lifecycle/staging/src/github.com/labring/image-cri-shim/README.md
+++ b/lifecycle/staging/src/github.com/labring/image-cri-shim/README.md
@@ -204,3 +204,41 @@ Dec 11 02:18:47 test-node-0 image-cri-shim[46869]: 2022-12-11T02:18:47 info User
 Dec 11 02:18:47 test-node-0 image-cri-shim[46869]: 2022-12-11T02:18:47 info Password: passw0rd
 Dec 11 02:18:47 test-node-0 image-cri-shim[46869]: 2022-12-11T02:18:47 info CRIVersion: v1
 ```
+
+# Contribution Policy
+
+🚫 **This repository does NOT accept any form of contributions.**  
+This includes:
+- ❌ Pull requests
+- ❌ Direct code submissions
+- ❌ Bug reports
+- ❌ Feature requests
+- ❌ Documentation changes
+
+**All contributions must be submitted exclusively to the central repository:**  
+👉 **https://github.com/labring/sealos**
+
+---
+
+## Contribution Guidelines
+1. **For bugs**  
+   → Report in the [Issues section of the main repository](https://github.com/labring/sealos/issues)  
+   → Include reproduction steps and environment details
+
+2. **For code contributions**  
+   → Submit changes via **main repository only**  
+   → Follow contribution guidelines at [sealos/CONTRIBUTING.md](https://github.com/labring/sealos/blob/main/CONTRIBUTING.md)
+
+3. **For feature requests**  
+   → Create an Issue in the [main repository](https://github.com/labring/sealos/issues) with `[Feature]` prefix
+
+---
+
+## Important Notes
+⚠️ **This repository is read-only**
+- Serves as reference implementation only
+- Active development occurs exclusively at [labring/sealos](https://github.com/labring/sealos)
+- PRs/issues submitted here will be **closed immediately without review**
+
+📌 **Any contributions made to this repository will be invalid**  
+For your submissions to be considered, please use the central repository.

--- a/lifecycle/staging/src/github.com/labring/lvscare/.github/workflows/close-pr.yml
+++ b/lifecycle/staging/src/github.com/labring/lvscare/.github/workflows/close-pr.yml
@@ -1,0 +1,20 @@
+name: ❌ Close Pull Requests
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  close-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Close Pull Request
+        uses: superbrothers/close-pull-request@v3
+        with:
+          comment: "❌ PRs are not accepted in this repository."
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lifecycle/staging/src/github.com/labring/lvscare/README.md
+++ b/lifecycle/staging/src/github.com/labring/lvscare/README.md
@@ -165,3 +165,42 @@ lvscare care --vs 169.254.0.1:80 --logger DEBG --mode link -C
 ```
 
 Welcome to give it a shot, have fun with it.
+
+
+# Contribution Policy
+
+🚫 **This repository does NOT accept any form of contributions.**  
+This includes:
+- ❌ Pull requests
+- ❌ Direct code submissions
+- ❌ Bug reports
+- ❌ Feature requests
+- ❌ Documentation changes
+
+**All contributions must be submitted exclusively to the central repository:**  
+👉 **https://github.com/labring/sealos**
+
+---
+
+## Contribution Guidelines
+1. **For bugs**  
+   → Report in the [Issues section of the main repository](https://github.com/labring/sealos/issues)  
+   → Include reproduction steps and environment details
+
+2. **For code contributions**  
+   → Submit changes via **main repository only**  
+   → Follow contribution guidelines at [sealos/CONTRIBUTING.md](https://github.com/labring/sealos/blob/main/CONTRIBUTING.md)
+
+3. **For feature requests**  
+   → Create an Issue in the [main repository](https://github.com/labring/sealos/issues) with `[Feature]` prefix
+
+---
+
+## Important Notes
+⚠️ **This repository is read-only**
+- Serves as reference implementation only
+- Active development occurs exclusively at [labring/sealos](https://github.com/labring/sealos)
+- PRs/issues submitted here will be **closed immediately without review**
+
+📌 **Any contributions made to this repository will be invalid**  
+For your submissions to be considered, please use the central repository.


### PR DESCRIPTION
This pull request introduces changes to enforce a strict no-contributions policy across multiple repositories (`image-cri-shim` and `lvscare`). It includes both workflow automation to close pull requests and updates to documentation to clarify the policy.

### Workflow Automation:
* Added a GitHub Actions workflow (`close-pr.yml`) in both `image-cri-shim` and `lvscare` repositories to automatically close any pull requests with a predefined comment stating that contributions are not accepted. [[1]](diffhunk://#diff-7f817f350a37ad638d0fb2918511b0e5586154556ec5ebb9095c2c10c4408a4fR1-R20) [[2]](diffhunk://#diff-7f817f350a37ad638d0fb2918511b0e5586154556ec5ebb9095c2c10c4408a4fR1-R20)

### Documentation Updates:
* Updated `README.md` files in `image-cri-shim` and `lvscare` repositories to include a "Contribution Policy" section. This section explicitly states that the repositories are read-only, do not accept contributions, and directs users to the central repository (`labring/sealos`) for all contributions, bug reports, and feature requests. [[1]](diffhunk://#diff-c09ea6414301ebfebba9bbd466ec15cb86b739482272b3afe6c19e580f41bfbbR207-R244) [[2]](diffhunk://#diff-94155fa766772382bb74308227d84ef99d104009b70ac5d9099f53e12a72b684R168-R206)<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
