### PR TITLE
fix(applaunchpad): align within_5_minutes locale key

### DIFF
--- a/frontend/providers/applaunchpad/public/locales/en/common.json
+++ b/frontend/providers/applaunchpad/public/locales/en/common.json
@@ -424,5 +424,5 @@
   "websocket": "WebSocket",
   "within_1_day": "Within 1 day",
   "within_1_hour": "Within 1 hour",
-  "within_5_minute": "Within 5 minute"
+  "within_5_minutes": "Within 5 minutes"
 }

--- a/frontend/providers/applaunchpad/public/locales/zh/common.json
+++ b/frontend/providers/applaunchpad/public/locales/zh/common.json
@@ -424,5 +424,5 @@
   "websocket": "WebSocket",
   "within_1_day": "一天内",
   "within_1_hour": "一小时内",
-  "within_5_minute": "五分钟内"
+  "within_5_minutes": "五分钟内"
 }


### PR DESCRIPTION
Fix the locale key mismatch for the pod log time-range option in applaunchpad.

This aligns the zh/en locale keys with `within_5_minutes` used by the log modal.

Related issue: N/A