### PR TITLE
feat(pr-lint): add workflow for linting pull request titles

### DIFF
--- a/.github/workflows/check-pr-title-lint-semantic.yml
+++ b/.github/workflows/check-pr-title-lint-semantic.yml
@@ -1,0 +1,43 @@
+name: 'Lint PR title semantic'
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # https://github.com/amannn/action-semantic-pull-request
+          wip: true
+          # Default: https://github.com/commitizen/conventional-commit-types
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+          requireScope: false
+          ignoreLabels: |
+            bot
+          headerPattern: '^(\w*)(?:\(([\w$.\-*/ ]*)\))?: (.*)$'
+          headerPatternCorrespondence: type, scope, subject

--- a/.github/workflows/new_version_dispatch.yml
+++ b/.github/workflows/new_version_dispatch.yml
@@ -53,6 +53,8 @@ jobs:
           branch: tagpr-new-${{ inputs.version }}
           signoff: true
           delete-branch: true
+          labels: |
+            bot
           token: ${{ secrets.GITHUB_TOKEN }}
           committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: peter-evans/create-pull-request@v5
         if: ${{ (github.event_name == 'workflow_dispatch') && (steps.tagpr.outputs.version != '') }}
         with:
-          title: 'Release ${{ steps.tagpr.outputs.name }} for ${{ steps.tagpr.outputs.version }}'
+          title: 'Release ${{ steps.tagpr.outputs.name }} note and fix version for ${{ steps.tagpr.outputs.version }}'
           body: |
             
             Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
@@ -48,6 +48,8 @@ jobs:
           branch: tagpr-${{ steps.tagpr.outputs.version }}
           draft: true
           signoff: true
+          labels: |
+            bot
           delete-branch: true
           token: ${{ secrets.GITHUB_TOKEN }}
           committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to enforce semantic pull request titles. The workflow checks that PR titles follow a conventional commit format and ensures consistency across contributions.

Continuous integration and linting:

* Added a `.github/workflows/pr-lint-semantic.yml` workflow that uses the `amannn/action-semantic-pull-request` GitHub Action to validate that pull request titles follow semantic conventions, including commit type and subject formatting.
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
