### PR TITLE
feat(tagpr): add configuration files and scripts for automated changelog generation

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,46 @@
+{{ range .Versions }}
+# Welcome to the {{ .Tag.Name }} release of Sealos!🎉🎉!
+
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]({{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}){{ else }}{{ .Tag.Name }}{{ end }} ({{ datetime "2006-01-02" .Tag.Date }})
+
+{{ range .CommitGroups -}}
+### {{ .Title }}
+
+{{ range .Commits -}}
+* {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+
+{{- if .RevertCommits -}}
+### Reverts
+
+{{ range .RevertCommits -}}
+* {{ .Revert.Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .MergeCommits -}}
+### Pull Requests
+
+{{ range .MergeCommits -}}
+* {{ .Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+See [the CHANGELOG](https://github.com/labring/sealos/blob/main/CHANGELOG/CHANGELOG.md) for more details.
+
+Your patronage towards Sealos is greatly appreciated 🎉🎉.
+
+If you encounter any problems during its usage, please create an issue in the [GitHub repository](https://github.com/labring/sealos), we're committed to resolving your problem as soon as possible.

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,29 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/labring/sealos
+options:
+  tag_filter_pattern: '^v'
+  commits:
+    # filters:
+    #   Type:
+    #     - feat
+    #     - fix
+    #     - perf
+    #     - refactor
+  commit_groups:
+    # title_maps:
+    #   feat: Features
+    #   fix: Bug Fixes
+    #   perf: Performance Improvements
+    #   refactor: Code Refactoring
+  header:
+    pattern: '^(\w*)(?:\(([\w$.\-*/ ]*)\))?: (.*)$'
+    pattern_maps:
+      - Type
+      - Scope
+      - Subject
+  notes:
+    keywords:
+      - BREAKING CHANGE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,44 +96,6 @@ jobs:
           SEALOS_ISSUE_REPO: "labring-actions/cluster-image"
           SEALOS_COMMENT_BODY: "/imagebuild_apps sealos ${{steps.get-current-tag.outputs.tag }}"
 
-  changelog:
-    runs-on: ubuntu-24.04
-    needs:
-      - goreleaser
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Fetch Current version
-        id: get-current-tag
-        uses: actions-ecosystem/action-get-latest-tag@v1.6.0
-      - run: git fetch --prune --prune-tags
-      - run: git tag -l 'v*'
-      - name: Generator changelog
-        env:
-          REPOSITORY: ${{ github.repository }}
-        run: ./scripts/changelog.sh "${REPOSITORY}"
-      - uses: peter-evans/create-pull-request@v5
-        with:
-          title: "docs: Automated Changelog Update for ${{steps.get-current-tag.outputs.tag }}"
-          body: |
-            copilot:all
-
-            Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
-          commit-message: |
-            🤖 add release changelog using rebot.
-          branch: changelog-${{steps.get-current-tag.outputs.tag }}
-          base: main
-          signoff: true
-          delete-branch: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-          committer: sealos-release-robot <sealos-release-robot@sealos.io>
-          author: sealos-release-robot <sealos-release-robot@sealos.io>
-
   cloud-release:
     uses: ./.github/workflows/cloud-release.yml
     needs:

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -1,0 +1,71 @@
+name: 🚀 Tagpr for GitHub Actions
+on:
+  push:
+    branches:
+      - main
+jobs:
+  tagpr:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - run: | 
+          wget -q https://github.com/git-chglog/git-chglog/releases/download/v0.15.4/git-chglog_0.15.4_linux_amd64.tar.gz
+          tar -zxvf git-chglog_0.15.4_linux_amd64.tar.gz git-chglog
+          sudo mv git-chglog /usr/local/bin/
+          git-chglog --version
+          rm -rf git-chglog_0.15.4_linux_amd64.tar.gz
+        name: Install git-chglog
+      - run: |
+          # check if .tagpr.json exists
+          if [ ! -f .tagpr.json ]; then
+            echo "No .tagpr.json file found."
+            exit 1
+          else
+            echo ".tagpr.json file already exists."
+          fi
+          version=$(cat .tagpr.json | jq -r '.version')
+          command=$(cat .tagpr.json | jq -r '.command')
+          name=$(cat .tagpr.json | jq -r '.name')
+          echo "version: $version"
+          echo "command: $command"
+          echo "name: $name"
+          echo "release: $release"
+          echo name=${name} >> $GITHUB_OUTPUT
+          echo version=${version} >> $GITHUB_OUTPUT
+          echo command=${command} >> $GITHUB_OUTPUT
+        id: tagpr
+        name: Print git-chglog tag
+      - name: Use command to generate version
+        if: "steps.tagpr.outputs.version != ''"
+        run: |
+          echo "Running command: ${{ steps.tagpr.outputs.command }}"
+          eval "${{ steps.tagpr.outputs.command }}"
+      - uses: peter-evans/create-pull-request@v5
+        if: "steps.tagpr.outputs.version != ''"
+        with:
+          title: 'Release ${{ steps.tagpr.outputs.name }} for ${{ steps.tagpr.outputs.version }}'
+          body: |
+            
+            Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
+          commit-message: |
+            🤖 New release for ${{ steps.tagpr.outputs.name }} using robot.
+          branch: tagpr-${{ steps.tagpr.outputs.version }}
+          draft: true
+          signoff: true
+          delete-branch: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+#      - name: Trigger Release Workflow(only when tagged)
+#        uses: actions/github-script@v6
+#        if: "steps.tagpr.outputs.tag != ''"
+#        with:
+#          script: |
+#            github.rest.actions.createWorkflowDispatch({
+#              owner: context.repo.owner,
+#              repo: context.repo.repo,
+#              workflow_id: 'release.yml',
+#              ref: "refs/tags/${{ steps.tagpr.outputs.tag }}",
+#            })

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -12,29 +12,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-REPO=$1
-TAG=$2
+TAG=$1
+PRE_VERSION=$2
 
-if [ -z "$REPO" ]; then
-   REPO="$GITHUB_REPOSITORY"
+if [ -z "${TAG}" ]; then
+    echo "Usage: $0 <tag> <previous_version>"
+    echo "Example: $0 v1.0.0 v0.9.0"
+    exit 1
 fi
 
-if [ -z "$TAG" ]; then
-   TAG=$(git describe --abbrev=0 --tags)
-fi
-set -ex
-# Fetch the release data using the GitHub API
-release_data=$(curl -s https://api.github.com/repos/"${REPO}"/releases/tags/"${TAG}")
-
-# Extract the release notes using jq
-release_notes=$(echo "$release_data" | jq -r '.body')
-
-if [ "$release_notes" == 'null' ]; then
-   echo "No release notes found for tag $TAG"
-   exit 1
+if [ ! -d CHANGELOG ]; then
+    mkdir CHANGELOG
 fi
 
-echo "$release_notes" > CHANGELOG/CHANGELOG-"${TAG#v}".md
+git-chglog --repository-url https://github.com/labring/sealos --output CHANGELOG/CHANGELOG-"${TAG#v}".md --next-tag ${TAG} ${TAG}
 
 echo "# Changelog" > CHANGELOG/CHANGELOG.md
 echo -e "\nAll notable changes to this project will be documented in this file.\n" >> CHANGELOG/CHANGELOG.md
@@ -43,3 +34,13 @@ for file in $(ls CHANGELOG |grep -v '^CHANGELOG.md$' | sort -V -r); do
     version=$(echo $file | sed -E 's/CHANGELOG-(.*)\.md/\1/')
     echo -e "- [CHANGELOG-${version}.md](./CHANGELOG-${version}.md)" >> CHANGELOG/CHANGELOG.md
 done
+
+## check version is release version
+if [[ ${TAG} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "!!!!! is release version, will update docs"
+    sed -i "s#${PRE_VERSION}#${TAG}#g" scripts/cloud/install.sh
+    sed -i "s#${PRE_VERSION}#${TAG}#g" scripts/cloud/build-offline-tar.sh
+    sed -i "s#${PRE_VERSION}#${TAG}#g" docs/5.0/i18n/zh-Hans/developer-guide/sealos/installation.md
+    sed -i "s#${PRE_VERSION}#${TAG}#g" docs/5.0/docs/developer-guide/sealos/installation.md
+    sed -i "s#${PRE_VERSION}#${TAG}#g" docs/4.0/docs/self-hosting/sealos/installation.md
+fi


### PR DESCRIPTION
This pull request introduces a new automated changelog generation workflow using `git-chglog`, replaces the previous changelog job in the release workflow, and adds configuration and templates for changelog formatting. It also updates the changelog script to use `git-chglog` and conditionally updates documentation files when a new release version is detected.

**Changelog Automation and Configuration:**

* Added a new workflow `.github/workflows/tagpr.yml` to automate changelog generation and release pull requests using `git-chglog` and `tagpr`.
* Added `.chglog/config.yml` and `.chglog/CHANGELOG.tpl.md` to configure and template the changelog output in GitHub style. [[1]](diffhunk://#diff-f27299617f81a75a6e22804bf0f13d035bf301b7a2b5ee7906bdda95be97055dR1-R29) [[2]](diffhunk://#diff-1f80ea1bb3b2ccb8356b3987ebb6c63076d206eacdb50de5a6d7b0027106841cR1-R46)

**Release Workflow Updates:**

* Removed the old `changelog` job from `.github/workflows/release.yml`, which previously generated changelogs and created PRs.

**Changelog Script Improvements:**

* Updated `scripts/changelog.sh` to use `git-chglog` for changelog generation, require both tag and previous version as arguments, and create the `CHANGELOG` directory if it doesn't exist.
* Enhanced `scripts/changelog.sh` to automatically update version references in documentation and install scripts when a new release version is detected.

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
