### PR TITLE
fix(template): pvc not get deleted in the new deletion flow

### DIFF
--- a/frontend/providers/template/src/pages/api/instance/deleteByName.ts
+++ b/frontend/providers/template/src/pages/api/instance/deleteByName.ts
@@ -8,7 +8,8 @@ import {
   deleteInstanceOnly,
   getInstanceOrThrow404,
   isInstanceOwnerReferencesReady,
-  legacyDeleteInstanceAll
+  legacyDeleteInstanceAll,
+  legacyDeletePersistentVolumeClaimsOnly
 } from '@/services/backend/instanceDelete';
 
 export default withErrorHandler(async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -28,6 +29,12 @@ export default withErrorHandler(async function handler(req: NextApiRequest, res:
   }
 
   if (isInstanceOwnerReferencesReady(instance)) {
+    // [FIXME] StatefulSet PVCs are not auto-deleted by GC in current cluster versions.
+    // ! Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+    // ! This manual PVC list+delete workaround can be replaced on Kubernetes >= 1.32
+    // ! after adopting StatefulSet `persistentVolumeClaimRetentionPolicy` in templates.
+    await legacyDeletePersistentVolumeClaimsOnly(k8s, instanceName);
+
     await deleteInstanceOnly(k8s.k8sCustomObjects, k8s.namespace, instance.metadata.name);
     return jsonRes(res, { message: `Instance "${instanceName}" deleted successfully` });
   }

--- a/frontend/providers/template/src/pages/api/v1/instance/[instanceName].ts
+++ b/frontend/providers/template/src/pages/api/v1/instance/[instanceName].ts
@@ -2,14 +2,14 @@ import { authSession } from '@/services/backend/auth';
 import { getK8s } from '@/services/backend/kubernetes';
 import { ResponseCode, ResponseMessages } from '@/types/response';
 import { NextApiRequest, NextApiResponse } from 'next';
-import * as operations from '@/services/backend/operations';
 import { jsonRes } from '@/services/backend/response';
 import { deleteInstanceSchemas } from '@/types/apis';
 import {
   getInstanceOrThrow404,
   isInstanceOwnerReferencesReady,
   legacyDeleteInstanceAll,
-  deleteInstanceOnly
+  deleteInstanceOnly,
+  legacyDeletePersistentVolumeClaimsOnly
 } from '@/services/backend/instanceDelete';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -61,6 +61,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
       // New instances: only delete Instance, rely on GC cascade
       if (isInstanceOwnerReferencesReady(instance)) {
+        // [FIXME] StatefulSet PVCs are not auto-deleted by GC in current cluster versions.
+        // ! Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+        // ! This manual PVC list+delete workaround can be replaced on Kubernetes >= 1.32
+        // ! after adopting StatefulSet `persistentVolumeClaimRetentionPolicy` in templates.
+        await legacyDeletePersistentVolumeClaimsOnly(k8s, instanceName);
+
         await deleteInstanceOnly(k8s.k8sCustomObjects, k8s.namespace, instance.metadata.name);
         return jsonRes(res, {
           code: ResponseCode.SUCCESS,

--- a/frontend/providers/template/src/services/backend/instanceDelete.ts
+++ b/frontend/providers/template/src/services/backend/instanceDelete.ts
@@ -61,6 +61,22 @@ export async function deleteInstanceOnly(
   await operations.deleteInstance(api, namespace, instanceName);
 }
 
+export async function legacyDeletePersistentVolumeClaimsOnly(
+  k8s: Awaited<ReturnType<typeof getK8s>>,
+  instanceName: string
+): Promise<void> {
+  const ns = k8s.namespace;
+
+  try {
+    await operations.deletePersistentVolumeClaimsInApp(k8s.k8sCore, ns, instanceName);
+  } catch (error: any) {
+    if (+error?.body?.code === 404) return;
+    throw (
+      error?.body || error || new Error('An error occurred whilst deleting PersistentVolumeClaims.')
+    );
+  }
+}
+
 async function listObjectStorageBucketsByInstance(
   api: CustomObjectsApi,
   namespace: string,
@@ -140,6 +156,8 @@ async function listHorizontalPodAutoscalersByInstance(
  *
  * IMPORTANT: This is intentionally comprehensive and should mirror (and extend) the resource
  * categories currently shown on the Instance detail page.
+ *
+ * @deprecated Use new ownerReference based deletion approach instead!
  */
 export async function legacyDeleteInstanceAll(
   k8s: Awaited<ReturnType<typeof getK8s>>,
@@ -255,11 +273,7 @@ export async function legacyDeleteInstanceAll(
   );
 
   // PVC
-  await deleteResourcesBatch(
-    operations.getPersistentVolumeClaims(k8s.k8sCore, ns, instanceName),
-    (name: string) => operations.deletePersistentVolumeClaim(k8s.k8sCore, ns, name),
-    'An error occurred whilst deleting PersistentVolumeClaims.'
-  );
+  await legacyDeletePersistentVolumeClaimsOnly(k8s, instanceName);
 
   // Monitoring (Prometheus Operator)
   await deleteResourcesBatch(


### PR DESCRIPTION
Related PRs: https://github.com/labring/sealos/pull/6659 (5.1) https://github.com/labring/sealos/pull/6649 (main)

Releated template: https://github.com/labring-actions/templates/blob/0ec72e3750649fd51ce8954e66e4a55c5d1ac513/template/CRMEB/index.yaml#L426-L438

According to the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#volume-claim-templates), we probably need to handle the deletion manually:
> Deleting and/or scaling a StatefulSet down will not delete the volumes associated with the StatefulSet. This is done to ensure data safety, which is generally more valuable than an automatic purge of all related StatefulSet resources.

---

Update:

Kubernetes 1.27 introduced a new StatefulSet PVC auto-deletion feature and it has reached stable in Kubernetes 1.32, we can use this *sometime later*. ([ref](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention))

So the workaround at this time is bring back the legacy app deletion behavior **only for PVCs**.

Fixes https://github.com/labring-sigs/sealos-issues/issues/59