### PR TITLE
fix(template): pvc not deleted for multi component instances

### DIFF
--- a/frontend/providers/template/__tests__/instance-pvc-cleanup.test.ts
+++ b/frontend/providers/template/__tests__/instance-pvc-cleanup.test.ts
@@ -1,0 +1,363 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { legacyAppLabelKey, templateDeployKey } from '@/constants/keys';
+import { deleteInstancePersistentVolumeClaims } from '@/services/backend/instanceDelete';
+
+function createK8sMock(statefulSets: any[] = []) {
+  return {
+    namespace: 'ns-test',
+    k8sApp: {
+      listNamespacedStatefulSet: vi.fn().mockResolvedValue({
+        body: {
+          items: statefulSets
+        }
+      })
+    },
+    k8sCore: {
+      deleteCollectionNamespacedPersistentVolumeClaim: vi.fn().mockResolvedValue({}),
+      deleteNamespacedPersistentVolumeClaim: vi.fn().mockResolvedValue({})
+    }
+  } as any;
+}
+
+function expectStatefulSetModeLogged(
+  consoleLogSpy: ReturnType<typeof vi.spyOn>,
+  statefulSetName: string,
+  inferredMode: string,
+  extraFields: Record<string, unknown> = {}
+) {
+  expect(consoleLogSpy).toHaveBeenCalledWith(
+    '[template pvc cleanup]',
+    'statefulset identified',
+    expect.objectContaining({
+      statefulSetName,
+      inferredMode,
+      ...extraFields
+    })
+  );
+}
+
+function expectSelectorDelete(k8s: any, selector: string) {
+  expect(k8s.k8sCore.deleteCollectionNamespacedPersistentVolumeClaim).toHaveBeenCalledWith(
+    'ns-test',
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    selector
+  );
+}
+
+describe('deleteInstancePersistentVolumeClaims', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('deletes PVCs by instance label, legacy app labels, and inferred names', async () => {
+    const k8s = createK8sMock([
+      {
+        metadata: {
+          name: 'mysql'
+        },
+        spec: {
+          replicas: 2,
+          volumeClaimTemplates: [
+            {
+              metadata: {
+                name: 'data'
+              }
+            }
+          ]
+        }
+      }
+    ]);
+
+    await deleteInstancePersistentVolumeClaims(k8s, 'instance-a');
+
+    expect(k8s.k8sApp.listNamespacedStatefulSet).toHaveBeenCalledWith(
+      'ns-test',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      `${templateDeployKey}=instance-a`
+    );
+    expect(k8s.k8sCore.deleteCollectionNamespacedPersistentVolumeClaim).toHaveBeenCalledWith(
+      'ns-test',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      `${templateDeployKey}=instance-a`
+    );
+    expect(k8s.k8sCore.deleteCollectionNamespacedPersistentVolumeClaim).toHaveBeenCalledWith(
+      'ns-test',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      `${legacyAppLabelKey}=instance-a`
+    );
+    expect(k8s.k8sCore.deleteCollectionNamespacedPersistentVolumeClaim).toHaveBeenCalledWith(
+      'ns-test',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      `${legacyAppLabelKey}=mysql`
+    );
+    expect(k8s.k8sCore.deleteNamespacedPersistentVolumeClaim).toHaveBeenCalledWith(
+      'data-mysql-0',
+      'ns-test'
+    );
+    expect(k8s.k8sCore.deleteNamespacedPersistentVolumeClaim).toHaveBeenCalledWith(
+      'data-mysql-1',
+      'ns-test'
+    );
+  });
+
+  it('handles legacy PVC cleanup mode with legacy app label and inferred PVC fallback', async () => {
+    const k8s = createK8sMock([
+      {
+        metadata: {
+          name: 'legacy-mysql'
+        },
+        spec: {
+          volumeClaimTemplates: [{ metadata: { name: 'data' } }]
+        }
+      }
+    ]);
+
+    await deleteInstancePersistentVolumeClaims(k8s, 'instance-a');
+
+    expectStatefulSetModeLogged(consoleLogSpy, 'legacy-mysql', 'legacy', {
+      ownerReferenceReady: false,
+      hasTemplateDeployLabelInVolumeClaimTemplates: false
+    });
+    expectSelectorDelete(k8s, `${templateDeployKey}=instance-a`);
+    expectSelectorDelete(k8s, `${legacyAppLabelKey}=instance-a`);
+    expectSelectorDelete(k8s, `${legacyAppLabelKey}=legacy-mysql`);
+    expect(k8s.k8sCore.deleteNamespacedPersistentVolumeClaim).toHaveBeenCalledWith(
+      'data-legacy-mysql-0',
+      'ns-test'
+    );
+  });
+
+  it('handles ownerReference-only PVC cleanup mode with legacy and inferred fallbacks', async () => {
+    const k8s = createK8sMock([
+      {
+        metadata: {
+          name: 'owner-only-mysql',
+          ownerReferences: [{ name: 'instance-a' }]
+        },
+        spec: {
+          volumeClaimTemplates: [{ metadata: { name: 'data' } }]
+        }
+      }
+    ]);
+
+    await deleteInstancePersistentVolumeClaims(k8s, 'instance-a');
+
+    expectStatefulSetModeLogged(consoleLogSpy, 'owner-only-mysql', 'owner-reference-only', {
+      ownerReferenceReady: true,
+      hasTemplateDeployLabelInVolumeClaimTemplates: false
+    });
+    expectSelectorDelete(k8s, `${templateDeployKey}=instance-a`);
+    expectSelectorDelete(k8s, `${legacyAppLabelKey}=instance-a`);
+    expectSelectorDelete(k8s, `${legacyAppLabelKey}=owner-only-mysql`);
+    expect(k8s.k8sCore.deleteNamespacedPersistentVolumeClaim).toHaveBeenCalledWith(
+      'data-owner-only-mysql-0',
+      'ns-test'
+    );
+  });
+
+  it('handles labeled PVC cleanup mode with instance label first and compatibility fallbacks', async () => {
+    const k8s = createK8sMock([
+      {
+        metadata: {
+          name: 'labeled-mysql'
+        },
+        spec: {
+          volumeClaimTemplates: [
+            {
+              metadata: {
+                name: 'data',
+                labels: {
+                  [templateDeployKey]: 'instance-a'
+                }
+              }
+            }
+          ]
+        }
+      }
+    ]);
+
+    await deleteInstancePersistentVolumeClaims(k8s, 'instance-a');
+
+    expectStatefulSetModeLogged(consoleLogSpy, 'labeled-mysql', 'labeled-pvc', {
+      hasTemplateDeployLabelInVolumeClaimTemplates: true
+    });
+    expectSelectorDelete(k8s, `${templateDeployKey}=instance-a`);
+    expectSelectorDelete(k8s, `${legacyAppLabelKey}=instance-a`);
+    expectSelectorDelete(k8s, `${legacyAppLabelKey}=labeled-mysql`);
+    expect(k8s.k8sCore.deleteNamespacedPersistentVolumeClaim).toHaveBeenCalledWith(
+      'data-labeled-mysql-0',
+      'ns-test'
+    );
+  });
+
+  it('handles native retention PVC cleanup mode and still runs compatibility fallbacks', async () => {
+    const k8s = createK8sMock([
+      {
+        metadata: {
+          name: 'native-mysql'
+        },
+        spec: {
+          persistentVolumeClaimRetentionPolicy: {
+            whenDeleted: 'Delete'
+          },
+          volumeClaimTemplates: [{ metadata: { name: 'data' } }]
+        }
+      }
+    ]);
+
+    await deleteInstancePersistentVolumeClaims(k8s, 'instance-a');
+
+    expectStatefulSetModeLogged(consoleLogSpy, 'native-mysql', 'native-retention', {
+      retentionWhenDeleted: 'Delete'
+    });
+    expectSelectorDelete(k8s, `${templateDeployKey}=instance-a`);
+    expectSelectorDelete(k8s, `${legacyAppLabelKey}=instance-a`);
+    expectSelectorDelete(k8s, `${legacyAppLabelKey}=native-mysql`);
+    expect(k8s.k8sCore.deleteNamespacedPersistentVolumeClaim).toHaveBeenCalledWith(
+      'data-native-mysql-0',
+      'ns-test'
+    );
+  });
+
+  it('uses one replica by default and handles multiple StatefulSets and claim templates', async () => {
+    const k8s = createK8sMock([
+      {
+        metadata: {
+          name: 'mysql'
+        },
+        spec: {
+          volumeClaimTemplates: [{ metadata: { name: 'data' } }, { metadata: { name: 'logs' } }]
+        }
+      },
+      {
+        metadata: {
+          name: 'redis'
+        },
+        spec: {
+          replicas: 2,
+          volumeClaimTemplates: [{ metadata: { name: 'cache' } }]
+        }
+      }
+    ]);
+
+    await deleteInstancePersistentVolumeClaims(k8s, 'instance-a');
+
+    expect(k8s.k8sCore.deleteNamespacedPersistentVolumeClaim).toHaveBeenCalledWith(
+      'data-mysql-0',
+      'ns-test'
+    );
+    expect(k8s.k8sCore.deleteNamespacedPersistentVolumeClaim).toHaveBeenCalledWith(
+      'logs-mysql-0',
+      'ns-test'
+    );
+    expect(k8s.k8sCore.deleteNamespacedPersistentVolumeClaim).toHaveBeenCalledWith(
+      'cache-redis-0',
+      'ns-test'
+    );
+    expect(k8s.k8sCore.deleteNamespacedPersistentVolumeClaim).toHaveBeenCalledWith(
+      'cache-redis-1',
+      'ns-test'
+    );
+  });
+
+  it('ignores 404 errors while deleting inferred PVC names', async () => {
+    const k8s = createK8sMock([
+      {
+        metadata: {
+          name: 'mysql'
+        },
+        spec: {
+          volumeClaimTemplates: [{ metadata: { name: 'data' } }]
+        }
+      }
+    ]);
+    k8s.k8sCore.deleteNamespacedPersistentVolumeClaim.mockRejectedValueOnce({
+      body: {
+        code: 404
+      }
+    });
+
+    await expect(deleteInstancePersistentVolumeClaims(k8s, 'instance-a')).resolves.toBeUndefined();
+  });
+
+  it('throws non-404 errors while deleting inferred PVC names', async () => {
+    const k8s = createK8sMock([
+      {
+        metadata: {
+          name: 'mysql'
+        },
+        spec: {
+          volumeClaimTemplates: [{ metadata: { name: 'data' } }]
+        }
+      }
+    ]);
+    const errorBody = {
+      code: 500,
+      message: 'delete failed'
+    };
+    k8s.k8sCore.deleteNamespacedPersistentVolumeClaim.mockRejectedValueOnce({
+      body: errorBody
+    });
+
+    await expect(deleteInstancePersistentVolumeClaims(k8s, 'instance-a')).rejects.toBe(errorBody);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[template pvc cleanup]',
+      'inferred pvc delete failed',
+      expect.objectContaining({
+        statefulSetName: 'mysql',
+        pvcName: 'data-mysql-0',
+        error: errorBody
+      })
+    );
+  });
+
+  it('throws non-404 errors while deleting PVCs by selector', async () => {
+    const k8s = createK8sMock();
+    const errorBody = {
+      code: 403,
+      message: 'forbidden'
+    };
+    k8s.k8sCore.deleteCollectionNamespacedPersistentVolumeClaim.mockRejectedValueOnce({
+      body: errorBody
+    });
+
+    await expect(deleteInstancePersistentVolumeClaims(k8s, 'instance-a')).rejects.toBe(errorBody);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[template pvc cleanup]',
+      'selector delete failed',
+      expect.objectContaining({
+        strategy: 'instance-label',
+        selector: `${templateDeployKey}=instance-a`,
+        error: errorBody
+      })
+    );
+  });
+});

