### PR TITLE
fix(ci): enable fetching tags in GitHub Actions workflow for changelog generation

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -9,6 +9,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - run: | 
           wget -q https://github.com/git-chglog/git-chglog/releases/download/v0.15.4/git-chglog_0.15.4_linux_amd64.tar.gz
           tar -zxvf git-chglog_0.15.4_linux_amd64.tar.gz git-chglog


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration. The main change is enabling tag fetching during the repository checkout step, which can help workflows that rely on git tags.

* Workflow configuration: Added `fetch-tags: true` to the `actions/checkout@v4` step in `.github/workflows/tagpr.yml` to ensure all tags are fetched during CI runs.

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
