### PR TITLE
feat(template): support relative readme and icon assets

### DIFF
--- a/frontend/providers/template/src/pages/api/getTemplateSource.ts
+++ b/frontend/providers/template/src/pages/api/getTemplateSource.ts
@@ -17,6 +17,7 @@ import { getTemplateEnvs } from '@/utils/tools';
 import { getResourceUsage, ResourceUsage } from '@/utils/usage';
 import { generateYamlData, getTemplateDefaultValues } from '@/utils/template';
 import { readmeCache } from '@/utils/readmeCache';
+import { resolveTemplateAssetUrls } from '@/utils/templateAsset';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
@@ -123,15 +124,15 @@ export async function GetTemplateByName({
   const TemplateEnvs = getTemplateEnvs(namespace);
 
   const originalPath = process.cwd();
-  const targetPath = path.resolve(originalPath, 'templates', targetFolder);
+  const repoRootPath = path.resolve(originalPath, 'templates');
+  const targetPath = path.resolve(repoRootPath, targetFolder);
 
   const jsonPath = path.resolve(originalPath, 'templates.json');
   const jsonData: TemplateType[] = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
   const _tempalte = jsonData.find((item) => item.metadata.name === templateName);
   const _tempalteName = _tempalte ? _tempalte.spec.fileName : `${templateName}.yaml`;
-  const yamlString = _tempalte?.spec?.filePath
-    ? fs.readFileSync(_tempalte?.spec?.filePath, 'utf-8')
-    : fs.readFileSync(`${targetPath}/${_tempalteName}`, 'utf-8');
+  const templateFilePath = _tempalte?.spec?.filePath || `${targetPath}/${_tempalteName}`;
+  const yamlString = fs.readFileSync(templateFilePath, 'utf-8');
 
   let { appYaml, templateYaml } = getYamlTemplate(yamlString);
 
@@ -142,6 +143,14 @@ export async function GetTemplateByName({
     };
   }
   templateYaml.spec.deployCount = _tempalte?.spec?.deployCount;
+  templateYaml = resolveTemplateAssetUrls(templateYaml, {
+    repo: {
+      url: TemplateEnvs.TEMPLATE_REPO_URL,
+      branch: TemplateEnvs.TEMPLATE_REPO_BRANCH
+    },
+    templateFilePath,
+    repoRootPath
+  });
 
   if (cdnUrl) {
     templateYaml.spec.readme = replaceRawWithCDN(templateYaml.spec.readme, cdnUrl);

--- a/frontend/providers/template/src/services/backend/template-repo.ts
+++ b/frontend/providers/template/src/services/backend/template-repo.ts
@@ -9,6 +9,7 @@ import util from 'util';
 import * as k8s from '@kubernetes/client-node';
 import { getYamlTemplate } from '@/utils/json-yaml';
 import { getTemplateEnvs } from '@/utils/tools';
+import { resolveTemplateAssetUrls } from '@/utils/templateAsset';
 
 const execAsync = util.promisify(exec);
 
@@ -105,8 +106,16 @@ export async function updateRepo() {
       if (!item) return;
       const fileName = path.basename(item);
       const content = fs.readFileSync(item, 'utf-8');
-      const { templateYaml } = getYamlTemplate(content);
+      let { templateYaml } = getYamlTemplate(content);
       if (!!templateYaml) {
+        templateYaml = resolveTemplateAssetUrls(templateYaml, {
+          repo: {
+            url: TemplateEnvs.TEMPLATE_REPO_URL,
+            branch: TemplateEnvs.TEMPLATE_REPO_BRANCH
+          },
+          templateFilePath: item,
+          repoRootPath: targetPath
+        });
         const appTitle = templateYaml.spec.title.toUpperCase();
         const currentCount = templateStaticMap[appTitle] || 0;
         const randomFactor = 11 + Math.floor(Math.random() * 5); // [11,12,13,14,15]

--- a/frontend/providers/template/src/utils/templateAsset.ts
+++ b/frontend/providers/template/src/utils/templateAsset.ts
@@ -1,0 +1,138 @@
+import path from 'path';
+import { TemplateType } from '@/types/app';
+
+type TemplateRepo = {
+  url: string;
+  branch: string;
+};
+
+type ResolveTemplateAssetUrlOptions = {
+  assetUrl?: string;
+  repo: TemplateRepo;
+  templateFilePath?: string;
+  repoRootPath?: string;
+};
+
+const ASSET_FIELDS = ['readme', 'icon'] as const;
+
+function isHttpUrl(value: string) {
+  return /^https?:\/\//i.test(value);
+}
+
+function isRelativeAssetUrl(value: string) {
+  return value.startsWith('./') || value.startsWith('/');
+}
+
+function normalizeUrlPath(value: string) {
+  return value.replace(/\\/g, '/').split('/').filter(Boolean).map(encodeURIComponent).join('/');
+}
+
+function getRelativeBasePath(templateFilePath?: string, repoRootPath?: string) {
+  if (!templateFilePath || !repoRootPath) return '';
+
+  const relativeFilePath = path.relative(repoRootPath, templateFilePath);
+  const relativeDir = path.dirname(relativeFilePath);
+
+  return relativeDir === '.' ? '' : relativeDir.replace(/\\/g, '/');
+}
+
+function resolveRepoAssetPath(assetUrl: string, templateFilePath?: string, repoRootPath?: string) {
+  const assetPath = assetUrl.replace(/^\.\/|^\//, '');
+
+  if (assetUrl.startsWith('/')) {
+    return normalizeUrlPath(assetPath);
+  }
+
+  return normalizeUrlPath(
+    path.posix.join(getRelativeBasePath(templateFilePath, repoRootPath), assetPath)
+  );
+}
+
+function parseGitRepoUrl(repoUrl: string) {
+  try {
+    const url = new URL(repoUrl.replace(/\.git$/, ''));
+    const parts = url.pathname.split('/').filter(Boolean);
+
+    if (parts.length < 2) return null;
+
+    return {
+      host: url.host,
+      origin: url.origin,
+      ownerPath: parts.slice(0, -1),
+      repo: parts[parts.length - 1]
+    };
+  } catch (error) {
+    return null;
+  }
+}
+
+function getRepoAssetRawUrl(repo: TemplateRepo, assetPath: string) {
+  const parsedRepo = parseGitRepoUrl(repo.url);
+  if (!parsedRepo || !assetPath) return '';
+
+  const encodedRef = encodeURIComponent(repo.branch);
+  const projectPath = [...parsedRepo.ownerPath, parsedRepo.repo].map(encodeURIComponent).join('/');
+
+  if (parsedRepo.host === 'github.com') {
+    return `https://raw.githubusercontent.com/${projectPath}/${encodedRef}/${assetPath}`;
+  }
+
+  if (parsedRepo.host === 'gitlab.com' || parsedRepo.host.includes('gitlab')) {
+    return `${parsedRepo.origin}/${projectPath}/-/raw/${encodedRef}/${assetPath}`;
+  }
+
+  return `${parsedRepo.origin}/${projectPath}/raw/branch/${encodedRef}/${assetPath}`;
+}
+
+export function resolveTemplateAssetUrl({
+  assetUrl,
+  repo,
+  templateFilePath,
+  repoRootPath
+}: ResolveTemplateAssetUrlOptions) {
+  if (!assetUrl || isHttpUrl(assetUrl) || !isRelativeAssetUrl(assetUrl)) {
+    return assetUrl || '';
+  }
+
+  const assetPath = resolveRepoAssetPath(assetUrl, templateFilePath, repoRootPath);
+  return getRepoAssetRawUrl(repo, assetPath) || assetUrl;
+}
+
+export function resolveTemplateAssetUrls(
+  template: TemplateType,
+  options: Omit<ResolveTemplateAssetUrlOptions, 'assetUrl'>
+) {
+  const resolvedTemplate = {
+    ...template,
+    spec: {
+      ...template.spec,
+      i18n: template.spec.i18n ? { ...template.spec.i18n } : template.spec.i18n
+    }
+  };
+
+  ASSET_FIELDS.forEach((field) => {
+    resolvedTemplate.spec[field] = resolveTemplateAssetUrl({
+      ...options,
+      assetUrl: resolvedTemplate.spec[field]
+    });
+  });
+
+  if (resolvedTemplate.spec.i18n) {
+    Object.entries(resolvedTemplate.spec.i18n).forEach(([lang, data]) => {
+      const resolvedI18nData = { ...data };
+
+      ASSET_FIELDS.forEach((field) => {
+        if (resolvedI18nData[field]) {
+          resolvedI18nData[field] = resolveTemplateAssetUrl({
+            ...options,
+            assetUrl: resolvedI18nData[field]
+          });
+        }
+      });
+
+      resolvedTemplate.spec.i18n![lang] = resolvedI18nData;
+    });
+  }
+
+  return resolvedTemplate;
+}


### PR DESCRIPTION
## Summary

- backport template relative asset URL resolution to `release-v5.1`
- resolve relative `readme` and `icon` fields from `TEMPLATE_REPO_URL` and `TEMPLATE_REPO_BRANCH`
- apply resolution during template catalog generation and template detail loading, including i18n assets

## Notes

This is the `release-v5.1` counterpart for the main-branch PR #6960. The release branch still uses env vars (`TEMPLATE_REPO_URL`, `TEMPLATE_REPO_BRANCH`, `TEMPLATE_REPO_FOLDER`, `CDN_URL`) rather than the newer config schema.

## Validation

- `pnpm --filter ./providers/template exec tsc --noEmit`
- `git diff --check`

Attempted `pnpm --filter ./providers/template build`, but the release branch local dependency tree fails in Chakra/React webpack re-exports before completing the build.
