### PR TITLE
feat(desktop): honor shared app ordering

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -65,6 +65,7 @@ RUN if [ "$name" = "desktop" ]; then \
     if [ -d "./desktop/prisma/providers" ]; then \
         mkdir -p desktop/.next/standalone/desktop/prisma/providers && \
         cp -r ./desktop/prisma/providers/* desktop/.next/standalone/desktop/prisma/providers/; \
+    fi; \
 fi
 # Production image, copy all the files and run next
 FROM base AS runner

--- a/frontend/desktop/README.md
+++ b/frontend/desktop/README.md
@@ -155,6 +155,12 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 3. src/layout/index.tsx
 4. src/components/desktop_content.tsx
 
+### 安装 App 数据流
+
+- `src/pages/api/desktop/getInstalledApps.ts` 负责组装桌面可见 App 列表。共享 App 来自 `app-system` namespace 的 `app.sealos.io/v1 App`，workspace App 来自当前 workspace namespace。
+- 共享 App 保持 `displayType` 分组顺序 `normal -> more -> hidden`，组内按 `spec.position` 从小到大排序；没有 `position` 的旧数据按 `0` 处理，再按创建时间倒序和 key 稳定排序。
+- `spec.position` 由管理端共享 App 图标管理写入，集群 App CRD 需要先包含 `spec.position` schema；workspace App 管理不写这个字段。
+
 ### 测试环境
 
 1. 需要设置环境变量`NODE_ENV=test` 或者 `$env:NODE_ENV="test"`

--- a/frontend/desktop/src/__tests__/unit/appSort.test.ts
+++ b/frontend/desktop/src/__tests__/unit/appSort.test.ts
@@ -1,0 +1,67 @@
+import { compareSystemAppOrder } from '@/utils/appSort';
+import { APPTYPE, TAppConfig } from '@/types';
+
+const createApp = (overrides: Partial<TAppConfig> & Pick<TAppConfig, 'key'>): TAppConfig => ({
+  name: overrides.key,
+  icon: '/logo.svg',
+  type: APPTYPE.IFRAME,
+  data: {
+    url: '',
+    desc: ''
+  },
+  representativeMeta: {
+    forcedIconStyle: 'fill'
+  },
+  displayType: 'normal',
+  ...overrides
+});
+
+describe('compareSystemAppOrder', () => {
+  it('sorts by display type, position, creation time, then key', () => {
+    const apps = [
+      createApp({
+        key: 'system-hidden',
+        displayType: 'hidden',
+        position: 0,
+        creationTimestamp: '2026-06-04T00:00:00Z'
+      }),
+      createApp({
+        key: 'system-more',
+        displayType: 'more',
+        position: 0,
+        creationTimestamp: '2026-06-01T00:00:00Z'
+      }),
+      createApp({
+        key: 'system-later',
+        position: 20,
+        creationTimestamp: '2026-06-03T00:00:00Z'
+      }),
+      createApp({
+        key: 'system-first',
+        position: 10,
+        creationTimestamp: '2026-06-02T00:00:00Z'
+      })
+    ].sort(compareSystemAppOrder);
+
+    expect(apps.map((app) => app.key)).toEqual([
+      'system-first',
+      'system-later',
+      'system-more',
+      'system-hidden'
+    ]);
+  });
+
+  it('treats missing position as zero', () => {
+    const apps = [
+      createApp({
+        key: 'system-positioned',
+        position: 1
+      }),
+      createApp({
+        key: 'system-default'
+      })
+    ].sort(compareSystemAppOrder);
+
+    expect(apps.map((app) => app.key)).toEqual(['system-default', 'system-positioned']);
+  });
+});

--- a/frontend/desktop/src/pages/api/desktop/getInstalledApps.ts
+++ b/frontend/desktop/src/pages/api/desktop/getInstalledApps.ts
@@ -13,6 +13,7 @@ import {
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 import { globalPrisma } from '@/services/backend/db/init';
+import { compareSystemAppOrder } from '@/utils/appSort';
 import { switchKubeconfigNamespace } from '@/utils/switchKubeconfigNamespace';
 import { UserStatus } from 'prisma/global/generated/client';
 
@@ -68,20 +69,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           key,
           ...item.spec,
           representativeMeta: getRepresentativeMeta(key, item.metadata.annotations),
+          displayType: item.spec.displayType || 'normal',
           creationTimestamp: item.metadata.creationTimestamp
         };
       })
-      .sort((a, b) => {
-        if (a.displayType === 'more' && b.displayType !== 'more') {
-          return 1;
-        } else if (a.displayType !== 'more' && b.displayType === 'more') {
-          return -1;
-        } else {
-          const timeA = a.creationTimestamp ? new Date(a.creationTimestamp).getTime() : 0;
-          const timeB = b.creationTimestamp ? new Date(b.creationTimestamp).getTime() : 0;
-          return timeB - timeA;
-        }
-      });
+      .sort(compareSystemAppOrder);
 
     const userArr = (await getRawAppList(getMeta(payload.workspaceId))).map<TAppConfig>((item) => {
       const key = `user-${item.metadata.name}` as const;

--- a/frontend/desktop/src/types/app.ts
+++ b/frontend/desktop/src/types/app.ts
@@ -59,6 +59,7 @@ export type TAppConfig = {
   };
   representativeMeta: TRepresentativeMeta;
   displayType: displayType;
+  position?: number;
   creationTimestamp?: string;
 };
 

--- a/frontend/desktop/src/types/crd.ts
+++ b/frontend/desktop/src/types/crd.ts
@@ -91,6 +91,7 @@ export type TAppCR = {
     icon: string;
     menuData?: TAppMenuData[];
     name: string;
+    position?: number;
     type: APPTYPE;
   };
 };

--- a/frontend/desktop/src/utils/appSort.ts
+++ b/frontend/desktop/src/utils/appSort.ts
@@ -1,0 +1,30 @@
+import type { TAppConfig, displayType } from '@/types';
+
+const DISPLAY_TYPE_ORDER: Record<displayType, number> = {
+  normal: 0,
+  more: 1,
+  hidden: 2
+};
+
+const getPosition = (position?: number) =>
+  typeof position === 'number' && Number.isFinite(position) ? position : 0;
+
+const getCreatedAt = (creationTimestamp?: string) => {
+  if (!creationTimestamp) return 0;
+  const timestamp = new Date(creationTimestamp).getTime();
+  return Number.isFinite(timestamp) ? timestamp : 0;
+};
+
+export const compareSystemAppOrder = (left: TAppConfig, right: TAppConfig) => {
+  const displayOrder = DISPLAY_TYPE_ORDER[left.displayType] - DISPLAY_TYPE_ORDER[right.displayType];
+  if (displayOrder !== 0) return displayOrder;
+
+  const positionOrder = getPosition(left.position) - getPosition(right.position);
+  if (positionOrder !== 0) return positionOrder;
+
+  const createdAtOrder =
+    getCreatedAt(right.creationTimestamp) - getCreatedAt(left.creationTimestamp);
+  if (createdAtOrder !== 0) return createdAtOrder;
+
+  return left.key.localeCompare(right.key, 'en', { sensitivity: 'base' });
+};


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->

## Summary
- Sort Sealos Desktop installed apps by shared App `spec.position` within display groups.
- Keep existing desktop pinned, more, and hidden grouping behavior while consuming the admin-managed order field.
- Add unit coverage for display group priority and position ordering.
- Document that Desktop honors `displayType` and `position` from App CRs.

## Verification
- `pnpm --dir frontend/desktop test src/__tests__/unit/appSort.test.ts`
- `pnpm --dir frontend/desktop lint`
- `pnpm --dir frontend/desktop build`
- Deployed desktop image to cluster 209 in the earlier verification flow for this branch.

## Related
- Depends on App CRD support for `spec.position` from labring/sealos#6981/#6985.
- Companion admin PR: sealos-apps/admin#89.
