### PR TITLE
fix(changelog): automate git-chglog installation and update CI triggers for changelog generation

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -1,6 +1,10 @@
 name: 🚀 Tagpr for GitHub Actions
 on:
   workflow_dispatch:
+  push:
+    branches: [ "**" ]
+    paths:
+      - "CHANGELOG/CHANGELOG.md"
 jobs:
   tagpr:
     runs-on: ubuntu-24.04
@@ -9,15 +13,9 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        if: ${{ (github.event_name == 'workflow_dispatch') }}
         with:
           fetch-depth: 0
-      - run: | 
-          wget -q https://github.com/git-chglog/git-chglog/releases/download/v0.15.4/git-chglog_0.15.4_linux_amd64.tar.gz
-          tar -zxvf git-chglog_0.15.4_linux_amd64.tar.gz git-chglog
-          sudo mv git-chglog /usr/local/bin/
-          git-chglog --version
-          rm -rf git-chglog_0.15.4_linux_amd64.tar.gz
-        name: Install git-chglog
       - run: |
           # check if .tagpr.json exists
           if [ ! -f .tagpr.json ]; then
@@ -29,21 +27,19 @@ jobs:
           version=$(cat .tagpr.json | jq -r '.version')
           command=$(cat .tagpr.json | jq -r '.command')
           name=$(cat .tagpr.json | jq -r '.name')
-          echo "version: $version"
-          echo "command: $command"
-          echo "name: $name"
           echo name=${name} >> $GITHUB_OUTPUT
           echo version=${version} >> $GITHUB_OUTPUT
           echo command=${command} >> $GITHUB_OUTPUT
         id: tagpr
         name: Print git-chglog tag
+        if: ${{ (github.event_name == 'workflow_dispatch') }}
       - name: Use command to generate version
-        if: "steps.tagpr.outputs.version != ''"
+        if: ${{ (github.event_name == 'workflow_dispatch') && (steps.tagpr.outputs.version != '') }}
         run: |
           echo "Running command: ${{ steps.tagpr.outputs.command }}"
           eval "${{ steps.tagpr.outputs.command }}"
       - uses: peter-evans/create-pull-request@v5
-        if: "steps.tagpr.outputs.version != ''"
+        if: ${{ (github.event_name == 'workflow_dispatch') && (steps.tagpr.outputs.version != '') }}
         with:
           title: 'Release ${{ steps.tagpr.outputs.name }} for ${{ steps.tagpr.outputs.version }}'
           body: |

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -25,6 +25,17 @@ if [ ! -d CHANGELOG ]; then
     mkdir CHANGELOG
 fi
 
+if command -v git-chglog &> /dev/null; then
+    echo "git-chglog is installed, proceeding with changelog generation."
+else
+    echo "git-chglog is not installed. Will install it first."
+    wget -q https://github.com/git-chglog/git-chglog/releases/download/v0.15.4/git-chglog_0.15.4_linux_amd64.tar.gz
+    tar -zxvf git-chglog_0.15.4_linux_amd64.tar.gz git-chglog &> /dev/null
+    sudo mv git-chglog /usr/local/bin/
+    git-chglog --version
+    rm -rf git-chglog_0.15.4_linux_amd64.tar.gz
+fi
+
 git-chglog --repository-url https://github.com/labring/sealos --output CHANGELOG/CHANGELOG-"${TAG#v}".md --next-tag ${TAG} ${TAG}
 
 echo "# Changelog" > CHANGELOG/CHANGELOG.md


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow and the changelog generation script to improve automation and reliability for changelog management and release tagging. The main changes include triggering the workflow on changes to the changelog file, refining workflow steps to run only on manual dispatch, and ensuring the required tool (`git-chglog`) is installed automatically when generating changelogs.

**Workflow automation improvements:**

* The `tagpr` workflow is now triggered on any push to any branch that modifies `CHANGELOG/CHANGELOG.md`, in addition to manual dispatch. This makes changelog and release automation more robust.
* Several workflow steps, including checkout, version extraction, changelog generation, and pull request creation, are now restricted to run only on manual workflow dispatch events for better control. [[1]](diffhunk://#diff-ffc7eb13f2d4fb8a7c238f2f81c30c7b932ba8582616312295a6b4c15a6ad83eR16-L20) [[2]](diffhunk://#diff-ffc7eb13f2d4fb8a7c238f2f81c30c7b932ba8582616312295a6b4c15a6ad83eL32-R42)

**Changelog generation reliability:**

* The `scripts/changelog.sh` script now checks for the presence of `git-chglog` and installs it automatically if missing, ensuring changelog generation does not fail due to missing dependencies.

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
