### PR TITLE
fix(dbprovider): apply storage quota limit

### DIFF
--- a/frontend/packages/shared/src/constants/resource.tsx
+++ b/frontend/packages/shared/src/constants/resource.tsx
@@ -64,3 +64,9 @@ export const resourcePropertyMap: Record<
     scale: 1024 * 1024 * 1024
   }
 };
+
+export const formatResourceQuotaValue = (value: number, type: WorkspaceQuotaItemType) => {
+  const scale = resourcePropertyMap[type].scale;
+
+  return (value / scale).toFixed(2);
+};

--- a/frontend/providers/applaunchpad/deploy/charts/applaunchpad-frontend/templates/configmap.yaml
+++ b/frontend/providers/applaunchpad/deploy/charts/applaunchpad-frontend/templates/configmap.yaml
@@ -8,45 +8,60 @@ metadata:
 data:
   config.yaml: |-
     cloud:
-      domain: {{ .Values.applaunchpadConfig.cloudDomain }}
+      domain: {{ .Values.applaunchpadConfig.cloudDomain | quote }}
       port: {{ include "applaunchpad-frontend.mainConfigPort" . }}
       httpPort: {{ include "applaunchpad-frontend.mainConfigHTTPPort" . }}
       disableHttps: {{ .Values.applaunchpadConfig.disableHttps }}
-      desktopDomain: {{ .Values.applaunchpadConfig.cloudDomain }}
+      desktopDomain: {{ .Values.applaunchpadConfig.cloudDomain | quote }}
       userDomains:
-        - name: {{ .Values.applaunchpadConfig.cloudDomain }}
-          secretName: {{ .Values.applaunchpadConfig.certSecretName }}
-    common:
-      guideEnabled: false
-      apiEnabled: false
+        - name: {{ .Values.applaunchpadConfig.cloudDomain | quote }}
+          secretName: {{ .Values.applaunchpadConfig.certSecretName | quote }}
     launchpad:
       infrastructure:
         provider: alibaba
-        requiresDomainReg: false
-        domainRegQueryLink: https://beian.miit.gov.cn/#/Integrated/index
+        requiresIcpReg: false
+        icpRegQueryLink: https://beian.miit.gov.cn/#/Integrated/index
         domainBindingDocumentationLink: null
-      eventAnalyze:
-        enabled: false
-        fastGPTKey: ""
+      features:
+        guide: false
+        api: false
+        gpu: false
+      ui:
+        currencySymbol: shellCoin
+        meta:
+          title: "Sealos App Launchpad"
+          description: "Deploy and manage your applications on Sealos"
+          scripts: []
+        appResourceFormSliderConfig:
+          default:
+            cpu: [100, 200, 500, 1000, 2000, 3000, 4000, 8000]
+            memory: [64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384]
+          default-gpu:
+            cpu: [8000, 16000, 32000, 48000, 64000, 80000, 108000]
+            memory: [16384, 32768, 65536, 131072, 262144, 524288, 614400]
       components:
-        monitor:
-          url: {{ .Values.applaunchpadConfig.monitorUrl }}
+        monitoring:
+          url: {{ .Values.applaunchpadConfig.monitorUrl | quote }}
         billing:
-          url: {{ .Values.applaunchpadConfig.billingUrl }}
-        log:
-          url: {{ .Values.applaunchpadConfig.logUrl }}
-      appResourceFormSliderConfig:
-        default:
-          cpu: [100, 200, 500, 1000, 2000, 3000, 4000, 8000]
-          memory: [64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384]
-        default-gpu:
-          cpu: [8000, 16000, 32000, 48000, 64000, 80000, 108000]
-          memory: [16384, 32768, 65536, 131072, 262144, 524288, 614400]
-      fileManger:
+          url: {{ .Values.applaunchpadConfig.billingUrl | quote }}
+        logging:
+          enabled: true
+          url: {{ .Values.applaunchpadConfig.logUrl | quote }}
+        eventAnalysis:
+          enabled: false
+          url: https://fastgpt.run/api/openapi/v1
+          fastGPTKey: ""
+      fileManager:
         uploadLimit: 50 # MB
         downloadLimit: 100 # MB
+      analytics:
+        gtm:
+          enabled: false
+          gtmId: ""
       checkIcpReg:
         enabled: false
         endpoint: cdn.aliyuncs.com
         accessKeyID: ''
         accessKeySecret: ''
+      domainChallengeSecret: default-dev-secret-change-in-production
+      pvcStorageMax: 100

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/QuotaBox.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/QuotaBox.tsx
@@ -10,7 +10,7 @@ import { Progress } from '@sealos/shadcn-ui/progress';
 import { Card, CardContent, CardHeader, CardTitle } from '@sealos/shadcn-ui/card';
 import { Cpu, MemoryStick, HardDrive, CircuitBoard, HdmiPort, ArrowUpDown } from 'lucide-react';
 
