### PR TITLE
fix(license): use short requeue duration for license validation and activation errors (#6220)

### DIFF
--- a/controllers/license/internal/controller/license_controller.go
+++ b/controllers/license/internal/controller/license_controller.go
@@ -57,6 +57,7 @@ type LicenseReconciler struct {
 
 var (
 	longRequeueRes   = ctrl.Result{RequeueAfter: 30 * time.Minute}
+	shortRequeueRes  = ctrl.Result{RequeueAfter: time.Minute}
 	immediateRequeue = ctrl.Result{Requeue: true}
 )
 
@@ -171,7 +172,7 @@ func (r *LicenseReconciler) reconcile(
 			return ctrl.Result{}, updateErr
 		}
 		r.Logger.V(1).Error(err, "failed to validate license", "license", nsName)
-		return ctrl.Result{}, nil
+		return shortRequeueRes, nil
 	}
 
 	if err := r.activator.Active(ctx, license); err != nil {
@@ -194,7 +195,7 @@ func (r *LicenseReconciler) reconcile(
 			return ctrl.Result{}, updateErr
 		}
 		r.Logger.Error(err, "failed to activate license", "license", nsName)
-		return ctrl.Result{}, nil
+		return shortRequeueRes, nil
 	}
 	r.Logger.V(1).
 		Info("license activated successfully", "license", nsName, "phase", license.Status.Phase)


### PR DESCRIPTION
…ctivation errors (#6220)

(cherry picked from commit 1d1bd66591c0b028fe65d12beda23bd1f668e11b)

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
