### PR TITLE
feat(sshgate): return errors message to ssh clients

### DIFF
--- a/service/sshgate/gateway/agent.go
+++ b/service/sshgate/gateway/agent.go
@@ -64,6 +64,7 @@ func (g *Gateway) handleAgentForwardMode(
 	backendChannel, backendRequests, err := backendConn.OpenChannel("session", nil)
 	if err != nil {
 		sessionLogger.WithError(err).Error("Failed to open devbox channel")
+		fmt.Fprintf(channel, "Failed to open devbox session: %v\r\n", err)
 		return
 	}
 	defer backendChannel.Close()

--- a/service/sshgate/gateway/proxyjump.go
+++ b/service/sshgate/gateway/proxyjump.go
@@ -52,7 +52,9 @@ func (g *Gateway) handleProxyJumpMode(
 		proxyLogger.WithField("devbox_addr", devboxAddr).
 			WithError(err).
 			Error("Failed to connect to devbox")
-		_ = newChannel.Reject(ssh.ConnectionFailed, fmt.Sprintf("failed to connect: %v", err))
+		errMsg := fmt.Sprintf("Failed to connect to devbox: %v\r\n"+
+			"The devbox may be starting up or the SSH service is not ready\r\n", err)
+		_ = newChannel.Reject(ssh.ConnectionFailed, errMsg)
 
 		return
 	}


### PR DESCRIPTION
allow clients to view specific error messages, like this:

```
ssh xxx
channel 0: open failed: connect failed: Failed to connect to devbox: dial tcp xxx:22: connect: connection refused
The devbox may be starting up or the SSH service is not ready

Connection to xxx closed.
```