### PR TITLE
feat(devbox): add flag to enable Block IO pod annotation

### DIFF
--- a/controllers/devbox/cmd/main.go
+++ b/controllers/devbox/cmd/main.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -101,6 +102,8 @@ func main() {
 	var mergeBaseImageTopLayer bool
 	// default base image flag for setLvRemovable's temp container
 	var defaultBaseImage string
+	// when this option is enabled, the controller will set up the block io resource configuration of a devbox pod
+	var enableBlockIOResouce bool
 	flag.StringVar(
 		&defaultBaseImage,
 		"default-base-image",
@@ -231,6 +234,12 @@ func main() {
 		"merge-base-image-top-layer",
 		false,
 		"If set true, devbox will merge base image top layers during create and remove top layer during commit.",
+	)
+	flag.BoolVar(
+		&enableBlockIOResouce,
+		"enable-block-io-resource",
+		false,
+		"If this option is set to true, the controller will set up the block io resource configuration of a devbox pod",
 	)
 	opts := zap.Options{
 		Development: true,
@@ -378,6 +387,7 @@ func main() {
 		},
 		PodMatchers:               podMatchers,
 		DebugMode:                 debugMode,
+		EnableBlockIOResource:     enableBlockIOResouce,
 		StartupConfigMapName:      startupCMName,
 		StartupConfigMapNamespace: startupCMNamespace,
 		RestartPredicateDuration:  restartPredicateDuration,

--- a/controllers/devbox/cmd/main.go
+++ b/controllers/devbox/cmd/main.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"

--- a/controllers/devbox/internal/controller/devbox_controller.go
+++ b/controllers/devbox/internal/controller/devbox_controller.go
@@ -66,6 +66,7 @@ type DevboxReconciler struct {
 
 	DebugMode                 bool
 	MergeBaseImageTopLayer    bool
+	EnableBlockIOResource     bool
 	StartupConfigMapName      string
 	StartupConfigMapNamespace string
 
@@ -1206,7 +1207,7 @@ func (r *DevboxReconciler) generateDevboxPod(
 		Name:        devbox.Name,
 		Namespace:   devbox.Namespace,
 		Labels:      helper.GeneratePodLabels(devbox),
-		Annotations: helper.GeneratePodAnnotations(devbox),
+		Annotations: helper.GeneratePodAnnotations(devbox, r.EnableBlockIOResource),
 	}
 
 	// ports := devbox.Spec.Config.Ports

--- a/controllers/devbox/internal/controller/helper/devbox.go
+++ b/controllers/devbox/internal/controller/helper/devbox.go
@@ -121,7 +121,7 @@ func GeneratePodLabels(devbox *devboxv1alpha2.Devbox) map[string]string {
 	return labels
 }
 
-func GeneratePodAnnotations(devbox *devboxv1alpha2.Devbox) map[string]string {
+func GeneratePodAnnotations(devbox *devboxv1alpha2.Devbox, enableBlockIOResource bool) map[string]string {
 	annotations := make(map[string]string)
 	if devbox.Spec.Config.Annotations != nil {
 		for k, v := range devbox.Spec.Config.Annotations {
@@ -129,8 +129,10 @@ func GeneratePodAnnotations(devbox *devboxv1alpha2.Devbox) map[string]string {
 		}
 	}
 	annotations[devboxv1alpha2.AnnotationStorageLimit] = devbox.Spec.StorageLimit
-	// Currently we use hardcoded value for BlockIOResources annotation
-	annotations[devboxv1alpha2.AnnotationBlockIOResources] = "Devbox"
+	// If BlockIOClass is enabled, add the annotation for BlockIOResources, currently we use hardcoded value for BlockIOResources annotation, in the future we can consider to make it configurable by users
+	if enableBlockIOResource {
+		annotations[devboxv1alpha2.AnnotationBlockIOResources] = "Devbox"
+	}
 	return annotations
 }
 

--- a/controllers/devbox/internal/controller/helper/devbox.go
+++ b/controllers/devbox/internal/controller/helper/devbox.go
@@ -121,7 +121,10 @@ func GeneratePodLabels(devbox *devboxv1alpha2.Devbox) map[string]string {
 	return labels
 }
 
-func GeneratePodAnnotations(devbox *devboxv1alpha2.Devbox, enableBlockIOResource bool) map[string]string {
+func GeneratePodAnnotations(
+	devbox *devboxv1alpha2.Devbox,
+	enableBlockIOResource bool,
+) map[string]string {
 	annotations := make(map[string]string)
 	if devbox.Spec.Config.Annotations != nil {
 		for k, v := range devbox.Spec.Config.Annotations {
@@ -129,7 +132,8 @@ func GeneratePodAnnotations(devbox *devboxv1alpha2.Devbox, enableBlockIOResource
 		}
 	}
 	annotations[devboxv1alpha2.AnnotationStorageLimit] = devbox.Spec.StorageLimit
-	// If BlockIOClass is enabled, add the annotation for BlockIOResources, currently we use hardcoded value for BlockIOResources annotation, in the future we can consider to make it configurable by users
+	// If BlockIOClass is enabled, add the annotation for BlockIOResources.
+	// Currently we use a hardcoded value but may make it user configurable later.
 	if enableBlockIOResource {
 		annotations[devboxv1alpha2.AnnotationBlockIOResources] = "Devbox"
 	}


### PR DESCRIPTION
Introduce a boolean CLI flag --enable-block-io-resource to control the BlockIOResources pod annotation. GeneratePodAnnotations now accepts the flag and adds AnnotationBlockIOResources="Devbox" only when enabled, and the reconciler carries the EnableBlockIOResource setting through the stack.

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
