### PR TITLE
fix(deploy): add namespace to cluster role binding in deploy manifest

### DIFF
--- a/service/hubble/deploy/manifests/deploy.yaml
+++ b/service/hubble/deploy/manifests/deploy.yaml
@@ -22,6 +22,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: service-hubble-sa
+    namespace: hubble-service
 roleRef:
   kind: ClusterRole
   name: service-hubble-role


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