--- a/frontend/providers/template/__tests__/instance-pvc-cleanup.test.ts
+++ b/frontend/providers/template/__tests__/instance-pvc-cleanup.test.ts
@@ -1,7 +1,51 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { legacyAppLabelKey, templateDeployKey } from '@/constants/keys';
-import { deleteInstancePersistentVolumeClaims } from '@/services/backend/instanceDelete';
+import {
+  deleteInstancePersistentVolumeClaims,
+  deleteOwnerReferencedInstance,
+  legacyDeleteInstanceAll
+} from '@/services/backend/instanceDelete';
+import * as operations from '@/services/backend/operations';
+
+vi.mock('@/services/backend/operations', () => ({
+  deleteInstance: vi.fn(),
+  deleteStatefulSet: vi.fn(),
+  getAppLaunchpad: vi.fn().mockResolvedValue([]),
+  deleteAppLaunchpad: vi.fn().mockResolvedValue({}),
+  getDatabases: vi.fn().mockResolvedValue([]),
+  deleteDatabase: vi.fn(),
+  getAppCRs: vi.fn().mockResolvedValue([]),
+  deleteAppCR: vi.fn(),
+  getDevboxes: vi.fn().mockResolvedValue([]),
+  deleteCustomResource: vi.fn(),
+  getJobs: vi.fn().mockResolvedValue([]),
+  deleteJob: vi.fn(),
+  getSecrets: vi.fn().mockResolvedValue([]),
+  deleteSecret: vi.fn(),
+  getConfigMaps: vi.fn().mockResolvedValue([]),
+  deleteConfigMap: vi.fn(),
+  getRoles: vi.fn().mockResolvedValue([]),
+  deleteRole: vi.fn(),
+  getRoleBindings: vi.fn().mockResolvedValue([]),
+  deleteRoleBinding: vi.fn(),
+  getServiceAccounts: vi.fn().mockResolvedValue([]),
+  deleteServiceAccount: vi.fn(),
+  getCertIssuers: vi.fn().mockResolvedValue([]),
+  deleteCertIssuer: vi.fn(),
+  deleteCertificate: vi.fn(),
+  deleteHorizontalPodAutoscaler: vi.fn(),
+  getPrometheusRules: vi.fn().mockResolvedValue([]),
+  deletePrometheusRule: vi.fn(),
+  getPrometheuses: vi.fn().mockResolvedValue([]),
+  deletePrometheus: vi.fn(),
+  getServiceMonitors: vi.fn().mockResolvedValue([]),
+  deleteServiceMonitor: vi.fn(),
+  getProbes: vi.fn().mockResolvedValue([]),
+  deleteProbe: vi.fn(),
+  getServices: vi.fn().mockResolvedValue([]),
+  deleteService: vi.fn()
+}));
 
 function createK8sMock(statefulSets: any[] = []) {
   return {
@@ -13,9 +57,22 @@ function createK8sMock(statefulSets: any[] = []) {
         }
       })
     },
