### PR TITLE
fix: update Kubernetes and Sealos version references to v5.0.1 in documentation and scripts

### DIFF
--- a/docs/4.0/i18n/zh-Hans/self-hosting/sealos/installation.md
+++ b/docs/4.0/i18n/zh-Hans/self-hosting/sealos/installation.md
@@ -101,8 +101,8 @@ Sealos 需要使用证书来保证通信安全，默认在您不提供证书的�
 使用 nip.io 作为 Sealos 的域名非常简单，只需在第一个 Master 节点上执行以下命令，并根据提示输入参数：
 
 ```bash 
-$ curl -sfL https://mirror.ghproxy.com/https://raw.githubusercontent.com/labring/sealos/v5.0.0/scripts/cloud/install.sh -o /tmp/install.sh && bash /tmp/install.sh \
-  --cloud-version=v5.0.0 \
+$ curl -sfL https://mirror.ghproxy.com/https://raw.githubusercontent.com/labring/sealos/v5.0.1/scripts/cloud/install.sh -o /tmp/install.sh && bash /tmp/install.sh \
+  --cloud-version=v5.0.1 \
   --image-registry=registry.cn-shanghai.aliyuncs.com --zh \
   --proxy-prefix=https://mirror.ghproxy.com
 ```
@@ -145,8 +145,8 @@ cloud.example.io   A   192.168.1.10
 然后在第一个 Master 节点上执行以下命令，并根据提示输入参数：
 
 ```bash
-$ curl -sfL https://mirror.ghproxy.com/https://raw.githubusercontent.com/labring/sealos/v5.0.0/scripts/cloud/install.sh -o /tmp/install.sh && bash /tmp/install.sh \
-  --cloud-version=v5.0.0 \
+$ curl -sfL https://mirror.ghproxy.com/https://raw.githubusercontent.com/labring/sealos/v5.0.1/scripts/cloud/install.sh -o /tmp/install.sh && bash /tmp/install.sh \
+  --cloud-version=v5.0.1 \
   --image-registry=registry.cn-shanghai.aliyuncs.com --zh \
   --proxy-prefix=https://mirror.ghproxy.com \
   --cloud-domain=<your_domain> \
@@ -172,8 +172,8 @@ cloud.example.io   A   192.168.1.10
 然后在第一个 Master 节点上执行以下命令，并根据提示输入参数：
 
 ```bash
-$ curl -sfL https://mirror.ghproxy.com/https://raw.githubusercontent.com/labring/sealos/v5.0.0/scripts/cloud/install.sh -o /tmp/install.sh && bash /tmp/install.sh \
-  --cloud-version=v5.0.0 \
+$ curl -sfL https://mirror.ghproxy.com/https://raw.githubusercontent.com/labring/sealos/v5.0.1/scripts/cloud/install.sh -o /tmp/install.sh && bash /tmp/install.sh \
+  --cloud-version=v5.0.1 \
   --image-registry=registry.cn-shanghai.aliyuncs.com --zh \
   --proxy-prefix=https://mirror.ghproxy.com \
   --cloud-domain=<your_domain>