-import { useUserQuota, resourcePropertyMap } from '@sealos/shared';
+import { useUserQuota, resourcePropertyMap, formatResourceQuotaValue } from '@sealos/shared';
 
 const iconMap: Record<string, React.ReactNode> = {
   cpu: <Cpu className="h-5 w-5" />,
@@ -33,11 +33,10 @@ const QuotaBox = () => {
       .map((item) => {
         const { limit, used, type } = item;
         const unit = resourcePropertyMap[type]?.unit;
-        const scale = resourcePropertyMap[type]?.scale;
 
-        const tip = `${t('Total')}: ${(limit / scale).toFixed(2)} ${unit}
-${t('common.Used')}: ${(used / scale).toFixed(2)} ${unit}
-${t('common.Surplus')}: ${Math.max(0, limit - used).toFixed(2)} ${unit}`;
+        const tip = `${t('Total')}: ${formatResourceQuotaValue(limit, type)} ${unit}
+${t('common.Used')}: ${formatResourceQuotaValue(used, type)} ${unit}
+${t('common.Surplus')}: ${formatResourceQuotaValue(Math.max(0, limit - used), type)} ${unit}`;
 
         const percentage = Math.min((used / limit) * 100, 100);
 

--- a/frontend/providers/dbprovider/src/components/BaseTable/customMenu.tsx
+++ b/frontend/providers/dbprovider/src/components/BaseTable/customMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { Box, Portal } from '@chakra-ui/react';
 
 interface MenuItemProps {
@@ -13,12 +13,56 @@ interface CustomMenuProps {
   width: number;
   Button: React.ReactNode;
   menuList: MenuItemProps[];
+  isOpen?: boolean;
+  onOpen?: () => void;
+  onClose?: () => void;
 }
 
-export const CustomMenu = ({ width, Button, menuList }: CustomMenuProps) => {
-  const [isOpen, setIsOpen] = useState(false);
+export const CustomMenu = ({
+  width,
+  Button,
+  menuList,
+  isOpen: controlledIsOpen,
+  onOpen,
+  onClose
+}: CustomMenuProps) => {
+  const [uncontrolledIsOpen, setUncontrolledIsOpen] = useState(false);
+  const [position, setPosition] = useState({ top: 0, left: 0 });
   const buttonRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const isControlled = controlledIsOpen !== undefined;
+  const isOpen = controlledIsOpen ?? uncontrolledIsOpen;
+
+  const closeMenu = useCallback(() => {
+    if (isControlled) {
+      onClose?.();
+    } else {
+      setUncontrolledIsOpen(false);
+    }
+  }, [isControlled, onClose]);
+
+  const toggleMenu = useCallback(() => {
+    if (isOpen) {
+      closeMenu();
+      return;
+    }
+
+    if (isControlled) {
+      onOpen?.();
+    } else {
+      setUncontrolledIsOpen(true);
+    }
+  }, [closeMenu, isControlled, isOpen, onOpen]);
+
+  const updatePosition = useCallback(() => {
+    const rect = buttonRef.current?.getBoundingClientRect();
+    if (!rect) return;
+
+    setPosition({
+      top: rect.bottom + 10,
+      left: rect.left - 10
+    });
+  }, []);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -28,18 +72,31 @@ export const CustomMenu = ({ width, Button, menuList }: CustomMenuProps) => {
         !menuRef.current.contains(event.target as Node) &&
         !buttonRef.current.contains(event.target as Node)
       ) {
-        setIsOpen(false);
+        closeMenu();
       }
     };
 
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
+  }, [closeMenu]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    updatePosition();
+
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+    return () => {
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+    };
+  }, [isOpen, updatePosition]);
 
   const handleItemClick = (item: MenuItemProps) => {
     if (!item.isDisabled) {
       item.onClick();
-      setIsOpen(false);
+      closeMenu();
     }
   };
 
@@ -58,15 +115,15 @@ export const CustomMenu = ({ width, Button, menuList }: CustomMenuProps) => {
 
   return (
     <Box position="relative" ref={buttonRef}>
-      <Box onClick={() => setIsOpen(!isOpen)}>{Button}</Box>
+      <Box onClick={toggleMenu}>{Button}</Box>
 
       {isOpen && (
         <Portal>
           <Box
             ref={menuRef}
             position="absolute"
-            top={`${(buttonRef.current?.getBoundingClientRect().bottom || 0) + 10}px`}
-            left={`${(buttonRef.current?.getBoundingClientRect().left || 0) - 10}px`}
+            top={`${position.top}px`}
+            left={`${position.left}px`}
             maxH="300px"
             overflowY="auto"
             borderRadius="md"

--- a/frontend/providers/dbprovider/src/components/DBStatusTag/index.tsx
+++ b/frontend/providers/dbprovider/src/components/DBStatusTag/index.tsx
@@ -10,8 +10,7 @@ import {
   useDisclosure,
   ModalCloseButton,
   IconButton,
-  Tooltip,
-  Text
+  Tooltip
 } from '@chakra-ui/react';
 import type { DBConditionItemType, DBStatusMapType } from '@/types/db';
 import MyIcon from '../Icon';
@@ -24,15 +23,18 @@ import { Maximize2 } from 'lucide-react';
 const DBStatusTag = ({
   conditions = [],
   status,
-  showBorder = false,
   alertReason,
-  alertDetails
+  alertDetails,
+  onOpenStatusDetails,
+  onOpenAlertDetails
 }: {
   conditions: DBConditionItemType[];
   status: DBStatusMapType;
   showBorder?: boolean;
   alertReason?: string;
   alertDetails?: string;
+  onOpenStatusDetails?: () => void;
+  onOpenAlertDetails?: () => void;
 }) => {
   const { t } = useTranslation();
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -46,6 +48,8 @@ const DBStatusTag = ({
   // Check if status is not Running or Stopped
   const shouldShowQuestionIcon =
     status.value !== DBStatusEnum.Running && status.value !== DBStatusEnum.Stopped && alertReason;
+  const handleOpenStatusDetails = onOpenStatusDetails || onOpen;
+  const handleOpenAlertDetails = onOpenAlertDetails || onQuestionOpen;
 
   return (
     <>
@@ -81,7 +85,12 @@ const DBStatusTag = ({
           >
             {label}
           </Box>
-          <Maximize2 size={14} color="#71717A" cursor={'pointer'} onClick={onOpen} />
+          <Maximize2
+            size={14}
+            color="#71717A"
+            cursor={'pointer'}
+            onClick={handleOpenStatusDetails}
+          />
         </Flex>
         {shouldShowQuestionIcon && (
           <Tooltip label={t('click_for_details')} placement="top">
@@ -91,7 +100,7 @@ const DBStatusTag = ({
               variant="ghost"
               aria-label="Question mark"
               icon={<MyIcon name="help" w="14px" h="14px" color="#F04438" />}
-              onClick={onQuestionOpen}
+              onClick={handleOpenAlertDetails}
               color="#F04438"
               backgroundColor="#FEF3F2"
               w="14px"
@@ -102,65 +111,67 @@ const DBStatusTag = ({
           </Tooltip>
         )}
 
-        {/* Status details modal */}
-        <Modal isOpen={isOpen} onClose={onClose} lockFocusAcrossFrames={false}>
-          <ModalOverlay />
-          <ModalContent minW={'520px'}>
-            <ModalHeader display={'flex'} alignItems={'center'}>
-              <Box flex={1}>{label}</Box>
-              <ModalCloseButton top={'10px'} right={'10px'} />
-            </ModalHeader>
-            <ModalBody>
-              {conditions.map((item, i) => (
-                <Box
-                  key={i}
-                  pl={6}
-                  pb={6}
-                  ml={4}
-                  borderLeft={`2px solid ${
-                    i === conditions.length - 1 ? 'transparent' : '#DCE7F1'
-                  }`}
-                  position={'relative'}
-                  _before={{
-                    content: '""',
-                    position: 'absolute',
-                    left: '-6.5px',
-                    w: '8px',
-                    h: '8px',
-                    borderRadius: '8px',
-                    backgroundColor: '#fff',
-                    border: '2px solid',
-                    borderColor: item.status === 'False' ? '#D92D20' : '#039855'
-                  }}
-                >
-                  <Flex lineHeight={1} mb={2} alignItems={'center'}>
-                    <Box fontWeight={'bold'}>
-                      {item.reason},&ensp;Last Occur:{' '}
-                      {formatPodTime(item.lastTransitionTime as unknown as Date)}
-                    </Box>
-                  </Flex>
-                  <Box color={'blackAlpha.700'}>{item.message}</Box>
-                </Box>
-              ))}
-            </ModalBody>
-          </ModalContent>
-        </Modal>
+        {!onOpenStatusDetails && (
+          <Modal isOpen={isOpen} onClose={onClose} lockFocusAcrossFrames={false}>
+            <ModalOverlay />
+            <ModalContent minW={'520px'}>
+              <ModalHeader display={'flex'} alignItems={'center'}>
+                <Box flex={1}>{label}</Box>
+                <ModalCloseButton top={'10px'} right={'10px'} />
+              </ModalHeader>
+              <ModalBody>
+                {conditions.map((item, i) => (
+                  <Box
+                    key={i}
+                    pl={6}
+                    pb={6}
+                    ml={4}
+                    borderLeft={`2px solid ${
+                      i === conditions.length - 1 ? 'transparent' : '#DCE7F1'
+                    }`}
+                    position={'relative'}
+                    _before={{
+                      content: '""',
+                      position: 'absolute',
+                      left: '-6.5px',
+                      w: '8px',
+                      h: '8px',
+                      borderRadius: '8px',
+                      backgroundColor: '#fff',
+                      border: '2px solid',
+                      borderColor: item.status === 'False' ? '#D92D20' : '#039855'
+                    }}
+                  >
+                    <Flex lineHeight={1} mb={2} alignItems={'center'}>
+                      <Box fontWeight={'bold'}>
+                        {item.reason},&ensp;Last Occur:{' '}
+                        {formatPodTime(item.lastTransitionTime as unknown as Date)}
+                      </Box>
+                    </Flex>
+                    <Box color={'blackAlpha.700'}>{item.message}</Box>
+                  </Box>
+                ))}
+              </ModalBody>
+            </ModalContent>
+          </Modal>
+        )}
 
-        {/* Question mark modal */}
-        <Modal isOpen={isQuestionOpen} onClose={onQuestionClose} lockFocusAcrossFrames={false}>
-          <ModalOverlay />
-          <ModalContent minW={'520px'}>
-            <ModalHeader display={'flex'} alignItems={'center'}>
-              <Box flex={1}>{alertReason || 'Status Details'}</Box>
-              <ModalCloseButton top={'10px'} right={'10px'} />
-            </ModalHeader>
-            <ModalBody>
-              <Box whiteSpace={'pre-wrap'} color={'gray.700'}>
-                {alertDetails || ''}
-              </Box>
-            </ModalBody>
-          </ModalContent>
-        </Modal>
+        {!onOpenAlertDetails && (
+          <Modal isOpen={isQuestionOpen} onClose={onQuestionClose} lockFocusAcrossFrames={false}>
+            <ModalOverlay />
+            <ModalContent minW={'520px'}>
+              <ModalHeader display={'flex'} alignItems={'center'}>
+                <Box flex={1}>{alertReason || 'Status Details'}</Box>
+                <ModalCloseButton top={'10px'} right={'10px'} />
+              </ModalHeader>
+              <ModalBody>
+                <Box whiteSpace={'pre-wrap'} color={'gray.700'}>
+                  {alertDetails || ''}
+                </Box>
+              </ModalBody>
+            </ModalContent>
+          </Modal>
+        )}
       </Flex>
     </>
   );

--- a/frontend/providers/dbprovider/src/components/QuotaBox/index.tsx
+++ b/frontend/providers/dbprovider/src/components/QuotaBox/index.tsx
@@ -3,7 +3,7 @@ import { Box, Flex, useTheme, Progress, css, Text } from '@chakra-ui/react';
 import { useTranslation } from 'next-i18next';
 import { MyTooltip } from '@sealos/ui';
 
-import { useUserQuota, resourcePropertyMap } from '@sealos/shared';
+import { useUserQuota, resourcePropertyMap, formatResourceQuotaValue } from '@sealos/shared';
 
 const sourceMap = {
   cpu: {
@@ -39,12 +39,11 @@ const QuotaBox = () => {
       .map((item) => {
         const { limit, used, type } = item;
         const unit = resourcePropertyMap[type]?.unit;
-        const scale = resourcePropertyMap[type]?.scale;
         const color = sourceMap[type]?.color;
 
-        const tip = `${t('Total')}: ${(limit / scale).toFixed(2)} ${unit}
-${t('common.Used')}: ${(used / scale).toFixed(2)} ${unit}
-${t('common.Surplus')}: ${Math.max(0, limit - used).toFixed(2)} ${unit}`;
+        const tip = `${t('Total')}: ${formatResourceQuotaValue(limit, type)} ${unit}
+${t('common.Used')}: ${formatResourceQuotaValue(used, type)} ${unit}
+${t('common.Surplus')}: ${formatResourceQuotaValue(Math.max(0, limit - used), type)} ${unit}`;
         return { ...item, tip, color };
       });
   }, [userQuota, t]);

--- a/frontend/providers/dbprovider/src/constants/db.ts
+++ b/frontend/providers/dbprovider/src/constants/db.ts
@@ -64,6 +64,23 @@ export enum DBStatusEnum {
   Deleting = 'Deleting'
 }
 
+export const DB_OPERATION_LOCKED_STATUSES = new Set<`${DBStatusEnum}`>([
+  DBStatusEnum.Creating,
+  DBStatusEnum.Starting,
+  DBStatusEnum.Stopping,
+  DBStatusEnum.Updating,
+  DBStatusEnum.SpecUpdating,
+  DBStatusEnum.Rebooting,
+  DBStatusEnum.Upgrade,
+  DBStatusEnum.VerticalScaling,
+  DBStatusEnum.VolumeExpanding,
+  DBStatusEnum.UnKnow,
+  DBStatusEnum.Deleting
+]);
+
+export const isDBOperationLocked = (status?: `${DBStatusEnum}`) =>
+  !!status && DB_OPERATION_LOCKED_STATUSES.has(status);
+
 export enum ReconfigStatus {
   Deleting = 'Deleting',
   Creating = 'Creating',

--- a/frontend/providers/dbprovider/src/pages/db/detail/components/Header.tsx
+++ b/frontend/providers/dbprovider/src/pages/db/detail/components/Header.tsx
@@ -1,7 +1,7 @@
 import { pauseDBByName, restartDB, startDBByName, type DatabaseAlertItem } from '@/api/db';
 import DBStatusTag from '@/components/DBStatusTag';
 import MyIcon from '@/components/Icon';
-import { defaultDBDetail } from '@/constants/db';
+import { DBStatusEnum, defaultDBDetail, isDBOperationLocked } from '@/constants/db';
 import { useConfirm } from '@/hooks/useConfirm';
 import { useDBOperation } from '@/hooks/useDBOperation';
 import type { DBDetailType } from '@/types/db';
@@ -68,6 +68,9 @@ const Header = ({
 
   const { executeOperation, loading, errorModalState, closeErrorModal } = useDBOperation();
   const config = useClientAppConfig();
+  const isOperationLocked = isDBOperationLocked(db.status.value);
+  const canUpdate =
+    !isOperationLocked || (db.status.value === DBStatusEnum.Updating && db.isDiskSpaceOverflow);
 
   const handleRestartApp = useCallback(async () => {
     await executeOperation(() => restartDB(db), {
@@ -217,7 +220,7 @@ const Header = ({
             background={'#FFF'}
             boxShadow={'0 1px 2px 0 rgba(0, 0, 0, 0.05)'}
             isLoading={loading}
-            isDisabled={db.status.value === 'Updating'}
+            isDisabled={isOperationLocked}
             _hover={{
               color: '#71717A'
             }}
@@ -269,7 +272,7 @@ const Header = ({
                 lineHeight={'20px'}
                 borderRadius={'8px 0 0 8px'}
                 isLoading={loading}
-                isDisabled={db.status.value === 'Updating'}
+                isDisabled={isOperationLocked}
                 _hover={{
                   color: '#FFF',
                   bg: '#000'
@@ -299,7 +302,7 @@ const Header = ({
                   lineHeight={'20px'}
                   borderRadius={'0'}
                   isLoading={loading}
-                  isDisabled={db.status.value === 'Updating' && !db.isDiskSpaceOverflow}
+                  isDisabled={!canUpdate}
                   _hover={{
                     color: '#FFF',
                     bg: '#000'
@@ -331,7 +334,7 @@ const Header = ({
                   fontWeight={'500'}
                   lineHeight={'20px'}
                   borderRadius={'0 8px 8px 0'}
-                  isDisabled={db.status.value === 'Updating'}
+                  isDisabled={isOperationLocked}
                   onClick={openRestartConfirm(handleRestartApp)}
                   isLoading={loading}
                   _hover={{

--- a/frontend/providers/dbprovider/src/pages/db/edit/components/Form.tsx
+++ b/frontend/providers/dbprovider/src/pages/db/edit/components/Form.tsx
@@ -12,7 +12,7 @@ import {
   WeekSelectList
 } from '@/constants/db';
 import { CpuSlideMarkList, MemorySlideMarkList } from '@/constants/editApp';
-import { resourcePropertyMap } from '@sealos/shared';
+import { resourcePropertyMap, useUserQuota } from '@sealos/shared';
 import { useClientAppConfig } from '@/hooks/useClientAppConfig';
 import { DBVersionMap, INSTALL_ACCOUNT } from '@/store/static';
 import type { QueryType } from '@/types';
@@ -201,6 +201,7 @@ const Form = ({
   const { name } = router.query as QueryType;
   const theme = useTheme();
   const isEdit = useMemo(() => !!name, [name]);
+  const { userQuota } = useUserQuota();
   const {
     register,
     setValue,
@@ -226,6 +227,7 @@ const Form = ({
   const isMaxConnectionsCustomized = watch('parameterConfig')?.isMaxConnectionsCustomized;
   const maxmemory = watch('parameterConfig')?.maxmemory;
   const memory = watch('memory');
+  const replicas = watch('replicas');
 
   const Label = ({
     children,
@@ -359,6 +361,70 @@ const Form = ({
     };
     //eslint-disable-next-line react-hooks/exhaustive-deps
   }, [getValues('dbType'), allocatedStorage]);
+
+  const storageMax = useMemo(() => {
+    const storageQuota = userQuota.find((item) => item.type === 'storage');
+    if (!storageQuota) return config.storageMaxSize;
+
+    const oldReplicas = isEdit ? formHook.formState.defaultValues?.replicas ?? 0 : 0;
+    const currentReplicas = getValues('replicas');
+    const currentDbType = getValues('dbType');
+    const availableStorage =
+      (storageQuota.limit - storageQuota.used) / resourcePropertyMap.storage.scale;
+
+    const oldComponents = distributeResources({
+      dbType: currentDbType,
+      cpu: getValues('cpu'),
+      memory: getValues('memory'),
+      storage: isEdit ? formHook.formState.defaultValues?.storage ?? 0 : 0,
+      replicas: oldReplicas,
+      forDisplay: false
+    });
+
+    const oldStorage = Object.values(oldComponents).reduce(
+      (acc, cur) => acc + Number(cur.storage) * (cur?.other?.replicas ?? oldReplicas),
+      0
+    );
+    const targetAvailableStorage = availableStorage + oldStorage;
+
+    const getTotalStorage = (storage: number) => {
+      const components = distributeResources({
+        dbType: currentDbType,
+        cpu: getValues('cpu'),
+        memory: getValues('memory'),
+        storage,
+        replicas: currentReplicas,
+        forDisplay: false
+      });
+
+      return Object.values(components).reduce(
+        (acc, cur) => acc + Number(cur.storage) * (cur?.other?.replicas ?? currentReplicas),
+        0
+      );
+    };
+
+    if (targetAvailableStorage < minStorage) return minStorage;
+
+    let maxStorage = minStorage;
+    for (let storage = minStorage; storage <= targetAvailableStorage; storage += minStorageChange) {
+      if (getTotalStorage(storage) <= targetAvailableStorage) {
+        maxStorage = storage;
+      } else {
+        break;
+      }
+    }
+
+    return maxStorage;
+  }, [
+    dbType,
+    formHook.formState.defaultValues,
+    getValues,
+    isEdit,
+    minStorage,
+    minStorageChange,
+    replicas,
+    userQuota
+  ]);
 
   useEffect(() => {
     if (getValues('cpu') < minCPU) {
@@ -947,12 +1013,10 @@ const Form = ({
               <FormControl isInvalid={!!errors.storage} paddingTop={1}>
                 <Flex alignItems={'center'}>
                   <Label w={100}>{t('storage')}</Label>
-                  <MyTooltip
-                    label={`${t('storage_range')}${minStorage}~${config.storageMaxSize} Gi`}
-                  >
+                  <MyTooltip label={`${t('storage_range')}${minStorage}~${storageMax} Gi`}>
                     <NumberInput
                       w={'180px'}
-                      max={config.storageMaxSize}
+                      max={storageMax}
                       min={minStorage}
                       step={minStorageChange}
                       position={'relative'}
@@ -985,13 +1049,13 @@ const Form = ({
                             message: `${t('storage_min')}${minStorage} Gi`
                           },
                           max: {
-                            value: config.storageMaxSize,
-                            message: `${t('storage_max')}${config.storageMaxSize} Gi`
+                            value: storageMax,
+                            message: `${t('storage_max')}${storageMax} Gi`
                           },
                           valueAsNumber: true
                         })}
                         min={minStorage}
-                        max={config.storageMaxSize}
+                        max={storageMax}
                         borderRadius={'md'}
                         borderColor={'#E8EBF0'}
                         bg={'#F7F8FA'}

--- a/frontend/providers/dbprovider/src/pages/dbs/components/dbList.tsx
+++ b/frontend/providers/dbprovider/src/pages/dbs/components/dbList.tsx
@@ -4,7 +4,7 @@ import { CustomMenu } from '@/components/BaseTable/customMenu';
 import DBStatusTag from '@/components/DBStatusTag';
 import type { DatabaseAlertItem } from '@/api/db';
 import MyIcon from '@/components/Icon';
-import { DBStatusEnum, DBTypeList } from '@/constants/db';
+import { DBStatusEnum, DBTypeList, isDBOperationLocked } from '@/constants/db';
 import { applistDriverObj, startDriver } from '@/hooks/driver';
 import { useClientSideValue } from '@/hooks/useClientSideValue';
 import { useConfirm } from '@/hooks/useConfirm';
@@ -14,7 +14,8 @@ import { useClientAppConfig } from '@/hooks/useClientAppConfig';
 import { useGlobalStore } from '@/store/global';
 import { useGuideStore } from '@/store/guide';
 import { DBListItemType } from '@/types/db';
-import { printMemory } from '@/utils/tools';
+import { I18nCommonKey } from '@/types/i18next';
+import { formatPodTime, printMemory } from '@/utils/tools';
 import { TriangleAlert } from 'lucide-react';
 import {
   Box,
@@ -66,6 +67,11 @@ import { useQuotaGuarded } from '@sealos/shared';
 const DelModal = dynamic(() => import('@/pages/db/detail/components/DelModal'));
 const ErrorModal = dynamic(() => import('@/components/ErrorModal'));
 
+type StatusModalState = {
+  type: 'status' | 'alert';
+  dbName: string;
+} | null;
+
 const DBList = ({
   dbList = [],
   refetchApps,
@@ -95,6 +101,8 @@ const DBList = ({
   const [delAppName, setDelAppName] = useState('');
   const [updateAppName, setUpdateAppName] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
+  const [statusModalState, setStatusModalState] = useState<StatusModalState>(null);
+  const [openMenuDbName, setOpenMenuDbName] = useState('');
 
   const { openConfirm: onOpenPause, ConfirmChild: PauseChild } = useConfirm({
     content: t('pause_hint')
@@ -220,6 +228,13 @@ const DBList = ({
     }
     return DBTypeList.find((i) => i.id === dbType)?.label || dbType;
   };
+
+  const openedStatusDb = useMemo(
+    () => dbList.find((item) => item.name === statusModalState?.dbName),
+    [dbList, statusModalState?.dbName]
+  );
+  const openedStatusAlert = statusModalState?.dbName ? alerts[statusModalState.dbName] : undefined;
+  const closeStatusModal = useCallback(() => setStatusModalState(null), []);
 
   const columns = useMemo<Array<ColumnDef<DBListItemType>>>(
     () => [
@@ -351,6 +366,12 @@ const DBList = ({
             status={row.original.status}
             alertReason={alerts[row.original.name]?.reason}
             alertDetails={alerts[row.original.name]?.details}
+            onOpenStatusDetails={() =>
+              setStatusModalState({ type: 'status', dbName: row.original.name })
+            }
+            onOpenAlertDetails={() =>
+              setStatusModalState({ type: 'alert', dbName: row.original.name })
+            }
           />
         )
       },
@@ -397,6 +418,11 @@ const DBList = ({
         header: () => t('operation'),
         cell: ({ row }) => {
           const manageDataDisabledReason = getManageDataDisabledReason(row.original);
+          const isOperationLocked = isDBOperationLocked(row.original.status.value);
+          const canUpdate =
+            !isOperationLocked ||
+            (row.original.status.value === DBStatusEnum.Updating &&
+              row.original.isDiskSpaceOverflow);
           const manageDataButton = (
             <Button
               size={'sm'}
@@ -466,6 +492,9 @@ const DBList = ({
 
               <CustomMenu
                 width={100}
+                isOpen={openMenuDbName === row.original.name}
+                onOpen={() => setOpenMenuDbName(row.original.name)}
+                onClose={() => setOpenMenuDbName('')}
                 Button={
                   <Button
                     bg={'white'}
@@ -522,10 +551,7 @@ const DBList = ({
                         router.push(`/db/edit?name=${row.original.name}`);
                       }
                     },
-                    isDisabled:
-                      row.original.status.value === DBStatusEnum.Stopped ||
-                      (row.original.status.value === 'Updating' &&
-                        !row.original.isDiskSpaceOverflow)
+                    isDisabled: row.original.status.value === DBStatusEnum.Stopped || !canUpdate
                   },
                   {
                     child: (
@@ -543,8 +569,7 @@ const DBList = ({
                       handleRestartApp(row.original);
                     },
                     isDisabled:
-                      row.original.status.value === DBStatusEnum.Stopped ||
-                      row.original.status.value === 'Updating'
+                      row.original.status.value === DBStatusEnum.Stopped || isOperationLocked
                   },
                   {
                     child: (
@@ -577,8 +602,7 @@ const DBList = ({
                         bg: 'rgba(17, 24, 36, 0.05)'
                       }
                     },
-                    onClick: () => setDelAppName(row.original.name),
-                    isDisabled: row.original.status.value === 'Updating'
+                    onClick: () => setDelAppName(row.original.name)
                   }
                 ]}
               />
@@ -593,6 +617,7 @@ const DBList = ({
       alerts,
       config.dataflowEnabled,
       getManageDataDisabledReason,
+      openMenuDbName,
       onOpenPause,
       handleManageData,
       router,
@@ -707,6 +732,65 @@ const DBList = ({
           }
         }}
       />
+
+      <Modal
+        isOpen={statusModalState !== null && openedStatusDb !== undefined}
+        onClose={closeStatusModal}
+        lockFocusAcrossFrames={false}
+      >
+        <ModalOverlay />
+        <ModalContent minW={'520px'}>
+          <ModalHeader display={'flex'} alignItems={'center'}>
+            <Box flex={1}>
+              {statusModalState?.type === 'alert'
+                ? openedStatusAlert?.reason || 'Status Details'
+                : openedStatusDb
+                ? t(openedStatusDb.status.label as I18nCommonKey)
+                : ''}
+            </Box>
+            <ModalCloseButton top={'10px'} right={'10px'} />
+          </ModalHeader>
+          <ModalBody>
+            {statusModalState?.type === 'alert' ? (
+              <Box whiteSpace={'pre-wrap'} color={'gray.700'}>
+                {openedStatusAlert?.details || ''}
+              </Box>
+            ) : (
+              openedStatusDb?.conditions.map((item, i) => (
+                <Box
+                  key={i}
+                  pl={6}
+                  pb={6}
+                  ml={4}
+                  borderLeft={`2px solid ${
+                    i === openedStatusDb.conditions.length - 1 ? 'transparent' : '#DCE7F1'
+                  }`}
+                  position={'relative'}
+                  _before={{
+                    content: '""',
+                    position: 'absolute',
+                    left: '-6.5px',
+                    w: '8px',
+                    h: '8px',
+                    borderRadius: '8px',
+                    backgroundColor: '#fff',
+                    border: '2px solid',
+                    borderColor: item.status === 'False' ? '#D92D20' : '#039855'
+                  }}
+                >
+                  <Flex lineHeight={1} mb={2} alignItems={'center'}>
+                    <Box fontWeight={'bold'}>
+                      {item.reason},&ensp;Last Occur:{' '}
+                      {formatPodTime(item.lastTransitionTime as unknown as Date)}
+                    </Box>
+                  </Flex>
+                  <Box color={'blackAlpha.700'}>{item.message}</Box>
+                </Box>
+              ))
+            )}
+          </ModalBody>
+        </ModalContent>
+      </Modal>
 
       <PauseChild />
       {!!delApp && (

--- a/frontend/providers/devbox/app/[lang]/(platform)/devbox/create/components/QuotaBox.tsx
+++ b/frontend/providers/devbox/app/[lang]/(platform)/devbox/create/components/QuotaBox.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import { useTranslations } from 'next-intl';
 
 import { cn } from '@sealos/shadcn-ui';
-import { useUserQuota, resourcePropertyMap } from '@sealos/shared';
+import { useUserQuota, resourcePropertyMap, formatResourceQuotaValue } from '@sealos/shared';
 
 import { Progress } from '@sealos/shadcn-ui/progress';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@sealos/shadcn-ui/tooltip';
@@ -23,11 +23,10 @@ const QuotaBox = ({ className }: { className?: string }) => {
         const { limit, used, type } = item;
         const unit = resourcePropertyMap[type]?.unit;
         const Icon = resourcePropertyMap[type]?.icon;
-        const scale = resourcePropertyMap[type]?.scale;
 
-        const tip = `${t('total')}: ${(limit / scale).toFixed(2)} ${unit}
-${t('used')}: ${(used / scale).toFixed(2)} ${unit}
-${t('remaining')}: ${Math.max(0, limit - used).toFixed(2)} ${unit}`;
+        const tip = `${t('total')}: ${formatResourceQuotaValue(limit, type)} ${unit}
+${t('used')}: ${formatResourceQuotaValue(used, type)} ${unit}
+${t('remaining')}: ${formatResourceQuotaValue(Math.max(0, limit - used), type)} ${unit}`;
         return { ...item, tip, Icon };
       });
   }, [userQuota, t]);

--- a/frontend/providers/template/src/pages/deploy/components/QuotaBox.tsx
+++ b/frontend/providers/template/src/pages/deploy/components/QuotaBox.tsx
@@ -3,7 +3,12 @@ import { Box, Flex, useTheme, Progress, css, Text } from '@chakra-ui/react';
 import { useTranslation } from 'next-i18next';
 import { MyTooltip } from '@sealos/ui';
 
-import { useUserQuota, resourcePropertyMap, type WorkspaceQuotaItem } from '@sealos/shared';
+import {
+  useUserQuota,
+  resourcePropertyMap,
+  formatResourceQuotaValue,
+  type WorkspaceQuotaItem
+} from '@sealos/shared';
 
 const sourceMap = {
   cpu: {
@@ -39,12 +44,11 @@ const QuotaBox = () => {
       .map((item) => {
         const { limit, used, type } = item;
         const unit = resourcePropertyMap[type]?.unit;
-        const scale = resourcePropertyMap[type]?.scale;
         const color = sourceMap[type]?.color;
 
-        const tip = `${t('Total')}: ${(limit / scale).toFixed(2)} ${unit}
-${t('common.Used')}: ${(used / scale).toFixed(2)} ${unit}
-${t('common.Surplus')}: ${Math.max(0, limit - used).toFixed(2)} ${unit}`;
+        const tip = `${t('Total')}: ${formatResourceQuotaValue(limit, type)} ${unit}
+${t('common.Used')}: ${formatResourceQuotaValue(used, type)} ${unit}
+${t('common.Surplus')}: ${formatResourceQuotaValue(Math.max(0, limit - used), type)} ${unit}`;
 
         return { ...item, tip, color };
       });


### PR DESCRIPTION
## Summary
- add shared quota value formatting for resource quota tooltips
- apply dynamic workspace storage quota limits to DBProvider storage editing
- refresh AppLaunchpad chart config keys to match the current config schema

## Why
DBProvider still used the static `storageMaxSize` cap in the storage input, so users with a lower workspace storage quota could see an invalid maximum such as 300 Gi. The form now derives the maximum from current workspace storage quota and accounts for existing allocated storage while editing.

## Validation
- `pnpm --filter ./providers/dbprovider typecheck`