### PR TITLE
fix(account-webhook): block Start OpsRequest in debt-limit0 namespaces

### DIFF
--- a/controllers/account/api/v1/debt_webhook.go
+++ b/controllers/account/api/v1/debt_webhook.go
@@ -18,6 +18,7 @@ package v1
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -33,6 +34,8 @@ import (
 	"gorm.io/gorm"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -55,6 +58,7 @@ const (
 var logger = logf.Log.WithName("debt-resource")
 
 //+kubebuilder:webhook:path=/validate-v1-sealos-cloud,mutating=false,failurePolicy=ignore,groups="*",resources=*,verbs=create;update;delete,versions=v1,name=debt.sealos.io,admissionReviewVersions=v1,sideEffects=None,timeoutSeconds=10
+//+kubebuilder:webhook:path=/validate-v1-sealos-cloud,mutating=false,failurePolicy=ignore,groups=apps.kubeblocks.io,resources=opsrequests,verbs=create,versions=v1alpha1,name=kbstartops.debt.sealos.io,admissionReviewVersions=v1,sideEffects=None,timeoutSeconds=10
 // +kubebuilder:object:generate=false
 
 type DebtValidate struct {
@@ -75,6 +79,9 @@ func (d *DebtValidate) Handle(ctx context.Context, req admission.Request) admiss
 	// skip delete request (删除quota资源除外)
 	if req.Operation == admissionv1.Delete && !strings.Contains(getGVRK(req), "quotas") {
 		return admission.Allowed("")
+	}
+	if resp, handled := d.handleKubeBlocksStartDebtGuard(ctx, req); handled {
+		return resp
 	}
 
 	for _, g := range req.UserInfo.Groups {
@@ -139,6 +146,77 @@ func (d *DebtValidate) Handle(ctx context.Context, req admission.Request) admiss
 	}
 	logger.V(1).Info("pass ", "req.Namespace", req.Namespace)
 	return admission.ValidationResponse(true, "")
+}
+
+func (d *DebtValidate) handleKubeBlocksStartDebtGuard(
+	ctx context.Context,
+	req admission.Request,
+) (admission.Response, bool) {
+	if hasPrivilegedDebtBypass(req.UserInfo.Groups) || !isKBStartOpsRequest(req) {
+		return admission.Response{}, false
+	}
+	if !d.hasDebtLimit0Quota(ctx, req.Namespace) {
+		return admission.Response{}, false
+	}
+	logger.Info(
+		"blocked Start OpsRequest in debt-suspended namespace",
+		"namespace",
+		req.Namespace,
+		"name",
+		req.Name,
+		"resource",
+		req.Resource.Resource,
+	)
+	return admission.Denied(
+		fmt.Sprintf(
+			code.MessageFormat,
+			code.InsufficientBalance,
+			"database start is not allowed: namespace is under debt suspension",
+		),
+	), true
+}
+
+func hasPrivilegedDebtBypass(groups []string) bool {
+	for _, g := range groups {
+		if g == mastersGroup || g == kubeSystemGroup {
+			return true
+		}
+	}
+	return false
+}
+
+func isKBStartOpsRequest(req admission.Request) bool {
+	if req.Kind.Group != "apps.kubeblocks.io" || req.Kind.Kind != "OpsRequest" {
+		return false
+	}
+	if req.Resource.Resource != "opsrequests" || req.Operation != admissionv1.Create {
+		return false
+	}
+	obj := &unstructured.Unstructured{}
+	if err := json.Unmarshal(req.Object.Raw, &obj.Object); err != nil {
+		return false
+	}
+	opsType, found, err := unstructured.NestedString(obj.Object, "spec", "type")
+	return err == nil && found && opsType == "Start"
+}
+
+func (d *DebtValidate) hasDebtLimit0Quota(ctx context.Context, namespace string) bool {
+	if namespace == "" {
+		return false
+	}
+	quota := &corev1.ResourceQuota{}
+	err := d.Client.Get(ctx, types.NamespacedName{
+		Name:      debtLimit0QuotaName,
+		Namespace: namespace,
+	}, quota)
+	if err == nil {
+		return true
+	}
+	if apierrors.IsNotFound(err) {
+		return false
+	}
+	logger.Error(err, "failed to get debt-limit0 quota", "namespace", namespace)
+	return false
 }
 
 func getGVRK(req admission.Request) string {

--- a/controllers/account/api/v1/debt_webhook.go
+++ b/controllers/account/api/v1/debt_webhook.go
@@ -54,7 +54,7 @@ const (
 
 var logger = logf.Log.WithName("debt-resource")
 
-//+kubebuilder:webhook:path=/validate-v1-sealos-cloud,mutating=false,failurePolicy=ignore,groups="*",resources=*,verbs=create;update;delete,versions=v1,name=debt.sealos.io,admissionReviewVersions=v1,sideEffects=None,timeoutSeconds=10
+//+kubebuilder:webhook:path=/validate-v1-sealos-cloud,mutating=false,failurePolicy=ignore,groups="*",resources=*,verbs=create;update;delete,versions=*,name=debt.sealos.io,admissionReviewVersions=v1,sideEffects=None,timeoutSeconds=10
 // +kubebuilder:object:generate=false
 
 type DebtValidate struct {

--- a/controllers/account/api/v1/debt_webhook_test.go
+++ b/controllers/account/api/v1/debt_webhook_test.go
@@ -1,0 +1,182 @@
+package v1
+
+import (
+	"context"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestIsKBStartOpsRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  admission.Request
+		want bool
+	}{
+		{
+			name: "start opsrequest",
+			req:  newOpsRequestAdmission("apps.kubeblocks.io", "Start", admissionv1.Create, nil),
+			want: true,
+		},
+		{
+			name: "stop opsrequest",
+			req:  newOpsRequestAdmission("apps.kubeblocks.io", "Stop", admissionv1.Create, nil),
+			want: false,
+		},
+		{
+			name: "wrong group",
+			req:  newOpsRequestAdmission("operations.kubeblocks.io", "Start", admissionv1.Create, nil),
+			want: false,
+		},
+		{
+			name: "update request",
+			req:  newOpsRequestAdmission("apps.kubeblocks.io", "Start", admissionv1.Update, nil),
+			want: false,
+		},
+		{
+			name: "malformed payload",
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind{
+						Group:   "apps.kubeblocks.io",
+						Version: "v1alpha1",
+						Kind:    "OpsRequest",
+					},
+					Resource: metav1.GroupVersionResource{
+						Group:    "apps.kubeblocks.io",
+						Version:  "v1alpha1",
+						Resource: "opsrequests",
+					},
+					Operation: admissionv1.Create,
+					Object:    runtime.RawExtension{Raw: []byte("{invalid")},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isKBStartOpsRequest(tt.req); got != tt.want {
+				t.Fatalf("isKBStartOpsRequest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasDebtLimit0Quota(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add client-go scheme: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		objects []runtime.Object
+		want    bool
+	}{
+		{
+			name: "quota exists",
+			objects: []runtime.Object{
+				&corev1.ResourceQuota{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      debtLimit0QuotaName,
+						Namespace: "test-ns",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name:    "quota missing",
+			objects: nil,
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validator := &DebtValidate{
+				Client: clientfake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tt.objects...).Build(),
+			}
+			if got := validator.hasDebtLimit0Quota(context.Background(), "test-ns"); got != tt.want {
+				t.Fatalf("hasDebtLimit0Quota() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHandleKubeBlocksStartDebtGuard(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add client-go scheme: %v", err)
+	}
+
+	quota := &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      debtLimit0QuotaName,
+			Namespace: "test-ns",
+		},
+	}
+	validator := &DebtValidate{
+		Client: clientfake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(quota).Build(),
+	}
+
+	t.Run("deny normal caller", func(t *testing.T) {
+		req := newOpsRequestAdmission("apps.kubeblocks.io", "Start", admissionv1.Create, []string{"system:serviceaccounts:user-system"})
+		resp, handled := validator.handleKubeBlocksStartDebtGuard(context.Background(), req)
+		if !handled {
+			t.Fatal("expected guard to handle request")
+		}
+		if resp.Allowed {
+			t.Fatal("expected start opsrequest to be denied")
+		}
+	})
+
+	t.Run("bypass masters", func(t *testing.T) {
+		req := newOpsRequestAdmission("apps.kubeblocks.io", "Start", admissionv1.Create, []string{mastersGroup})
+		_, handled := validator.handleKubeBlocksStartDebtGuard(context.Background(), req)
+		if handled {
+			t.Fatal("expected privileged caller to bypass guard")
+		}
+	})
+}
+
+func newOpsRequestAdmission(
+	group string,
+	opsType string,
+	operation admissionv1.Operation,
+	groups []string,
+) admission.Request {
+	raw := []byte(`{"apiVersion":"` + group + `/v1alpha1","kind":"OpsRequest","spec":{"type":"` + opsType + `"}}`)
+	return admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Kind: metav1.GroupVersionKind{
+				Group:   group,
+				Version: "v1alpha1",
+				Kind:    "OpsRequest",
+			},
+			Resource: metav1.GroupVersionResource{
+				Group:    group,
+				Version:  "v1alpha1",
+				Resource: "opsrequests",
+			},
+			Namespace: "test-ns",
+			Operation: operation,
+			Object: runtime.RawExtension{
+				Raw: raw,
+			},
+			UserInfo: authenticationv1.UserInfo{
+				Username: "system:serviceaccount:user-system:test",
+				Groups:   groups,
+			},
+		},
+	}
+}

--- a/controllers/account/api/v1/debt_webhook_test.go
+++ b/controllers/account/api/v1/debt_webhook_test.go
@@ -1,0 +1,328 @@
+package v1
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	pkgtype "github.com/labring/sealos/controllers/pkg/types"
+	"github.com/labring/sealos/controllers/pkg/utils/maps"
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// stubClient wraps a fake client and overrides Get for Namespace objects
+// to be compatible with the production code's {Name: ns, Namespace: ns} key pattern.
+type stubClient struct {
+	client.WithWatch
+	nsMap map[string]*corev1.Namespace
+	scheme *runtime.Scheme
+}
+
+func (s *stubClient) Get(_ context.Context, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+	if ns, ok := s.nsMap[key.Name]; ok {
+		ns.DeepCopyInto(obj.(*corev1.Namespace))
+		return nil
+	}
+	return apierrors.NewNotFound(corev1.Resource("namespaces"), key.Name)
+}
+
+func (s *stubClient) List(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
+	return nil
+}
+
+func (s *stubClient) Scheme() *runtime.Scheme { return s.scheme }
+
+func newDebtWithNS(namespaces ...*corev1.Namespace) *DebtValidate {
+	nsMap := make(map[string]*corev1.Namespace)
+	objs := make([]client.Object, len(namespaces))
+	for i, ns := range namespaces {
+		nsMap[ns.Name] = ns
+		objs[i] = ns
+	}
+	fc := fake.NewClientBuilder().WithObjects(objs...).Build()
+	return &DebtValidate{
+		Client:     &stubClient{WithWatch: fc, nsMap: nsMap, scheme: fc.Scheme()},
+		AccountV2:  nil,
+		TTLUserMap: maps.New[*pkgtype.UsableBalanceWithCredits](600),
+	}
+}
+
+func makeReq(op admissionv1.Operation, kind, group, version, resource string) admission.Request {
+	return admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: op,
+			Kind:      metav1.GroupVersionKind{Kind: kind, Group: group, Version: version},
+			Resource:  metav1.GroupVersionResource{Resource: resource, Group: group, Version: version},
+			UserInfo: authenticationv1.UserInfo{
+				Username: "test-user",
+				Groups:   []string{"system:serviceaccounts:user-system"},
+			},
+			Namespace: "ns-test",
+			Name:      "test-resource",
+		},
+	}
+}
+
+func makeReqWithGroups(op admissionv1.Operation, groups []string) admission.Request {
+	req := makeReq(op, "Pod", "", "v1", "pods")
+	req.UserInfo = authenticationv1.UserInfo{
+		Username: "test-user",
+		Groups:   groups,
+	}
+	return req
+}
+
+// --- Identity bypass tests (no client/DB needed) ---
+
+func TestHandle_SystemMastersBypass(t *testing.T) {
+	d := &DebtValidate{}
+	resp := d.Handle(context.Background(), makeReqWithGroups(admissionv1.Create, []string{"system:masters"}))
+	if !resp.Allowed {
+		t.Fatalf("system:masters should be allowed, got: %s", resp.Result.Message)
+	}
+}
+
+func TestHandle_KubeSystemBypass(t *testing.T) {
+	d := &DebtValidate{}
+	resp := d.Handle(context.Background(), makeReqWithGroups(admissionv1.Create, []string{"system:serviceaccounts:kube-system"}))
+	if !resp.Allowed {
+		t.Fatalf("kube-system SA should be allowed, got: %s", resp.Result.Message)
+	}
+}
+
+func TestHandle_NonUserSASkipped(t *testing.T) {
+	d := &DebtValidate{}
+	resp := d.Handle(context.Background(), makeReqWithGroups(admissionv1.Create, []string{"system:serviceaccounts:account-system"}))
+	if !resp.Allowed {
+		t.Fatalf("non-user-system SA should be allowed, got: %s", resp.Result.Message)
+	}
+}
+
+func TestHandle_UserControllerManagerBreaks(t *testing.T) {
+	d := &DebtValidate{}
+	req := makeReqWithGroups(admissionv1.Create, []string{"system:serviceaccounts:user-system"})
+	req.UserInfo.Username = "system:serviceaccount:user-system:user-controller-manager"
+	resp := d.Handle(context.Background(), req)
+	if !resp.Allowed {
+		t.Fatalf("user-controller-manager should be allowed, got: %s", resp.Result.Message)
+	}
+}
+
+func TestHandle_UserSA_AdminBypass(t *testing.T) {
+	d := &DebtValidate{}
+	req := makeReqWithGroups(admissionv1.Create, []string{"system:serviceaccounts:user-system"})
+	req.UserInfo.Username = "system:serviceaccount:user-system:admin"
+	resp := d.Handle(context.Background(), req)
+	if !resp.Allowed {
+		t.Fatalf("ns-admin should be allowed, got: %s", resp.Result.Message)
+	}
+}
+
+func TestHandle_WhitelistBypass(t *testing.T) {
+	os.Setenv("WHITELIST", "terminals.Terminal.terminal.sealos.io/v1")
+	defer os.Unsetenv("WHITELIST")
+
+	d := &DebtValidate{}
+	req := makeReq(admissionv1.Create, "Terminal", "terminal.sealos.io", "v1", "terminals")
+	req.UserInfo = authenticationv1.UserInfo{
+		Username: "test-user",
+		Groups:   []string{"system:serviceaccounts:user-system"},
+	}
+	resp := d.Handle(context.Background(), req)
+	if !resp.Allowed {
+		t.Fatalf("whitelisted resource should be allowed, got: %s", resp.Result.Message)
+	}
+}
+
+func TestHandle_WhitelistNoMatch_EntersCheck(t *testing.T) {
+	os.Setenv("WHITELIST", "terminals.Terminal.terminal.sealos.io/v1")
+	defer os.Unsetenv("WHITELIST")
+
+	d := newDebtWithNS(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-test"}})
+	req := makeReq(admissionv1.Create, "Pod", "", "v1", "pods")
+	req.UserInfo = authenticationv1.UserInfo{
+		Username: "test-user",
+		Groups:   []string{"system:serviceaccounts:user-system"},
+	}
+	resp := d.Handle(context.Background(), req)
+	if resp.Allowed {
+		t.Fatal("non-whitelisted Pod from user SA without owner label namespace should be denied")
+	}
+}
+
+func TestHandle_DeleteNonQuotaAllowed(t *testing.T) {
+	d := &DebtValidate{}
+	resp := d.Handle(context.Background(), makeReq(admissionv1.Delete, "Pod", "", "v1", "pods"))
+	if !resp.Allowed {
+		t.Fatalf("DELETE non-quota should be allowed, got: %s", resp.Result.Message)
+	}
+}
+
+func TestHandle_DeleteQuotaNotBypassed(t *testing.T) {
+	d := newDebtWithNS(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-test"}})
+	req := makeReq(admissionv1.Delete, "ResourceQuota", "", "v1", "quotas")
+	resp := d.Handle(context.Background(), req)
+	if resp.Allowed {
+		t.Fatal("DELETE quota from user SA without owner label should be denied")
+	}
+}
+
+// --- Resource-type denial tests (no client/DB needed) ---
+
+func TestHandle_NamespaceDenied(t *testing.T) {
+	d := &DebtValidate{}
+	req := makeReqWithGroups(admissionv1.Create, []string{"system:serviceaccounts:user-system"})
+	req.Kind = metav1.GroupVersionKind{Kind: "Namespace", Version: "v1"}
+	req.Resource = metav1.GroupVersionResource{Resource: "namespaces", Version: "v1"}
+	if resp := d.Handle(context.Background(), req); resp.Allowed {
+		t.Fatal("Namespace should be denied for user SA")
+	}
+}
+
+func TestHandle_PaymentUpdateDenied(t *testing.T) {
+	d := &DebtValidate{}
+	req := makeReqWithGroups(admissionv1.Update, []string{"system:serviceaccounts:user-system"})
+	req.Kind = metav1.GroupVersionKind{Kind: "Payment", Group: "account.sealos.io", Version: "v1"}
+	req.Resource = metav1.GroupVersionResource{Resource: "payments", Group: "account.sealos.io", Version: "v1"}
+	if resp := d.Handle(context.Background(), req); resp.Allowed {
+		t.Fatal("Payment Update should be denied for user SA")
+	}
+}
+
+func TestHandle_ResourceQuota_Denied(t *testing.T) {
+	d := &DebtValidate{}
+	req := makeReqWithGroups(admissionv1.Create, []string{"system:serviceaccounts:user-system"})
+	req.Kind = metav1.GroupVersionKind{Kind: "ResourceQuota", Version: "v1"}
+	req.Resource = metav1.GroupVersionResource{Resource: "resourcequotas", Version: "v1"}
+	req.Name = "quota-default"
+	if resp := d.Handle(context.Background(), req); resp.Allowed {
+		t.Fatal("ResourceQuota with quota-xxx name should be denied for user SA")
+	}
+}
+
+func TestHandle_DebtLimit0Quota_Denied(t *testing.T) {
+	d := &DebtValidate{}
+	req := makeReqWithGroups(admissionv1.Create, []string{"system:serviceaccounts:user-system"})
+	req.Kind = metav1.GroupVersionKind{Kind: "ResourceQuota", Version: "v1"}
+	req.Resource = metav1.GroupVersionResource{Resource: "resourcequotas", Version: "v1"}
+	req.Name = debtLimit0QuotaName
+	if resp := d.Handle(context.Background(), req); resp.Allowed {
+		t.Fatal("debt-limit0 ResourceQuota should be denied for user SA")
+	}
+}
+
+// --- API version coverage: verifies handler treats v1alpha1 same as v1 ---
+
+func TestHandle_V1Alpha1OpsRequest_EntersDebtCheck(t *testing.T) {
+	d := newDebtWithNS(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-test"}})
+	req := makeReq(admissionv1.Create, "OpsRequest", "apps.kubeblocks.io", "v1alpha1", "opsrequests")
+	if resp := d.Handle(context.Background(), req); resp.Allowed {
+		t.Fatal("v1alpha1 OpsRequest from user SA without owner label namespace should be denied")
+	}
+}
+
+func TestHandle_V1Pod_EntersDebtCheck(t *testing.T) {
+	d := newDebtWithNS(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-test"}})
+	req := makeReq(admissionv1.Create, "Pod", "", "v1", "pods")
+	if resp := d.Handle(context.Background(), req); resp.Allowed {
+		t.Fatal("v1 Pod from user SA without owner label namespace should be denied")
+	}
+}
+
+func TestHandle_V1Beta1Deployment_EntersDebtCheck(t *testing.T) {
+	d := newDebtWithNS(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-test"}})
+	req := makeReq(admissionv1.Create, "Deployment", "apps", "v1beta1", "deployments")
+	if resp := d.Handle(context.Background(), req); resp.Allowed {
+		t.Fatal("v1beta1 Deployment from user SA without owner label namespace should be denied")
+	}
+}
+
+// --- checkOption ---
+
+func TestCheckOption_EmptyNamespace(t *testing.T) {
+	d := &DebtValidate{}
+	if resp := d.checkOption(context.Background(), logger, nil, ""); !resp.Allowed {
+		t.Fatal("empty namespace should be allowed")
+	}
+}
+
+func TestCheckOption_NonUserNamespace_Denied(t *testing.T) {
+	d := newDebtWithNS(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns-test"}})
+	if resp := d.checkOption(context.Background(), logger, d.Client, "ns-test"); resp.Allowed {
+		t.Fatal("namespace without owner label should be denied")
+	}
+}
+
+func TestCheckOption_CacheHit_InsufficientBalance(t *testing.T) {
+	d := newDebtWithNS(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "ns-test",
+			Labels: map[string]string{"user.sealos.io/owner": "user-1"},
+		},
+	})
+	d.TTLUserMap.Put("account:user-1", &pkgtype.UsableBalanceWithCredits{
+		Balance:         0,
+		UsableCredits:   0,
+		DeductionBalance: 100,
+	})
+	if resp := d.checkOption(context.Background(), logger, d.Client, "ns-test"); resp.Allowed {
+		t.Fatal("insufficient balance from cache should be denied")
+	}
+}
+
+func TestCheckOption_CacheHit_SufficientBalance(t *testing.T) {
+	d := newDebtWithNS(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "ns-test",
+			Labels: map[string]string{"user.sealos.io/owner": "user-1"},
+		},
+	})
+	d.TTLUserMap.Put("account:user-1", &pkgtype.UsableBalanceWithCredits{
+		Balance:         100,
+		UsableCredits:   0,
+		DeductionBalance: 0,
+	})
+	if resp := d.checkOption(context.Background(), logger, d.Client, "ns-test"); !resp.Allowed {
+		t.Fatalf("sufficient balance from cache should be allowed, got: %s", resp.Result.Message)
+	}
+}
+
+// --- Helpers ---
+
+func TestIsDefaultQuotaName(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected bool
+	}{
+		{"quota-default", true},
+		{"quota-", true},
+		{"debt-limit0", true},
+		{"my-quota", false},
+		{"default", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := isDefaultQuotaName(tt.name); got != tt.expected {
+			t.Errorf("isDefaultQuotaName(%q) = %v, want %v", tt.name, got, tt.expected)
+		}
+	}
+}
+
+func TestGetGVRK(t *testing.T) {
+	reqWithGroup := makeReq(admissionv1.Create, "Pod", "apps", "v1", "deployments")
+	if got := getGVRK(reqWithGroup); got != "deployments.Pod.apps/v1" {
+		t.Errorf("getGVRK with group = %q, want deployments.Pod.apps/v1", got)
+	}
+	reqWithoutGroup := makeReq(admissionv1.Create, "Pod", "", "v1", "pods")
+	if got := getGVRK(reqWithoutGroup); got != "pods.Pod/v1" {
+		t.Errorf("getGVRK without group = %q, want pods.Pod/v1", got)
+	}
+}

--- a/controllers/account/config/webhook/manifests.yaml
+++ b/controllers/account/config/webhook/manifests.yaml
@@ -44,6 +44,14 @@ webhooks:
       resources:
         - '*'
     - apiGroups:
+        - apps.kubeblocks.io
+      apiVersions:
+        - v1alpha1
+      operations:
+        - CREATE
+      resources:
+        - opsrequests
+    - apiGroups:
         - account.sealos.io
       apiVersions:
         - v1

--- a/controllers/account/config/webhook/manifests.yaml
+++ b/controllers/account/config/webhook/manifests.yaml
@@ -36,7 +36,7 @@ webhooks:
     - apiGroups:
         - '*'
       apiVersions:
-        - v1
+        - '*'
       operations:
         - CREATE
         - UPDATE

--- a/controllers/account/deploy/charts/account-controller/templates/webhook.yaml
+++ b/controllers/account/deploy/charts/account-controller/templates/webhook.yaml
@@ -31,6 +31,14 @@ webhooks:
         resources:
           - '*'
       - apiGroups:
+          - apps.kubeblocks.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+        resources:
+          - opsrequests
+      - apiGroups:
           - account.sealos.io
         apiVersions:
           - v1

--- a/controllers/account/deploy/charts/account-controller/templates/webhook.yaml
+++ b/controllers/account/deploy/charts/account-controller/templates/webhook.yaml
@@ -23,7 +23,7 @@ webhooks:
       - apiGroups:
           - '*'
         apiVersions:
-          - v1
+          - '*'
         operations:
           - CREATE
           - UPDATE


### PR DESCRIPTION
widen apiVersions from v1 to * in debt that denies KubeBlocks Start OpsRequest creation when the target namespace still has debt-limit0 applied.
