### PR TITLE
fix(changelog): update release notes path in CI configuration and copy latest changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          args: release --clean --release-footer-tmpl=scripts/release/footer.md.tmpl --release-header-tmpl=scripts/release/head.md.tmpl
+          args: release --clean --release-notes=../CHANGELOG/CHANGELOG-latest.md
           workdir: ./lifecycle
         env:
           USERNAME: ${{ github.repository_owner }}

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -43,6 +43,9 @@ echo -e "\nAll notable changes to this project will be documented in this file.\
 
 for file in $(ls CHANGELOG |grep -v '^CHANGELOG.md$' | sort -V -r); do
     version=$(echo $file | sed -E 's/CHANGELOG-(.*)\.md/\1/')
+    if [ "$version" = "latest" ]; then
+        continue
+    fi
     echo -e "- [CHANGELOG-${version}.md](./CHANGELOG-${version}.md)" >> CHANGELOG/CHANGELOG.md
 done
 
@@ -52,3 +55,5 @@ if [[ ${TAG} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     sed -i "s#${PRE_VERSION}#${TAG}#g" scripts/cloud/install.sh
     sed -i "s#${PRE_VERSION}#${TAG}#g" scripts/cloud/build-offline-tar.sh
 fi
+
+cp CHANGELOG/CHANGELOG-"${TAG#v}".md CHANGELOG/CHANGELOG-latest.md


### PR DESCRIPTION
This pull request updates the release workflow to improve how release notes are managed and referenced. The main change is that the release process now uses the latest changelog file as release notes, and the changelog script ensures this file is always up to date.

**Release workflow improvements:**

* Updated the GoReleaser step in `.github/workflows/release.yml` to use `CHANGELOG/CHANGELOG-latest.md` for release notes instead of custom header and footer templates.

**Changelog management:**

* Modified `scripts/changelog.sh` to copy the changelog for the current tag to `CHANGELOG/CHANGELOG-latest.md`, ensuring the latest release notes are always available for the workflow.

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
