### PR TITLE
feat(auth): unified userType determination based on subscriptionEnabled

### DIFF
--- a/frontend/desktop/src/pages/api/auth/namespace/create.ts
+++ b/frontend/desktop/src/pages/api/auth/namespace/create.ts
@@ -18,9 +18,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     if (!payload) return jsonRes(res, { code: 401, message: 'token verify error' });
     const { teamName, userType } = req.body as {
       teamName?: string;
-      userType: 'subscription' | 'payg';
+      userType?: 'subscription' | 'payg';
     };
-    console.log('create team workspace', userType, teamName, payload);
+
+    const finalUserType: 'subscription' | 'payg' =
+      global.AppConfig?.desktop?.layout?.common?.subscriptionEnabled === true
+        ? userType || 'subscription'
+        : 'payg';
+
+    console.log('create team workspace', finalUserType, teamName, payload);
 
     if (!teamName) return jsonRes(res, { code: 400, message: 'teamName is required' });
     const currentNamespaces = await prisma.userWorkspace.findMany({
@@ -114,7 +120,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       const creater_kc_str = await getTeamKubeconfig(
         workspace_creater,
         payload.userCrName,
-        userType
+        finalUserType
       );
       if (!creater_kc_str) throw new Error('fail to get kubeconfig');
 

--- a/frontend/desktop/src/services/backend/regionAuth.ts
+++ b/frontend/desktop/src/services/backend/regionAuth.ts
@@ -17,6 +17,17 @@ const HostnameLength = 8;
 
 const nanoid = customAlphabet(LetterBytes, HostnameLength);
 
+/**
+ * Determines the user type based on the global subscription configuration.
+ *
+ * @returns {'subscription' | 'payg'} - Returns 'subscription' if subscription is enabled, otherwise 'payg'
+ */
+function getUserType(): 'subscription' | 'payg' {
+  return global.AppConfig?.desktop?.layout?.common?.subscriptionEnabled === true
+    ? 'subscription'
+    : 'payg';
+}
+
 export async function get_k8s_username() {
   return await retrySerially<string | null>(async () => {
     const crName = nanoid();
@@ -29,6 +40,7 @@ export async function get_k8s_username() {
     else return Promise.reject(null);
   }, 3);
 }
+
 export async function getRegionToken({
   userUid,
   userId
@@ -324,7 +336,7 @@ export async function getRegionToken({
     const kubeconfig = await getUserKubeconfig(
       payload.userCrUid,
       payload.userCrName,
-      'subscription'
+      getUserType()
     );
     if (!kubeconfig) {
       throw new Error('Failed to get user from k8s');
@@ -534,7 +546,7 @@ export async function initRegionToken({
     const kubeconfig = await getUserKubeconfig(
       regionalDbResult.userCrUid,
       regionalDbResult.userCrName,
-      'subscription'
+      getUserType()
     );
     if (!kubeconfig) {
       const failureMessage = 'failed to get user from k8s';


### PR DESCRIPTION
- Add getUserType() utility function in regionAuth.ts to centralize user type logic
- Update namespace/create.ts to use consistent userType determination
- Ensure subscription mode only activates when subscriptionEnabled is explicitly true
- Maintain payg as default when subscription is disabled or config is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
