### PR TITLE
feat(pr-lint): add workflow for linting pull request titles

### DIFF
--- a/.github/workflows/pr-lint-semantic.yml
+++ b/.github/workflows/pr-lint-semantic.yml
@@ -1,0 +1,40 @@
+name: 'Lint PR title semantic'
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # https://github.com/amannn/action-semantic-pull-request
+          validateSingleCommit: true
+          validateSingleCommitMatchesPrTitle: true
+          wip: true
+          # Default: https://github.com/commitizen/conventional-commit-types
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          subjectPattern: ^(?![A-Z]).+$
+          requireScope: true
+          headerPattern: '^(\w*)(?:\(([\w$.\-*/ ]*)\))?: (.*)$'
+          headerPatternCorrespondence: type, scope, subject


### PR DESCRIPTION
This pull request adds two new GitHub Actions workflows to enforce PR title conventions and improve PR quality. The new workflows check that PR titles follow semantic commit message guidelines and ensure only a single commit is present in a PR.

**PR title and commit validation workflows:**

* Added `.github/workflows/pr-lint-semantic.yml` to enforce semantic PR titles, require a scope, and validate that the PR contains a single commit matching the PR title using the `amannn/action-semantic-pull-request` action.
* Added `.github/workflows/pr-lint-count.yml` to ensure PRs contain only one commit using the `Gaurang033/OneCommit` action.