### PR TITLE
fix(desktop): fallback to getRegionToken when user already initialized

### DIFF
--- a/frontend/desktop/src/pages/api/auth/autoInitRegionToken.ts
+++ b/frontend/desktop/src/pages/api/auth/autoInitRegionToken.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { jsonRes } from '@/services/backend/response';
-import { autoInitRegionToken } from '@/services/backend/regionAuth';
+import { autoInitRegionToken, getRegionToken } from '@/services/backend/regionAuth';
 import { ErrorHandler } from '@/services/backend/middleware/error';
 import { filterAuthenticationToken } from '@/services/backend/middleware/access';
 import { HttpStatusCode } from 'axios';
@@ -13,9 +13,18 @@ export default ErrorHandler(async function handler(req: NextApiRequest, res: Nex
     });
 
     if (!regionData) {
+      // user may already be initialized (isInited=true), fall back to getRegionToken
+      const fallbackData = await getRegionToken({ userId, userUid });
+      if (!fallbackData) {
+        return jsonRes(res, {
+          code: HttpStatusCode.InternalServerError,
+          message: 'Failed to auto initialize workspace'
+        });
+      }
       return jsonRes(res, {
-        code: HttpStatusCode.InternalServerError,
-        message: 'Failed to auto initialize workspace'
+        code: 200,
+        message: 'Successfully',
+        data: fallbackData
       });
     }
 


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
