### PR TITLE
feat(devbox): support GPU configuration sync from devbox to launchpad

### DIFF
--- a/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
@@ -437,6 +437,15 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
         }));
         formHook.setValue('networks', completeNetworks);
       }
+
+      // Handle GPU configuration
+      if (parsedData.gpu && parsedData.gpu.type) {
+        formHook.setValue('gpu', {
+          type: parsedData.gpu.type,
+          amount: parsedData.gpu.amount || 0,
+          manufacturers: parsedData.gpu.manufacturers || 'nvidia'
+        });
+      }
     } catch (error) {}
   }, [router.query, already]);
 

--- a/frontend/providers/applaunchpad/src/types/app.d.ts
+++ b/frontend/providers/applaunchpad/src/types/app.d.ts
@@ -137,6 +137,7 @@ export type AppEditSyncedFields = Pick<
   | 'runCMD'
   | 'appName'
   | 'labels'
+  | 'gpu'
 >;
 
 export type TAppSourceType = 'app_store' | 'sealaf';

--- a/frontend/providers/devbox/app/[lang]/(platform)/devbox/detail/[name]/components/Release.tsx
+++ b/frontend/providers/devbox/app/[lang]/(platform)/devbox/detail/[name]/components/Release.tsx
@@ -123,7 +123,7 @@ const Release = () => {
       const config = parseTemplateConfig(result.template.config);
       const releaseArgs = config.releaseArgs.join(' ');
       const releaseCommand = config.releaseCommand.join(' ');
-      const { cpu, memory, networks, name } = devbox;
+      const { cpu, memory, networks, name, gpu } = devbox;
       const newNetworks = networks.map((network) => {
         return {
           port: network.port,
@@ -140,6 +140,7 @@ const Release = () => {
         cpu: cpu,
         memory: memory,
         imageName: imageName,
+        gpu: gpu,
         networks:
           newNetworks.length > 0
             ? newNetworks


### PR DESCRIPTION
- Add gpu field to AppEditSyncedFields type definition
- Handle GPU configuration in launchpad edit page when receiving formData
- Pass GPU configuration from devbox deploy handler to launchpad

This enables GPU settings to be properly transferred when deploying devbox releases to launchpad applications.

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
