### PR TITLE
feat(desktop): support overriding icon size style in app cr

### DIFF
--- a/frontend/desktop/src/components/AppDock/index.tsx
+++ b/frontend/desktop/src/components/AppDock/index.tsx
@@ -230,6 +230,9 @@ export default function AppDock() {
           url: '',
           desc: ''
         },
+        representativeMeta: {
+          forcedIconStyle: 'fill'
+        },
         displayType: 'hidden'
       },
       ...normalApps.slice(0, 5).map((app, index) => ({ ...app, pid: -2 }))

--- a/frontend/desktop/src/components/desktop_content/apps.tsx
+++ b/frontend/desktop/src/components/desktop_content/apps.tsx
@@ -54,6 +54,8 @@ const AppItem = ({
 
   const { i18n } = useTranslation();
   const fallbackIcon = useConfigStore().layoutConfig?.logo || '/logo.svg';
+  const forcedIconStyle = app.representativeMeta.forcedIconStyle;
+  const iconSize = forcedIconStyle === 'contain' ? '60px' : '100%';
 
   return (
     <Flex
@@ -91,10 +93,11 @@ const AppItem = ({
         draggable
       >
         <Image
-          w={app.key.startsWith('user-') ? '60px' : '100%'}
-          h={app.key.startsWith('user-') ? '60px' : '100%'}
+          w={iconSize}
+          h={iconSize}
           src={app?.icon}
           fallbackSrc={fallbackIcon}
+          objectFit={forcedIconStyle}
           draggable={false}
           pointerEvents={'none'}
           alt="app logo"

--- a/frontend/desktop/src/components/floating_button/index.tsx
+++ b/frontend/desktop/src/components/floating_button/index.tsx
@@ -61,6 +61,9 @@ export default function FloatingButton() {
         url: '',
         desc: ''
       },
+      representativeMeta: {
+        forcedIconStyle: 'fill'
+      },
       displayType: 'hidden'
     },
     ...runningInfo
@@ -133,8 +136,8 @@ export default function FloatingButton() {
       x < leftBoundary
         ? handleSuction(Suction.Left)
         : x > rightBoundary
-          ? handleSuction(Suction.Right)
-          : null;
+        ? handleSuction(Suction.Right)
+        : null;
     } catch (error) {
       console.log(error);
     }

--- a/frontend/desktop/src/pages/api/desktop/getDefaultApps.ts
+++ b/frontend/desktop/src/pages/api/desktop/getDefaultApps.ts
@@ -1,8 +1,33 @@
 import { K8sApiDefault } from '@/services/backend/kubernetes/admin';
 import { ListCRD } from '@/services/backend/kubernetes/user';
 import { jsonRes } from '@/services/backend/response';
-import { CRDMeta, TAppCRList, TAppConfig } from '@/types';
+import {
+  CRDMeta,
+  ForcedIconStyleAnnotation,
+  TAppCR,
+  TAppCRList,
+  TAppConfig,
+  TForcedIconStyle
+} from '@/types';
 import type { NextApiRequest, NextApiResponse } from 'next';
+
+const normalizeForcedIconStyle = (value: string | undefined): TForcedIconStyle | undefined => {
+  if (value === 'contain' || value === 'fill') {
+    return value;
+  }
+
+  return undefined;
+};
+
+const getRepresentativeMeta = (key: string, annotations?: TAppCR['metadata']['annotations']) => {
+  const forcedIconStyleFromAnnotation = normalizeForcedIconStyle(
+    annotations?.[ForcedIconStyleAnnotation]
+  );
+
+  return {
+    forcedIconStyle: forcedIconStyleFromAnnotation || (key.startsWith('user-') ? 'contain' : 'fill')
+  };
+};
 
 export default async function handler(_req: NextApiRequest, res: NextApiResponse) {
   try {
@@ -20,9 +45,12 @@ export default async function handler(_req: NextApiRequest, res: NextApiResponse
 
     const defaultArr = (await getRawAppList(getMeta()))
       .map<TAppConfig>((item) => {
+        const key = `system-${item.metadata.name}` as const;
+
         return {
-          key: `system-${item.metadata.name}`,
+          key,
           ...item.spec,
+          representativeMeta: getRepresentativeMeta(key, item.metadata.annotations),
           creationTimestamp: item.metadata.creationTimestamp
         };
       })

--- a/frontend/desktop/src/pages/api/desktop/getInstalledApps.ts
+++ b/frontend/desktop/src/pages/api/desktop/getInstalledApps.ts
@@ -2,12 +2,37 @@ import { verifyAccessToken } from '@/services/backend/auth';
 import { getUserKubeconfigNotPatch } from '@/services/backend/kubernetes/admin';
 import { K8sApi, ListCRD } from '@/services/backend/kubernetes/user';
 import { jsonRes } from '@/services/backend/response';
-import { CRDMeta, TAppCRList, TAppConfig } from '@/types';
+import {
+  CRDMeta,
+  ForcedIconStyleAnnotation,
+  TAppCR,
+  TAppCRList,
+  TAppConfig,
+  TForcedIconStyle
+} from '@/types';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 import { globalPrisma } from '@/services/backend/db/init';
 import { switchKubeconfigNamespace } from '@/utils/switchKubeconfigNamespace';
 import { UserStatus } from 'prisma/global/generated/client';
+
+const normalizeForcedIconStyle = (value: string | undefined): TForcedIconStyle | undefined => {
+  if (value === 'contain' || value === 'fill') {
+    return value;
+  }
+
+  return undefined;
+};
+
+const getRepresentativeMeta = (key: string, annotations?: TAppCR['metadata']['annotations']) => {
+  const forcedIconStyleFromAnnotation = normalizeForcedIconStyle(
+    annotations?.[ForcedIconStyleAnnotation]
+  );
+
+  return {
+    forcedIconStyle: forcedIconStyleFromAnnotation || (key.startsWith('user-') ? 'contain' : 'fill')
+  };
+};
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
@@ -37,9 +62,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const defaultArr = (await getRawAppList(getMeta()))
       .map<TAppConfig>((item) => {
+        const key = `system-${item.metadata.name}` as const;
+
         return {
-          key: `system-${item.metadata.name}`,
+          key,
           ...item.spec,
+          representativeMeta: getRepresentativeMeta(key, item.metadata.annotations),
           creationTimestamp: item.metadata.creationTimestamp
         };
       })
@@ -56,9 +84,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       });
 
     const userArr = (await getRawAppList(getMeta(payload.workspaceId))).map<TAppConfig>((item) => {
+      const key = `user-${item.metadata.name}` as const;
+
       return {
-        key: `user-${item.metadata.name}`,
+        key,
         ...item.spec,
+        representativeMeta: getRepresentativeMeta(key, item.metadata.annotations),
         displayType: 'normal',
         creationTimestamp: item.metadata.creationTimestamp
       };

--- a/frontend/desktop/src/stores/app.ts
+++ b/frontend/desktop/src/stores/app.ts
@@ -36,6 +36,7 @@ export class AppInfo {
   menuData?: TAppMenuData[];
   displayType: displayType;
   i18n?: any;
+  representativeMeta: TApp['representativeMeta'];
 
   constructor(app: TApp, pid: number) {
     this.isShow = false;
@@ -55,6 +56,7 @@ export class AppInfo {
     this.pid = pid;
     this.displayType = app.displayType;
     this.i18n = app?.i18n;
+    this.representativeMeta = cloneDeep(app.representativeMeta);
   }
 }
 

--- a/frontend/desktop/src/types/app.ts
+++ b/frontend/desktop/src/types/app.ts
@@ -9,6 +9,10 @@ export enum APPTYPE {
 
 export type WindowSize = 'maximize' | 'maxmin' | 'minimize';
 export type displayType = 'normal' | 'hidden' | 'more';
+export type TForcedIconStyle = 'contain' | 'fill';
+export type TRepresentativeMeta = {
+  forcedIconStyle: TForcedIconStyle;
+};
 
 export type TAppFront = {
   isShow: boolean;
@@ -53,6 +57,7 @@ export type TAppConfig = {
       name: string;
     };
   };
+  representativeMeta: TRepresentativeMeta;
   displayType: displayType;
   creationTimestamp?: string;
 };

--- a/frontend/desktop/src/types/crd.ts
+++ b/frontend/desktop/src/types/crd.ts
@@ -1,5 +1,12 @@
-import { APPTYPE, TAppMenuData, displayType } from './app';
+import { APPTYPE, TAppMenuData, TForcedIconStyle, displayType } from './app';
 import { LicenseFrontendKey } from '@/constants/account';
+
+export const ForcedIconStyleAnnotation =
+  'app.sealos.io/representative-meta.forced-icon-style' as const;
+
+export type TAppRepresentativeAnnotations = {
+  [ForcedIconStyleAnnotation]?: TForcedIconStyle;
+} & Record<string, string | undefined>;
 
 export type CRDMeta = {
   group: string; // group
@@ -68,7 +75,7 @@ export type TAppCR = {
   apiVersion: 'app.sealos.io/v1';
   kind: 'App';
   metadata: {
-    annotations: any;
+    annotations?: TAppRepresentativeAnnotations;
     creationTimestamp: string;
     generation: number;
     labels: Record<string, string>;


### PR DESCRIPTION
```yaml
apiVersion: app.sealos.io/v1
kind: App
metadata:
  annotations:
    # contain: resize the icon to stay contained in the frame
    # fill: stretch the icon to fit the frame
    app.sealos.io/representative-meta.forced-icon-style: contain
```