### PR TITLE
fix(ci): fix cloud release version

### DIFF
--- a/.github/workflows/cloud-release.yml
+++ b/.github/workflows/cloud-release.yml
@@ -1,18 +1,6 @@
 name: Release Cloud
 
 on:
-  workflow_call:
-    inputs:
-      tag:
-        description: "Tag for manual release"
-        required: false
-        default: ""
-        type: string
-      build_offline_tar_only:
-        description: "Build offline tar only"
-        required: false
-        default: false
-        type: boolean
   workflow_dispatch:
     inputs:
       tag:
@@ -31,6 +19,10 @@ env:
   GO_VERSION: "1.20"
   DEFAULT_OWNER: "labring"
 
+permissions:
+  contents: write
+  actions: write
+
 jobs:
   save-sealos:
     uses: ./.github/workflows/import-save-sealos.yml
@@ -39,29 +31,59 @@ jobs:
 
   release-controllers:
     if: ${{ inputs.build_offline_tar_only == false }}
-    uses: ./.github/workflows/controllers.yml
-    with:
-      push_image: true
-      push_image_tag: ${{inputs.tag }}
-    secrets: inherit
-
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Trigger Cloud Controller Release Workflow(only when tagged)
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'controllers.yml',
+              ref: "refs/tags/${{ github.ref_name }}",
+              inputs: {
+                  push_image_tag: "${{ github.ref_name }}",
+                  push_image: true
+              }
+            })
   release-frontends:
     if: ${{ inputs.build_offline_tar_only == false }}
-    uses: ./.github/workflows/frontends.yml
-    with:
-      push_image: true
-      push_image_tag: ${{ inputs.tag }}
-    secrets: inherit
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Trigger Cloud Frontends Release Workflow(only when tagged)
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'frontends.yml',
+              ref: "refs/tags/${{ github.ref_name }}",
+              inputs: {
+                  push_image_tag: "${{ github.ref_name }}",
+                  push_image: true
+              }
+            })
 
   release-service:
     if: ${{ inputs.build_offline_tar_only == false }}
-    needs:
-      - save-sealos
-    uses: ./.github/workflows/services.yml
-    with:
-      push_image: true
-      push_image_tag: ${{ inputs.tag }}
-    secrets: inherit
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Trigger Cloud Services Release Workflow(only when tagged)
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'services.yml',
+              ref: "refs/tags/${{ github.ref_name }}",
+              inputs: {
+                  push_image_tag: "${{ github.ref_name }}",
+                  push_image: true
+              }
+            })
 
   release-cloud:
     if: ${{ inputs.build_offline_tar_only == false }}

--- a/.github/workflows/controllers.yml
+++ b/.github/workflows/controllers.yml
@@ -1,20 +1,6 @@
 name: Build Controllers image
 
 on:
-  create:
-    tags:
-  workflow_call:
-    inputs:
-      push_image:
-        description: "Push image"
-        required: false
-        type: boolean
-        default: false
-      push_image_tag:
-        description: "Push image tag"
-        default: "latest"
-        required: false
-        type: string
   workflow_dispatch:
     inputs:
       push_image:

--- a/.github/workflows/frontends.yml
+++ b/.github/workflows/frontends.yml
@@ -1,18 +1,6 @@
 name: Build Frontends Image
 
 on:
-  workflow_call:
-    inputs:
-      push_image:
-        description: "Push image"
-        required: false
-        type: boolean
-        default: false
-      push_image_tag:
-        description: "Push image tag"
-        default: "latest"
-        required: false
-        type: string
   workflow_dispatch:
     inputs:
       push_image:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  goreleaser:
+  releaser:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -49,13 +49,25 @@ jobs:
           FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
 
   cloud-release:
-    uses: ./.github/workflows/cloud-release.yml
+    runs-on: ubuntu-24.04
     needs:
-      - goreleaser
+      - releaser
     permissions:
       contents: read
       packages: write
-    secrets: inherit
-    with:
-      tag: ${{ github.ref_name }}
-      build_offline_tar_only: false
+      actions: write
+    steps:
+      - name: Trigger Cloud Release Workflow(only when tagged)
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'cloud-release.yml',
+              ref: "refs/tags/${{ github.ref_name }}",
+              inputs: {
+                  tag: "${{ github.ref_name }}",
+                  build_offline_tar_only: false
+              }
+            })

