### PR TITLE
fix(resources): resources controller ignore refresh gpu config for init

### DIFF
--- a/controllers/resources/controllers/monitor_controller.go
+++ b/controllers/resources/controllers/monitor_controller.go
@@ -162,7 +162,7 @@ func NewMonitorReconciler(mgr ctrl.Manager) (*MonitorReconciler, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		fmt.Printf("INFO: refresh gpu config: %v, will retry in next reconcile", err)
 	}
 	r.gpuMutex.RLock()
 	aliasCount := len(r.gpuAliasCard)


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
