### PR TITLE
fix(image-cri-shim): handle missing HOME env in systemd environments

### DIFF
--- a/lifecycle/staging/src/github.com/labring/image-cri-shim/pkg/types/configmap_sync.go
+++ b/lifecycle/staging/src/github.com/labring/image-cri-shim/pkg/types/configmap_sync.go
@@ -119,7 +119,15 @@ func buildKubeClient() (kubernetes.Interface, error) {
 	kubeconfigCandidates = append(kubeconfigCandidates,
 		"/etc/kubernetes/admin.conf",
 		"/etc/rancher/k3s/k3s.yaml",
-		filepath.Join(os.Getenv("HOME"), ".kube", "config"),
+	)
+	// Try to get home directory from environment
+	// Default to /root for systemd environments where HOME may not be set
+	homeDir := os.Getenv("HOME")
+	if homeDir == "" {
+		homeDir = "/root"
+	}
+	kubeconfigCandidates = append(kubeconfigCandidates,
+		filepath.Join(homeDir, ".kube", "config"),
 	)
 	for _, path := range kubeconfigCandidates {
 		if path == "" {


### PR DESCRIPTION
## Summary
- Fix kubeconfig lookup in `buildKubeClient()` to properly handle systemd environments where `HOME` environment variable may not be set
- Add fallback to `/root` as default home directory when `HOME` is empty
- Ensures kubeconfig can be found at `/root/.kube/config` in systemd services

## Problem
When image-cri-shim is managed by systemd, the `HOME` environment variable is often not set, causing the kubeconfig lookup to fail when trying to access `~/.kube/config`. This prevents the service from properly syncing configuration from Kubernetes ConfigMaps.

## Solution
Modified `buildKubeClient()` function to:
1. First try to get home directory from `HOME` environment variable
2. If empty, fallback to `/root` (default for systemd services running as root)
3. Use this home directory to construct the kubeconfig path

## Test plan
- [x] Code compiles successfully
- [ ] Test in systemd environment without HOME env variable
- [ ] Verify kubeconfig is found at `/root/.kube/config`
- [ ] Test backward compatibility with normal environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)