### PR TITLE
feat(launchpad): Add AppLaunchpad operation audit logs

### DIFF
--- a/frontend/providers/applaunchpad/src/pages/api/pauseApp.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/pauseApp.ts
@@ -5,6 +5,26 @@ import { pauseApp, createK8sContext } from '@/services/backend';
 import { withErrorHandler } from '@/services/backend/middleware';
 import { ResponseCode } from '@/types/response';
 
+const sanitizeUrl = (value?: string | string[]) => {
+  const url = Array.isArray(value) ? value[0] : value;
+  if (!url) return undefined;
+
+  try {
+    const parsed = new URL(url);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return url.split('?')[0];
+  }
+};
+
+const getRequestSource = (req: NextApiRequest) => ({
+  method: req.method,
+  forwardedFor: req.headers['x-forwarded-for'],
+  realIp: req.headers['x-real-ip'],
+  userAgent: req.headers['user-agent'],
+  referer: sanitizeUrl(req.headers.referer)
+});
+
 export default withErrorHandler(async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ApiResp>
@@ -19,7 +39,26 @@ export default withErrorHandler(async function handler(
   }
 
   const k8s = await createK8sContext(req);
-  await pauseApp(appName, k8s);
+  const logPayload = {
+    action: 'pause',
+    appName,
+    namespace: k8s.namespace,
+    user: k8s.kube_user?.name,
+    request: getRequestSource(req)
+  };
+
+  console.info('[applaunchpad app operation] received', logPayload);
+
+  try {
+    await pauseApp(appName, k8s);
+    console.info('[applaunchpad app operation] succeeded', logPayload);
+  } catch (error) {
+    console.error('[applaunchpad app operation] failed', {
+      ...logPayload,
+      error
+    });
+    throw error;
+  }
 
   jsonRes(res, {
     message: 'App paused successfully'

--- a/frontend/providers/applaunchpad/src/pages/api/restartApp.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/restartApp.ts
@@ -7,6 +7,26 @@ import { withErrorHandler } from '@/services/backend/middleware';
 import { ResponseCode } from '@/types/response';
 import dayjs from 'dayjs';
 
+const sanitizeUrl = (value?: string | string[]) => {
+  const url = Array.isArray(value) ? value[0] : value;
+  if (!url) return undefined;
+
+  try {
+    const parsed = new URL(url);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return url.split('?')[0];
+  }
+};
+
+const getRequestSource = (req: NextApiRequest) => ({
+  method: req.method,
+  forwardedFor: req.headers['x-forwarded-for'],
+  realIp: req.headers['x-real-ip'],
+  userAgent: req.headers['user-agent'],
+  referer: sanitizeUrl(req.headers.referer)
+});
+
 export default withErrorHandler(async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ApiResp>
@@ -19,10 +39,18 @@ export default withErrorHandler(async function handler(
     });
   }
 
-  const { getDeployApp, apiClient } = await getK8s({
+  const { getDeployApp, apiClient, namespace, kube_user } = await getK8s({
     kubeconfig: await authSession(req.headers)
   });
+  const logPayload = {
+    action: 'restart',
+    appName,
+    namespace,
+    user: kube_user?.name,
+    request: getRequestSource(req)
+  };
 
+  console.info('[applaunchpad app operation] received', logPayload);
   const app = await getDeployApp(appName);
 
   if (!app.spec?.template.metadata?.labels) {
@@ -32,8 +60,26 @@ export default withErrorHandler(async function handler(
     });
   }
 
-  app.spec.template.metadata.labels['restartTime'] = `${dayjs().format('YYYYMMDDHHmmss')}`;
-  await apiClient.replace(app);
+  const previousRestartTime = app.spec.template.metadata.labels.restartTime;
+  const nextRestartTime = `${dayjs().format('YYYYMMDDHHmmss')}`;
+  app.spec.template.metadata.labels.restartTime = nextRestartTime;
+
+  try {
+    await apiClient.replace(app);
+    console.info('[applaunchpad app operation] succeeded', {
+      ...logPayload,
+      previousRestartTime,
+      nextRestartTime
+    });
+  } catch (error) {
+    console.error('[applaunchpad app operation] failed', {
+      ...logPayload,
+      previousRestartTime,
+      nextRestartTime,
+      error
+    });
+    throw error;
+  }
 
   jsonRes(res);
 });

--- a/frontend/providers/applaunchpad/src/pages/api/startApp.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/startApp.ts
@@ -5,6 +5,26 @@ import { startApp, createK8sContext } from '@/services/backend';
 import { withErrorHandler } from '@/services/backend/middleware';
 import { ResponseCode } from '@/types/response';
 
+const sanitizeUrl = (value?: string | string[]) => {
+  const url = Array.isArray(value) ? value[0] : value;
+  if (!url) return undefined;
+
+  try {
+    const parsed = new URL(url);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return url.split('?')[0];
+  }
+};
+
+const getRequestSource = (req: NextApiRequest) => ({
+  method: req.method,
+  forwardedFor: req.headers['x-forwarded-for'],
+  realIp: req.headers['x-real-ip'],
+  userAgent: req.headers['user-agent'],
+  referer: sanitizeUrl(req.headers.referer)
+});
+
 export default withErrorHandler(async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ApiResp>
@@ -19,7 +39,26 @@ export default withErrorHandler(async function handler(
   }
 
   const k8s = await createK8sContext(req);
-  await startApp(appName, k8s);
+  const logPayload = {
+    action: 'start',
+    appName,
+    namespace: k8s.namespace,
+    user: k8s.kube_user?.name,
+    request: getRequestSource(req)
+  };
+
+  console.info('[applaunchpad app operation] received', logPayload);
+
+  try {
+    await startApp(appName, k8s);
+    console.info('[applaunchpad app operation] succeeded', logPayload);
+  } catch (error) {
+    console.error('[applaunchpad app operation] failed', {
+      ...logPayload,
+      error
+    });
+    throw error;
+  }
 
   jsonRes(res, {
     message: 'App started successfully'

--- a/frontend/providers/applaunchpad/src/services/backend/appService.ts
+++ b/frontend/providers/applaunchpad/src/services/backend/appService.ts
@@ -126,7 +126,7 @@ export async function createApp(appForm: AppEditType, k8s: K8sContext) {
  * @param k8s Kubernetes context containing clients and configuration
  */
 export async function startApp(appName: string, k8s: K8sContext) {
-  const { apiClient, getDeployApp, applyYamlList, namespace, k8sNetworkingApp } = k8s;
+  const { apiClient, getDeployApp, applyYamlList, namespace, k8sNetworkingApp, kube_user } = k8s;
 
   const app = await getDeployApp(appName);
 
@@ -142,11 +142,26 @@ export async function startApp(appName: string, k8s: K8sContext) {
     target: string;
     value: string;
   } = JSON.parse(app.metadata.annotations[pauseKey]);
+  const previousReplicas = app.spec.replicas;
+  const previousPauseData = app.metadata.annotations[pauseKey];
 
   delete app.metadata.annotations[pauseKey];
   app.spec.replicas = app.metadata.annotations[minReplicasKey]
     ? +app.metadata.annotations[minReplicasKey]
     : 1;
+
+  console.info('[applaunchpad app operation] applying start', {
+    action: 'start',
+    appName,
+    namespace,
+    user: kube_user?.name,
+    previousReplicas,
+    nextReplicas: app.spec.replicas,
+    previousPauseData,
+    minReplicas: app.metadata.annotations[minReplicasKey],
+    maxReplicas: app.metadata.annotations[maxReplicasKey],
+    restoreHpa: !!pauseData.target
+  });
 
   const requestQueue: Promise<any>[] = [apiClient.replace(app)];
   if (pauseData.target) {
@@ -195,6 +210,14 @@ export async function startApp(appName: string, k8s: K8sContext) {
           }
 
           if (Object.keys(patchData).length > 0) {
+            console.info('[applaunchpad app operation] patch ingress', {
+              action: 'start',
+              appName,
+              namespace,
+              user: kube_user?.name,
+              ingressName: ingressItem.metadata.name,
+              patchData
+            });
             requestQueue.push(
               k8sNetworkingApp.patchNamespacedIngress(
                 ingressItem.metadata.name,
@@ -219,6 +242,15 @@ export async function startApp(appName: string, k8s: K8sContext) {
   }
 
   await Promise.all(requestQueue);
+  console.info('[applaunchpad app operation] applied start', {
+    action: 'start',
+    appName,
+    namespace,
+    user: kube_user?.name,
+    previousReplicas,
+    nextReplicas: app.spec.replicas,
+    restoredHpa: !!pauseData.target
+  });
 }
 
 /**
@@ -227,12 +259,14 @@ export async function startApp(appName: string, k8s: K8sContext) {
  * @param k8s Kubernetes context containing clients and configuration
  */
 export async function pauseApp(appName: string, k8s: K8sContext) {
-  const { apiClient, k8sAutoscaling, getDeployApp, namespace, k8sNetworkingApp } = k8s;
+  const { apiClient, k8sAutoscaling, getDeployApp, namespace, k8sNetworkingApp, kube_user } = k8s;
 
   const app = await getDeployApp(appName);
   if (!app.metadata?.name || !app?.metadata?.annotations || !app.spec) {
     throw new Error('app data error');
   }
+  const previousReplicas = app.spec.replicas;
+  const previousPauseData = app.metadata.annotations[pauseKey];
 
   const restartAnnotations: Record<string, string> = {
     target: '',
@@ -251,6 +285,14 @@ export async function pauseApp(appName: string, k8s: K8sContext) {
       hpa?.spec?.metrics?.[0]?.resource?.target?.averageUtilization || 50
     }`;
 
+    console.info('[applaunchpad app operation] delete hpa before pause', {
+      action: 'pause',
+      appName,
+      namespace,
+      user: kube_user?.name,
+      hpaName: hpa.metadata?.name,
+      restartAnnotations
+    });
     requestQueue.push(k8sAutoscaling.deleteNamespacedHorizontalPodAutoscaler(appName, namespace));
   } catch (error: any) {
     if (error?.statusCode !== 404) {
@@ -285,6 +327,14 @@ export async function pauseApp(appName: string, k8s: K8sContext) {
           }
 
           if (Object.keys(patchData).length > 0) {
+            console.info('[applaunchpad app operation] patch ingress', {
+              action: 'pause',
+              appName,
+              namespace,
+              user: kube_user?.name,
+              ingressName: ingressItem.metadata.name,
+              patchData
+            });
             requestQueue.push(
               k8sNetworkingApp.patchNamespacedIngress(
                 ingressItem.metadata.name,
@@ -311,9 +361,31 @@ export async function pauseApp(appName: string, k8s: K8sContext) {
   app.metadata.annotations[pauseKey] = JSON.stringify(restartAnnotations);
   app.spec.replicas = 0;
 
+  console.info('[applaunchpad app operation] applying pause', {
+    action: 'pause',
+    appName,
+    namespace,
+    user: kube_user?.name,
+    previousReplicas,
+    nextReplicas: app.spec.replicas,
+    previousPauseData,
+    nextPauseData: app.metadata.annotations[pauseKey],
+    minReplicas: app.metadata.annotations[minReplicasKey],
+    maxReplicas: app.metadata.annotations[maxReplicasKey]
+  });
+
   requestQueue.push(apiClient.replace(app));
 
   await Promise.all(requestQueue);
+  console.info('[applaunchpad app operation] applied pause', {
+    action: 'pause',
+    appName,
+    namespace,
+    user: kube_user?.name,
+    previousReplicas,
+    nextReplicas: app.spec.replicas,
+    nextPauseData: app.metadata.annotations[pauseKey]
+  });
 }
 
 /**
@@ -322,7 +394,7 @@ export async function pauseApp(appName: string, k8s: K8sContext) {
  * @param k8s Kubernetes context containing clients and configuration
  */
 export async function restartApp(appName: string, k8s: K8sContext) {
-  const { apiClient, getDeployApp } = k8s;
+  const { apiClient, getDeployApp, namespace, kube_user } = k8s;
 
   const app = await getDeployApp(appName);
 
@@ -335,8 +407,25 @@ export async function restartApp(appName: string, k8s: K8sContext) {
     .replace(/[:T]/g, '')
     .replace(/\./g, '')
     .replace(/-/g, '');
+  const previousRestartTime = app.spec.template.metadata.labels.restartTime;
   app.spec.template.metadata.labels['restartTime'] = timestamp;
+  console.info('[applaunchpad app operation] applying restart', {
+    action: 'restart',
+    appName,
+    namespace,
+    user: kube_user?.name,
+    previousRestartTime,
+    nextRestartTime: timestamp
+  });
   await apiClient.replace(app);
+  console.info('[applaunchpad app operation] applied restart', {
+    action: 'restart',
+    appName,
+    namespace,
+    user: kube_user?.name,
+    previousRestartTime,
+    nextRestartTime: timestamp
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- add backend audit logs for AppLaunchpad pause, start, and restart API handlers
- log the final Kubernetes mutation path for pause, start, and restart operations
- sanitize referer logging by dropping query strings before writing request metadata

## Why
Support needs a backend-side timeline for incidents where a paused app appears to start unexpectedly. These logs record the authenticated user, namespace, app name, request source, and the before/after Kubernetes state without logging kubeconfig, authorization headers, cookies, request bodies, or secrets.

## Validation
- `pnpm dlx prettier@2.8.8 --check providers/applaunchpad/src/pages/api/pauseApp.ts providers/applaunchpad/src/pages/api/restartApp.ts providers/applaunchpad/src/pages/api/startApp.ts providers/applaunchpad/src/services/backend/appService.ts`
- `git diff --check`

Note: targeted `next lint` could not run in this worktree because `node_modules` is not installed and `next` is unavailable locally.