@@ -231,8 +231,8 @@ $ curl -sfL https://mirror.ghproxy.com/https://raw.githubusercontent.com/labring
 然后在第一个 Master 节点上执行以下命令，并根据提示输入参数：
 
 ```bash
-$ curl -sfL https://mirror.ghproxy.com/https://raw.githubusercontent.com/labring/sealos/v5.0.0/scripts/cloud/install.sh -o /tmp/install.sh && bash /tmp/install.sh \
-  --cloud-version=v5.0.0 \
+$ curl -sfL https://mirror.ghproxy.com/https://raw.githubusercontent.com/labring/sealos/v5.0.1/scripts/cloud/install.sh -o /tmp/install.sh && bash /tmp/install.sh \
+  --cloud-version=v5.0.1 \
   --image-registry=registry.cn-shanghai.aliyuncs.com --zh \
   --proxy-prefix=https://mirror.ghproxy.com \
   --cloud-domain=<your_domain>

--- a/docs/5.0/docs/developer-guide/lifecycle-management/quick-start/deploy-kubernetes.md
+++ b/docs/5.0/docs/developer-guide/lifecycle-management/quick-start/deploy-kubernetes.md
@@ -175,6 +175,7 @@ Containerd benefit from enhanced performance and optimized resource usage. Here 
 | `>=1.26`           | `>=v4.1.4-rc3`          | v1          | labring/kubernetes:v1.26.0 |
 | `>=1.27`           | `>=v4.2.0-alpha3`       | v1          | labring/kubernetes:v1.27.0 |
 | `>=1.28`           | `>=v5.0.0`              | v1          | labring/kubernetes:v1.28.0 |
+| `>=1.30`           | `>=v5.1.0`              | v1          | labring/kubernetes:v1.28.0 |
 
 The choice of Sealos and CRI versions is dependent on the Kubernetes version in question. For instance, Kubernetes
 v1.26.0 would require Sealos v4.1.4-rc3 or newer, along with the v1 CRI version.
@@ -191,6 +192,7 @@ Kubernetes versions with their corresponding Sealos and CRI versions for Docker-
 | `>=1.26`           | `>=v4.1.4-rc3`          | v1          | labring/kubernetes-docker:v1.26.0 |
 | `>=1.27`           | `>=v4.2.0-alpha3`       | v1          | labring/kubernetes-docker:v1.27.0 |
 | `>=1.28`           | `>=v5.0.0`              | v1          | labring/kubernetes-docker:v1.28.0 |
+| `>=1.30`           | `>=v5.1.0`              | v1          | labring/kubernetes-docker:v1.28.0 |
 
 As with the Containerd setup, the appropriate Sealos and CRI versions must be matched with the specific version of
 Kubernetes being used. For a Kubernetes v1.26.0 setup, this means selecting Sealos v4.1.4-rc3 or later, and a v1 CRI

--- a/docs/5.0/i18n/zh-Hans/developer-guide/lifecycle-management/quick-start/deploy-kubernetes.md
+++ b/docs/5.0/i18n/zh-Hans/developer-guide/lifecycle-management/quick-start/deploy-kubernetes.md
@@ -157,13 +157,14 @@ $ sealos run kubernetes.tar # 单机安装，集群安装同理
 
 推荐使用 Containerd 作为容器运行时 (CRI) 的集群镜像版本，Containerd 是一种轻量级、高性能的容器运行时，与 Docker 兼容。使用 Containerd 的 Kubernetes 镜像可以提供更高的性能和资源利用率。以下是支持 Containerd 的集群镜像版本支持说明：
 
-| K8s 版本 | Sealos 版本       | CRI 版本 | 集群镜像版本               |
-| -------- | ----------------- | -------- | -------------------------- |
+| K8s 版本   | Sealos 版本         | CRI 版本 | 集群镜像版本               |
+|----------|-------------------| -------- | -------------------------- |
 | `<1.25`  | `>=v4.0.0`        | v1alpha2 | labring/kubernetes:v1.24.0 |
 | `>=1.25` | `>=v4.1.0`        | v1alpha2 | labring/kubernetes:v1.25.0 |
 | `>=1.26` | `>=v4.1.4-rc3`    | v1       | labring/kubernetes:v1.26.0 |
 | `>=1.27` | `>=v4.2.0-alpha3` | v1       | labring/kubernetes:v1.27.0 |
 | `>=1.28` | `>=v5.0.0`        | v1       | labring/kubernetes:v1.28.0 |
+| `>=1.30` | `>=v5.1.0`        | v1       | labring/kubernetes:v1.28.0 |
 
 根据 Kubernetes 版本的不同，您可以选择不同的 Sealos 版本和 CRI 版本。例如，如果您要使用 Kubernetes v1.26.0 版本，您可以选择 sealos v4.1.4-rc3 及更高版本，并使用 v1 CRI 版本。
 
@@ -171,14 +172,14 @@ $ sealos run kubernetes.tar # 单机安装，集群安装同理
 
 当然，你也可以选择使用 Docker 作为容器运行时，以下是支持 Docker 的集群镜像版本支持说明：
 
-| K8s 版本 | Sealos 版本       | CRI 版本 | 集群镜像版本                      |
-| -------- | ----------------- | -------- | --------------------------------- |
+| K8s 版本   | Sealos 版本         | CRI 版本 | 集群镜像版本                      |
+|----------|-------------------| -------- | --------------------------------- |
 | `<1.25`  | `>=v4.0.0`        | v1alpha2 | labring/kubernetes-docker:v1.24.0 |
 | `>=1.25` | `>=v4.1.0`        | v1alpha2 | labring/kubernetes-docker:v1.25.0 |
 | `>=1.26` | `>=v4.1.4-rc3`    | v1       | labring/kubernetes-docker:v1.26.0 |
 | `>=1.27` | `>=v4.2.0-alpha3` | v1       | labring/kubernetes-docker:v1.27.0 |
 | `>=1.28` | `>=v5.0.0`        | v1       | labring/kubernetes-docker:v1.28.0 |
-
+| `>=1.30` | `>=v5.1.0`        | v1       | labring/kubernetes-docker:v1.28.0 |
 
 与支持 Containerd 的 Kubernetes 镜像类似，您可以根据 Kubernetes 版本的不同选择不同的 Sealos 版本和 CRI 版本。例如，如果您要使用 Kubernetes v1.26.0 版本，您可以选择 sealos v4.1.4-rc3 及更高版本，并使用 v1 CRI 版本。
 

--- a/scripts/cloud/upgrade/template/images/shim/images
+++ b/scripts/cloud/upgrade/template/images/shim/images
@@ -1,1 +1,1 @@
-ghcr.io/labring/sealos-applaunchpad-frontend:v5.0.0
+ghcr.io/labring/sealos-applaunchpad-frontend:v5.0.1

--- a/scripts/cloud/upgrade/template/scripts/upgrade-images.sh
+++ b/scripts/cloud/upgrade/template/scripts/upgrade-images.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # This script is used to upgrade the images for sealos cloud components
-kubectl set image deployment/applaunchpad-frontend -n applaunchpad-frontend applaunchpad-frontend=ghcr.io/labring/sealos-applaunchpad-frontend:v5.0.0
+kubectl set image deployment/applaunchpad-frontend -n applaunchpad-frontend applaunchpad-frontend=ghcr.io/labring/sealos-applaunchpad-frontend:v5.0.1


### PR DESCRIPTION
This pull request updates documentation and deployment scripts to use the latest version (`v5.0.1`) of the `sealos-applaunchpad-frontend` image and updates Kubernetes compatibility tables to include support for Kubernetes `>=1.30` with Sealos `>=v5.1.0`. The changes ensure users and scripts are aligned with the latest releases and compatibility information.

**Documentation updates:**

* Updated all installation command examples in `installation.md` to reference `sealos` version `v5.0.1` instead of `v5.0.0`, ensuring users install the latest stable version. [[1]](diffhunk://#diff-d5255295330e4f4a455ba1c2c6d28c4e4ae0d233841a40a400b6511da8acd691L104-R105) [[2]](diffhunk://#diff-d5255295330e4f4a455ba1c2c6d28c4e4ae0d233841a40a400b6511da8acd691L148-R149) [[3]](diffhunk://#diff-d5255295330e4f4a455ba1c2c6d28c4e4ae0d233841a40a400b6511da8acd691L175-R176) [[4]](diffhunk://#diff-d5255295330e4f4a455ba1c2c6d28c4e4ae0d233841a40a400b6511da8acd691L234-R235)
* Added Kubernetes `>=1.30` and Sealos `>=v5.1.0` compatibility rows to both Containerd and Docker tables in the English and Chinese quick start guides. [[1]](diffhunk://#diff-95b9aef560178515c54fee327d99aca93f716672df19bf4c7fe7158263c9d27bR178) [[2]](diffhunk://#diff-95b9aef560178515c54fee327d99aca93f716672df19bf4c7fe7158263c9d27bR195) [[3]](diffhunk://#diff-99bd87ae8dc168bb15a8345992cc81f62e7e5b8e881c6349f42979996efda790L161-R167) [[4]](diffhunk://#diff-99bd87ae8dc168bb15a8345992cc81f62e7e5b8e881c6349f42979996efda790L175-R182)

**Deployment and upgrade scripts:**

* Updated the `images` file and the `upgrade-images.sh` script to use `ghcr.io/labring/sealos-applaunchpad-frontend:v5.0.1` instead of `v5.0.0`, ensuring deployments and upgrades use the latest frontend image. [[1]](diffhunk://#diff-4250a22d921c69fa5e558ccc968945c453a5e7c79c9bffc4f23c11ed30a04e6dL1-R1) [[2]](diffhunk://#diff-cc67b2347c78256978c35a2d8932d39a43ed806da82d507a190f3249a9f08d4eL4-R4)

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
