### PR TITLE
fix(ci): update paths to use PROJECT_PATH variable in ci-patch-image.yml

### DIFF
--- a/.github/workflows/ci-patch-image.yml
+++ b/.github/workflows/ci-patch-image.yml
@@ -4,6 +4,7 @@ env:
   # Common versions
   GO_VERSION: "1.20"
   DEFAULT_OWNER: "labring"
+  PROJECT_PATH: "./lifecycle"
 
 on:
   workflow_dispatch:
@@ -73,20 +74,20 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: sealos-amd64
-          path: docker/sealos/bin/sealos-amd64
+          path: ${{ env.PROJECT_PATH }}/docker/sealos/bin/sealos-amd64
 
       - name: Download sealos
         uses: actions/download-artifact@v4
         with:
           name: sealos-arm64
-          path: docker/sealos/bin/sealos-arm64
+          path: ${{ env.PROJECT_PATH }}/docker/sealos/bin/sealos-arm64
 
       - name: build (and publish) main sealos image
         env:
           REPOSITORY_OWNER: ${{ github.repository_owner }}
           GIT_COMMIT_SHORT_SHA: ${{ env.GIT_COMMIT_SHORT_SHA }}
           DOCKER_REPO: ghcr.io/${{ github.repository_owner }}/sealos
-        working-directory: docker/sealos
+        working-directory: ${{ env.PROJECT_PATH }}/docker/sealos
         run: |
           docker buildx build \
           --platform linux/amd64,linux/arm64 \
@@ -182,7 +183,7 @@ jobs:
           sudo sealos load -i /tmp/sealos/images/patch-arm64.tar
           sudo sealos load -i /tmp/sealos/images/patch-amd64.tar
           sudo sealos images
-          bash scripts/manifest-cluster-images.sh
+          bash ${{ env.PROJECT_PATH }}/scripts/manifest-cluster-images.sh
 
       - name: Manifest Cluster Images for latest
         env:
@@ -192,7 +193,7 @@ jobs:
           sudo sealos tag "ghcr.io/${REPOSITORY_OWNER}/sealos-patch:${GIT_COMMIT_SHORT_SHA}-amd64" "ghcr.io/${REPOSITORY_OWNER}/sealos-patch:latest-amd64"
           sudo sealos tag "ghcr.io/${REPOSITORY_OWNER}/sealos-patch:${GIT_COMMIT_SHORT_SHA}-arm64" "ghcr.io/${REPOSITORY_OWNER}/sealos-patch:latest-arm64"
           sudo sealos images
-          bash scripts/manifest-cluster-images.sh "ghcr.io/${REPOSITORY_OWNER}/sealos-patch:latest"
+          bash ${{ env.PROJECT_PATH }}/scripts/manifest-cluster-images.sh "ghcr.io/${REPOSITORY_OWNER}/sealos-patch:latest"
 
       - name: Renew issue and Sync Images
         uses: labring/gh-rebot@v0.0.6


### PR DESCRIPTION
This pull request updates the `.github/workflows/ci-patch-image.yml` file to improve flexibility by introducing a `PROJECT_PATH` environment variable. This change centralizes the project directory path, reducing hardcoded values and improving maintainability.

### Workflow improvements:

* Added a new `PROJECT_PATH` environment variable (`./lifecycle`) to the workflow's environment configuration, enabling dynamic path management. (`[.github/workflows/ci-patch-image.ymlR7](diffhunk://#diff-32e7e1062e41bfef162eb5aa471d42365df677ace95527c7ce0cdf492a4a40faR7)`)
* Updated artifact download paths to use the `PROJECT_PATH` variable, replacing hardcoded paths for `sealos-amd64` and `sealos-arm64` binaries. (`[.github/workflows/ci-patch-image.ymlL76-R90](diffhunk://#diff-32e7e1062e41bfef162eb5aa471d42365df677ace95527c7ce0cdf492a4a40faL76-R90)`)
* Adjusted the `working-directory` for the main `sealos` image build step to use the `PROJECT_PATH` variable. (`[.github/workflows/ci-patch-image.ymlL76-R90](diffhunk://#diff-32e7e1062e41bfef162eb5aa471d42365df677ace95527c7ce0cdf492a4a40faL76-R90)`)
* Modified script execution paths to include the `PROJECT_PATH` variable for `manifest-cluster-images.sh`, ensuring consistency across related steps. (`[[1]](diffhunk://#diff-32e7e1062e41bfef162eb5aa471d42365df677ace95527c7ce0cdf492a4a40faL185-R186)`, `[[2]](diffhunk://#diff-32e7e1062e41bfef162eb5aa471d42365df677ace95527c7ce0cdf492a4a40faL195-R196)`)<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
