### PR TITLE
feat(applaunchpad): update GPU node info structure

### DIFF
--- a/frontend/providers/applaunchpad/src/pages/api/platform/resourcePrice.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/platform/resourcePrice.ts
@@ -69,7 +69,7 @@ function countGpuSource(rawData: ResourcePriceType['data']['properties'], gpuNod
       alias: gpuNode['gpu.alias'],
       type: gpuNode['gpu.product'],
       price: (item.unit_price * valuationMap.gpu) / PRICE_SCALE,
-      inventory: +gpuNode['gpu.count'],
+      inventory: +gpuNode['gpu.available'],
       vm: +gpuNode['gpu.memory'] / 1024
     });
   });

--- a/frontend/providers/applaunchpad/src/services/backend/gpu.ts
+++ b/frontend/providers/applaunchpad/src/services/backend/gpu.ts
@@ -20,6 +20,8 @@ export async function getGpuNode() {
         'gpu.count': string;
         'gpu.memory': string;
         'gpu.product': string;
+        'gpu.available': string;
+        'gpu.used': string;
       }
     >;
 
@@ -32,12 +34,16 @@ export async function getGpuNode() {
       const index = gpuList.findIndex((gpu) => gpu['gpu.product'] === item['gpu.product']);
       if (index > -1) {
         gpuList[index]['gpu.count'] += Number(item['gpu.count']);
+        gpuList[index]['gpu.available'] += Number(item['gpu.available']);
+        gpuList[index]['gpu.used'] += Number(item['gpu.used']);
       } else {
         gpuList.push({
           ['gpu.count']: +item['gpu.count'],
           ['gpu.memory']: +item['gpu.memory'],
           ['gpu.product']: item['gpu.product'],
-          ['gpu.alias']: alias[item['gpu.product']] || item['gpu.product']
+          ['gpu.alias']: alias[item['gpu.product']] || item['gpu.product'],
+          ['gpu.available']: +item['gpu.available'],
+          ['gpu.used']: +item['gpu.used']
         });
       }
     });

--- a/frontend/providers/applaunchpad/src/types/app.d.ts
+++ b/frontend/providers/applaunchpad/src/types/app.d.ts
@@ -230,4 +230,6 @@ export type GpuNodeType = {
   'gpu.memory': number;
   'gpu.product': string;
   'gpu.alias': string;
+  'gpu.available': number;
+  'gpu.used': number;
 };


### PR DESCRIPTION
…le and used fields

- Add gpu.available and gpu.used fields to GpuNodeType
- Update GPU node parsing logic to handle new ConfigMap structure
- Change inventory calculation to use gpu.available instead of gpu.count
- gpu.count now represents total GPU count, gpu.available represents available count

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
