### PR TITLE
feat(deploy): add NODE_TLS_REJECT_UNAUTHORIZED environment variable to frontend containers

### DIFF
--- a/frontend/providers/applaunchpad/deploy/manifests/deploy.yaml.tmpl
+++ b/frontend/providers/applaunchpad/deploy/manifests/deploy.yaml.tmpl
@@ -68,6 +68,9 @@ spec:
     spec:
       containers:
         - name: applaunchpad-frontend
+          env:
+          - name: NODE_TLS_REJECT_UNAUTHORIZED
+            value: {{ default "" .tlsRejectUnauthorized }}
           securityContext:
             runAsNonRoot: true
             runAsUser: 1001

--- a/frontend/providers/devbox/deploy/manifests/deploy.yaml.tmpl
+++ b/frontend/providers/devbox/deploy/manifests/deploy.yaml.tmpl
@@ -37,6 +37,8 @@ spec:
       containers:
         - name: devbox-frontend
           env:
+            - name: NODE_TLS_REJECT_UNAUTHORIZED
+              value: {{ default "" .tlsRejectUnauthorized }}
             - name: DOCUMENT_URL_ZH
               value: https://sealos.run/docs/overview/intro
             - name: DOCUMENT_URL_EN


### PR DESCRIPTION
This pull request introduces a new environment variable configuration to the deployment manifests for both the `applaunchpad-frontend` and `devbox-frontend` containers. The change allows the value of `NODE_TLS_REJECT_UNAUTHORIZED` to be set via Helm templating, enabling more flexible control over Node.js TLS behavior in different deployment environments.

Environment variable configuration:

* Added support for setting the `NODE_TLS_REJECT_UNAUTHORIZED` environment variable in the `applaunchpad-frontend` deployment manifest using a Helm template value.
* Added support for setting the `NODE_TLS_REJECT_UNAUTHORIZED` environment variable in the `devbox-frontend` deployment manifest using a Helm template value.

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
