### PR TITLE
fix(applaunchpad): add null check for appName in domain verification handler

### DIFF
--- a/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
@@ -262,6 +262,7 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
   const handleDomainVerified = useCallback(
     ({ index, customDomain }: { index: number; customDomain: string }) => {
       try {
+        if (!appName) return;
         const data = formHook.getValues();
         if (!data?.appName) return;
         if (data.networks?.[index]) {


### PR DESCRIPTION
## Summary
- Add safety check to prevent potential errors when `appName` is undefined in the `handleDomainVerified` callback

## Changes
- Added null check for `appName` parameter before processing domain verification in `src/pages/app/edit/index.tsx:265`

## Test plan
- [x] Verify that domain verification still works correctly when appName is present
- [x] Verify that the function returns early without errors when appName is undefined
- [x] Check that no console errors occur during domain verification process

🤖 Generated with [Claude Code](https://claude.com/claude-code)