### PR TITLE
feat(desktop): support desktop SDK windowed app open

### DIFF
--- a/frontend/desktop/src/stores/app.ts
+++ b/frontend/desktop/src/stores/app.ts
@@ -158,7 +158,7 @@ const useAppStore = create<TOSState>()(
           });
         },
 
-        openApp: async (app: TApp, { query, raw, pathname = '/', appSize = 'maximize' } = {}) => {
+        openApp: async (app: TApp, { query, raw, pathname = '/', appSize } = {}) => {
           console.log('open app: ', app.key);
 
           useDesktopConfigStore.getState().temporarilyDisableAnimation();
@@ -167,7 +167,16 @@ const useAppStore = create<TOSState>()(
           // 未支持多实例
           let alreadyApp = get().runningInfo.find((x) => x.key === app.key);
           if (alreadyApp) {
-            get().switchAppById(alreadyApp.pid);
+            if (appSize) {
+              get().updateOpenedAppInfo({
+                ...alreadyApp,
+                isShow: true,
+                size: appSize,
+                cacheSize: appSize
+              });
+            } else {
+              get().switchAppById(alreadyApp.pid);
+            }
             get().setToHighestLayerById(alreadyApp.pid);
             return;
           }
@@ -182,8 +191,10 @@ const useAppStore = create<TOSState>()(
           let run_app = get().runner.openApp(app.key);
 
           const _app = new AppInfo(app, run_app.pid);
+          const initialAppSize = appSize || 'maximize';
           _app.zIndex = zIndex;
-          _app.size = appSize;
+          _app.size = initialAppSize;
+          _app.cacheSize = initialAppSize;
           _app.isShow = true;
 
           if (_app.data?.url) {
@@ -209,7 +220,7 @@ const useAppStore = create<TOSState>()(
             state.runningInfo.push(_app);
             state.currentAppPid = _app.pid;
             // Only save currentAppKey when app is maximized
-            if (appSize === 'maximize') {
+            if (initialAppSize === 'maximize') {
               state.currentAppKey = _app.key;
             }
             state.maxZIndex = zIndex;

--- a/frontend/packages/client-sdk/README.md
+++ b/frontend/packages/client-sdk/README.md
@@ -87,6 +87,25 @@ const { lng } = await sealosApp.getLanguage();
 // lng: 'zh' | 'en' | other language codes
 ```
 
+### Open Desktop App
+
+```typescript
+// Open an app in a small desktop window
+await sealosApp.openApp({
+  appKey: 'system-costcenter',
+  appSize: 'windowed'
+});
+
+// Open an app with route, query, and message data
+await sealosApp.openApp({
+  appKey: 'system-template',
+  pathname: '/instance',
+  query: { instanceName: 'demo' },
+  messageData: { source: 'my-app' },
+  appSize: 'maximized'
+});
+```
+
 ### Event Communication
 
 ```typescript
@@ -157,6 +176,7 @@ createMasterAPP(allowedOrigins);
 | ----------------------------- | ------------------ | ------------------------ | ---------------------------- |
 | `getSession()`                | -                  | `Promise<SessionV1>`     | Get user session information |
 | `getLanguage()`               | -                  | `Promise<{lng: string}>` | Get language settings        |
+| `openApp(options)`            | `OpenAppOptions`   | `Promise<any>`           | Open a desktop app           |
 | `runEvents(name, data)`       | `string, any`      | `Promise<any>`           | Trigger main app events      |
 | `addAppEventListen(name, fn)` | `string, function` | `function`               | Listen to main app events    |
 

--- a/frontend/packages/client-sdk/README_zh.md
+++ b/frontend/packages/client-sdk/README_zh.md
@@ -87,6 +87,25 @@ const { lng } = await sealosApp.getLanguage();
 // lng: 'zh' | 'en' | 其他语言代码
 ```
 
+### 打开 Desktop 应用
+
+```typescript
+// 以 desktop 小窗口打开应用
+await sealosApp.openApp({
+  appKey: 'system-costcenter',
+  appSize: 'windowed'
+});
+
+// 打开应用时传递路由、查询参数和消息数据
+await sealosApp.openApp({
+  appKey: 'system-template',
+  pathname: '/instance',
+  query: { instanceName: 'demo' },
+  messageData: { source: 'my-app' },
+  appSize: 'maximized'
+});
+```
+
 ### 事件通信
 
 ```typescript
@@ -153,12 +172,13 @@ createMasterAPP(allowedOrigins);
 
 ## 📖 API 参考
 
-| API                           | 参数               | 返回值                   | 说明             |
-| ----------------------------- | ------------------ | ------------------------ | ---------------- |
-| `getSession()`                | -                  | `Promise<SessionV1>`     | 获取用户会话信息 |
-| `getLanguage()`               | -                  | `Promise<{lng: string}>` | 获取语言设置     |
-| `runEvents(name, data)`       | `string, any`      | `Promise<any>`           | 触发主应用事件   |
-| `addAppEventListen(name, fn)` | `string, function` | `function`               | 监听主应用事件   |
+| API                           | 参数               | 返回值                   | 说明              |
+| ----------------------------- | ------------------ | ------------------------ | ----------------- |
+| `getSession()`                | -                  | `Promise<SessionV1>`     | 获取用户会话信息  |
+| `getLanguage()`               | -                  | `Promise<{lng: string}>` | 获取语言设置      |
+| `openApp(options)`            | `OpenAppOptions`   | `Promise<any>`           | 打开 desktop 应用 |
+| `runEvents(name, data)`       | `string, any`      | `Promise<any>`           | 触发主应用事件    |
+| `addAppEventListen(name, fn)` | `string, function` | `function`               | 监听主应用事件    |
 
 ## 🤝 贡献
 

--- a/frontend/packages/client-sdk/src/app.ts
+++ b/frontend/packages/client-sdk/src/app.ts
@@ -1,13 +1,22 @@
 import { v4 } from 'uuid';
 import { API_NAME } from './constants';
-import {
+import type {
   AppMessageType,
   AppSendMessageType,
   MasterReplyMessageType,
+  OpenAppOptions,
   SessionV1,
   WorkspaceQuotaItem
 } from './types';
 import { isBrowser } from './utils';
+
+export type { OpenAppOptions, WindowSize } from './types';
+
+const windowSizeMap = {
+  maximized: 'maximize',
+  windowed: 'maxmin',
+  minimized: 'minimize'
+} as const;
 
 class ClientSDK {
   private readonly eventBus = new Map<string, (e?: any) => any>();
@@ -134,6 +143,15 @@ class ClientSDK {
     return this.sendMessageToMaster(API_NAME.EVENT_BUS, {
       eventName,
       eventData
+    });
+  }
+
+  openApp(options: OpenAppOptions) {
+    const { pathname = '/', appSize, ...eventData } = options;
+    return this.runEvents('openDesktopApp', {
+      pathname,
+      ...eventData,
+      ...(appSize ? { appSize: windowSizeMap[appSize] } : {})
     });
   }
 

--- a/frontend/packages/client-sdk/src/types/app.d.ts
+++ b/frontend/packages/client-sdk/src/types/app.d.ts
@@ -36,3 +36,13 @@ export type MasterOptions = {
     };
   }>;
 };
+
+export type WindowSize = 'maximized' | 'windowed' | 'minimized';
+
+export type OpenAppOptions = {
+  appKey: string;
+  query?: Record<string, string>;
+  messageData?: Record<string, any>;
+  pathname?: string;
+  appSize?: WindowSize;
+};


### PR DESCRIPTION
## Summary
- add `sealosApp.openApp(options)` to the desktop SDK
- support passing `appSize: 'maxmin'` to open desktop apps in window mode
- preserve existing focus behavior when reopening an already running app without an explicit size
- document the new API in English and Chinese README files

## Validation
- `pnpm --filter sealos-desktop-sdk run build`
- `pnpm --filter desktop exec tsc --noEmit`
- pre-commit `lint-staged`
