### PR TITLE
feat(apply): conditionally append components based on distribution type

### DIFF
--- a/lifecycle/pkg/apply/applydrivers/apply_drivers_default.go
+++ b/lifecycle/pkg/apply/applydrivers/apply_drivers_default.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/labring/sealos/pkg/runtime/k3s"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"golang.org/x/sync/errgroup"
@@ -123,9 +125,12 @@ func (c *Applier) Apply() error {
 
 func (c *Applier) getWriteBackObjects() []interface{} {
 	obj := []interface{}{c.ClusterDesired}
+	distribution := c.ClusterFile.GetCluster().GetDistribution()
 	if runtimeConfig := c.ClusterFile.GetRuntimeConfig(); runtimeConfig != nil {
 		if components := runtimeConfig.GetComponents(); len(components) > 0 {
-			obj = append(obj, components...)
+			if distribution == k3s.Distribution {
+				obj = append(obj, components...)
+			}
 		}
 	}
 	if configs := c.ClusterFile.GetConfigs(); len(configs) > 0 {

--- a/lifecycle/pkg/types/v1beta1/utils.go
+++ b/lifecycle/pkg/types/v1beta1/utils.go
@@ -109,6 +109,9 @@ func (c *Cluster) GetAllIPS() []string {
 }
 
 func (c *Cluster) GetRootfsImage() *MountImage {
+	if c == nil || len(c.Status.Mounts) == 0 {
+		return nil
+	}
 	for _, img := range c.Status.Mounts {
 		if img.IsRootFs() {
 			return &img


### PR DESCRIPTION
This pull request introduces a small update to the cluster application driver logic, specifically targeting the handling of runtime components based on distribution type. The change ensures that components are only written back when the distribution is `k3s`, improving correctness for multi-distribution support.

Distribution-specific handling:

* Added import of the `k3s` distribution identifier from `github.com/labring/sealos/pkg/runtime/k3s` to enable distribution checks.
* Updated the `getWriteBackObjects` method in `apply_drivers_default.go` to append runtime components only if the cluster distribution is `k3s`, preventing unintended writes for other distributions.