### PR TITLE
fix(docker): install uidmap and fuse-overlayfs in Dockerfiles (#6195)

### DIFF
--- a/lifecycle/docker/sealos/Dockerfile.main
+++ b/lifecycle/docker/sealos/Dockerfile.main
@@ -3,5 +3,9 @@ ARG TARGETARCH
 
 WORKDIR /usr/bin/
 
+RUN  apt update -y \
+  && apt install -y uidmap fuse-overlayfs \
+  && rm -rf /var/lib/apt/lists/*
+
 COPY --chmod=0755 /bin/sealos-$TARGETARCH/sealos .
 ENTRYPOINT ["/usr/bin/sealos"]

--- a/lifecycle/docker/sealos/Dockerfile.release
+++ b/lifecycle/docker/sealos/Dockerfile.release
@@ -1,5 +1,9 @@
 FROM ubuntu:22.04
 
+RUN  apt update -y \
+  && apt install -y uidmap fuse-overlayfs \
+  && rm -rf /var/lib/apt/lists/*
+
 COPY sealos /usr/bin/
 
 # nosemgrep: dockerfile.security.missing-user.missing-user


### PR DESCRIPTION
* fix(docker): install uidmap and fuse-overlayfs in Dockerfiles



* fix(docker): streamline installation of uidmap and fuse-overlayfs in Dockerfiles



* fix(docker): remove redundant apt update in Dockerfiles



* fix(docker): reorder COPY command in Dockerfile.release



---------


(cherry picked from commit 531406eabbb5e864b803afcebb9c17f267d8f055)

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
