### PR TITLE
fix(devbox): remove init container and add migration job for database deployment

### DIFF
--- a/frontend/providers/devbox/deploy/manifests/deploy.yaml.tmpl
+++ b/frontend/providers/devbox/deploy/manifests/deploy.yaml.tmpl
@@ -34,16 +34,6 @@ spec:
       labels:
         app: devbox-frontend
     spec:
-      initContainers:
-        - name: devbox-frontend-init
-          image: ghcr.io/labring/sealos-devbox-frontend:latest
-          imagePullPolicy: Always
-          env:
-            - name: REGION_UID
-              value: {{ .regionUid }} # -nsealos cm desktop-frontend-config ->regionUid
-            - name: DATABASE_URL
-              value: {{ .databaseUrl }} # -nsealos cm desktop-frontend-config ->database->global + devbox
-          command: ['/bin/bash', '-c', '/app/providers/devbox/init-database.sh']
       containers:
         - name: devbox-frontend
           env:

--- a/frontend/providers/devbox/deploy/manifests/job.yaml.tmpl
+++ b/frontend/providers/devbox/deploy/manifests/job.yaml.tmpl
@@ -14,7 +14,7 @@ spec:
         - sh
         - -c
         args:
-        - cd /app/providers/devbox && npx prisma@5.10.2 migrate deploy
+        - cd /app/providers/devbox && prisma migrate deploy
         env:
         - name: DATABASE_URL
           value: {{ .databaseUrl }}

--- a/frontend/providers/devbox/deploy/manifests/job.yaml.tmpl
+++ b/frontend/providers/devbox/deploy/manifests/job.yaml.tmpl
@@ -1,0 +1,22 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: prisma-migrate-deploy
+  namespace: devbox-frontend
+spec:
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      containers:
+      - name: migrate
+        image: ghcr.io/labring/sealos-devbox-frontend:latest
+        command:
+        - sh
+        - -c
+        args:
+        - cd /app/providers/devbox && npx prisma@5.10.2 migrate deploy
+        env:
+        - name: DATABASE_URL
+          value: {{ .databaseUrl }}
+      restartPolicy: Never
+  backoffLimit: 1


### PR DESCRIPTION
This pull request refactors how database migrations are handled during deployment for the devbox frontend. The main change is moving the migration logic from an init container within the deployment to a dedicated Kubernetes Job, improving separation of concerns and reliability.

**Deployment manifest changes:**

* Removed the `devbox-frontend-init` init container from the deployment manifest, which previously ran database initialization and migrations using a shell script.

**Database migration handling:**

* Added a new `prisma-migrate-deploy` Kubernetes Job manifest to run Prisma migrations separately, using the latest devbox frontend image and the provided `DATABASE_URL` environment variable.

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
