### PR TITLE
feat(pr-lint): update workflow to validate pull request titles against semantic rules

### DIFF
--- a/.github/workflows/check-pr-title-lint-semantic.yml
+++ b/.github/workflows/check-pr-title-lint-semantic.yml
@@ -1,24 +1,24 @@
-name: 'Lint PR title semantic'
+name: 'Check PR title semantic'
 on:
   pull_request_target:
     types:
       - opened
       - edited
       - synchronize
+permissions:
+  pull-requests: write
+  statuses: write
 
 jobs:
-  main:
-    runs-on: ubuntu-22.04
-    permissions:
-      pull-requests: write
+  validate-pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          # https://github.com/amannn/action-semantic-pull-request
-          wip: true
-          # Default: https://github.com/commitizen/conventional-commit-types
           types: |
             feat
             fix
@@ -31,13 +31,35 @@ jobs:
             ci
             chore
             revert
-          subjectPattern: ^(?![A-Z]).+$
+          requireScope: false
+          ignoreLabels: |
+            bot
+          subjectPattern: ^.+$
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}"
             didn't match the configured pattern. Please ensure that the subject
             doesn't start with an uppercase character.
-          requireScope: false
-          ignoreLabels: |
-            bot
+          wip: true
           headerPattern: '^(\w*)(?:\(([\w$.\-*/ ]*)\))?: (.*)$'
           headerPatternCorrespondence: type, scope, subject
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+
+            Details:
+
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for semantic PR title checks, improving both validation and user feedback. The changes modernize the workflow configuration, enhance error messaging for contributors, and ensure that outdated error comments are removed automatically.

**Workflow configuration improvements:**

* Renamed the workflow from `'Lint PR title semantic'` to `'Check PR title semantic'` for clarity and updated the job name to `'Validate PR title'`. The runner was changed from `ubuntu-22.04` to `ubuntu-latest`, and the permissions now include `statuses: write` for better status reporting.
* Refactored the workflow to use the latest recommended configuration for `amannn/action-semantic-pull-request@v5`, including moving the `id` to the step, and reorganizing environment and input parameters.

**Validation and feedback enhancements:**

* Adjusted input parameters for semantic PR title validation: removed the restriction that subjects cannot start with an uppercase character (`subjectPattern`), set `requireScope: false`, and added `ignoreLabels: bot` to skip bot PRs.
* Added a step using `marocchino/sticky-pull-request-comment@v2` to post a detailed error message as a comment when PR title validation fails, helping contributors understand and resolve issues with their PR titles.
* Implemented automatic deletion of previous error comments when the PR title is corrected, keeping the conversation clean and up-to-date.

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
