### PR TITLE
fix(ssh): increase default execution timeout from 300s to 2h

### DIFF
--- a/lifecycle/pkg/ssh/ssh.go
+++ b/lifecycle/pkg/ssh/ssh.go
@@ -29,7 +29,7 @@ import (
 
 var (
 	defaultMaxRetry         = 5
-	defaultExecutionTimeout = 300 * time.Second
+	defaultExecutionTimeout = 2 * time.Hour
 )
 
 func RegisterFlags(fs *pflag.FlagSet) {


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
