### PR TITLE
fix(ci): update permissions to allow write access for contents in new_version_dispatch.yml

### DIFF
--- a/.github/workflows/new_version_dispatch.yml
+++ b/.github/workflows/new_version_dispatch.yml
@@ -15,7 +15,7 @@ jobs:
   config:
     runs-on: ubuntu-22.04
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     steps:
       - name: Checkout


### PR DESCRIPTION
This pull request makes a minor update to the workflow permissions in `.github/workflows/new_version_dispatch.yml`, expanding the `contents` permission from `read` to `write` for the `config` job. This change allows the workflow to perform write operations on repository contents, such as creating or updating files.

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
