### PR TITLE
fix(sync): update LICENSE file references to LICENSE.md in sync_code.yml

### DIFF
--- a/.github/sync_code.yml
+++ b/.github/sync_code.yml
@@ -2,13 +2,13 @@ labring/lvscare:
   - source: lifecycle/staging/src/github.com/labring/lvscare/
     dest: .
     deleteOrphaned: true
-  - source: LICENSE
-    dest: LICENSE
+  - source: LICENSE.md
+    dest: LICENSE.md
     deleteOrphaned: true
 labring/image-cri-shim:
   - source: lifecycle/staging/src/github.com/labring/image-cri-shim/
     dest: .
     deleteOrphaned: true
-  - source: LICENSE
-    dest: LICENSE
+  - source: LICENSE.md
+    dest: LICENSE.md
     deleteOrphaned: true


### PR DESCRIPTION
This pull request updates the `.github/sync_code.yml` configuration to use `LICENSE.md` files instead of `LICENSE` for both the `labring/lvscare` and `labring/image-cri-shim` repositories.

Configuration updates:

* Changed the license file references from `LICENSE` to `LICENSE.md` for both `labring/lvscare` and `labring/image-cri-shim` in `.github/sync_code.yml`.<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
