### PR TITLE
fix(applaunchpad): fix command text overflow in app detail advanced info

### DIFF
--- a/frontend/providers/applaunchpad/src/components/app/detail/index/AdvancedInfo.tsx
+++ b/frontend/providers/applaunchpad/src/components/app/detail/index/AdvancedInfo.tsx
@@ -55,8 +55,11 @@ const AdvancedInfo = ({ app = MOCK_APP_DETAIL }: { app: AppDetailType }) => {
               fontSize={'12px'}
               fontWeight={400}
               color={'grayModern.600'}
+              flex={'1 1 0'}
+              minW={0}
+              overflow={'hidden'}
             >
-              <Text>
+              <Text noOfLines={1} flex={'0 1 auto'} minW={0}>
                 {t('Command')}: {app.runCMD || 'Not Configured'}
               </Text>
               <Divider
@@ -64,8 +67,9 @@ const AdvancedInfo = ({ app = MOCK_APP_DETAIL }: { app: AppDetailType }) => {
                 h={'12px'}
                 mx={'16px'}
                 borderColor={'grayModern.300'}
+                flexShrink={0}
               />
-              <Text>
+              <Text flexShrink={0} whiteSpace={'nowrap'}>
                 {t('Environment Variables')}: {app.envs?.length}
               </Text>
               <Divider
@@ -73,15 +77,19 @@ const AdvancedInfo = ({ app = MOCK_APP_DETAIL }: { app: AppDetailType }) => {
                 h={'12px'}
                 mx={'16px'}
                 borderColor={'grayModern.300'}
+                flexShrink={0}
               />
-              <Text>ConfigMaps: {app.configMapList?.length}</Text>
+              <Text flexShrink={0} whiteSpace={'nowrap'}>
+                ConfigMaps: {app.configMapList?.length}
+              </Text>
               <Divider
                 orientation="vertical"
                 h={'12px'}
                 mx={'16px'}
                 borderColor={'grayModern.300'}
+                flexShrink={0}
               />
-              <Text>
+              <Text flexShrink={0} whiteSpace={'nowrap'}>
                 {t('Storage')}: {(app.storeList?.length || 0) + (app.networkStoreList?.length || 0)}
               </Text>
             </Flex>
@@ -115,7 +123,9 @@ const AdvancedInfo = ({ app = MOCK_APP_DETAIL }: { app: AppDetailType }) => {
                         <Box flex={'0 0 80px'} w={0}>
                           {t(item.label)}
                         </Box>
-                        <Box color={'grayModern.900'}>{item.value}</Box>
+                        <Box color={'grayModern.900'} wordBreak={'break-all'}>
+                          {item.value}
+                        </Box>
                       </Flex>
                     ))}
                   </Box>

--- a/frontend/providers/template/src/services/backend/instanceOwnerReferencesApply.ts
+++ b/frontend/providers/template/src/services/backend/instanceOwnerReferencesApply.ts
@@ -201,10 +201,25 @@ export async function applyWithInstanceOwnerReferences(
     meta.ownerReferences = addOrReplaceOwnerReference(meta.ownerReferences, instanceOwnerRef);
   }
 
-  // 4) apply dependents
+  // 4) apply dependents — rollback Instance on failure so cascade deletes all dependents
   if (dependentResources.length > 0) {
     const dependentYamlList = dependentResources.map((r) => JsYaml.dump(r));
-    await deps.applyYamlList(dependentYamlList, mode);
+    try {
+      await deps.applyYamlList(dependentYamlList, mode);
+    } catch (error) {
+      try {
+        await deps.k8sCustomObjects.deleteNamespacedCustomObject(
+          'app.sealos.io',
+          'v1',
+          deps.namespace,
+          'instances',
+          instanceName
+        );
+      } catch (cleanupError) {
+        console.error('Failed to cleanup Instance after deployment failure:', cleanupError);
+      }
+      throw error;
+    }
   }
 
   return { appliedKinds: resources.map((r) => r?.kind).filter(Boolean) as string[] };


### PR DESCRIPTION
Truncate long command text in the accordion header with ellipsis and add word-break in the expanded panel to prevent layout overflow.

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
