### PR TITLE
fix(tagpr): remove unused release variable from output in tagpr.yml

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -32,7 +32,6 @@ jobs:
           echo "version: $version"
           echo "command: $command"
           echo "name: $name"
-          echo "release: $release"
           echo name=${name} >> $GITHUB_OUTPUT
           echo version=${version} >> $GITHUB_OUTPUT
           echo command=${command} >> $GITHUB_OUTPUT


### PR DESCRIPTION
This pull request makes a small change to the `.github/workflows/tagpr.yml` workflow file by removing the line that prints the value of the `release` variable.
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
