### PR TITLE
feat(dbprovider): enhance termination policy handling in create-datab…

### DIFF
--- a/frontend/providers/dbprovider/src/services/backend/v2alpha/create-database.ts
+++ b/frontend/providers/dbprovider/src/services/backend/v2alpha/create-database.ts
@@ -20,6 +20,14 @@ import { fetchDatabaseVersions } from '../db-version';
 const versionCache = new Map<string, { version: string; timestamp: number }>();
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes cache
 
+const terminationPolicyMap = {
+  delete: 'Delete',
+  wipeout: 'WipeOut'
+} as const satisfies Record<
+  NonNullable<z.infer<typeof createDatabaseSchemas.body>['terminationPolicy']>,
+  DBEditType['terminationPolicy']
+>;
+
 /**
  * Get latest version of database
  */
@@ -76,9 +84,7 @@ const schema2Raw = (dbForm: z.infer<typeof createDatabaseSchemas.body>): DBEditT
     memory: resources.memory,
     storage: resources.storage,
     labels: {},
-    terminationPolicy: (terminationPolicy.charAt(0).toUpperCase() + terminationPolicy.slice(1)) as
-      | 'Delete'
-      | 'WipeOut',
+    terminationPolicy: terminationPolicyMap[terminationPolicy],
     autoBackup: dbForm.autoBackup,
     parameterConfig: dbForm.parameterConfig || {}
   };


### PR DESCRIPTION
…ase service

- Introduced a terminationPolicyMap to standardize termination policy values ('Delete' and 'WipeOut').
- Updated the schema2Raw function to utilize the new mapping for improved clarity and maintainability.

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
