### PR TITLE
feat(ci): add automated workflow for updating tagpr configuration

### DIFF
--- a/.github/workflows/new_version_dispatch.yml
+++ b/.github/workflows/new_version_dispatch.yml
@@ -1,0 +1,58 @@
+name: 🤖 Automated Update tagpr config
+
+on:
+  workflow_dispatch:
+    inputs:
+      pre-version:
+        description: 'Pre Version to release. Has v prefix'
+        required: true
+        default: 'v5.0.1'
+      version:
+        description: 'Version to release. Has v prefix'
+        required: true
+        default: 'v5.1.0'
+jobs:
+  config:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Update tagpr config
+        env:
+          VERSION: "${{ inputs.version }}"
+          PRE_VERSION: "${{ inputs.pre-version }}"
+        run: |
+          # Create a .tagpr.json file with the necessary configuration
+          if [[ -z "$VERSION" || -z "$PRE_VERSION" ]]; then
+            echo "Error: VERSION and PRE_VERSION inputs are required."
+            exit 1
+          fi
+          cat << EOF > .tagpr.json
+          {
+              "name": "sealos",
+              "version": "${VERSION}",
+              "command": "bash scripts/changelog.sh ${VERSION} ${PRE_VERSION}",
+              "pre-version": "${PRE_VERSION}"
+          }
+          EOF
+      - uses: peter-evans/create-pull-request@v5
+        with:
+          title: 'config: Automated Tagpr Update for ${{ inputs.version }}'
+          add-paths: |
+            .tagpr.json
+          body: |
+            
+            Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
+          commit-message: |
+            🤖 update tagpr config using robot.
+          branch: tagpr-new-${{ inputs.version }}
+          signoff: true
+          delete-branch: true
+          token: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+          committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow that automates the process of updating the `tagpr` configuration for releases. The workflow allows triggering a configuration update via the GitHub UI, generates a new `.tagpr.json` file based on input versions, and creates a pull request with the changes.

**New automated release workflow:**

* Added `.github/workflows/new_version_dispatch.yml` to enable manual triggering of a workflow that updates the `.tagpr.json` file with new release version information and automates the creation of a corresponding pull request.<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
