### PR TITLE
fix(user-controller): add AnnotationChangedPredicate for metadata Previously

### DIFF
--- a/controllers/user/controllers/user_controller.go
+++ b/controllers/user/controllers/user_controller.go
@@ -157,7 +157,7 @@ func (r *UserReconciler) SetupWithManager(mgr ctrl.Manager, opts ratelimiter.Rat
 	ownerEventHandler := handler.EnqueueRequestForOwner(r.Scheme, r.Client.RESTMapper(), &userv1.User{}, handler.OnlyControllerOwner())
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&userv1.User{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}))).
+		For(&userv1.User{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{}))).
 		Watches(&rbacv1.Role{}, ownerEventHandler).
 		Watches(&rbacv1.RoleBinding{}, ownerEventHandler).
 		Watches(&v1.Secret{}, ownerEventHandler).


### PR DESCRIPTION
…nges

Previously, the User controller only watched for GenerationChangedPredicate, which meant changes to metadata annotations (like owner transfers) would not trigger reconciliation. This caused namespace owner annotations to become out of sync when user ownership was transferred via OperationRequest.

Adding AnnotationChangedPredicate ensures that any annotation changes on the User resource will trigger a reconcile, keeping namespace annotations in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
