### PR TITLE
[codex] add password auth diagnostics

### DIFF
--- a/frontend/desktop/src/pages/api/auth/password/index.ts
+++ b/frontend/desktop/src/pages/api/auth/password/index.ts
@@ -46,14 +46,27 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     // Auto init region for new users so callers can directly use regionToken API
     if (data.needInit && data.user) {
+      const regionUid = getRegionUid();
+      console.log('password auth: auto init workspace start', {
+        providerId: name,
+        userUid: data.user.userUid,
+        userId: data.user.userId,
+        regionUid
+      });
       try {
         const regionData = await initRegionToken({
           userUid: data.user.userUid,
           userId: data.user.userId,
-          regionUid: getRegionUid(),
+          regionUid,
           workspaceName: 'My Workspace'
         });
         if (!regionData) {
+          console.error('password auth: auto init workspace returned empty result', {
+            providerId: name,
+            userUid: data.user.userUid,
+            userId: data.user.userId,
+            regionUid
+          });
           return jsonRes(res, {
             data: {
               token: data.token,
@@ -64,7 +77,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           });
         }
       } catch (e) {
-        console.error('Auto init region failed:', e);
+        console.error('password auth: auto init workspace failed', {
+          providerId: name,
+          userUid: data.user.userUid,
+          userId: data.user.userId,
+          regionUid,
+          error: e
+        });
         return jsonRes(res, {
           data: {
             token: data.token,

--- a/frontend/desktop/src/services/backend/globalAuth.ts
+++ b/frontend/desktop/src/services/backend/globalAuth.ts
@@ -24,6 +24,25 @@ type TransactionClient = Omit<
   '$connect' | '$disconnect' | '$on' | '$transaction' | '$use' | '$extends'
 >;
 
+function logAuthError(message: string, error: unknown, context: Record<string, unknown> = {}) {
+  const knownError = error as {
+    code?: string;
+    message?: string;
+    meta?: unknown;
+    stack?: string;
+    name?: string;
+  };
+
+  console.error(message, {
+    ...context,
+    errorName: knownError?.name,
+    errorCode: knownError?.code,
+    errorMessage: knownError?.message,
+    errorMeta: knownError?.meta,
+    stack: knownError?.stack
+  });
+}
+
 async function signIn({ provider, id }: { provider: ProviderType; id: string }) {
   const userProvider = await globalPrisma.oauthProvider.findUnique({
     where: {
@@ -300,9 +319,21 @@ export async function signUpByPassword({
 }) {
   const name = nanoid(10);
   const displayName = nickname?.trim() ? nickname : nanoid(8);
+  const regionUid = getRegionUid();
 
   try {
+    console.log('globalAuth: password sign up start', {
+      providerId: id,
+      generatedUserId: name,
+      displayName,
+      regionUid
+    });
     const result = await globalPrisma.$transaction(async (tx) => {
+      console.log('globalAuth: creating password user', {
+        providerId: id,
+        generatedUserId: name,
+        regionUid
+      });
       const user: User = await tx.user.create({
         data: {
           nickname: displayName,
@@ -318,14 +349,24 @@ export async function signUpByPassword({
           },
           userInfo: {
             create: {
-              signUpRegionUid: getRegionUid(),
+              signUpRegionUid: regionUid,
               isInited: false
             }
           }
         }
       });
+      console.log('globalAuth: password user created', {
+        providerId: id,
+        userUid: user.uid,
+        generatedUserId: user.name
+      });
 
       if (semData?.channel) {
+        console.log('globalAuth: creating password user sem channel', {
+          providerId: id,
+          userUid: user.uid,
+          channel: semData.channel
+        });
         await tx.userSemChannel.create({
           data: {
             userUid: user.uid,
@@ -335,13 +376,31 @@ export async function signUpByPassword({
         });
       }
 
+      console.log('globalAuth: creating password user tasks', {
+        providerId: id,
+        userUid: user.uid
+      });
       await createNewUserTasks(tx, user.uid);
+      console.log('globalAuth: password user tasks created', {
+        providerId: id,
+        userUid: user.uid
+      });
 
       return { user };
     });
+    console.log('globalAuth: password sign up success', {
+      providerId: id,
+      userUid: result.user.uid,
+      generatedUserId: result.user.name
+    });
     return result;
   } catch (error) {
-    console.error('globalAuth: Error during sign up:', error);
+    logAuthError('globalAuth: password sign up failed', error, {
+      providerId: id,
+      generatedUserId: name,
+      displayName,
+      regionUid
+    });
     return null;
   }
 }
@@ -423,7 +482,12 @@ export const getGlobalToken = async ({
     }
     if (!_user) {
       // Auto sign up when user not found
-      if (!enableSignUp()) throw new AuthError('Failed to signUp user', 'SIGNUP_FAILED');
+      if (!enableSignUp()) {
+        console.error('globalAuth: password sign up blocked because signUpEnabled is false', {
+          providerId
+        });
+        throw new AuthError('Failed to signUp user', 'SIGNUP_FAILED');
+      }
       const signUpResult = await signUpByPassword({
         id: providerId,
         name: name,
@@ -432,6 +496,9 @@ export const getGlobalToken = async ({
         semData
       });
       if (!signUpResult) {
+        console.error('globalAuth: password sign up returned null', {
+          providerId
+        });
         throw new AuthError('Failed to sign up user', 'SIGNUP_FAILED');
       }
       user = signUpResult.user;

--- a/frontend/desktop/src/services/backend/regionAuth.ts
+++ b/frontend/desktop/src/services/backend/regionAuth.ts
@@ -527,6 +527,12 @@ export async function initRegionToken({
     );
     if (!regionalDbResult) {
       const failureMessage = 'failed to get user from db';
+      console.error('initRegionToken: failed to get user from regional db', {
+        userUid,
+        userId,
+        regionUid: region.uid,
+        workspaceUid
+      });
       throw new Error(failureMessage);
     }
     // k8s 操作会自动创建, 幂等
@@ -536,6 +542,15 @@ export async function initRegionToken({
     );
     if (!kubeconfig) {
       const failureMessage = 'failed to get user from k8s';
+      console.error('initRegionToken: failed to get user kubeconfig from k8s', {
+        userUid,
+        userId,
+        regionUid: region.uid,
+        workspaceUid: regionalDbResult.workspaceUid,
+        userCrUid: regionalDbResult.userCrUid,
+        userCrName: regionalDbResult.userCrName,
+        workspaceId: regionalDbResult.workspaceId
+      });
       throw new Error(failureMessage);
     }
     console.log('first sign up workspace id: ', firstSignUpWorkspaceId);


### PR DESCRIPTION
## Summary
- add structured diagnostics around password sign-up failures
- log password workspace auto-init context when init returns empty or throws
- log region-token init failure context for regional DB and kubeconfig failures

## Why
Customer deployments currently only show `AuthError: Failed to signUp user`, which hides the actual failing step. This PR keeps the API behavior unchanged and adds enough server-side context to distinguish disabled signup, password user creation failure, SEM/task creation failure, regional DB init failure, and kubeconfig generation failure.

## Safety
- Does not log the submitted password.
- Does not change auth success/failure response semantics.
- Logs provider/user/region identifiers and Prisma-style error code/message/meta for diagnosis.

## Validation
- `pnpm dlx prettier@2.8.8 --check desktop/src/services/backend/globalAuth.ts desktop/src/pages/api/auth/password/index.ts desktop/src/services/backend/regionAuth.ts`
- `git diff --check`
- `pnpm exec lint-staged`
