### PR TITLE
fix(deploy): add wait loop for desktop-frontend pods to ensure readiness

### DIFF
--- a/frontend/desktop/deploy/scripts/init.sh
+++ b/frontend/desktop/deploy/scripts/init.sh
@@ -8,3 +8,15 @@ else
   echo "create desktop config"
   kubectl apply -f manifests/configmap.yaml --validate=false
 fi
+
+ while true; do
+    # shellcheck disable=SC2126
+    NOT_RUNNING=$(kubectl get pods -n sealos --no-headers | grep desktop-frontend | grep -v "Running" | wc -l)
+    if [[ $NOT_RUNNING -eq 0 ]]; then
+        echo "All pods are in Running state for desktop-frontend !"
+        break
+    else
+        echo "Waiting for pods to be in Running state for desktop-frontend..."
+        sleep 2
+    fi
+done


### PR DESCRIPTION
This pull request adds a readiness check to the `frontend/desktop/deploy/scripts/init.sh` deployment script to ensure that all `desktop-frontend` pods are running before proceeding. This helps prevent issues caused by moving forward before the pods are fully started.

Deployment reliability improvement:

* Added a loop to `init.sh` that waits until all `desktop-frontend` pods are in the `Running` state, improving deployment robustness by ensuring readiness before continuing.
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
