### PR TITLE
feat(pr-lint): add support for labeled and unlabeled events in PR title linting workflow

### DIFF
--- a/.github/workflows/check-pr-title-lint-semantic.yml
+++ b/.github/workflows/check-pr-title-lint-semantic.yml
@@ -5,6 +5,8 @@ on:
       - opened
       - edited
       - synchronize
+      - labeled
+      - unlabeled
 permissions:
   pull-requests: write
   statuses: write


### PR DESCRIPTION
This pull request makes a minor update to the workflow trigger events in `.github/workflows/check-pr-title-lint-semantic.yml`. The workflow will now also run when a pull request is labeled or unlabeled.

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
