### PR TITLE
feat(config): add allowed origins for cloud domain in configmap

### DIFF
--- a/frontend/desktop/deploy/manifests/configmap.yaml.tmpl
+++ b/frontend/desktop/deploy/manifests/configmap.yaml.tmpl
@@ -10,6 +10,21 @@ data:
       port: "{{ .cloudPort }}"
       regionUID: "{{ .regionUID }}"
       certSecretName: "{{ .certSecretName }}"
+      allowedOrigins:
+      - "https://workorder.{{ .cloudDomain }}"
+      - "https://invite.{{ .cloudDomain }}"
+      - "https://applaunchpad.{{ .cloudDomain }}"
+      - "https://dbprovider.{{ .cloudDomain }}"
+      - "https://costcenter.{{ .cloudDomain }}"
+      - "https://cronjob.{{ .cloudDomain }}"
+      - "https://objectstorage.{{ .cloudDomain }}"
+      - "https://template.{{ .cloudDomain }}"
+      - "https://terminal.{{ .cloudDomain }}"
+      - "https://kubepanel.{{ .cloudDomain }}"
+      - "https://devbox.{{ .cloudDomain }}"
+      - "https://sealaf.{{ .cloudDomain }}"
+      - "https://aiproxy-web.{{ .cloudDomain }}"
+      - "https://ba0516339c3261c4f603.{{ .cloudDomain }}"
     common:
       guideEnabled: false
       apiEnabled: false


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
