### PR TITLE
fix(build): enable static linking for Go binaries (#6189)

### DIFF
--- a/lifecycle/.goreleaser.yml
+++ b/lifecycle/.goreleaser.yml
@@ -42,6 +42,7 @@ builds:
       - -X github.com/labring/sealos/pkg/version.gitCommit={{.ShortCommit}}
       - -X github.com/labring/sealos/pkg/version.buildDate={{.Date}}
       - -s -w
+      - -extldflags '-static --static'
     overrides:
       - goos: linux
         goarch: amd64
@@ -77,6 +78,7 @@ builds:
       - -X github.com/labring/sealos/pkg/version.gitCommit={{.ShortCommit}}
       - -X github.com/labring/sealos/pkg/version.buildDate={{.Date}}
       - -s -w
+      - -extldflags '-static --static'
     overrides:
       - goos: linux
         goarch: amd64
@@ -111,7 +113,7 @@ builds:
       - -X github.com/labring/sealos/pkg/version.gitCommit={{.ShortCommit}}
       - -X github.com/labring/sealos/pkg/version.buildDate={{.Date}}
       - -s -w
-
+      - -extldflags '-static --static'
   - id: image-cri-shim
     env:
       - CGO_ENABLED=0
@@ -136,7 +138,7 @@ builds:
       - -X github.com/labring/sealos/pkg/version.gitCommit={{.ShortCommit}}
       - -X github.com/labring/sealos/pkg/version.buildDate={{.Date}}
       - -s -w
-
+      - -extldflags '-static --static'
 dockers:
   - use: buildx
     ids:

--- a/lifecycle/pkg/constants/consts.go
+++ b/lifecycle/pkg/constants/consts.go
@@ -58,7 +58,7 @@ var Contact = `
     \::/  /       \:\__\         /:/  /       \:\__\    \::/  /       \::/  /
      \/__/         \/__/         \/__/         \/__/     \/__/         \/__/
 
-                  Website: https://www.sealos.io/
+                  Website: https://sealos.io/
                   Address: github.com/labring/sealos
                   Version: %s
 `

--- a/lifecycle/scripts/make-rules/golang.mk
+++ b/lifecycle/scripts/make-rules/golang.mk
@@ -16,7 +16,8 @@ GO := go
 GO_LDFLAGS += -X $(VERSION_PACKAGE).gitVersion=${GIT_TAG} \
 	-X $(VERSION_PACKAGE).gitCommit=${GIT_COMMIT} \
 	-X $(VERSION_PACKAGE).buildDate=${BUILD_DATE} \
-	-s -w
+	-s -w \
+	-extldflags '-static --static'
 ifeq ($(DEBUG), 1)
 	GO_BUILD_FLAGS += -gcflags "all=-N -l"
 	GO_LDFLAGS=


### PR DESCRIPTION
* fix(build): enable static linking for Go binaries



* fix(build): correct extldflags syntax for static linking in Go binaries



---------


(cherry picked from commit 09d305e42682e3cf77f5df993a25ff88e44e4361)

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