+    k8sBatch: {
+      listNamespacedCronJob: vi.fn().mockResolvedValue({ body: { items: [] } })
+    },
+    k8sAutoscaling: {
+      listNamespacedHorizontalPodAutoscaler: vi.fn().mockResolvedValue({ body: { items: [] } })
+    },
+    k8sCustomObjects: {
+      listNamespacedCustomObject: vi.fn().mockResolvedValue({ body: { items: [] } })
+    },
     k8sCore: {
       deleteCollectionNamespacedPersistentVolumeClaim: vi.fn().mockResolvedValue({}),
       deleteNamespacedPersistentVolumeClaim: vi.fn().mockResolvedValue({})
+    },
+    k8sAuth: {
+      listNamespacedRole: vi.fn().mockResolvedValue({ body: { items: [] } }),
+      listNamespacedRoleBinding: vi.fn().mockResolvedValue({ body: { items: [] } })
     }
   } as any;
 }
@@ -183,7 +240,7 @@ describe('deleteInstancePersistentVolumeClaims', () => {
     );
   });
 
-  it('handles labeled PVC cleanup mode with instance label first and compatibility fallbacks', async () => {
+  it('handles labeled PVC cleanup mode with instance label only', async () => {
     const k8s = createK8sMock([
       {
         metadata: {
@@ -210,12 +267,19 @@ describe('deleteInstancePersistentVolumeClaims', () => {
       hasTemplateDeployLabelInVolumeClaimTemplates: true
     });
     expectSelectorDelete(k8s, `${templateDeployKey}=instance-a`);
+    expect(k8s.k8sCore.deleteCollectionNamespacedPersistentVolumeClaim).toHaveBeenCalledTimes(1);
+    expect(k8s.k8sCore.deleteNamespacedPersistentVolumeClaim).not.toHaveBeenCalled();
+  });
+
+  it('keeps instance legacy label fallback when no StatefulSets are found by instance label', async () => {
+    const k8s = createK8sMock();
+
+    await deleteInstancePersistentVolumeClaims(k8s, 'instance-a');
+
+    expectSelectorDelete(k8s, `${templateDeployKey}=instance-a`);
     expectSelectorDelete(k8s, `${legacyAppLabelKey}=instance-a`);
-    expectSelectorDelete(k8s, `${legacyAppLabelKey}=labeled-mysql`);
-    expect(k8s.k8sCore.deleteNamespacedPersistentVolumeClaim).toHaveBeenCalledWith(
-      'data-labeled-mysql-0',
-      'ns-test'
-    );
+    expect(k8s.k8sCore.deleteCollectionNamespacedPersistentVolumeClaim).toHaveBeenCalledTimes(2);
+    expect(k8s.k8sCore.deleteNamespacedPersistentVolumeClaim).not.toHaveBeenCalled();
   });
 
   it('handles native retention PVC cleanup mode and still runs compatibility fallbacks', async () => {
@@ -360,4 +424,84 @@ describe('deleteInstancePersistentVolumeClaims', () => {
       })
     );
   });
+});
+
+describe('template instance deletion ordering', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(operations.deleteInstance).mockResolvedValue(undefined);
+    vi.mocked(operations.deleteStatefulSet).mockResolvedValue(undefined);
+    vi.mocked(operations.getAppLaunchpad).mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('foreground deletes owner-referenced StatefulSets before cleaning PVCs', async () => {
+    const k8s = createK8sMock([
+      {
+        metadata: {
+          name: 'mysql'
+        },
+        spec: {
+          volumeClaimTemplates: [{ metadata: { name: 'data' } }]
+        }
+      }
+    ]);
+
+    await deleteOwnerReferencedInstance(k8s, 'instance-a');
+
+    expect(k8s.k8sApp.listNamespacedStatefulSet).toHaveBeenCalledWith(
+      'ns-test',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      `${templateDeployKey}=instance-a`
+    );
+    expect(operations.deleteStatefulSet).toHaveBeenCalledWith(k8s.k8sApp, 'ns-test', 'mysql');
+    expect(k8s.k8sCore.deleteNamespacedPersistentVolumeClaim).toHaveBeenCalledWith(
+      'data-mysql-0',
+      'ns-test'
+    );
+    expect(vi.mocked(operations.deleteStatefulSet).mock.invocationCallOrder[0]).toBeLessThan(
+      k8s.k8sCore.deleteNamespacedPersistentVolumeClaim.mock.invocationCallOrder[0]
+    );
+    expect(vi.mocked(operations.deleteInstance).mock.invocationCallOrder[0]).toBeGreaterThan(
+      k8s.k8sCore.deleteNamespacedPersistentVolumeClaim.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('foreground deletes legacy AppLaunchpad StatefulSets before final PVC cleanup', async () => {
+    const k8s = createK8sMock([
+      {
+        metadata: {
+          name: 'mysql'
+        },
+        spec: {
+          volumeClaimTemplates: [{ metadata: { name: 'data' } }]
+        }
+      }
+    ]);
+    vi.mocked(operations.getAppLaunchpad).mockResolvedValue([{ metadata: { name: 'mysql' } }]);
+
+    await legacyDeleteInstanceAll(k8s, 'instance-a');
+
+    expect(operations.deleteAppLaunchpad).toHaveBeenCalledWith(k8s, 'ns-test', 'mysql');
+    expect(k8s.k8sCore.deleteNamespacedPersistentVolumeClaim).toHaveBeenCalledWith(
+      'data-mysql-0',
+      'ns-test'
+    );
+    expect(vi.mocked(operations.deleteAppLaunchpad).mock.invocationCallOrder[0]).toBeLessThan(
+      k8s.k8sCore.deleteNamespacedPersistentVolumeClaim.mock.invocationCallOrder[0]
+    );
+  });
+
+  void consoleLogSpy;
+  void consoleErrorSpy;
 });

--- a/frontend/providers/template/__tests__/operations-statefulset-delete.test.ts
+++ b/frontend/providers/template/__tests__/operations-statefulset-delete.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { deleteStatefulSet } from '@/services/backend/operations';
+
+describe('deleteStatefulSet', () => {
+  it('uses foreground propagation before PVC cleanup runs', async () => {
+    const api = {
+      deleteNamespacedStatefulSet: vi.fn().mockResolvedValue({})
+    };
+
+    await deleteStatefulSet(api as any, 'ns-test', 'mysql');
+
+    expect(api.deleteNamespacedStatefulSet).toHaveBeenCalledWith(
+      'mysql',
+      'ns-test',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'Foreground',
+      { propagationPolicy: 'Foreground' }
+    );
+  });
+});

--- a/frontend/providers/template/__tests__/template-pvc-labels.test.ts
+++ b/frontend/providers/template/__tests__/template-pvc-labels.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { templateDeployKey } from '@/constants/keys';
+import { processEnvValue } from '@/utils/common';
+
+describe('template deploy label injection', () => {
+  it('adds templateDeployKey to StatefulSet and every volumeClaimTemplate', () => {
+    const resource = {
+      kind: 'StatefulSet',
+      metadata: {
+        name: 'mysql',
+        labels: {
+          app: 'mysql'
+        }
+      },
+      spec: {
+        volumeClaimTemplates: [
+          {
+            metadata: {
+              name: 'data',
+              labels: {
+                app: 'mysql'
+              }
+            }
+          },
+          {
+            metadata: {
+              name: 'logs',
+              labels: {
+                tier: 'storage'
+              }
+            }
+          }
+        ]
+      }
+    };
+
+    const result = processEnvValue(resource, 'instance-a');
+
+    expect(result.metadata.labels).toEqual({
+      app: 'mysql',
+      [templateDeployKey]: 'instance-a'
+    });
+    expect(result.spec.volumeClaimTemplates[0].metadata.labels).toEqual({
+      app: 'mysql',
+      [templateDeployKey]: 'instance-a'
+    });
+    expect(result.spec.volumeClaimTemplates[1].metadata.labels).toEqual({
+      tier: 'storage',
+      [templateDeployKey]: 'instance-a'
+    });
+  });
+
+  it('creates missing metadata and labels on StatefulSet volumeClaimTemplates', () => {
+    const result = processEnvValue(
+      {
+        kind: 'StatefulSet',
+        spec: {
+          volumeClaimTemplates: [
+            {
+              metadata: {
+                name: 'data'
+              }
+            },
+            {
+              spec: {}
+            }
+          ]
+        }
+      },
+      'instance-a'
+    );
+
+    expect(result.metadata.labels[templateDeployKey]).toBe('instance-a');
+    expect(result.spec.volumeClaimTemplates[0].metadata.labels[templateDeployKey]).toBe(
+      'instance-a'
+    );
+    expect(result.spec.volumeClaimTemplates[1].metadata.labels[templateDeployKey]).toBe(
+      'instance-a'
+    );
+  });
+
+  it('does not add volumeClaimTemplates or retention policy to non-StatefulSet resources', () => {
+    const result = processEnvValue(
+      {
+        kind: 'Deployment',
+        metadata: {
+          labels: {
+            app: 'api'
+          }
+        },
+        spec: {}
+      },
+      'instance-a'
+    );
+
+    expect(result.metadata.labels).toEqual({
+      app: 'api',
+      [templateDeployKey]: 'instance-a'
+    });
+    expect(result.spec.volumeClaimTemplates).toBeUndefined();
+    expect(result.spec.persistentVolumeClaimRetentionPolicy).toBeUndefined();
+  });
+
+  it('does not inject StatefulSet persistentVolumeClaimRetentionPolicy', () => {
+    const result = processEnvValue(
+      {
+        kind: 'StatefulSet',
+        spec: {
+          volumeClaimTemplates: []
+        }
+      },
+      'instance-a'
+    );
+
+    expect(result.spec.persistentVolumeClaimRetentionPolicy).toBeUndefined();
+  });
+});

--- a/frontend/providers/template/src/constants/keys.ts
+++ b/frontend/providers/template/src/constants/keys.ts
@@ -5,6 +5,16 @@ export const noGpuSliderKey = 'NoGpu';
 export const maxReplicasKey = 'deploy.cloud.sealos.io/maxReplicas';
 export const minReplicasKey = 'deploy.cloud.sealos.io/minReplicas';
 export const appDeployKey = 'cloud.sealos.io/app-deploy-manager';
+/**
+ * Legacy Applaunchpad application label used by old templates and StatefulSet PVCs.
+ *
+ * Keep new Template lifecycle logic on `templateDeployKey`; use this label only for
+ * legacy cleanup/read paths that must find resources created before Template injected
+ * instance-level labels into `volumeClaimTemplates`.
+ *
+ * @deprecated Prefer `templateDeployKey` for Template instance ownership.
+ */
+export const legacyAppLabelKey = 'app';
 export const publicDomainKey = `cloud.sealos.io/app-deploy-manager-domain`;
 export const gpuNodeSelectorKey = 'nvidia.com/gpu.product';
 export const gpuResourceKey = 'nvidia.com/gpu';

--- a/frontend/providers/template/src/pages/api/instance/deleteByName.ts
+++ b/frontend/providers/template/src/pages/api/instance/deleteByName.ts
@@ -6,10 +6,10 @@ import { jsonRes } from '@/services/backend/response';
 import { withErrorHandler } from '@/services/backend/middleware';
 import {
   deleteInstanceOnly,
+  deleteInstancePersistentVolumeClaims,
   getInstanceOrThrow404,
   isInstanceOwnerReferencesReady,
-  legacyDeleteInstanceAll,
-  legacyDeletePersistentVolumeClaimsOnly
+  legacyDeleteInstanceAll
 } from '@/services/backend/instanceDelete';
 
 export default withErrorHandler(async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -29,11 +29,7 @@ export default withErrorHandler(async function handler(req: NextApiRequest, res:
   }
 
   if (isInstanceOwnerReferencesReady(instance)) {
-    // [FIXME] StatefulSet PVCs are not auto-deleted by GC in current cluster versions.
-    // ! Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
-    // ! This manual PVC list+delete workaround can be replaced on Kubernetes >= 1.32
-    // ! after adopting StatefulSet `persistentVolumeClaimRetentionPolicy` in templates.
-    await legacyDeletePersistentVolumeClaimsOnly(k8s, instanceName);
+    await deleteInstancePersistentVolumeClaims(k8s, instanceName);
 
     await deleteInstanceOnly(k8s.k8sCustomObjects, k8s.namespace, instance.metadata.name);
     return jsonRes(res, { message: `Instance "${instanceName}" deleted successfully` });

--- a/frontend/providers/template/src/pages/api/instance/deleteByName.ts
+++ b/frontend/providers/template/src/pages/api/instance/deleteByName.ts
@@ -6,7 +6,7 @@ import { jsonRes } from '@/services/backend/response';
 import { withErrorHandler } from '@/services/backend/middleware';
 import {
   deleteInstanceOnly,
-  deleteInstancePersistentVolumeClaims,
+  deleteOwnerReferencedInstance,
   getInstanceOrThrow404,
   isInstanceOwnerReferencesReady,
   legacyDeleteInstanceAll
@@ -29,9 +29,7 @@ export default withErrorHandler(async function handler(req: NextApiRequest, res:
   }
 
   if (isInstanceOwnerReferencesReady(instance)) {
-    await deleteInstancePersistentVolumeClaims(k8s, instanceName);
-
-    await deleteInstanceOnly(k8s.k8sCustomObjects, k8s.namespace, instance.metadata.name);
+    await deleteOwnerReferencedInstance(k8s, instance.metadata.name);
     return jsonRes(res, { message: `Instance "${instanceName}" deleted successfully` });
   }
 

--- a/frontend/providers/template/src/pages/api/resource/delApplaunchpad.ts
+++ b/frontend/providers/template/src/pages/api/resource/delApplaunchpad.ts
@@ -3,7 +3,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { authSession } from '@/services/backend/auth';
 import { getK8s } from '@/services/backend/kubernetes';
 import { jsonRes } from '@/services/backend/response';
-import { appDeployKey } from '@/constants/keys';
+import { appDeployKey, legacyAppLabelKey } from '@/constants/keys';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
@@ -93,14 +93,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           );
         }),
       k8sCore.deleteCollectionNamespacedPersistentVolumeClaim(
-        // delete pvc
+        // Legacy Applaunchpad PVC cleanup. New Template instance cleanup uses templateDeployKey.
         namespace,
         undefined,
         undefined,
         undefined,
         undefined,
         undefined,
-        `app=${instanceName}`
+        `${legacyAppLabelKey}=${instanceName}`
       ),
       k8sAutoscaling.deleteNamespacedHorizontalPodAutoscaler(instanceName, namespace) // delete HorizontalPodAutoscaler
     ]);

--- a/frontend/providers/template/src/pages/api/v1/instance/[instanceName].ts
+++ b/frontend/providers/template/src/pages/api/v1/instance/[instanceName].ts
@@ -9,7 +9,7 @@ import {
   isInstanceOwnerReferencesReady,
   legacyDeleteInstanceAll,
   deleteInstanceOnly,
-  legacyDeletePersistentVolumeClaimsOnly
+  deleteInstancePersistentVolumeClaims
 } from '@/services/backend/instanceDelete';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -61,11 +61,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
       // New instances: only delete Instance, rely on GC cascade
       if (isInstanceOwnerReferencesReady(instance)) {
-        // [FIXME] StatefulSet PVCs are not auto-deleted by GC in current cluster versions.
-        // ! Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
-        // ! This manual PVC list+delete workaround can be replaced on Kubernetes >= 1.32
-        // ! after adopting StatefulSet `persistentVolumeClaimRetentionPolicy` in templates.
-        await legacyDeletePersistentVolumeClaimsOnly(k8s, instanceName);
+        await deleteInstancePersistentVolumeClaims(k8s, instanceName);
 
         await deleteInstanceOnly(k8s.k8sCustomObjects, k8s.namespace, instance.metadata.name);
         return jsonRes(res, {

--- a/frontend/providers/template/src/pages/api/v1/instance/[instanceName].ts
+++ b/frontend/providers/template/src/pages/api/v1/instance/[instanceName].ts
@@ -9,7 +9,7 @@ import {
   isInstanceOwnerReferencesReady,
   legacyDeleteInstanceAll,
   deleteInstanceOnly,
-  deleteInstancePersistentVolumeClaims
+  deleteOwnerReferencedInstance
 } from '@/services/backend/instanceDelete';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -61,9 +61,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
       // New instances: only delete Instance, rely on GC cascade
       if (isInstanceOwnerReferencesReady(instance)) {
-        await deleteInstancePersistentVolumeClaims(k8s, instanceName);
-
-        await deleteInstanceOnly(k8s.k8sCustomObjects, k8s.namespace, instance.metadata.name);
+        await deleteOwnerReferencedInstance(k8s, instance.metadata.name);
         return jsonRes(res, {
           code: ResponseCode.SUCCESS,
           message: ResponseMessages[ResponseCode.SUCCESS]

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/instances/[instanceName].ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/instances/[instanceName].ts
@@ -3,10 +3,10 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { authSession } from '@/services/backend/auth';
 import {
   deleteInstanceOnly,
+  deleteInstancePersistentVolumeClaims,
   getInstanceOrThrow404,
   isInstanceOwnerReferencesReady,
-  legacyDeleteInstanceAll,
-  legacyDeletePersistentVolumeClaimsOnly
+  legacyDeleteInstanceAll
 } from '@/services/backend/instanceDelete';
 import { getK8s } from '@/services/backend/kubernetes';
 import * as deleteInstanceSchemas from '@/types/apis/v2alpha/delete-instance';
@@ -90,9 +90,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     if (isInstanceOwnerReferencesReady(instance)) {
-      // StatefulSet volumeClaimTemplates PVCs are not reliably garbage-collected with the
-      // workload in current supported clusters, so keep the existing explicit PVC cleanup.
-      await legacyDeletePersistentVolumeClaimsOnly(k8s, instanceName);
+      await deleteInstancePersistentVolumeClaims(k8s, instanceName);
       await deleteInstanceOnly(k8s.k8sCustomObjects, k8s.namespace, instance.metadata.name);
     } else {
       await legacyDeleteInstanceAll(k8s, instanceName);

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/instances/[instanceName].ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/instances/[instanceName].ts
@@ -3,7 +3,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { authSession } from '@/services/backend/auth';
 import {
   deleteInstanceOnly,
-  deleteInstancePersistentVolumeClaims,
+  deleteOwnerReferencedInstance,
   getInstanceOrThrow404,
   isInstanceOwnerReferencesReady,
   legacyDeleteInstanceAll
@@ -90,8 +90,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     if (isInstanceOwnerReferencesReady(instance)) {
-      await deleteInstancePersistentVolumeClaims(k8s, instanceName);
-      await deleteInstanceOnly(k8s.k8sCustomObjects, k8s.namespace, instance.metadata.name);
+      await deleteOwnerReferencedInstance(k8s, instance.metadata.name);
     } else {
       await legacyDeleteInstanceAll(k8s, instanceName);
       await deleteInstanceOnly(k8s.k8sCustomObjects, k8s.namespace, instance.metadata.name);

--- a/frontend/providers/template/src/services/backend/instanceDelete.ts
+++ b/frontend/providers/template/src/services/backend/instanceDelete.ts
@@ -32,6 +32,16 @@ type StatefulSetResource = KubernetesObject & {
     }>;
   };
 };
+type StatefulSetPvcCleanupMode =
+  | 'legacy'
+  | 'owner-reference-only'
+  | 'labeled-pvc'
+  | 'native-retention';
+type StatefulSetPvcCleanupTarget = {
+  statefulSet: StatefulSetResource;
+  statefulSetName: string;
+  mode: StatefulSetPvcCleanupMode;
+};
 
 const pvcCleanupLogPrefix = '[template pvc cleanup]';
 
@@ -81,6 +91,27 @@ export async function deleteInstanceOnly(
   instanceName: string
 ): Promise<void> {
   await operations.deleteInstance(api, namespace, instanceName);
+}
+
+export async function deleteOwnerReferencedInstance(
+  k8s: Awaited<ReturnType<typeof getK8s>>,
+  instanceName: string
+): Promise<void> {
+  const ns = k8s.namespace;
+  const statefulSets = await listStatefulSetsByInstance(k8s.k8sApp, ns, instanceName).catch(
+    (error) => {
+      if (isK8sNotFound(error)) return [];
+      throw error;
+    }
+  );
+
+  await deleteResourcesBatch(
+    Promise.resolve(statefulSets),
+    (name: string) => operations.deleteStatefulSet(k8s.k8sApp, ns, name),
+    'An error occurred whilst deleting StatefulSets.'
+  );
+  await deleteInstancePersistentVolumeClaims(k8s, instanceName, statefulSets);
+  await deleteInstanceOnly(k8s.k8sCustomObjects, ns, instanceName);
 }
 
 export async function legacyDeletePersistentVolumeClaimsOnly(
@@ -171,7 +202,7 @@ async function deletePersistentVolumeClaimByName(
 function inferStatefulSetPvcCleanupMode(
   statefulSet: StatefulSetResource,
   instanceName: string
-): 'legacy' | 'owner-reference-only' | 'labeled-pvc' | 'native-retention' {
+): StatefulSetPvcCleanupMode {
   const volumeClaimTemplates = statefulSet.spec?.volumeClaimTemplates ?? [];
   const hasTemplateDeployLabelInVolumeClaimTemplates =
     volumeClaimTemplates.length > 0 &&
@@ -189,18 +220,19 @@ function inferStatefulSetPvcCleanupMode(
 
 export async function deleteInstancePersistentVolumeClaims(
   k8s: Awaited<ReturnType<typeof getK8s>>,
-  instanceName: string
+  instanceName: string,
+  knownStatefulSets?: StatefulSetResource[]
 ): Promise<void> {
   const ns = k8s.namespace;
 
   console.log(pvcCleanupLogPrefix, 'cleanup start', { instanceName, namespace: ns });
 
-  const statefulSets = await listStatefulSetsByInstance(k8s.k8sApp, ns, instanceName).catch(
-    (error) => {
+  const statefulSets =
+    knownStatefulSets ??
+    (await listStatefulSetsByInstance(k8s.k8sApp, ns, instanceName).catch((error) => {
       if (isK8sNotFound(error)) return [];
       throw error;
-    }
-  );
+    }));
 
   // ? PVC cleanup modes:
   // * 1. legacy: resources do not have Instance ownerReference.
@@ -210,6 +242,8 @@ export async function deleteInstancePersistentVolumeClaims(
 
   // [TODO] Migrate instance creation to mode 4 in the future.
   // ? Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+
+  const statefulSetCleanupTargets: StatefulSetPvcCleanupTarget[] = [];
 
   for (const statefulSet of statefulSets) {
     const statefulSetName = statefulSet.metadata?.name ?? '';
@@ -225,13 +259,22 @@ export async function deleteInstancePersistentVolumeClaims(
     const retentionWhenDeleted =
       statefulSet.spec?.persistentVolumeClaimRetentionPolicy?.whenDeleted;
 
+    const inferredMode = inferStatefulSetPvcCleanupMode(statefulSet, instanceName);
+
     console.log(pvcCleanupLogPrefix, 'statefulset identified', {
       statefulSetName,
       ownerReferenceReady: (statefulSet.metadata?.ownerReferences ?? []).length > 0,
       retentionWhenDeleted,
       hasTemplateDeployLabelInVolumeClaimTemplates,
       volumeClaimTemplateNames,
-      inferredMode: inferStatefulSetPvcCleanupMode(statefulSet, instanceName)
+      inferredMode
+    });
+
+    if (!statefulSetName) continue;
+    statefulSetCleanupTargets.push({
+      statefulSet,
+      statefulSetName,
+      mode: inferredMode
     });
   }
 
@@ -241,6 +284,13 @@ export async function deleteInstancePersistentVolumeClaims(
     `${templateDeployKey}=${instanceName}`,
     'instance-label'
   );
+
+  const needsLegacyPvcFallbacks =
+    statefulSetCleanupTargets.some(({ mode }) => mode !== 'labeled-pvc') ||
+    statefulSetCleanupTargets.length === 0;
+
+  if (!needsLegacyPvcFallbacks) return;
+
   // Legacy fallback for old Applaunchpad-style PVCs that were labeled by application name.
   await deletePersistentVolumeClaimsBySelector(
     k8s.k8sCore,
@@ -249,9 +299,8 @@ export async function deleteInstancePersistentVolumeClaims(
     'legacy-app-label-instance'
   );
 
-  for (const statefulSet of statefulSets) {
-    const statefulSetName = statefulSet.metadata?.name;
-    if (!statefulSetName) continue;
+  for (const { statefulSet, statefulSetName, mode } of statefulSetCleanupTargets) {
+    if (mode === 'labeled-pvc') continue;
 
     // Legacy fallback for component-level StatefulSet PVCs, for example `app=mysql`.
     await deletePersistentVolumeClaimsBySelector(
@@ -366,6 +415,12 @@ export async function legacyDeleteInstanceAll(
   instanceName: string
 ): Promise<void> {
   const ns = k8s.namespace;
+  const statefulSets = await listStatefulSetsByInstance(k8s.k8sApp, ns, instanceName).catch(
+    (error) => {
+      if (isK8sNotFound(error)) return [];
+      throw error;
+    }
+  );
 
   // Workloads and applaunchpad dependents
   await deleteResourcesBatch(
@@ -475,7 +530,7 @@ export async function legacyDeleteInstanceAll(
   );
 
   // PVC
-  await deleteInstancePersistentVolumeClaims(k8s, instanceName);
+  await deleteInstancePersistentVolumeClaims(k8s, instanceName, statefulSets);
 
   // Monitoring (Prometheus Operator)
   await deleteResourcesBatch(

--- a/frontend/providers/template/src/services/backend/instanceDelete.ts
+++ b/frontend/providers/template/src/services/backend/instanceDelete.ts
@@ -1,4 +1,5 @@
 import type {
+  AppsV1Api,
   AutoscalingV2Api,
   CoreV1Api,
   CustomObjectsApi,
@@ -6,12 +7,33 @@ import type {
 } from '@kubernetes/client-node';
 import type { IncomingMessage } from 'http';
 
-import { ownerReferencesKey, ownerReferencesReadyValue, templateDeployKey } from '@/constants/keys';
+import {
+  legacyAppLabelKey,
+  ownerReferencesKey,
+  ownerReferencesReadyValue,
+  templateDeployKey
+} from '@/constants/keys';
 import type { TemplateInstanceType } from '@/types/app';
-import { getK8s, type CRDMeta } from '@/services/backend/kubernetes';
+import { getK8s } from '@/services/backend/kubernetes';
 import * as operations from '@/services/backend/operations';
 
 type AnyResource = { metadata?: { name?: string } } & Record<string, any>;
+type StatefulSetResource = KubernetesObject & {
+  spec?: {
+    replicas?: number;
+    persistentVolumeClaimRetentionPolicy?: {
+      whenDeleted?: string;
+    };
+    volumeClaimTemplates?: Array<{
+      metadata?: {
+        name?: string;
+        labels?: Record<string, string>;
+      };
+    }>;
+  };
+};
+
+const pvcCleanupLogPrefix = '[template pvc cleanup]';
 
 async function deleteResourcesBatch<T extends AnyResource>(
   resourcesPromise: Promise<T[]>,
@@ -65,15 +87,195 @@ export async function legacyDeletePersistentVolumeClaimsOnly(
   k8s: Awaited<ReturnType<typeof getK8s>>,
   instanceName: string
 ): Promise<void> {
-  const ns = k8s.namespace;
+  await deleteInstancePersistentVolumeClaims(k8s, instanceName);
+}
+
+function isK8sNotFound(error: any): boolean {
+  return +error?.body?.code === 404 || +error?.code === 404 || +error?.statusCode === 404;
+}
+
+function getK8sErrorBody(error: any, fallbackMessage: string): unknown {
+  return error?.body || error || new Error(fallbackMessage);
+}
+
+async function listStatefulSetsByInstance(
+  api: AppsV1Api,
+  namespace: string,
+  instanceName: string
+): Promise<StatefulSetResource[]> {
+  const selector = `${templateDeployKey}=${instanceName}`;
+  const result = await api.listNamespacedStatefulSet(
+    namespace,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    selector
+  );
+
+  return (result.body?.items ?? []) as StatefulSetResource[];
+}
+
+async function deletePersistentVolumeClaimsBySelector(
+  api: CoreV1Api,
+  namespace: string,
+  selector: string,
+  strategy: string
+): Promise<void> {
+  console.log(pvcCleanupLogPrefix, 'selector delete', { strategy, selector });
 
   try {
-    await operations.deletePersistentVolumeClaimsInApp(k8s.k8sCore, ns, instanceName);
-  } catch (error: any) {
-    if (+error?.body?.code === 404) return;
-    throw (
-      error?.body || error || new Error('An error occurred whilst deleting PersistentVolumeClaims.')
+    await api.deleteCollectionNamespacedPersistentVolumeClaim(
+      namespace,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      selector
     );
+  } catch (error: any) {
+    if (isK8sNotFound(error)) return;
+
+    console.error(pvcCleanupLogPrefix, 'selector delete failed', {
+      strategy,
+      selector,
+      error: getK8sErrorBody(error, 'An error occurred whilst deleting PersistentVolumeClaims.')
+    });
+    throw getK8sErrorBody(error, 'An error occurred whilst deleting PersistentVolumeClaims.');
+  }
+}
+
+async function deletePersistentVolumeClaimByName(
+  api: CoreV1Api,
+  namespace: string,
+  statefulSetName: string,
+  pvcName: string
+): Promise<void> {
+  console.log(pvcCleanupLogPrefix, 'inferred pvc delete', { statefulSetName, pvcName });
+
+  try {
+    await api.deleteNamespacedPersistentVolumeClaim(pvcName, namespace);
+  } catch (error: any) {
+    if (isK8sNotFound(error)) return;
+
+    console.error(pvcCleanupLogPrefix, 'inferred pvc delete failed', {
+      statefulSetName,
+      pvcName,
+      error: getK8sErrorBody(error, 'An error occurred whilst deleting PersistentVolumeClaims.')
+    });
+    throw getK8sErrorBody(error, 'An error occurred whilst deleting PersistentVolumeClaims.');
+  }
+}
+
+function inferStatefulSetPvcCleanupMode(
+  statefulSet: StatefulSetResource,
+  instanceName: string
+): 'legacy' | 'owner-reference-only' | 'labeled-pvc' | 'native-retention' {
+  const volumeClaimTemplates = statefulSet.spec?.volumeClaimTemplates ?? [];
+  const hasTemplateDeployLabelInVolumeClaimTemplates =
+    volumeClaimTemplates.length > 0 &&
+    volumeClaimTemplates.every(
+      (template) => template.metadata?.labels?.[templateDeployKey] === instanceName
+    );
+  const hasOwnerReference = (statefulSet.metadata?.ownerReferences ?? []).length > 0;
+  const retentionWhenDeleted = statefulSet.spec?.persistentVolumeClaimRetentionPolicy?.whenDeleted;
+
+  if (retentionWhenDeleted === 'Delete') return 'native-retention';
+  if (hasTemplateDeployLabelInVolumeClaimTemplates) return 'labeled-pvc';
+  if (hasOwnerReference) return 'owner-reference-only';
+  return 'legacy';
+}
+
+export async function deleteInstancePersistentVolumeClaims(
+  k8s: Awaited<ReturnType<typeof getK8s>>,
+  instanceName: string
+): Promise<void> {
+  const ns = k8s.namespace;
+
+  console.log(pvcCleanupLogPrefix, 'cleanup start', { instanceName, namespace: ns });
+
+  const statefulSets = await listStatefulSetsByInstance(k8s.k8sApp, ns, instanceName).catch(
+    (error) => {
+      if (isK8sNotFound(error)) return [];
+      throw error;
+    }
+  );
+
+  // ? PVC cleanup modes:
+  // * 1. legacy: resources do not have Instance ownerReference.
+  // * 2. ownerReference only: resources are owned by Instance, but StatefulSet PVCs lack templateDeployKey.
+  // * 3. labeled PVC: volumeClaimTemplates/PVCs carry templateDeployKey and can be deleted by instance label.
+  // * 4. native retention: StatefulSet uses persistentVolumeClaimRetentionPolicy.whenDeleted=Delete.
+
+  // [TODO] Migrate instance creation to mode 4 in the future.
+  // ? Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+
+  for (const statefulSet of statefulSets) {
+    const statefulSetName = statefulSet.metadata?.name ?? '';
+    const volumeClaimTemplates = statefulSet.spec?.volumeClaimTemplates ?? [];
+    const volumeClaimTemplateNames = volumeClaimTemplates
+      .map((template) => template.metadata?.name)
+      .filter((name): name is string => typeof name === 'string' && name.length > 0);
+    const hasTemplateDeployLabelInVolumeClaimTemplates =
+      volumeClaimTemplates.length > 0 &&
+      volumeClaimTemplates.every(
+        (template) => template.metadata?.labels?.[templateDeployKey] === instanceName
+      );
+    const retentionWhenDeleted =
+      statefulSet.spec?.persistentVolumeClaimRetentionPolicy?.whenDeleted;
+
+    console.log(pvcCleanupLogPrefix, 'statefulset identified', {
+      statefulSetName,
+      ownerReferenceReady: (statefulSet.metadata?.ownerReferences ?? []).length > 0,
+      retentionWhenDeleted,
+      hasTemplateDeployLabelInVolumeClaimTemplates,
+      volumeClaimTemplateNames,
+      inferredMode: inferStatefulSetPvcCleanupMode(statefulSet, instanceName)
+    });
+  }
+
+  await deletePersistentVolumeClaimsBySelector(
+    k8s.k8sCore,
+    ns,
+    `${templateDeployKey}=${instanceName}`,
+    'instance-label'
+  );
+  // Legacy fallback for old Applaunchpad-style PVCs that were labeled by application name.
+  await deletePersistentVolumeClaimsBySelector(
+    k8s.k8sCore,
+    ns,
+    `${legacyAppLabelKey}=${instanceName}`,
+    'legacy-app-label-instance'
+  );
+
+  for (const statefulSet of statefulSets) {
+    const statefulSetName = statefulSet.metadata?.name;
+    if (!statefulSetName) continue;
+
+    // Legacy fallback for component-level StatefulSet PVCs, for example `app=mysql`.
+    await deletePersistentVolumeClaimsBySelector(
+      k8s.k8sCore,
+      ns,
+      `${legacyAppLabelKey}=${statefulSetName}`,
+      'legacy-app-label-statefulset'
+    );
+
+    const replicas = statefulSet.spec?.replicas ?? 1;
+    const volumeClaimTemplateNames = (statefulSet.spec?.volumeClaimTemplates ?? [])
+      .map((template) => template.metadata?.name)
+      .filter((name): name is string => typeof name === 'string' && name.length > 0);
+
+    for (const claimTemplateName of volumeClaimTemplateNames) {
+      for (let ordinal = 0; ordinal < replicas; ordinal++) {
+        await deletePersistentVolumeClaimByName(
+          k8s.k8sCore,
+          ns,
+          statefulSetName,
+          `${claimTemplateName}-${statefulSetName}-${ordinal}`
+        );
+      }
+    }
   }
 }
 
@@ -273,7 +475,7 @@ export async function legacyDeleteInstanceAll(
   );
 
   // PVC
-  await legacyDeletePersistentVolumeClaimsOnly(k8s, instanceName);
+  await deleteInstancePersistentVolumeClaims(k8s, instanceName);
 
   // Monitoring (Prometheus Operator)
   await deleteResourcesBatch(

--- a/frontend/providers/template/src/services/backend/operations.ts
+++ b/frontend/providers/template/src/services/backend/operations.ts
@@ -618,7 +618,16 @@ export async function deleteDeployment(api: AppsV1Api, namespace: string, resour
 }
 
 export async function deleteStatefulSet(api: AppsV1Api, namespace: string, resourceName: string) {
-  await api.deleteNamespacedStatefulSet(resourceName, namespace);
+  await api.deleteNamespacedStatefulSet(
+    resourceName,
+    namespace,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    'Foreground',
+    { propagationPolicy: 'Foreground' }
+  );
 }
 
 export async function deleteCustomResource(
@@ -846,7 +855,6 @@ export async function deleteAppLaunchpad(
     ...certificates.map((item: any) =>
       deleteCertificate(apis.k8sCustomObjects, namespace, item.metadata.name)
     ),
-    legacyDeletePersistentVolumeClaimsByAppLabel(apis.k8sCore, namespace, resourceName),
     deleteHorizontalPodAutoscaler(apis.k8sAutoscaling, namespace, resourceName)
   ]);
 
@@ -871,6 +879,8 @@ export async function deleteAppLaunchpad(
       });
     }
   });
+
+  await legacyDeletePersistentVolumeClaimsByAppLabel(apis.k8sCore, namespace, resourceName);
 }
 
 export async function getDatabases(api: CustomObjectsApi, namespace: string, instanceName: string) {

--- a/frontend/providers/template/src/services/backend/operations.ts
+++ b/frontend/providers/template/src/services/backend/operations.ts
@@ -10,7 +10,13 @@ import {
 } from '@kubernetes/client-node';
 import { CRDMeta, getK8s } from './kubernetes';
 import { TemplateInstanceType } from '@/types/app';
-import { templateDeployKey, dbProviderKey, deployManagerKey, appDeployKey } from '@/constants/keys';
+import {
+  templateDeployKey,
+  dbProviderKey,
+  deployManagerKey,
+  appDeployKey,
+  legacyAppLabelKey
+} from '@/constants/keys';
 import { adaptAppListItem, adaptCronJobList, adaptObjectStorageItem } from '@/utils/adapt';
 import { DBListItemType } from '@/types/db';
 import { ObjectStorageCR } from '@/types/objectStorage';
@@ -763,11 +769,19 @@ export async function deleteIngressesInApp(
   );
 }
 
-export async function deletePersistentVolumeClaimsInApp(
+/**
+ * Legacy Applaunchpad/StatefulSet PVC cleanup only.
+ *
+ * @deprecated - This is a fallback for legacy resources. New Template cleanup should use `templateDeployKey`
+ */
+export async function legacyDeletePersistentVolumeClaimsByAppLabel(
   api: CoreV1Api,
   namespace: string,
   appName: string
 ) {
+  // Legacy Applaunchpad/StatefulSet PVC cleanup only. New Template cleanup should use
+  // `templateDeployKey`; this selector remains for PVCs created before that label was
+  // injected into StatefulSet `volumeClaimTemplates`.
   await api.deleteCollectionNamespacedPersistentVolumeClaim(
     namespace,
     undefined,
@@ -775,8 +789,7 @@ export async function deletePersistentVolumeClaimsInApp(
     undefined,
     undefined,
     undefined,
-    // ! Why `app` here?
-    `app=${appName}`
+    `${legacyAppLabelKey}=${appName}`
   );
 }
 
@@ -833,7 +846,7 @@ export async function deleteAppLaunchpad(
     ...certificates.map((item: any) =>
       deleteCertificate(apis.k8sCustomObjects, namespace, item.metadata.name)
     ),
-    deletePersistentVolumeClaimsInApp(apis.k8sCore, namespace, resourceName),
+    legacyDeletePersistentVolumeClaimsByAppLabel(apis.k8sCore, namespace, resourceName),
     deleteHorizontalPodAutoscaler(apis.k8sAutoscaling, namespace, resourceName)
   ]);
 

--- a/frontend/providers/template/src/utils/common.ts
+++ b/frontend/providers/template/src/utils/common.ts
@@ -31,13 +31,28 @@ export const processEnvValue = (obj: any, labelName: string) => {
   });
 
   if (labelName) {
-    newDeployment.metadata = newDeployment.metadata || {};
-    newDeployment.metadata.labels = newDeployment.metadata.labels || {};
-    newDeployment.metadata.labels[templateDeployKey] = labelName;
+    injectTemplateDeployLabels(newDeployment, labelName);
   }
 
   return newDeployment;
 };
+
+export function injectTemplateDeployLabels(resource: any, instanceName: string): void {
+  resource.metadata = resource.metadata || {};
+  resource.metadata.labels = resource.metadata.labels || {};
+  resource.metadata.labels[templateDeployKey] = instanceName;
+
+  if (resource.kind !== 'StatefulSet') return;
+
+  forEach(resource.spec?.volumeClaimTemplates, (volumeClaimTemplate) => {
+    volumeClaimTemplate.metadata = volumeClaimTemplate.metadata || {};
+    volumeClaimTemplate.metadata.labels = volumeClaimTemplate.metadata.labels || {};
+    volumeClaimTemplate.metadata.labels[templateDeployKey] = instanceName;
+  });
+
+  // Future K8s 1.32+ only clusters can consider injecting
+  // persistentVolumeClaimRetentionPolicy.whenDeleted=Delete here.
+}
 
 export function deepSearch(obj: any): string {
   if (has(obj, 'message')) {


### PR DESCRIPTION
Fix Template StatefulSet PVC cleanup.

This PR makes Template PVC ownership explicit and keeps legacy cleanup paths contained:

  - Injects `cloud.sealos.io/deploy-on-sealos` into StatefulSet `volumeClaimTemplates` so newly created PVCs can be selected by Template instance label.
  - Adds unified Instance PVC cleanup covering four modes: legacy resources, ownerReference-only resources, labeled PVC resources, and K8s native retention-
    policy resources.
  - Keeps `app` label cleanup as a deprecated legacy fallback via `legacyAppLabelKey`, with comments and legacy-focused naming.
  - Updates Instance delete paths to use the unified PVC cleanup before deleting the Instance.
  - Adds unit tests for label injection, four PVC cleanup modes, 404 handling, non-404 failures, default replicas, and multi-template PVC inference.