### PR TITLE
feat(template): support relative readme and icon assets

### DIFF
--- a/frontend/providers/template/__tests__/template-asset.test.ts
+++ b/frontend/providers/template/__tests__/template-asset.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { replaceRawWithCDN } from '@/pages/api/listTemplate';
+import { resolveTemplateAssetUrl, resolveTemplateAssetUrls } from '@/utils/templateAsset';
+import type { TemplateType } from '@/types/app';
+
+const repo = {
+  url: 'https://github.com/labring-actions/templates',
+  branch: 'main'
+};
+
+const repoRootPath = '/app/providers/template/templates';
+
+function createTemplate(overrides: Partial<TemplateType['spec']> = {}): TemplateType {
+  return {
+    apiVersion: 'app.sealos.io/v1',
+    kind: 'Template',
+    metadata: { name: 'visible' },
+    spec: {
+      fileName: 'index.yaml',
+      filePath: `${repoRootPath}/template/appsmith/index.yaml`,
+      categories: ['low-code'],
+      templateType: 'inline',
+      gitRepo: 'https://github.com/appsmithorg/appsmith',
+      author: '',
+      title: 'Visible',
+      url: '',
+      readme: './README.md',
+      icon: './static/logo.png',
+      description: '',
+      draft: false,
+      ...overrides
+    }
+  };
+}
+
+describe('template asset URL resolution', () => {
+  it('resolves GitHub template asset URLs relative to the template yaml directory', () => {
+    expect(
+      resolveTemplateAssetUrl({
+        assetUrl: './README.md',
+        repo,
+        templateFilePath: `${repoRootPath}/template/appsmith/index.yaml`,
+        repoRootPath
+      })
+    ).toBe(
+      'https://raw.githubusercontent.com/labring-actions/templates/main/template/appsmith/README.md'
+    );
+  });
+
+  it('resolves icon URLs for templates stored as a yaml file in a directory', () => {
+    expect(
+      resolveTemplateAssetUrl({
+        assetUrl: './static/logo.png',
+        repo,
+        templateFilePath: `${repoRootPath}/template/appsmith.yaml`,
+        repoRootPath
+      })
+    ).toBe(
+      'https://raw.githubusercontent.com/labring-actions/templates/main/template/static/logo.png'
+    );
+  });
+
+  it('keeps absolute URLs unchanged', () => {
+    expect(
+      resolveTemplateAssetUrl({
+        assetUrl: 'https://example.com/logo.png',
+        repo,
+        templateFilePath: `${repoRootPath}/template/appsmith/index.yaml`,
+        repoRootPath
+      })
+    ).toBe('https://example.com/logo.png');
+  });
+
+  it('resolves i18n readme and icon URLs', () => {
+    const template = resolveTemplateAssetUrls(
+      createTemplate({
+        i18n: {
+          en: {
+            readme: './README_en.md',
+            icon: './images/logo-en.png',
+            description: 'English'
+          }
+        }
+      }),
+      {
+        repo,
+        templateFilePath: `${repoRootPath}/template/appsmith/index.yaml`,
+        repoRootPath
+      }
+    );
+
+    expect(template.spec.readme).toBe(
+      'https://raw.githubusercontent.com/labring-actions/templates/main/template/appsmith/README.md'
+    );
+    expect(template.spec.icon).toBe(
+      'https://raw.githubusercontent.com/labring-actions/templates/main/template/appsmith/static/logo.png'
+    );
+    expect(template.spec.i18n?.en.readme).toBe(
+      'https://raw.githubusercontent.com/labring-actions/templates/main/template/appsmith/README_en.md'
+    );
+    expect(template.spec.i18n?.en.icon).toBe(
+      'https://raw.githubusercontent.com/labring-actions/templates/main/template/appsmith/images/logo-en.png'
+    );
+  });
+
+  it('keeps GitHub CDN replacement for resolved raw URLs', () => {
+    const rawUrl = resolveTemplateAssetUrl({
+      assetUrl: './README.md',
+      repo,
+      templateFilePath: `${repoRootPath}/template/appsmith/index.yaml`,
+      repoRootPath
+    });
+
+    expect(replaceRawWithCDN(rawUrl, 'cdn.jsdelivr.net')).toBe(
+      'https://cdn.jsdelivr.net/gh/labring-actions/templates@main/template/appsmith/README.md'
+    );
+  });
+});

