### PR TITLE
fix(ci): namespace digest artifacts to avoid name collisions

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ env.MODULE_NAME }}-${{ matrix.arch }}
+          name: frontend-digests-${{ env.MODULE_NAME }}-${{ matrix.arch }}
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -174,7 +174,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: ${{ runner.temp }}/digests
-          pattern: digests-${{ env.MODULE_NAME }}-*
+          pattern: frontend-digests-${{ env.MODULE_NAME }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx

--- a/.github/workflows/service-build.yml
+++ b/.github/workflows/service-build.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ inputs.module }}-${{ matrix.arch }}
+          name: service-digests-${{ inputs.module }}-${{ matrix.arch }}
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -196,7 +196,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: ${{ runner.temp }}/digests
-          pattern: digests-${{ inputs.module }}-*
+          pattern: service-digests-${{ inputs.module }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx

--- a/.github/workflows/service-rs-build.yml
+++ b/.github/workflows/service-rs-build.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ inputs.module }}-${{ matrix.arch }}
+          name: service-rs-digests-${{ inputs.module }}-${{ matrix.arch }}
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -167,7 +167,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: ${{ runner.temp }}/digests
-          pattern: digests-${{ inputs.module }}-*
+          pattern: service-rs-digests-${{ inputs.module }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
```markdown
## Summary

This PR fixes a GitHub Actions artifact name collision in the release workflows.

Previously, multiple reusable workflows uploaded digest artifacts using the same naming pattern:

- `digests-${module}-${arch}`

That becomes a problem when different workflow families resolve to the same module name in a single workflow run. For example:

- frontend: `providers/devbox` -> `devbox`
- service: `devbox`

Both can end up trying to upload an artifact named `digests-devbox-amd64`, which causes `actions/upload-artifact@v4` to fail with:

> 409 Conflict: an artifact with this name already exists on the workflow run

## Root Cause

The frontend workflow uses `basename(inputs.module)`, while service workflows use the module name directly.  
As a result, frontend and service builds can produce identical digest artifact names even though they belong to different workflow families.

## Changes

Namespace digest artifact names by workflow family and update the corresponding download patterns:

- frontend
  - upload: `frontend-digests-${{ env.MODULE_NAME }}-${{ matrix.arch }}`
  - download: `frontend-digests-${{ env.MODULE_NAME }}-*`

- service
  - upload: `service-digests-${{ inputs.module }}-${{ matrix.arch }}`
  - download: `service-digests-${{ inputs.module }}-*`

- service-rs
  - upload: `service-rs-digests-${{ inputs.module }}-${{ matrix.arch }}`
  - download: `service-rs-digests-${{ inputs.module }}-*`

## Why This Fix

This keeps the change narrowly scoped to CI artifact naming and avoids touching any build, push, or manifest logic.

Benefits:

- prevents cross-workflow artifact collisions in the same run
- keeps upload and download behavior aligned
- minimizes regression risk

## Verification

- confirmed the failing case was caused by artifact creation conflict, not image build failure
- verified upload names and download patterns are updated in all 3 related workflows
- parsed the modified workflow YAML files successfully
- performed a repository-wide check for related `digests-*` usage in the affected workflow family

## Notes

This change only affects internal CI artifact names. It does not change image tags, image repositories, or release output.
```