### PR TITLE
fix(init.sh): streamline image pulling and saving process with associative array

### DIFF
--- a/deploy/cloud/init.sh
+++ b/deploy/cloud/init.sh
@@ -24,46 +24,40 @@ retryPullImage() {
     fi
 }
 
-retryPullImage ghcr.io/labring/sealos-cloud-user-controller:latest
-retryPullImage ghcr.io/labring/sealos-cloud-terminal-controller:latest
-retryPullImage ghcr.io/labring/sealos-cloud-app-controller:latest
-retryPullImage ghcr.io/labring/sealos-cloud-resources-controller:latest
-retryPullImage ghcr.io/labring/sealos-cloud-account-controller:latest
-retryPullImage ghcr.io/labring/sealos-cloud-license-controller:latest
+declare -A images=(
+  # controllers
+  ["ghcr.io/labring/sealos-cloud-user-controller:latest"]="user.tar"
+  ["ghcr.io/labring/sealos-cloud-terminal-controller:latest"]="terminal.tar"
+  ["ghcr.io/labring/sealos-cloud-app-controller:latest"]="app.tar"
+  ["ghcr.io/labring/sealos-cloud-resources-controller:latest"]="monitoring.tar"
+  ["ghcr.io/labring/sealos-cloud-account-controller:latest"]="account.tar"
+  ["ghcr.io/labring/sealos-cloud-license-controller:latest"]="license.tar"
 
-retryPullImage ghcr.io/labring/sealos-cloud-desktop-frontend:latest
-retryPullImage ghcr.io/labring/sealos-cloud-terminal-frontend:latest
-retryPullImage ghcr.io/labring/sealos-cloud-applaunchpad-frontend:latest
-retryPullImage ghcr.io/labring/sealos-cloud-dbprovider-frontend:latest
-retryPullImage ghcr.io/labring/sealos-cloud-costcenter-frontend:latest
-retryPullImage ghcr.io/labring/sealos-cloud-template-frontend:latest
-retryPullImage ghcr.io/labring/sealos-cloud-license-frontend:latest
-retryPullImage ghcr.io/labring/sealos-cloud-cronjob-frontend:latest
+  # frontends
+  ["ghcr.io/labring/sealos-cloud-desktop-frontend:latest"]="frontend-desktop.tar"
+  ["ghcr.io/labring/sealos-cloud-terminal-frontend:latest"]="frontend-terminal.tar"
+  ["ghcr.io/labring/sealos-cloud-applaunchpad-frontend:latest"]="frontend-applaunchpad.tar"
+  ["ghcr.io/labring/sealos-cloud-dbprovider-frontend:latest"]="frontend-dbprovider.tar"
+  ["ghcr.io/labring/sealos-cloud-costcenter-frontend:latest"]="frontend-costcenter.tar"
+  ["ghcr.io/labring/sealos-cloud-template-frontend:latest"]="frontend-template.tar"
+  ["ghcr.io/labring/sealos-cloud-license-frontend:latest"]="frontend-license.tar"
+  ["ghcr.io/labring/sealos-cloud-cronjob-frontend:latest"]="frontend-cronjob.tar"
 
-retryPullImage ghcr.io/labring/sealos-cloud-database-service:latest
-retryPullImage ghcr.io/labring/sealos-cloud-account-service:latest
-retryPullImage ghcr.io/labring/sealos-cloud-launchpad-service:latest
-retryPullImage ghcr.io/labring/sealos-cloud-job-init-controller:latest
-retryPullImage ghcr.io/labring/sealos-cloud-job-heartbeat-controller:latest
+  # services
+  ["ghcr.io/labring/sealos-cloud-database-service:latest"]="database-service.tar"
+  ["ghcr.io/labring/sealos-cloud-account-service:latest"]="account-service.tar"
+  ["ghcr.io/labring/sealos-cloud-launchpad-service:latest"]="launchpad-service.tar"
+  ["ghcr.io/labring/sealos-cloud-job-init-controller:latest"]="job-init.tar"
+  ["ghcr.io/labring/sealos-cloud-job-heartbeat-controller:latest"]="job-heartbeat.tar"
+)
 
-sealos save -o tars/user.tar ghcr.io/labring/sealos-cloud-user-controller:latest
-sealos save -o tars/terminal.tar ghcr.io/labring/sealos-cloud-terminal-controller:latest
-sealos save -o tars/app.tar ghcr.io/labring/sealos-cloud-app-controller:latest
-sealos save -o tars/monitoring.tar ghcr.io/labring/sealos-cloud-resources-controller:latest
-sealos save -o tars/account.tar ghcr.io/labring/sealos-cloud-account-controller:latest
-sealos save -o tars/license.tar ghcr.io/labring/sealos-cloud-license-controller:latest
+mkdir -p tars
 
-sealos save -o tars/frontend-desktop.tar  ghcr.io/labring/sealos-cloud-desktop-frontend:latest
-sealos save -o tars/frontend-terminal.tar  ghcr.io/labring/sealos-cloud-terminal-frontend:latest
-sealos save -o tars/frontend-dbprovider.tar ghcr.io/labring/sealos-cloud-dbprovider-frontend:latest
-sealos save -o tars/frontend-costcenter.tar ghcr.io/labring/sealos-cloud-costcenter-frontend:latest
-sealos save -o tars/frontend-applaunchpad.tar ghcr.io/labring/sealos-cloud-applaunchpad-frontend:latest
-sealos save -o tars/frontend-template.tar ghcr.io/labring/sealos-cloud-template-frontend:latest
-sealos save -o tars/frontend-license.tar ghcr.io/labring/sealos-cloud-license-frontend:latest
-sealos save -o tars/frontend-cronjob.tar ghcr.io/labring/sealos-cloud-cronjob-frontend:latest
+for img in "${!images[@]}"; do
+  echo "=== Pulling $img ==="
+  retryPullImage "$img"
 
-sealos save -o tars/database-service.tar ghcr.io/labring/sealos-cloud-database-service:latest
-sealos save -o tars/account-service.tar ghcr.io/labring/sealos-cloud-account-service:latest
-sealos save -o tars/launchpad-service.tar ghcr.io/labring/sealos-cloud-launchpad-service:latest
-sealos save -o tars/job-init.tar ghcr.io/labring/sealos-cloud-job-init-controller:latest
-sealos save -o tars/job-heartbeat.tar ghcr.io/labring/sealos-cloud-job-heartbeat-controller:latest
+  tar_name=${images[$img]}
+  echo "=== Saving $img to tars/$tar_name ==="
+  sealos save -o "tars/$tar_name" "$img"
+done


### PR DESCRIPTION
This pull request refactors the image pulling and saving logic in `deploy/cloud/init.sh` to make it more maintainable and scalable. Instead of listing each image and its tar file individually, the script now uses an associative array to manage image-to-tar mappings and loops over them to perform the operations. This reduces code duplication and makes it easier to add or modify images in the future.

**Refactoring and maintainability improvements:**

* Replaced multiple individual `retryPullImage` and `sealos save` calls with a single associative array (`images`) mapping image names to their respective tar files, streamlining the process.
* Added a loop to iterate over the array, pulling each image and saving it to the correct location, which simplifies future updates and reduces the risk of errors.
* Ensured the `tars` directory is created before saving images, improving robustness.