### PR TITLE
fix(dbprovider): resolve migration failure error display issue

### DIFF
--- a/frontend/providers/dbprovider/src/api/platform.ts
+++ b/frontend/providers/dbprovider/src/api/platform.ts
@@ -22,9 +22,9 @@ export const uploadFile = (
   onUploadProgress?: (progressEvent: AxiosProgressEvent) => void
 ) => {
   return POST<string[]>('/api/minio/upload', data, {
-    headers: {
-      'Content-Type': 'multipart/form-data'
-    },
+    // headers: {
+    //   'Content-Type': 'multipart/form-data'
+    // },
     timeout: 3 * 60 * 1000,
     onUploadProgress
   });


### PR DESCRIPTION
## Problem
When database migration fails, the error modal displays "have_error" instead of specific error details. The root cause is a 400 Bad Request error when trying to fetch logs due to incorrect container name being used.

## Solution
1. **Added Pod Information Retrieval**: Implemented `getPodStatusByName` API call to fetch complete Pod information including container details
2. **Container Name Extraction**: Added logic to extract the correct container name from Pod spec
3. **Fixed Log Fetching**: Updated `getLogByNameAndContainerName` to use the actual container name instead of migration task name
4. **Enhanced Error Handling**: Improved error display with debugging information when logs cannot be retrieved

## Changes Made
- **Added imports**: `getPodStatusByName` and `useMemo`
- **New query**: `getFullPodInfo` to fetch complete Pod information
- **Container name logic**: `useMemo` hook to extract container name from Pod spec
- **Updated log fetching**: Use correct container name in `getLogByNameAndContainerName`
- **Improved error display**: Better fallback message with debugging information

## Related Issues
Fixes the issue where users couldn't see specific error details when database migration fails.