### PR TITLE
fix(template): allow template fallback to local cache when git fails (#6155)

### DIFF
--- a/frontend/providers/template/src/services/backend/template-repo.ts
+++ b/frontend/providers/template/src/services/backend/template-repo.ts
@@ -85,8 +85,8 @@ export async function updateRepo() {
 
     console.log('git operation:', result);
   } catch (error) {
-    console.log('git operation timed out: \n', error);
-    throw new Error('Git operation failed: ');
+    // Note: git operation timeout should not block the process. Just log the error, do not throw.
+    console.log('git operation timed out (non-blocking): \n', error);
   }
 
   if (!fs.existsSync(targetPath)) {


### PR DESCRIPTION


(cherry picked from commit 87914355b3d16d07e2a3259bfbf40f23a55dcbe8)

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