--- a/.github/workflows/services.yml
+++ b/.github/workflows/services.yml
@@ -1,20 +1,6 @@
 name: Build Services image
 
 on:
-  create:
-    tags:
-  workflow_call:
-    inputs:
-      push_image:
-        description: "Push image"
-        required: false
-        type: boolean
-        default: false
-      push_image_tag:
-        description: "Push image tag"
-        default: "latest"
-        required: false
-        type: string
   workflow_dispatch:
     inputs:
       push_image:

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/deploy/cloud/init.sh
+++ b/deploy/cloud/init.sh
@@ -3,13 +3,12 @@ set -e
 export readonly ARCH=${1:-amd64}
 mkdir -p tars
 
-RetryPullImageInterval=3
-RetrySleepSeconds=3
+RetryPullImageInterval=1000
+RetrySleepSeconds=15
 
 retryPullImage() {
     local image=$1
     local retry=0
-    local retryMax=3
     set +e
     while [ $retry -lt $RetryPullImageInterval ]; do
         sealos pull --policy=always --platform=linux/"${ARCH}" $image >/dev/null && break
@@ -18,10 +17,6 @@ retryPullImage() {
         sleep $RetrySleepSeconds
     done
     set -e
-    if [ $retry -eq $retryMax ]; then
-        echo "pull image $image failed"
-        exit 1
-    fi
 }
 
 declare -A images=(


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files and a deployment script to improve workflow triggering, permissions, and reliability. The main focus is on simplifying workflow calls by replacing `workflow_call` triggers with explicit dispatches via `github-script`, standardizing permissions, and making the image pull process in deployment more robust.

**GitHub Actions workflow improvements:**

* Replaced `workflow_call` triggers with explicit `workflow_dispatch` and now use `actions/github-script` to programmatically trigger dependent workflows (`cloud-release.yml`, `controllers.yml`, `frontends.yml`, `services.yml`) with the correct input parameters and tags. This change improves workflow traceability and flexibility. [[1]](diffhunk://#diff-1ebe2a71c6faae100a83a25e137b8faa06863d5839030ead4821fb599f8a9008L42-R86) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L52-R73)
* Standardized permissions across workflows, adding `actions: write` and `contents: write` where necessary to enable workflow dispatching and artifact management. [[1]](diffhunk://#diff-1ebe2a71c6faae100a83a25e137b8faa06863d5839030ead4821fb599f8a9008R22-R25) [[2]](diffhunk://#diff-ffc7eb13f2d4fb8a7c238f2f81c30c7b932ba8582616312295a6b4c15a6ad83eR14)

**Workflow configuration simplification:**

* Removed `workflow_call` input definitions from `controllers.yml`, `frontends.yml`, and `services.yml`, as these workflows are now triggered via dispatch with explicit parameters. [[1]](diffhunk://#diff-8e0e4903d4e4f8b8844d36370ca2d71c7c72d03ddb7a9cdcedc6328dfc5da8faL4-L17) [[2]](diffhunk://#diff-f54e73070debc3cb4778e1841e1f17b0e3f87cb8448b47c27e71009f1b81e2c6L4-L15) [[3]](diffhunk://#diff-48839d65f7bfedd91312ee406fd94da103ede7d3c7e791eb2c1657f46afdea00L4-L17)
* Renamed the `goreleaser` job to `releaser` in `release.yml` for clarity and consistency.

**Deployment reliability improvements:**

* Increased the retry interval and sleep duration in the `retryPullImage` function within `deploy/cloud/init.sh`, making image pulls more robust against transient failures. Also removed the hard exit after a fixed number of retries, allowing for longer retry attempts. [[1]](diffhunk://#diff-7c20f8ecac334e472df2875627ce9de0e4297d7c839ef4ed0da3e80cb4e16595L6-L12) [[2]](diffhunk://#diff-7c20f8ecac334e472df2875627ce9de0e4297d7c839ef4ed0da3e80cb4e16595L21-L24)
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
