### PR TITLE
fix(dbprovider): fix inflated storage values during backup restore

### DIFF
--- a/frontend/providers/dbprovider/src/utils/tools.ts
+++ b/frontend/providers/dbprovider/src/utils/tools.ts
@@ -144,12 +144,7 @@ export const memoryFormatToGi = (memory: string | number = '0'): string => {
  * @deprecated We need to migrate all resource representations to Quantity (in the near future).
  */
 export const storageFormatToNum = (storage = '0') => {
-  return (
-    Math.round(
-      (Number(Quantity.fromJSON(storage).withFormat('BinarySI').scaledValue(Scale.Mega)) / 1024) *
-        100
-    ) / 100
-  );
+  return Math.round((Number(Quantity.fromJSON(storage).value()) / 1024 / 1024 / 1024) * 100) / 100;
 };
 
 /**
@@ -161,11 +156,11 @@ export const storageFormatToNum = (storage = '0') => {
  * @deprecated We need to migrate all resource representations to Quantity (in the near future).
  */
 export const storageFormatToGi = (value: string | undefined, defaultValue: number = 0): number => {
-  return (
-    Math.round(
-      (Number(Quantity.fromJSON(value).withFormat('BinarySI').scaledValue(Scale.Mega)) / 1024) * 100
-    ) / 100
-  );
+  try {
+    return Math.round((Number(Quantity.fromJSON(value).value()) / 1024 / 1024 / 1024) * 100) / 100;
+  } catch {
+    return defaultValue;
+  }
 };
 
 /**


### PR DESCRIPTION
## Summary
- fix dbprovider storage quantity parsing to keep Gi values unchanged when reading from Kubernetes
- prevent restore-created databases from inheriting inflated storage values
- fix database detail and list storage display to use the correct converted size

## Root Cause
- dbprovider used `scaledValue(Scale.Mega) / 1024` to convert storage quantities
- in the shared quantity implementation, `Scale.Mega` is decimal `10^6`, not binary `Mi`
- that caused BinarySI values like `1Gi`, `2Gi`, and `3Gi` to be parsed as inflated numbers such as `1.05`, `2.10`, and `3.15`
- restore then wrote the inflated value back into the new cluster as `${storage}Gi`, which made restored database storage larger than the source

## Changes
- replace the storage conversion logic in `storageFormatToNum` and `storageFormatToGi`
- convert storage quantities by reading the raw quantity value and dividing by `1024^3`
- keep the existing rounding behavior and fallback handling

## Testing
- not run (small utility fix; verified the conversion logic manually with `1Gi`, `2Gi`, `3Gi`, `5Gi`, and `10Gi`)