### PR TITLE
feat(kubeadm): refactor kubeadm config merging and improve node handling

### DIFF
--- a/lifecycle/pkg/buildah/create.go
+++ b/lifecycle/pkg/buildah/create.go
@@ -32,11 +32,12 @@ import (
 
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/storage/pkg/unshare"
-	"github.com/labring/sreg/pkg/utils/file"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/labring/sealos/pkg/utils/file"
 
 	"github.com/labring/sealos/pkg/utils/logger"
 	"github.com/labring/sealos/pkg/utils/maps"

--- a/lifecycle/pkg/runtime/kubernetes/master.go
+++ b/lifecycle/pkg/runtime/kubernetes/master.go
@@ -20,6 +20,8 @@ import (
 	"path"
 	"strings"
 
+	"github.com/labring/sealos/pkg/utils/iputils"
+
 	"github.com/labring/sreg/pkg/registry/crane"
 	"k8s.io/apimachinery/pkg/util/json"
 
@@ -112,7 +114,7 @@ func (k *KubeadmRuntime) ConfigJoinMasterKubeadmToMaster(master string) error {
 	if err != nil {
 		return fmt.Errorf("failed to generate join master kubeadm config: %s", err.Error())
 	}
-	joinConfigPath := path.Join(k.pathResolver.TmpPath(), defaultJoinMasterKubeadmFileName)
+	joinConfigPath := path.Join(k.pathResolver.TmpPath(), iputils.GetHostIP(master), defaultJoinMasterKubeadmFileName)
 	outConfigPath := path.Join(k.pathResolver.ConfigsPath(), defaultJoinMasterKubeadmFileName)
 	err = file.WriteFile(joinConfigPath, data)
 	if err != nil {

--- a/lifecycle/pkg/runtime/kubernetes/node.go
+++ b/lifecycle/pkg/runtime/kubernetes/node.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/labring/sealos/pkg/ssh"
 	"github.com/labring/sealos/pkg/utils/file"
+	"github.com/labring/sealos/pkg/utils/iputils"
 	"github.com/labring/sealos/pkg/utils/logger"
 
 	"golang.org/x/sync/errgroup"
@@ -76,7 +77,7 @@ func (k *KubeadmRuntime) copyKubeadmConfigToNode(node string) error {
 	if err != nil {
 		return fmt.Errorf("failed to generate join kubeadm config: %v", err)
 	}
-	joinConfigPath := path.Join(k.pathResolver.TmpPath(), defaultJoinNodeKubeadmFileName)
+	joinConfigPath := path.Join(k.pathResolver.TmpPath(), iputils.GetHostIP(node), defaultJoinNodeKubeadmFileName)
 	outConfigPath := path.Join(k.pathResolver.ConfigsPath(), defaultJoinNodeKubeadmFileName)
 	err = file.WriteFile(joinConfigPath, data)
 	if err != nil {

--- a/lifecycle/pkg/runtime/kubernetes/types/default_kubeadm_config.go
+++ b/lifecycle/pkg/runtime/kubernetes/types/default_kubeadm_config.go
@@ -21,9 +21,7 @@ const (
 kind: InitConfiguration
 localAPIEndpoint:
   # advertiseAddress: 192.168.2.110
-  bindPort: 6443
-nodeRegistration:
-  criSocket: /run/containerd/containerd.sock`
+  bindPort: 6443`
 	defaultKubeadmClusterConfiguration = `apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 kubernetesVersion: v1.19.8
@@ -194,8 +192,6 @@ kind: JoinConfiguration
 caCertPath: /etc/kubernetes/pki/ca.crt
 discovery:
   timeout: 5m0s
-nodeRegistration:
-  criSocket: /run/containerd/containerd.sock
 controlPlane:
   localAPIEndpoint:
     # advertiseAddress: 192.168.56.7


### PR DESCRIPTION
This pull request refactors the kubeadm configuration handling in the Kubernetes runtime implementation to improve node-specific configuration and correctness. The main changes include making kubeadm config merging node-aware, updating how temporary config files are generated per node, and ensuring image pull policies are set consistently. Additionally, some code simplifications and dependency updates were made.

### Node-specific kubeadm config handling

* Refactored `MergeKubeadmConfig` to accept a `node` parameter, making the kubeadm config merge process node-aware and removing the use of `sync.Once` for improved correctness and flexibility. (`kubeadm.go`) [[1]](diffhunk://#diff-f11e9288eaffe6827f03da8996c69e3a5e4208f7ef36c3791101f04047aab8baL103-R114) [[2]](diffhunk://#diff-f11e9288eaffe6827f03da8996c69e3a5e4208f7ef36c3791101f04047aab8baL130)
* Updated `getDefaultKubeadmConfig` to accept a `node` parameter and generate a temporary kubeadm config file for the specific node, using its IP address, improving per-node configuration accuracy. (`kubeadm.go`)
* Changed calls to `MergeKubeadmConfig` in config generation functions to pass the appropriate node or master IP, ensuring that config merging is node-specific. (`kubeadm.go`) [[1]](diffhunk://#diff-f11e9288eaffe6827f03da8996c69e3a5e4208f7ef36c3791101f04047aab8baL473-R486) [[2]](diffhunk://#diff-f11e9288eaffe6827f03da8996c69e3a5e4208f7ef36c3791101f04047aab8baL497-R510) [[3]](diffhunk://#diff-f11e9288eaffe6827f03da8996c69e3a5e4208f7ef36c3791101f04047aab8baL517-R530)

### Temporary file generation improvements

* Modified paths for temporary join config files to include the node's IP address, preventing file collisions and improving traceability of node-specific config files. (`master.go`, `node.go`) [[1]](diffhunk://#diff-adb080595d966a280c1442130d8611e989ed3cf4546aac43fd30a1ba1d524345L115-R116) [[2]](diffhunk://#diff-36fc7a045a554383e063a70ec69faacc0a3dec2335cec0a8dc2aaa4bfc173327L79-R79)

### Image pull policy and CRI socket handling

* Ensured image pull policies are set to `PullNever` for both init and join configurations, and improved logic for setting CRI sockets only if not already set, reducing unnecessary overwrites. (`kubeadm.go`) [[1]](diffhunk://#diff-f11e9288eaffe6827f03da8996c69e3a5e4208f7ef36c3791101f04047aab8baR436-R445) [[2]](diffhunk://#diff-f11e9288eaffe6827f03da8996c69e3a5e4208f7ef36c3791101f04047aab8baR567-R568)

### Dependency and import updates

* Added missing imports for utilities such as `file` and `iputils` where needed to support new functionality. (`kubeadm.go`, `master.go`, `node.go`) [[1]](diffhunk://#diff-f11e9288eaffe6827f03da8996c69e3a5e4208f7ef36c3791101f04047aab8baR20-L22) [[2]](diffhunk://#diff-adb080595d966a280c1442130d8611e989ed3cf4546aac43fd30a1ba1d524345R20) [[3]](diffhunk://#diff-36fc7a045a554383e063a70ec69faacc0a3dec2335cec0a8dc2aaa4bfc173327L20-R24)

### Default configuration cleanup

* Removed hardcoded `nodeRegistration` sections from default kubeadm configuration templates to avoid conflicts with dynamic config generation. (`default_kubeadm_config.go`) [[1]](diffhunk://#diff-7b353333f60bcf670d687e9603d4b670f1574c9cb7c69d8f441aec9ad4e8c66eL24-R24) [[2]](diffhunk://#diff-7b353333f60bcf670d687e9603d4b670f1574c9cb7c69d8f441aec9ad4e8c66eL197-L198)