--- a/frontend/providers/template/src/pages/api/getTemplateSource.ts
+++ b/frontend/providers/template/src/pages/api/getTemplateSource.ts
@@ -18,6 +18,7 @@ import { getResourceUsage, ResourceUsage } from '@/utils/usage';
 import { generateYamlData, getTemplateDefaultValues } from '@/utils/template';
 import { readmeCache } from '@/utils/readmeCache';
 import { Config } from '@/config';
+import { resolveTemplateAssetUrls } from '@/utils/templateAsset';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
@@ -120,12 +121,14 @@ export async function GetTemplateByName({
   locale?: string;
   includeReadme?: string;
 }) {
-  const cdnUrl = Config().template.cdnHost;
+  const config = Config();
+  const cdnUrl = config.template.cdnHost;
 
   const TemplateEnvs = getTemplateEnvs(namespace);
 
   const originalPath = process.cwd();
-  const targetPath = path.resolve(originalPath, 'templates', Config().template.repo.localDir);
+  const repoRootPath = path.resolve(originalPath, 'templates');
+  const targetPath = path.resolve(repoRootPath, config.template.repo.localDir);
 
   const jsonPath = path.resolve(originalPath, 'templates.json');
   const jsonData: TemplateType[] = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
@@ -154,6 +157,11 @@ export async function GetTemplateByName({
     };
   }
   templateYaml.spec.deployCount = _tempalte?.spec?.deployCount;
+  templateYaml = resolveTemplateAssetUrls(templateYaml, {
+    repo: config.template.repo,
+    templateFilePath,
+    repoRootPath
+  });
 
   if (cdnUrl) {
     templateYaml.spec.readme = replaceRawWithCDN(templateYaml.spec.readme, cdnUrl);

--- a/frontend/providers/template/src/services/backend/template-repo.ts
+++ b/frontend/providers/template/src/services/backend/template-repo.ts
@@ -10,6 +10,7 @@ import * as k8s from '@kubernetes/client-node';
 import { getYamlTemplate } from '@/utils/json-yaml';
 import { getTemplateEnvs } from '@/utils/common';
 import { Config } from '@/config';
+import { resolveTemplateAssetUrls } from '@/utils/templateAsset';
 
 const execAsync = util.promisify(exec);
 
@@ -71,6 +72,7 @@ export async function updateRepo() {
   const jsonPath = path.resolve(originalPath, 'templates.json');
 
   const TemplateEnvs = getTemplateEnvs();
+  const config = Config();
 
   try {
     const gitConfigResult = await execAsync(
@@ -94,7 +96,7 @@ export async function updateRepo() {
   }
 
   let fileList: unknown[] = [];
-  const _targetPath = path.join(targetPath, Config().template.repo.localDir);
+  const _targetPath = path.join(targetPath, config.template.repo.localDir);
   readFileList(_targetPath, fileList);
 
   const templateStaticMap: { [key: string]: number } = await GetTemplateStatic();
@@ -105,8 +107,13 @@ export async function updateRepo() {
       if (!item) return;
       const fileName = path.basename(item);
       const content = fs.readFileSync(item, 'utf-8');
-      const { templateYaml } = getYamlTemplate(content);
+      let { templateYaml } = getYamlTemplate(content);
       if (!!templateYaml) {
+        templateYaml = resolveTemplateAssetUrls(templateYaml, {
+          repo: config.template.repo,
+          templateFilePath: item,
+          repoRootPath: targetPath
+        });
         const appTitle = templateYaml.spec.title.toUpperCase();
         const currentCount = templateStaticMap[appTitle] || 0;
         const randomFactor = 11 + Math.floor(Math.random() * 5); // [11,12,13,14,15]

--- a/frontend/providers/template/src/utils/templateAsset.ts
+++ b/frontend/providers/template/src/utils/templateAsset.ts
@@ -1,0 +1,138 @@
+import path from 'path';
+import { TemplateType } from '@/types/app';
+
+type TemplateRepo = {
+  url: string;
+  branch: string;
+};
+
+type ResolveTemplateAssetUrlOptions = {
+  assetUrl?: string;
+  repo: TemplateRepo;
+  templateFilePath?: string;
+  repoRootPath?: string;
+};
+
+const ASSET_FIELDS = ['readme', 'icon'] as const;
+
+function isHttpUrl(value: string) {
+  return /^https?:\/\//i.test(value);
+}
+
+function isRelativeAssetUrl(value: string) {
+  return value.startsWith('./') || value.startsWith('/');
+}
+
+function normalizeUrlPath(value: string) {
+  return value.replace(/\\/g, '/').split('/').filter(Boolean).map(encodeURIComponent).join('/');
+}
+
+function getRelativeBasePath(templateFilePath?: string, repoRootPath?: string) {
+  if (!templateFilePath || !repoRootPath) return '';
+
+  const relativeFilePath = path.relative(repoRootPath, templateFilePath);
+  const relativeDir = path.dirname(relativeFilePath);
+
+  return relativeDir === '.' ? '' : relativeDir.replace(/\\/g, '/');
+}
+
+function resolveRepoAssetPath(assetUrl: string, templateFilePath?: string, repoRootPath?: string) {
+  const assetPath = assetUrl.replace(/^\.\/|^\//, '');
+
+  if (assetUrl.startsWith('/')) {
+    return normalizeUrlPath(assetPath);
+  }
+
+  return normalizeUrlPath(
+    path.posix.join(getRelativeBasePath(templateFilePath, repoRootPath), assetPath)
+  );
+}
+
+function parseGitRepoUrl(repoUrl: string) {
+  try {
+    const url = new URL(repoUrl.replace(/\.git$/, ''));
+    const parts = url.pathname.split('/').filter(Boolean);
+
+    if (parts.length < 2) return null;
+
+    return {
+      host: url.host,
+      origin: url.origin,
+      ownerPath: parts.slice(0, -1),
+      repo: parts[parts.length - 1]
+    };
+  } catch (error) {
+    return null;
+  }
+}
+
+function getRepoAssetRawUrl(repo: TemplateRepo, assetPath: string) {
+  const parsedRepo = parseGitRepoUrl(repo.url);
+  if (!parsedRepo || !assetPath) return '';
+
+  const encodedRef = encodeURIComponent(repo.branch);
+  const projectPath = [...parsedRepo.ownerPath, parsedRepo.repo].map(encodeURIComponent).join('/');
+
+  if (parsedRepo.host === 'github.com') {
+    return `https://raw.githubusercontent.com/${projectPath}/${encodedRef}/${assetPath}`;
+  }
+
+  if (parsedRepo.host === 'gitlab.com' || parsedRepo.host.includes('gitlab')) {
+    return `${parsedRepo.origin}/${projectPath}/-/raw/${encodedRef}/${assetPath}`;
+  }
+
+  return `${parsedRepo.origin}/${projectPath}/raw/branch/${encodedRef}/${assetPath}`;
+}
+
+export function resolveTemplateAssetUrl({
+  assetUrl,
+  repo,
+  templateFilePath,
+  repoRootPath
+}: ResolveTemplateAssetUrlOptions) {
+  if (!assetUrl || isHttpUrl(assetUrl) || !isRelativeAssetUrl(assetUrl)) {
+    return assetUrl || '';
+  }
+
+  const assetPath = resolveRepoAssetPath(assetUrl, templateFilePath, repoRootPath);
+  return getRepoAssetRawUrl(repo, assetPath) || assetUrl;
+}
+
+export function resolveTemplateAssetUrls(
+  template: TemplateType,
+  options: Omit<ResolveTemplateAssetUrlOptions, 'assetUrl'>
+) {
+  const resolvedTemplate = {
+    ...template,
+    spec: {
+      ...template.spec,
+      i18n: template.spec.i18n ? { ...template.spec.i18n } : template.spec.i18n
+    }
+  };
+
+  ASSET_FIELDS.forEach((field) => {
+    resolvedTemplate.spec[field] = resolveTemplateAssetUrl({
+      ...options,
+      assetUrl: resolvedTemplate.spec[field]
+    });
+  });
+
+  if (resolvedTemplate.spec.i18n) {
+    Object.entries(resolvedTemplate.spec.i18n).forEach(([lang, data]) => {
+      const resolvedI18nData = { ...data };
+
+      ASSET_FIELDS.forEach((field) => {
+        if (resolvedI18nData[field]) {
+          resolvedI18nData[field] = resolveTemplateAssetUrl({
+            ...options,
+            assetUrl: resolvedI18nData[field]
+          });
+        }
+      });
+
+      resolvedTemplate.spec.i18n![lang] = resolvedI18nData;
+    });
+  }
+
+  return resolvedTemplate;
+}


### PR DESCRIPTION
## Summary

- add shared template asset URL resolution for relative `readme` and `icon` fields
- resolve assets from the configured template repo URL and branch, relative to the template YAML location
- apply the resolver during catalog generation and template detail loading, including i18n assets

## Validation

- `pnpm --filter ./providers/template test:ci`
- `pnpm --filter ./providers/template exec tsc --noEmit`
