### PR TITLE
fix(applaunchpad): harden domain challenge SSRF checks

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/pages/api/platform/authDomainChallenge.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/pages/api/platform/authDomainChallenge.test.ts
@@ -278,33 +278,22 @@ describe('authDomainChallenge SSRF protections', () => {
   });
 
   it('allows same-host HTTP to HTTPS challenge redirects', async () => {
-    mockedQueryA
-      .mockResolvedValueOnce({
-        name: 'example.com',
-        type: 'A',
-        ttl: 60,
-        data: '93.184.216.34'
+    mockedQueryA.mockResolvedValueOnce({
+      name: 'example.com',
+      type: 'A',
+      ttl: 60,
+      data: '93.184.216.34'
+    });
+    mockedQueryAAAA.mockRejectedValueOnce(new Error('no AAAA'));
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(null, {
+        status: 301,
+        headers: {
+          Location:
+            'https://example.com/api/.well-known/applaunchpad-domain-challenge/abcdefghijklmnop'
+        }
       })
-      .mockResolvedValueOnce({
-        name: 'example.com',
-        type: 'A',
-        ttl: 60,
-        data: '93.184.216.34'
-      });
-    mockedQueryAAAA
-      .mockRejectedValueOnce(new Error('no AAAA'))
-      .mockRejectedValueOnce(new Error('no AAAA'));
-    vi.mocked(fetch)
-      .mockResolvedValueOnce(
-        new Response(null, {
-          status: 301,
-          headers: {
-            Location:
-              'https://example.com/api/.well-known/applaunchpad-domain-challenge/abcdefghijklmnop'
-          }
-        })
-      )
-      .mockResolvedValueOnce(Response.json(createValidChallengeResponse()));
+    );
     mockHttpsResponse(createValidChallengeResponse());
 
     const response = await callHandler({ customDomain: 'example.com' });
@@ -312,6 +301,8 @@ describe('authDomainChallenge SSRF protections', () => {
     expect(response.code).toBe(200);
     expect(response.data.verified).toBe(true);
     expect(fetch).toHaveBeenCalledTimes(1);
+    expect(mockedQueryA).toHaveBeenCalledTimes(1);
+    expect(mockedQueryAAAA).toHaveBeenCalledTimes(1);
     expect(mockedHttpsRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         hostname: '93.184.216.34',
@@ -325,23 +316,14 @@ describe('authDomainChallenge SSRF protections', () => {
     );
   });
 
-  it('rejects same-host HTTPS redirects when re-resolution becomes private', async () => {
-    mockedQueryA
-      .mockResolvedValueOnce({
-        name: 'example.com',
-        type: 'A',
-        ttl: 60,
-        data: '93.184.216.34'
-      })
-      .mockResolvedValueOnce({
-        name: 'example.com',
-        type: 'A',
-        ttl: 60,
-        data: '10.0.0.2'
-      });
-    mockedQueryAAAA
-      .mockRejectedValueOnce(new Error('no AAAA'))
-      .mockRejectedValueOnce(new Error('no AAAA'));
+  it('reuses the initially resolved IP for same-host HTTPS redirects', async () => {
+    mockedQueryA.mockResolvedValueOnce({
+      name: 'example.com',
+      type: 'A',
+      ttl: 60,
+      data: '93.184.216.34'
+    });
+    mockedQueryAAAA.mockRejectedValueOnce(new Error('no AAAA'));
     vi.mocked(fetch).mockResolvedValueOnce(
       new Response(null, {
         status: 301,
@@ -351,12 +333,24 @@ describe('authDomainChallenge SSRF protections', () => {
         }
       })
     );
+    mockHttpsResponse(createValidChallengeResponse());
 
     const response = await callHandler({ customDomain: 'example.com' });
 
-    expect(response.code).toBe(400);
-    expect(response.error.code).toBe('CHALLENGE_REQUEST_FAILED');
+    expect(response.code).toBe(200);
     expect(fetch).toHaveBeenCalledTimes(1);
+    expect(mockedQueryA).toHaveBeenCalledTimes(1);
+    expect(mockedQueryAAAA).toHaveBeenCalledTimes(1);
+    expect(mockedHttpsRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hostname: '93.184.216.34',
+        servername: 'example.com',
+        headers: expect.objectContaining({
+          Host: 'example.com'
+        })
+      }),
+      expect.any(Function)
+    );
   });
 
   it('rejects redirects to a different host', async () => {

--- a/frontend/providers/applaunchpad/__tests__/unit/pages/api/platform/authDomainChallenge.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/pages/api/platform/authDomainChallenge.test.ts
@@ -92,6 +92,10 @@ describe('authDomainChallenge SSRF protections', () => {
       expect(isPublicIp('169.254.169.254')).toBe(false);
       expect(isPublicIp('172.16.0.1')).toBe(false);
       expect(isPublicIp('192.168.1.1')).toBe(false);
+      expect(isPublicIp('192.0.0.1')).toBe(false);
+      expect(isPublicIp('192.0.2.1')).toBe(false);
+      expect(isPublicIp('198.51.100.1')).toBe(false);
+      expect(isPublicIp('203.0.113.1')).toBe(false);
       expect(isPublicIp('::1')).toBe(false);
       expect(isPublicIp('fc00::1')).toBe(false);
       expect(isPublicIp('fe80::1')).toBe(false);
@@ -107,6 +111,7 @@ describe('authDomainChallenge SSRF protections', () => {
 
     it('allows public addresses', () => {
       expect(isPublicIp('93.184.216.34')).toBe(true);
+      expect(isPublicIp('192.0.1.1')).toBe(true);
       expect(isPublicIp('2001:4860:4860::8888')).toBe(true);
     });
   });
@@ -124,17 +129,44 @@ describe('authDomainChallenge SSRF protections', () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it('requires a kubeconfig that can access its namespace', async () => {
+  it('returns forbidden when the kubeconfig cannot access its namespace', async () => {
     mockedGetK8s.mockResolvedValueOnce({
       namespace: 'ns-test',
       k8sCore: {
-        listNamespacedService: vi.fn().mockRejectedValue(new Error('forbidden'))
+        listNamespacedService: vi.fn().mockRejectedValue({
+          body: {
+            code: 403,
+            message: 'forbidden'
+          }
+        })
       }
     } as any);
 
     const response = await callHandler({ customDomain: 'example.com' }, 'not-a-kubeconfig');
 
-    expect(response.code).toBe(401);
+    expect(response.code).toBe(403);
+    expect(response.error.code).toBe('FORBIDDEN');
+    expect(mockedQueryA).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not report server-side authentication probe failures as unauthorized', async () => {
+    mockedGetK8s.mockResolvedValueOnce({
+      namespace: 'ns-test',
+      k8sCore: {
+        listNamespacedService: vi.fn().mockRejectedValue({
+          body: {
+            code: 500,
+            message: 'apiserver unavailable'
+          }
+        })
+      }
+    } as any);
+
+    const response = await callHandler({ customDomain: 'example.com' });
+
+    expect(response.code).toBe(500);
+    expect(response.error.code).toBe('INTERNAL_ERROR');
     expect(mockedQueryA).not.toHaveBeenCalled();
     expect(fetch).not.toHaveBeenCalled();
   });

--- a/frontend/providers/applaunchpad/__tests__/unit/pages/api/platform/authDomainChallenge.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/pages/api/platform/authDomainChallenge.test.ts
@@ -11,6 +11,7 @@ import handler, {
 } from '@/pages/api/platform/authDomainChallenge';
 import { queryA, queryAAAA } from '@/services/dns-resolver';
 import { getK8s } from '@/services/backend/kubernetes';
+import http from 'http';
 import https from 'https';
 
 const TEST_DOMAIN_CHALLENGE_SECRET = vi.hoisted(() => ['test', 'secret'].join('-'));
@@ -26,6 +27,12 @@ vi.mock('@/services/dns-resolver', () => ({
 
 vi.mock('@/services/backend/kubernetes', () => ({
   getK8s: vi.fn()
+}));
+
+vi.mock('http', () => ({
+  default: {
+    request: vi.fn()
+  }
 }));
 
 vi.mock('https', () => ({
@@ -45,6 +52,7 @@ vi.mock('@/config', () => ({
 const mockedQueryA = vi.mocked(queryA);
 const mockedQueryAAAA = vi.mocked(queryAAAA);
 const mockedGetK8s = vi.mocked(getK8s);
+const mockedHttpRequest = vi.mocked(http.request);
 const mockedHttpsRequest = vi.mocked(https.request);
 
 const createResponse = () => {
@@ -85,18 +93,43 @@ const createValidChallengeResponse = (host = 'example.com') => {
   };
 };
 
-const mockHttpsResponse = (body: unknown, statusCode = 200) => {
+const createMockNodeResponse = (
+  body: unknown,
+  statusCode = 200,
+  headers: Record<string, string> = { 'content-type': 'application/json' }
+) => {
+  const payload = body === null ? '' : JSON.stringify(body);
+  const res = Readable.from([Buffer.from(payload)]) as any;
+  res.statusCode = statusCode;
+  res.headers = headers;
+  return res;
+};
+
+const mockHttpResponse = (
+  body: unknown,
+  statusCode = 200,
+  headers: Record<string, string> = { 'content-type': 'application/json' }
+) => {
+  mockedHttpRequest.mockImplementationOnce((options: any, callback: any) => {
+    const req = new EventEmitter() as any;
+    req.end = vi.fn();
+
+    callback(createMockNodeResponse(body, statusCode, headers));
+
+    return req;
+  });
+};
+
+const mockHttpsResponse = (
+  body: unknown,
+  statusCode = 200,
+  headers: Record<string, string> = { 'content-type': 'application/json' }
+) => {
   mockedHttpsRequest.mockImplementationOnce((options: any, callback: any) => {
     const req = new EventEmitter() as any;
     req.end = vi.fn();
 
-    const res = Readable.from([Buffer.from(JSON.stringify(body))]) as any;
-    res.statusCode = statusCode;
-    res.headers = {
-      'content-type': 'application/json'
-    };
-
-    callback(res);
+    callback(createMockNodeResponse(body, statusCode, headers));
 
     return req;
   });
@@ -105,7 +138,6 @@ const mockHttpsResponse = (body: unknown, statusCode = 200) => {
 describe('authDomainChallenge SSRF protections', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.stubGlobal('fetch', vi.fn());
     mockedGetK8s.mockResolvedValue({
       namespace: 'ns-test',
       k8sCore: {
@@ -173,7 +205,7 @@ describe('authDomainChallenge SSRF protections', () => {
 
     expect(response.code).toBe(401);
     expect(mockedQueryA).not.toHaveBeenCalled();
-    expect(fetch).not.toHaveBeenCalled();
+    expect(mockedHttpRequest).not.toHaveBeenCalled();
   });
 
   it('returns forbidden when the kubeconfig cannot access its namespace', async () => {
@@ -194,7 +226,7 @@ describe('authDomainChallenge SSRF protections', () => {
     expect(response.code).toBe(403);
     expect(response.error.code).toBe('FORBIDDEN');
     expect(mockedQueryA).not.toHaveBeenCalled();
-    expect(fetch).not.toHaveBeenCalled();
+    expect(mockedHttpRequest).not.toHaveBeenCalled();
   });
 
   it('does not report server-side authentication probe failures as unauthorized', async () => {
@@ -215,7 +247,7 @@ describe('authDomainChallenge SSRF protections', () => {
     expect(response.code).toBe(500);
     expect(response.error.code).toBe('INTERNAL_ERROR');
     expect(mockedQueryA).not.toHaveBeenCalled();
-    expect(fetch).not.toHaveBeenCalled();
+    expect(mockedHttpRequest).not.toHaveBeenCalled();
   });
 
   it('rejects fragment path-control input before DNS resolution', async () => {
@@ -226,7 +258,7 @@ describe('authDomainChallenge SSRF protections', () => {
     expect(response.code).toBe(400);
     expect(response.error.code).toBe('INVALID_CUSTOM_DOMAIN');
     expect(mockedQueryA).not.toHaveBeenCalled();
-    expect(fetch).not.toHaveBeenCalled();
+    expect(mockedHttpRequest).not.toHaveBeenCalled();
   });
 
   it('rejects domains resolving to private addresses', async () => {
@@ -242,7 +274,7 @@ describe('authDomainChallenge SSRF protections', () => {
 
     expect(response.code).toBe(400);
     expect(response.error.code).toBe('PRIVATE_ADDRESS_NOT_ALLOWED');
-    expect(fetch).not.toHaveBeenCalled();
+    expect(mockedHttpRequest).not.toHaveBeenCalled();
   });
 
   it('rejects unsafe redirects during challenge fetch', async () => {
@@ -253,28 +285,25 @@ describe('authDomainChallenge SSRF protections', () => {
       data: '93.184.216.34'
     });
     mockedQueryAAAA.mockRejectedValueOnce(new Error('no AAAA'));
-    vi.mocked(fetch).mockResolvedValueOnce(
-      new Response(null, {
-        status: 302,
-        headers: {
-          Location: 'http://account-service.account-system.svc:2333/swagger/doc.json'
-        }
-      })
-    );
+    mockHttpResponse(null, 302, {
+      location: 'http://account-service.account-system.svc:2333/swagger/doc.json'
+    });
 
     const response = await callHandler({ customDomain: 'example.com' });
 
     expect(response.code).toBe(400);
     expect(response.error.code).toBe('CHALLENGE_REQUEST_FAILED');
-    expect(fetch).toHaveBeenCalledWith(
-      'http://93.184.216.34/api/.well-known/applaunchpad-domain-challenge/abcdefghijklmnop',
+    expect(mockedHttpRequest).toHaveBeenCalledWith(
       expect.objectContaining({
-        redirect: 'manual',
+        hostname: '93.184.216.34',
+        path: '/api/.well-known/applaunchpad-domain-challenge/abcdefghijklmnop',
         headers: expect.objectContaining({
           Host: 'example.com'
         })
-      })
+      }),
+      expect.any(Function)
     );
+    expect(mockedHttpsRequest).not.toHaveBeenCalled();
   });
 
   it('allows same-host HTTP to HTTPS challenge redirects', async () => {
@@ -285,24 +314,28 @@ describe('authDomainChallenge SSRF protections', () => {
       data: '93.184.216.34'
     });
     mockedQueryAAAA.mockRejectedValueOnce(new Error('no AAAA'));
-    vi.mocked(fetch).mockResolvedValueOnce(
-      new Response(null, {
-        status: 301,
-        headers: {
-          Location:
-            'https://example.com/api/.well-known/applaunchpad-domain-challenge/abcdefghijklmnop'
-        }
-      })
-    );
+    mockHttpResponse(null, 301, {
+      location: 'https://example.com/api/.well-known/applaunchpad-domain-challenge/abcdefghijklmnop'
+    });
     mockHttpsResponse(createValidChallengeResponse());
 
     const response = await callHandler({ customDomain: 'example.com' });
 
     expect(response.code).toBe(200);
     expect(response.data.verified).toBe(true);
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(mockedHttpRequest).toHaveBeenCalledTimes(1);
     expect(mockedQueryA).toHaveBeenCalledTimes(1);
     expect(mockedQueryAAAA).toHaveBeenCalledTimes(1);
+    expect(mockedHttpRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hostname: '93.184.216.34',
+        path: '/api/.well-known/applaunchpad-domain-challenge/abcdefghijklmnop',
+        headers: expect.objectContaining({
+          Host: 'example.com'
+        })
+      }),
+      expect.any(Function)
+    );
     expect(mockedHttpsRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         hostname: '93.184.216.34',
@@ -324,21 +357,15 @@ describe('authDomainChallenge SSRF protections', () => {
       data: '93.184.216.34'
     });
     mockedQueryAAAA.mockRejectedValueOnce(new Error('no AAAA'));
-    vi.mocked(fetch).mockResolvedValueOnce(
-      new Response(null, {
-        status: 301,
-        headers: {
-          Location:
-            'https://example.com/api/.well-known/applaunchpad-domain-challenge/abcdefghijklmnop'
-        }
-      })
-    );
+    mockHttpResponse(null, 301, {
+      location: 'https://example.com/api/.well-known/applaunchpad-domain-challenge/abcdefghijklmnop'
+    });
     mockHttpsResponse(createValidChallengeResponse());
 
     const response = await callHandler({ customDomain: 'example.com' });
 
     expect(response.code).toBe(200);
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(mockedHttpRequest).toHaveBeenCalledTimes(1);
     expect(mockedQueryA).toHaveBeenCalledTimes(1);
     expect(mockedQueryAAAA).toHaveBeenCalledTimes(1);
     expect(mockedHttpsRequest).toHaveBeenCalledWith(
@@ -361,21 +388,17 @@ describe('authDomainChallenge SSRF protections', () => {
       data: '93.184.216.34'
     });
     mockedQueryAAAA.mockRejectedValueOnce(new Error('no AAAA'));
-    vi.mocked(fetch).mockResolvedValueOnce(
-      new Response(null, {
-        status: 302,
-        headers: {
-          Location:
-            'https://evil.example/api/.well-known/applaunchpad-domain-challenge/abcdefghijklmnop'
-        }
-      })
-    );
+    mockHttpResponse(null, 302, {
+      location:
+        'https://evil.example/api/.well-known/applaunchpad-domain-challenge/abcdefghijklmnop'
+    });
 
     const response = await callHandler({ customDomain: 'example.com' });
 
     expect(response.code).toBe(400);
     expect(response.error.code).toBe('CHALLENGE_REQUEST_FAILED');
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(mockedHttpRequest).toHaveBeenCalledTimes(1);
+    expect(mockedHttpsRequest).not.toHaveBeenCalled();
   });
 
   it('rejects redirects that change the challenge path', async () => {
@@ -386,20 +409,16 @@ describe('authDomainChallenge SSRF protections', () => {
       data: '93.184.216.34'
     });
     mockedQueryAAAA.mockRejectedValueOnce(new Error('no AAAA'));
-    vi.mocked(fetch).mockResolvedValueOnce(
-      new Response(null, {
-        status: 302,
-        headers: {
-          Location: 'https://example.com/other-path'
-        }
-      })
-    );
+    mockHttpResponse(null, 302, {
+      location: 'https://example.com/other-path'
+    });
 
     const response = await callHandler({ customDomain: 'example.com' });
 
     expect(response.code).toBe(400);
     expect(response.error.code).toBe('CHALLENGE_REQUEST_FAILED');
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(mockedHttpRequest).toHaveBeenCalledTimes(1);
+    expect(mockedHttpsRequest).not.toHaveBeenCalled();
   });
 
   it('does not reflect invalid challenge response bodies', async () => {
@@ -410,13 +429,11 @@ describe('authDomainChallenge SSRF protections', () => {
       data: '93.184.216.34'
     });
     mockedQueryAAAA.mockRejectedValueOnce(new Error('no AAAA'));
-    vi.mocked(fetch).mockResolvedValueOnce(
-      Response.json({
-        internal: {
-          token: 'should-not-leak'
-        }
-      })
-    );
+    mockHttpResponse({
+      internal: {
+        token: 'should-not-leak'
+      }
+    });
 
     const response = await callHandler({ customDomain: 'example.com' });
 
@@ -426,7 +443,7 @@ describe('authDomainChallenge SSRF protections', () => {
     expect(JSON.stringify(response)).not.toContain('should-not-leak');
   });
 
-  it('uses bracketed URL authorities for IPv6 challenge targets', async () => {
+  it('uses resolved IPv6 host for HTTP challenge targets', async () => {
     mockedQueryA.mockRejectedValueOnce(new Error('no A'));
     mockedQueryAAAA.mockResolvedValueOnce({
       name: 'example.com',
@@ -434,23 +451,23 @@ describe('authDomainChallenge SSRF protections', () => {
       ttl: 60,
       data: '2001:4860:4860::8888'
     });
-    vi.mocked(fetch).mockResolvedValueOnce(
-      Response.json({
-        internal: {
-          token: 'should-not-leak'
-        }
-      })
-    );
+    mockHttpResponse({
+      internal: {
+        token: 'should-not-leak'
+      }
+    });
 
     await callHandler({ customDomain: 'example.com' });
 
-    expect(fetch).toHaveBeenCalledWith(
-      'http://[2001:4860:4860::8888]/api/.well-known/applaunchpad-domain-challenge/abcdefghijklmnop',
+    expect(mockedHttpRequest).toHaveBeenCalledWith(
       expect.objectContaining({
+        hostname: '2001:4860:4860::8888',
+        path: '/api/.well-known/applaunchpad-domain-challenge/abcdefghijklmnop',
         headers: expect.objectContaining({
           Host: 'example.com'
         })
-      })
+      }),
+      expect.any(Function)
     );
   });
 
@@ -463,16 +480,14 @@ describe('authDomainChallenge SSRF protections', () => {
     });
     mockedQueryAAAA.mockRejectedValueOnce(new Error('no AAAA'));
 
-    vi.mocked(fetch).mockResolvedValueOnce(
-      Response.json({
-        host: 'attacker-controlled.example',
-        token: 'abcdefghijklmnop',
-        timestamp: Math.floor(Date.now() / 1000),
-        service: 'applaunchpad',
-        isProxy: false,
-        signature: 'invalid-signature'
-      })
-    );
+    mockHttpResponse({
+      host: 'attacker-controlled.example',
+      token: 'abcdefghijklmnop',
+      timestamp: Math.floor(Date.now() / 1000),
+      service: 'applaunchpad',
+      isProxy: false,
+      signature: 'invalid-signature'
+    });
 
     const response = await callHandler({ customDomain: 'example.com' });
 
@@ -492,7 +507,7 @@ describe('authDomainChallenge SSRF protections', () => {
     });
     mockedQueryAAAA.mockRejectedValueOnce(new Error('no AAAA'));
 
-    vi.mocked(fetch).mockResolvedValueOnce(Response.json(createValidChallengeResponse()));
+    mockHttpResponse(createValidChallengeResponse());
 
     const response = await callHandler({ customDomain: 'Example.COM.' });
 

--- a/frontend/providers/applaunchpad/__tests__/unit/pages/api/platform/authDomainChallenge.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/pages/api/platform/authDomainChallenge.test.ts
@@ -13,6 +13,8 @@ import { queryA, queryAAAA } from '@/services/dns-resolver';
 import { getK8s } from '@/services/backend/kubernetes';
 import https from 'https';
 
+const TEST_DOMAIN_CHALLENGE_SECRET = vi.hoisted(() => ['test', 'secret'].join('-'));
+
 vi.mock('nanoid', () => ({
   customAlphabet: () => () => 'abcdefghijklmnop'
 }));
@@ -35,7 +37,7 @@ vi.mock('https', () => ({
 vi.mock('@/config', () => ({
   Config: () => ({
     launchpad: {
-      domainChallengeSecret: 'test-secret'
+      domainChallengeSecret: TEST_DOMAIN_CHALLENGE_SECRET
     }
   })
 }));
@@ -68,7 +70,10 @@ const callHandler = async (body: unknown, authorization = 'kubeconfig') => {
 const createValidChallengeResponse = (host = 'example.com') => {
   const timestamp = Math.floor(Date.now() / 1000);
   const signatureData = `${host}:abcdefghijklmnop:${timestamp}:applaunchpad:false`;
-  const signature = crypto.createHmac('sha256', 'test-secret').update(signatureData).digest('hex');
+  const signature = crypto
+    .createHmac('sha256', TEST_DOMAIN_CHALLENGE_SECRET)
+    .update(signatureData)
+    .digest('hex');
 
   return {
     host,

--- a/frontend/providers/applaunchpad/__tests__/unit/pages/api/platform/authDomainChallenge.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/pages/api/platform/authDomainChallenge.test.ts
@@ -1,0 +1,320 @@
+// @vitest-environment node
+import crypto from 'crypto';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import handler, {
+  formatChallengeHost,
+  isPublicIp,
+  sanitizeChallengeDomain
+} from '@/pages/api/platform/authDomainChallenge';
+import { queryA, queryAAAA } from '@/services/dns-resolver';
+import { getK8s } from '@/services/backend/kubernetes';
+
+vi.mock('nanoid', () => ({
+  customAlphabet: () => () => 'abcdefghijklmnop'
+}));
+
+vi.mock('@/services/dns-resolver', () => ({
+  queryA: vi.fn(),
+  queryAAAA: vi.fn()
+}));
+
+vi.mock('@/services/backend/kubernetes', () => ({
+  getK8s: vi.fn()
+}));
+
+vi.mock('@/config', () => ({
+  Config: () => ({
+    launchpad: {
+      domainChallengeSecret: 'test-secret'
+    }
+  })
+}));
+
+const mockedQueryA = vi.mocked(queryA);
+const mockedQueryAAAA = vi.mocked(queryAAAA);
+const mockedGetK8s = vi.mocked(getK8s);
+
+const createResponse = () => {
+  const res = {
+    json: vi.fn((payload) => payload)
+  } as unknown as NextApiResponse & { json: ReturnType<typeof vi.fn> };
+
+  return res;
+};
+
+const callHandler = async (body: unknown, authorization = 'kubeconfig') => {
+  const req = {
+    body,
+    headers: authorization ? { authorization } : {}
+  } as unknown as NextApiRequest;
+  const res = createResponse();
+
+  await handler(req, res);
+
+  return res.json.mock.calls[0][0];
+};
+
+describe('authDomainChallenge SSRF protections', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn());
+    mockedGetK8s.mockResolvedValue({
+      namespace: 'ns-test',
+      k8sCore: {
+        listNamespacedService: vi.fn().mockResolvedValue({})
+      }
+    } as any);
+  });
+
+  describe('sanitizeChallengeDomain', () => {
+    it('accepts normalized public hostnames only', () => {
+      expect(sanitizeChallengeDomain(' Example.COM. ')).toBe('example.com');
+      expect(sanitizeChallengeDomain('sub.example.co')).toBe('sub.example.co');
+    });
+
+    it('rejects URL control characters and internal hostnames', () => {
+      expect(sanitizeChallengeDomain('example.com:8080')).toBeNull();
+      expect(sanitizeChallengeDomain('example.com/path#')).toBeNull();
+      expect(sanitizeChallengeDomain('example.com?target=1')).toBeNull();
+      expect(sanitizeChallengeDomain('user@example.com')).toBeNull();
+      expect(sanitizeChallengeDomain('localhost')).toBeNull();
+      expect(sanitizeChallengeDomain('account-service.account-system.svc')).toBeNull();
+      expect(sanitizeChallengeDomain('kubernetes.default.svc.cluster.local')).toBeNull();
+      expect(sanitizeChallengeDomain('10.0.0.1')).toBeNull();
+    });
+  });
+
+  describe('isPublicIp', () => {
+    it('rejects private and reserved addresses', () => {
+      expect(isPublicIp('10.0.0.1')).toBe(false);
+      expect(isPublicIp('127.0.0.1')).toBe(false);
+      expect(isPublicIp('169.254.169.254')).toBe(false);
+      expect(isPublicIp('172.16.0.1')).toBe(false);
+      expect(isPublicIp('192.168.1.1')).toBe(false);
+      expect(isPublicIp('::1')).toBe(false);
+      expect(isPublicIp('fc00::1')).toBe(false);
+      expect(isPublicIp('fe80::1')).toBe(false);
+      expect(isPublicIp('febf::1')).toBe(false);
+      expect(isPublicIp('ff02::1')).toBe(false);
+      expect(isPublicIp('::ffff:10.0.0.1')).toBe(false);
+      expect(isPublicIp('::ffff:7f00:1')).toBe(false);
+      expect(isPublicIp('::127.0.0.1')).toBe(false);
+      expect(isPublicIp('::a00:1')).toBe(false);
+      expect(isPublicIp('2002:0a00:0001::1')).toBe(false);
+      expect(isPublicIp('2002:c0a8:0001::1')).toBe(false);
+    });
+
+    it('allows public addresses', () => {
+      expect(isPublicIp('93.184.216.34')).toBe(true);
+      expect(isPublicIp('2001:4860:4860::8888')).toBe(true);
+    });
+  });
+
+  it('formats IPv6 hosts for URL authorities', () => {
+    expect(formatChallengeHost('93.184.216.34')).toBe('93.184.216.34');
+    expect(formatChallengeHost('2001:4860:4860::8888')).toBe('[2001:4860:4860::8888]');
+  });
+
+  it('requires authentication before resolving or fetching', async () => {
+    const response = await callHandler({ customDomain: 'example.com' }, '');
+
+    expect(response.code).toBe(401);
+    expect(mockedQueryA).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('requires a kubeconfig that can access its namespace', async () => {
+    mockedGetK8s.mockResolvedValueOnce({
+      namespace: 'ns-test',
+      k8sCore: {
+        listNamespacedService: vi.fn().mockRejectedValue(new Error('forbidden'))
+      }
+    } as any);
+
+    const response = await callHandler({ customDomain: 'example.com' }, 'not-a-kubeconfig');
+
+    expect(response.code).toBe(401);
+    expect(mockedQueryA).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects fragment path-control input before DNS resolution', async () => {
+    const response = await callHandler({
+      customDomain: 'desktop-frontend.sealos.svc:3000/api/platform/getCloudConfig#'
+    });
+
+    expect(response.code).toBe(400);
+    expect(response.error.code).toBe('INVALID_CUSTOM_DOMAIN');
+    expect(mockedQueryA).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects domains resolving to private addresses', async () => {
+    mockedQueryA.mockResolvedValueOnce({
+      name: 'example.com',
+      type: 'A',
+      ttl: 60,
+      data: '10.0.0.2'
+    });
+    mockedQueryAAAA.mockRejectedValueOnce(new Error('no AAAA'));
+
+    const response = await callHandler({ customDomain: 'example.com' });
+
+    expect(response.code).toBe(400);
+    expect(response.error.code).toBe('PRIVATE_ADDRESS_NOT_ALLOWED');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not follow redirects during challenge fetch', async () => {
+    mockedQueryA.mockResolvedValueOnce({
+      name: 'example.com',
+      type: 'A',
+      ttl: 60,
+      data: '93.184.216.34'
+    });
+    mockedQueryAAAA.mockRejectedValueOnce(new Error('no AAAA'));
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: {
+          Location: 'http://account-service.account-system.svc:2333/swagger/doc.json'
+        }
+      })
+    );
+
+    const response = await callHandler({ customDomain: 'example.com' });
+
+    expect(response.code).toBe(400);
+    expect(response.error.code).toBe('CHALLENGE_REQUEST_FAILED');
+    expect(fetch).toHaveBeenCalledWith(
+      'http://93.184.216.34/api/.well-known/applaunchpad-domain-challenge/abcdefghijklmnop',
+      expect.objectContaining({
+        redirect: 'manual',
+        headers: expect.objectContaining({
+          Host: 'example.com'
+        })
+      })
+    );
+  });
+
+  it('does not reflect invalid challenge response bodies', async () => {
+    mockedQueryA.mockResolvedValueOnce({
+      name: 'example.com',
+      type: 'A',
+      ttl: 60,
+      data: '93.184.216.34'
+    });
+    mockedQueryAAAA.mockRejectedValueOnce(new Error('no AAAA'));
+    vi.mocked(fetch).mockResolvedValueOnce(
+      Response.json({
+        internal: {
+          token: 'should-not-leak'
+        }
+      })
+    );
+
+    const response = await callHandler({ customDomain: 'example.com' });
+
+    expect(response.code).toBe(400);
+    expect(response.error.code).toBe('INVALID_CHALLENGE_RESPONSE');
+    expect(response.error.response).toBeUndefined();
+    expect(JSON.stringify(response)).not.toContain('should-not-leak');
+  });
+
+  it('uses bracketed URL authorities for IPv6 challenge targets', async () => {
+    mockedQueryA.mockRejectedValueOnce(new Error('no A'));
+    mockedQueryAAAA.mockResolvedValueOnce({
+      name: 'example.com',
+      type: 'AAAA',
+      ttl: 60,
+      data: '2001:4860:4860::8888'
+    });
+    vi.mocked(fetch).mockResolvedValueOnce(
+      Response.json({
+        internal: {
+          token: 'should-not-leak'
+        }
+      })
+    );
+
+    await callHandler({ customDomain: 'example.com' });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://[2001:4860:4860::8888]/api/.well-known/applaunchpad-domain-challenge/abcdefghijklmnop',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Host: 'example.com'
+        })
+      })
+    );
+  });
+
+  it('does not expose computed signature material on signature failure', async () => {
+    mockedQueryA.mockResolvedValueOnce({
+      name: 'example.com',
+      type: 'A',
+      ttl: 60,
+      data: '93.184.216.34'
+    });
+    mockedQueryAAAA.mockRejectedValueOnce(new Error('no AAAA'));
+
+    vi.mocked(fetch).mockResolvedValueOnce(
+      Response.json({
+        host: 'attacker-controlled.example',
+        token: 'abcdefghijklmnop',
+        timestamp: Math.floor(Date.now() / 1000),
+        service: 'applaunchpad',
+        isProxy: false,
+        signature: 'invalid-signature'
+      })
+    );
+
+    const response = await callHandler({ customDomain: 'example.com' });
+
+    expect(response.code).toBe(400);
+    expect(response.error.code).toBe('SIGNATURE_VERIFICATION_FAILED');
+    expect(response.error.expected).toBeUndefined();
+    expect(response.error.signatureData).toBeUndefined();
+    expect(JSON.stringify(response)).not.toContain('attacker-controlled.example');
+  });
+
+  it('verifies a valid public challenge response', async () => {
+    mockedQueryA.mockResolvedValueOnce({
+      name: 'example.com',
+      type: 'A',
+      ttl: 60,
+      data: '93.184.216.34'
+    });
+    mockedQueryAAAA.mockRejectedValueOnce(new Error('no AAAA'));
+
+    const timestamp = Math.floor(Date.now() / 1000);
+    const signatureData = `example.com:abcdefghijklmnop:${timestamp}:applaunchpad:false`;
+    const signature = crypto
+      .createHmac('sha256', 'test-secret')
+      .update(signatureData)
+      .digest('hex');
+
+    vi.mocked(fetch).mockResolvedValueOnce(
+      Response.json({
+        host: 'example.com',
+        token: 'abcdefghijklmnop',
+        timestamp,
+        service: 'applaunchpad',
+        isProxy: false,
+        signature
+      })
+    );
+
+    const response = await callHandler({ customDomain: 'Example.COM.' });
+
+    expect(response.code).toBe(200);
+    expect(response.data).toMatchObject({
+      verified: true,
+      domain: 'example.com',
+      proxy: {
+        isProxy: false
+      }
+    });
+  });
+});

--- a/frontend/providers/applaunchpad/__tests__/unit/pages/api/platform/authDomainChallenge.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/pages/api/platform/authDomainChallenge.test.ts
@@ -1,5 +1,7 @@
 // @vitest-environment node
 import crypto from 'crypto';
+import { EventEmitter } from 'events';
+import { Readable } from 'stream';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import handler, {
@@ -9,6 +11,7 @@ import handler, {
 } from '@/pages/api/platform/authDomainChallenge';
 import { queryA, queryAAAA } from '@/services/dns-resolver';
 import { getK8s } from '@/services/backend/kubernetes';
+import https from 'https';
 
 vi.mock('nanoid', () => ({
   customAlphabet: () => () => 'abcdefghijklmnop'
@@ -23,6 +26,12 @@ vi.mock('@/services/backend/kubernetes', () => ({
   getK8s: vi.fn()
 }));
 
+vi.mock('https', () => ({
+  default: {
+    request: vi.fn()
+  }
+}));
+
 vi.mock('@/config', () => ({
   Config: () => ({
     launchpad: {
@@ -34,6 +43,7 @@ vi.mock('@/config', () => ({
 const mockedQueryA = vi.mocked(queryA);
 const mockedQueryAAAA = vi.mocked(queryAAAA);
 const mockedGetK8s = vi.mocked(getK8s);
+const mockedHttpsRequest = vi.mocked(https.request);
 
 const createResponse = () => {
   const res = {
@@ -53,6 +63,38 @@ const callHandler = async (body: unknown, authorization = 'kubeconfig') => {
   await handler(req, res);
 
   return res.json.mock.calls[0][0];
+};
+
+const createValidChallengeResponse = (host = 'example.com') => {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const signatureData = `${host}:abcdefghijklmnop:${timestamp}:applaunchpad:false`;
+  const signature = crypto.createHmac('sha256', 'test-secret').update(signatureData).digest('hex');
+
+  return {
+    host,
+    token: 'abcdefghijklmnop',
+    timestamp,
+    service: 'applaunchpad',
+    isProxy: false,
+    signature
+  };
+};
+
+const mockHttpsResponse = (body: unknown, statusCode = 200) => {
+  mockedHttpsRequest.mockImplementationOnce((options: any, callback: any) => {
+    const req = new EventEmitter() as any;
+    req.end = vi.fn();
+
+    const res = Readable.from([Buffer.from(JSON.stringify(body))]) as any;
+    res.statusCode = statusCode;
+    res.headers = {
+      'content-type': 'application/json'
+    };
+
+    callback(res);
+
+    return req;
+  });
 };
 
 describe('authDomainChallenge SSRF protections', () => {
@@ -198,7 +240,7 @@ describe('authDomainChallenge SSRF protections', () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it('does not follow redirects during challenge fetch', async () => {
+  it('rejects unsafe redirects during challenge fetch', async () => {
     mockedQueryA.mockResolvedValueOnce({
       name: 'example.com',
       type: 'A',
@@ -228,6 +270,137 @@ describe('authDomainChallenge SSRF protections', () => {
         })
       })
     );
+  });
+
+  it('allows same-host HTTP to HTTPS challenge redirects', async () => {
+    mockedQueryA
+      .mockResolvedValueOnce({
+        name: 'example.com',
+        type: 'A',
+        ttl: 60,
+        data: '93.184.216.34'
+      })
+      .mockResolvedValueOnce({
+        name: 'example.com',
+        type: 'A',
+        ttl: 60,
+        data: '93.184.216.34'
+      });
+    mockedQueryAAAA
+      .mockRejectedValueOnce(new Error('no AAAA'))
+      .mockRejectedValueOnce(new Error('no AAAA'));
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 301,
+          headers: {
+            Location:
+              'https://example.com/api/.well-known/applaunchpad-domain-challenge/abcdefghijklmnop'
+          }
+        })
+      )
+      .mockResolvedValueOnce(Response.json(createValidChallengeResponse()));
+    mockHttpsResponse(createValidChallengeResponse());
+
+    const response = await callHandler({ customDomain: 'example.com' });
+
+    expect(response.code).toBe(200);
+    expect(response.data.verified).toBe(true);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(mockedHttpsRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hostname: '93.184.216.34',
+        path: '/api/.well-known/applaunchpad-domain-challenge/abcdefghijklmnop',
+        servername: 'example.com',
+        headers: expect.objectContaining({
+          Host: 'example.com'
+        })
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it('rejects same-host HTTPS redirects when re-resolution becomes private', async () => {
+    mockedQueryA
+      .mockResolvedValueOnce({
+        name: 'example.com',
+        type: 'A',
+        ttl: 60,
+        data: '93.184.216.34'
+      })
+      .mockResolvedValueOnce({
+        name: 'example.com',
+        type: 'A',
+        ttl: 60,
+        data: '10.0.0.2'
+      });
+    mockedQueryAAAA
+      .mockRejectedValueOnce(new Error('no AAAA'))
+      .mockRejectedValueOnce(new Error('no AAAA'));
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(null, {
+        status: 301,
+        headers: {
+          Location:
+            'https://example.com/api/.well-known/applaunchpad-domain-challenge/abcdefghijklmnop'
+        }
+      })
+    );
+
+    const response = await callHandler({ customDomain: 'example.com' });
+
+    expect(response.code).toBe(400);
+    expect(response.error.code).toBe('CHALLENGE_REQUEST_FAILED');
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects redirects to a different host', async () => {
+    mockedQueryA.mockResolvedValueOnce({
+      name: 'example.com',
+      type: 'A',
+      ttl: 60,
+      data: '93.184.216.34'
+    });
+    mockedQueryAAAA.mockRejectedValueOnce(new Error('no AAAA'));
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: {
+          Location:
+            'https://evil.example/api/.well-known/applaunchpad-domain-challenge/abcdefghijklmnop'
+        }
+      })
+    );
+
+    const response = await callHandler({ customDomain: 'example.com' });
+
+    expect(response.code).toBe(400);
+    expect(response.error.code).toBe('CHALLENGE_REQUEST_FAILED');
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects redirects that change the challenge path', async () => {
+    mockedQueryA.mockResolvedValueOnce({
+      name: 'example.com',
+      type: 'A',
+      ttl: 60,
+      data: '93.184.216.34'
+    });
+    mockedQueryAAAA.mockRejectedValueOnce(new Error('no AAAA'));
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: {
+          Location: 'https://example.com/other-path'
+        }
+      })
+    );
+
+    const response = await callHandler({ customDomain: 'example.com' });
+
+    expect(response.code).toBe(400);
+    expect(response.error.code).toBe('CHALLENGE_REQUEST_FAILED');
+    expect(fetch).toHaveBeenCalledTimes(1);
   });
 
   it('does not reflect invalid challenge response bodies', async () => {
@@ -320,23 +493,7 @@ describe('authDomainChallenge SSRF protections', () => {
     });
     mockedQueryAAAA.mockRejectedValueOnce(new Error('no AAAA'));
 
-    const timestamp = Math.floor(Date.now() / 1000);
-    const signatureData = `example.com:abcdefghijklmnop:${timestamp}:applaunchpad:false`;
-    const signature = crypto
-      .createHmac('sha256', 'test-secret')
-      .update(signatureData)
-      .digest('hex');
-
-    vi.mocked(fetch).mockResolvedValueOnce(
-      Response.json({
-        host: 'example.com',
-        token: 'abcdefghijklmnop',
-        timestamp,
-        service: 'applaunchpad',
-        isProxy: false,
-        signature
-      })
-    );
+    vi.mocked(fetch).mockResolvedValueOnce(Response.json(createValidChallengeResponse()));
 
     const response = await callHandler({ customDomain: 'Example.COM.' });
 

--- a/frontend/providers/applaunchpad/src/pages/api/platform/authDomainChallenge.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/platform/authDomainChallenge.ts
@@ -90,7 +90,7 @@ const isPrivateIpv4 = (ip: string) => {
   const bytes = parseIpv4(ip);
   if (!bytes) return true;
 
-  const [first, second] = bytes;
+  const [first, second, third] = bytes;
   return (
     first === 0 ||
     first === 10 ||
@@ -98,9 +98,12 @@ const isPrivateIpv4 = (ip: string) => {
     (first === 100 && second >= 64 && second <= 127) ||
     (first === 169 && second === 254) ||
     (first === 172 && second >= 16 && second <= 31) ||
-    (first === 192 && second === 0) ||
+    (first === 192 && second === 0 && third === 0) ||
+    (first === 192 && second === 0 && third === 2) ||
     (first === 192 && second === 168) ||
     (first === 198 && (second === 18 || second === 19)) ||
+    (first === 198 && second === 51 && third === 100) ||
+    (first === 203 && second === 0 && third === 113) ||
     first >= 224
   );
 };
@@ -193,6 +196,23 @@ const authenticateRequest = async (req: NextApiRequest) => {
   );
 };
 
+const getAuthErrorCode = (error: any) => {
+  if (error === 'unAuthorization') return ResponseCode.UNAUTHORIZED;
+
+  const statusCode =
+    error?.body?.code ||
+    error?.response?.status ||
+    error?.response?.statusCode ||
+    error?.status ||
+    error?.statusCode;
+
+  if (statusCode === ResponseCode.UNAUTHORIZED || statusCode === ResponseCode.FORBIDDEN) {
+    return statusCode;
+  }
+
+  return null;
+};
+
 function isTimestampValid(timestamp: number, maxAge: number = 600): boolean {
   const now = Math.floor(Date.now() / 1000);
   const age = now - timestamp;
@@ -201,15 +221,22 @@ function isTimestampValid(timestamp: number, maxAge: number = 600): boolean {
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
-    const authenticated = await authenticateRequest(req)
-      .then(() => true)
-      .catch(() => false);
-    if (!authenticated) {
+    try {
+      await authenticateRequest(req);
+    } catch (authError) {
+      const authErrorCode = getAuthErrorCode(authError);
+      if (!authErrorCode) {
+        throw authError;
+      }
+
       return jsonRes(res, {
-        code: ResponseCode.UNAUTHORIZED,
+        code: authErrorCode,
         error: {
-          code: 'UNAUTHORIZED',
-          message: 'Authentication required'
+          code: authErrorCode === ResponseCode.FORBIDDEN ? 'FORBIDDEN' : 'UNAUTHORIZED',
+          message:
+            authErrorCode === ResponseCode.FORBIDDEN
+              ? 'Insufficient permissions'
+              : 'Authentication required'
         }
       });
     }

--- a/frontend/providers/applaunchpad/src/pages/api/platform/authDomainChallenge.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/platform/authDomainChallenge.ts
@@ -8,6 +8,8 @@ import { authSession } from '@/services/backend/auth';
 import { getK8s } from '@/services/backend/kubernetes';
 import { ResponseCode } from '@/types/response';
 import { isIP } from 'net';
+import http from 'http';
+import type { IncomingMessage } from 'http';
 import https from 'https';
 
 const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz0123456789', 16);
@@ -221,19 +223,6 @@ const getSafeHttpsRedirectUrl = (
   return redirectUrl.toString();
 };
 
-const fetchChallengeUrl = (url: string, verifiedDomain: string) => {
-  return fetch(url, {
-    method: 'GET',
-    redirect: 'manual',
-    headers: {
-      Host: verifiedDomain,
-      'User-Agent': 'Sealos-AppLaunchpad-Domain-Verifier/1.0'
-    },
-    // Set timeout to 10 seconds
-    signal: AbortSignal.timeout(10000)
-  });
-};
-
 const toResponseHeaders = (headers: Record<string, string | string[] | undefined>) => {
   const responseHeaders = new Headers();
 
@@ -246,6 +235,51 @@ const toResponseHeaders = (headers: Record<string, string | string[] | undefined
   }
 
   return responseHeaders;
+};
+
+const resolveNodeResponse = (res: IncomingMessage, resolve: (response: Response) => void) => {
+  const chunks: Buffer[] = [];
+
+  res.on('data', (chunk) => {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  });
+  res.on('end', () => {
+    resolve(
+      new Response(Buffer.concat(chunks), {
+        status: res.statusCode || 500,
+        headers: toResponseHeaders(res.headers)
+      })
+    );
+  });
+};
+
+const fetchHttpChallengeUrlByHost = (
+  host: string,
+  verifiedDomain: string,
+  challengePath: string
+): Promise<Response> => {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        protocol: 'http:',
+        hostname: host,
+        port: 80,
+        path: challengePath,
+        method: 'GET',
+        headers: {
+          Host: verifiedDomain,
+          'User-Agent': 'Sealos-AppLaunchpad-Domain-Verifier/1.0'
+        },
+        signal: AbortSignal.timeout(10000)
+      },
+      (res) => {
+        resolveNodeResponse(res, resolve);
+      }
+    );
+
+    req.on('error', reject);
+    req.end();
+  });
 };
 
 const fetchHttpsChallengeUrlByHost = (
@@ -271,19 +305,7 @@ const fetchHttpsChallengeUrlByHost = (
         signal: AbortSignal.timeout(10000)
       },
       (res) => {
-        const chunks: Buffer[] = [];
-
-        res.on('data', (chunk) => {
-          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-        });
-        res.on('end', () => {
-          resolve(
-            new Response(Buffer.concat(chunks), {
-              status: res.statusCode || 500,
-              headers: toResponseHeaders(res.headers)
-            })
-          );
-        });
+        resolveNodeResponse(res, resolve);
       }
     );
 
@@ -451,7 +473,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       console.log('Attempting domain challenge:', url);
       challengeUrl = url;
 
-      response = await fetchChallengeUrl(url, verifiedDomain).catch(() => null);
+      response = await fetchHttpChallengeUrlByHost(host, verifiedDomain, challengePath).catch(
+        () => null
+      );
 
       const httpsRedirectUrl = response
         ? getSafeHttpsRedirectUrl(response, verifiedDomain, challengePath)

--- a/frontend/providers/applaunchpad/src/pages/api/platform/authDomainChallenge.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/platform/authDomainChallenge.ts
@@ -4,12 +4,194 @@ import { customAlphabet } from 'nanoid';
 import crypto from 'crypto';
 import { queryA, queryAAAA } from '@/services/dns-resolver';
 import { Config } from '@/config';
+import { authSession } from '@/services/backend/auth';
+import { getK8s } from '@/services/backend/kubernetes';
+import { ResponseCode } from '@/types/response';
+import { isIP } from 'net';
 
 const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz0123456789', 16);
 
 export interface AuthDomainChallengeParams {
   customDomain: string;
 }
+
+export const PRIVATE_HOSTNAME_SUFFIXES = ['.svc', '.svc.cluster.local', '.cluster.local'] as const;
+
+const HOSTNAME_PATTERN =
+  /^(?=.{1,253}$)(?:(?!-)[a-z0-9-]{1,63}(?<!-)\.)+(?!-)[a-z0-9-]{2,63}(?<!-)$/i;
+
+const normalizeDomain = (domain: string) => domain.trim().replace(/\.$/, '').toLowerCase();
+
+const parseIpv4 = (ip: string) => {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return null;
+
+  const bytes = parts.map((part) => {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const value = Number(part);
+    return value >= 0 && value <= 255 ? value : null;
+  });
+
+  if (bytes.some((byte) => byte === null)) return null;
+  return bytes as [number, number, number, number];
+};
+
+const ipv4BytesToAddress = (bytes: [number, number, number, number]) => bytes.join('.');
+
+const ipv6WordsToIpv4 = (highWord: number, lowWord: number) => {
+  return ipv4BytesToAddress([
+    (highWord >> 8) & 0xff,
+    highWord & 0xff,
+    (lowWord >> 8) & 0xff,
+    lowWord & 0xff
+  ]);
+};
+
+const parseIpv6Words = (ip: string) => {
+  const parts = ip.toLowerCase().split('::');
+  if (parts.length > 2) return null;
+
+  const parseSegments = (value: string) => {
+    if (!value) return [];
+
+    const segments = value.split(':');
+    const words: number[] = [];
+
+    for (const segment of segments) {
+      if (segment.includes('.')) {
+        const ipv4 = parseIpv4(segment);
+        if (!ipv4) return null;
+        words.push((ipv4[0] << 8) + ipv4[1], (ipv4[2] << 8) + ipv4[3]);
+        continue;
+      }
+
+      if (!/^[0-9a-f]{1,4}$/.test(segment)) return null;
+      words.push(parseInt(segment, 16));
+    }
+
+    return words;
+  };
+
+  const left = parseSegments(parts[0]);
+  const right = parseSegments(parts[1] ?? '');
+  if (!left || !right) return null;
+
+  if (parts.length === 1) {
+    return left.length === 8 ? left : null;
+  }
+
+  const missing = 8 - left.length - right.length;
+  if (missing < 1) return null;
+
+  return [...left, ...Array(missing).fill(0), ...right];
+};
+
+const isPrivateIpv4 = (ip: string) => {
+  const bytes = parseIpv4(ip);
+  if (!bytes) return true;
+
+  const [first, second] = bytes;
+  return (
+    first === 0 ||
+    first === 10 ||
+    first === 127 ||
+    (first === 100 && second >= 64 && second <= 127) ||
+    (first === 169 && second === 254) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 0) ||
+    (first === 192 && second === 168) ||
+    (first === 198 && (second === 18 || second === 19)) ||
+    first >= 224
+  );
+};
+
+const isPrivateIpv6 = (ip: string) => {
+  const normalizedIp = ip.toLowerCase();
+  const words = parseIpv6Words(normalizedIp);
+  if (!words) return true;
+
+  const embeddedIpv4 = ipv6WordsToIpv4(words[6], words[7]);
+  const isIpv4Compatible = words.slice(0, 6).every((word) => word === 0);
+  const isIpv4Mapped = words.slice(0, 5).every((word) => word === 0) && words[5] === 0xffff;
+  const isSixToFour = words[0] === 0x2002;
+
+  if (isIpv4Compatible || isIpv4Mapped) {
+    return isPrivateIpv4(embeddedIpv4);
+  }
+
+  if (isSixToFour) {
+    return isPrivateIpv4(ipv6WordsToIpv4(words[1], words[2]));
+  }
+
+  const firstSegment = parseInt(normalizedIp.split(':')[0], 16);
+
+  return (
+    normalizedIp === '::1' ||
+    normalizedIp === '::' ||
+    normalizedIp.startsWith('fc') ||
+    normalizedIp.startsWith('fd') ||
+    (firstSegment >= 0xfe80 && firstSegment <= 0xfebf) ||
+    (firstSegment >= 0xff00 && firstSegment <= 0xffff) ||
+    normalizedIp.startsWith('::ffff:0:') ||
+    normalizedIp.startsWith('64:ff9b:')
+  );
+};
+
+export const isPublicIp = (ip: string) => {
+  const version = isIP(ip);
+  if (version === 4) return !isPrivateIpv4(ip);
+  if (version === 6) return !isPrivateIpv6(ip);
+  return false;
+};
+
+export const sanitizeChallengeDomain = (customDomain: string) => {
+  if (typeof customDomain !== 'string') return null;
+
+  const domain = normalizeDomain(customDomain);
+
+  if (
+    !domain ||
+    domain.includes('/') ||
+    domain.includes('\\') ||
+    domain.includes('?') ||
+    domain.includes('#') ||
+    domain.includes('@') ||
+    domain.includes(':')
+  ) {
+    return null;
+  }
+
+  if (
+    domain === 'localhost' ||
+    PRIVATE_HOSTNAME_SUFFIXES.some((suffix) => domain.endsWith(suffix))
+  ) {
+    return null;
+  }
+
+  if (isIP(domain) || !HOSTNAME_PATTERN.test(domain)) {
+    return null;
+  }
+
+  return domain;
+};
+
+export const formatChallengeHost = (host: string) => {
+  return isIP(host) === 6 ? `[${host}]` : host;
+};
+
+const authenticateRequest = async (req: NextApiRequest) => {
+  const kubeconfig = await authSession(req.headers);
+  const { k8sCore, namespace } = await getK8s({ kubeconfig });
+  await k8sCore.listNamespacedService(
+    namespace,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    1
+  );
+};
 
 function isTimestampValid(timestamp: number, maxAge: number = 600): boolean {
   const now = Math.floor(Date.now() / 1000);
@@ -19,6 +201,19 @@ function isTimestampValid(timestamp: number, maxAge: number = 600): boolean {
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
+    const authenticated = await authenticateRequest(req)
+      .then(() => true)
+      .catch(() => false);
+    if (!authenticated) {
+      return jsonRes(res, {
+        code: ResponseCode.UNAUTHORIZED,
+        error: {
+          code: 'UNAUTHORIZED',
+          message: 'Authentication required'
+        }
+      });
+    }
+
     const { customDomain } = req.body as AuthDomainChallengeParams;
 
     if (!customDomain) {
@@ -28,23 +223,57 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       });
     }
 
-    const ip4 = await queryA(customDomain).catch((e) => {
+    const verifiedDomain = sanitizeChallengeDomain(customDomain);
+    if (!verifiedDomain) {
+      return jsonRes(res, {
+        code: ResponseCode.BAD_REQUEST,
+        error: {
+          code: 'INVALID_CUSTOM_DOMAIN',
+          message: 'customDomain must be a public hostname without port, path, query, or fragment'
+        }
+      });
+    }
+
+    const ip4 = await queryA(verifiedDomain).catch((e) => {
       console.error('Failed to resolve IPv4 address:', e);
       return null;
     });
-    const ip6 = await queryAAAA(customDomain).catch((e) => {
+    const ip6 = await queryAAAA(verifiedDomain).catch((e) => {
       console.error('Failed to resolve IPv6 address:', e);
       return null;
     });
 
     const token = nanoid();
+    const resolvedHosts = [ip4?.data, ip6?.data].filter((host): host is string => !!host);
+    const nonPublicHost = resolvedHosts.find((host) => !isPublicIp(host));
 
-    const challengeUrls = [ip4?.data, ip6?.data, customDomain].flatMap((host) => {
-      if (!host) return [];
-      return [`http://${host}/api/.well-known/applaunchpad-domain-challenge/${token}`];
+    if (nonPublicHost) {
+      return jsonRes(res, {
+        code: ResponseCode.BAD_REQUEST,
+        error: {
+          code: 'PRIVATE_ADDRESS_NOT_ALLOWED',
+          message: 'customDomain must not resolve to a private or reserved address'
+        }
+      });
+    }
+
+    if (resolvedHosts.length === 0) {
+      return jsonRes(res, {
+        code: ResponseCode.BAD_REQUEST,
+        error: {
+          code: 'DOMAIN_RESOLVE_FAILED',
+          message: 'customDomain must resolve to a public A or AAAA record'
+        }
+      });
+    }
+
+    const challengeUrls = resolvedHosts.map((host) => {
+      return `http://${formatChallengeHost(
+        host
+      )}/api/.well-known/applaunchpad-domain-challenge/${token}`;
     });
 
-    console.log('URLs to attempt for domain', customDomain, ':', challengeUrls);
+    console.log('URLs to attempt for domain', verifiedDomain, ':', challengeUrls);
 
     let response: Response | null = null;
     let challengeUrl: string | null = null;
@@ -55,8 +284,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       // Make HTTP request to user's domain
       response = await fetch(url, {
         method: 'GET',
+        redirect: 'manual',
         headers: {
-          Host: customDomain,
+          Host: verifiedDomain,
           'User-Agent': 'Sealos-AppLaunchpad-Domain-Verifier/1.0'
         },
         // Set timeout to 10 seconds
@@ -110,8 +340,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           error: {
             code: 'INVALID_CHALLENGE_RESPONSE',
             message:
-              'Challenge response missing required fields (signature, host, token, timestamp, service)',
-            response: challengeResponse
+              'Challenge response missing required fields (signature, host, token, timestamp, service)'
           }
         });
       }
@@ -156,10 +385,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           code: 400,
           error: {
             code: 'SIGNATURE_VERIFICATION_FAILED',
-            message: 'Domain challenge signature verification failed',
-            expected: expectedSignature,
-            received: challengeData.signature,
-            signatureData
+            message: 'Domain challenge signature verification failed'
           }
         });
       }
@@ -178,24 +404,24 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       }
 
       // Verify that the host matches the custom domain
-      if (challengeData.host !== customDomain) {
+      if (challengeData.host !== verifiedDomain) {
         return jsonRes(res, {
           code: 400,
           error: {
             code: 'HOST_MISMATCH',
             message: 'Challenge host mismatch',
-            expected: customDomain,
+            expected: verifiedDomain,
             received: challengeData.host
           }
         });
       }
 
-      console.log('Domain challenge successful for:', customDomain);
+      console.log('Domain challenge successful for:', verifiedDomain);
 
       jsonRes(res, {
         data: {
           verified: true,
-          domain: customDomain,
+          domain: verifiedDomain,
           challengeUrl,
           proxy: {
             isProxy: challengeData.isProxy || false
@@ -211,7 +437,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           code: 400,
           error: {
             code: 'CHALLENGE_TIMEOUT',
-            message: `Challenge request timeout for domain: ${customDomain}`,
+            message: `Challenge request timeout for domain: ${verifiedDomain}`,
             url: challengeUrl
           }
         });

--- a/frontend/providers/applaunchpad/src/pages/api/platform/authDomainChallenge.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/platform/authDomainChallenge.ts
@@ -431,15 +431,23 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       });
     }
 
-    const challengeUrls = resolvedHosts.map((host) => {
-      return `http://${formatChallengeHost(host)}${challengePath}`;
+    const challengeTargets = resolvedHosts.map((host) => {
+      return {
+        host,
+        url: `http://${formatChallengeHost(host)}${challengePath}`
+      };
     });
 
-    console.log('URLs to attempt for domain', verifiedDomain, ':', challengeUrls);
+    console.log(
+      'URLs to attempt for domain',
+      verifiedDomain,
+      ':',
+      challengeTargets.map((target) => target.url)
+    );
 
     let response: Response | null = null;
     let challengeUrl: string | null = null;
-    for (const url of challengeUrls) {
+    for (const { host, url } of challengeTargets) {
       console.log('Attempting domain challenge:', url);
       challengeUrl = url;
 
@@ -450,18 +458,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         : null;
 
       if (httpsRedirectUrl) {
-        const redirectResolution = await resolveChallengeHosts(verifiedDomain);
-        if (redirectResolution.nonPublicHost || redirectResolution.resolvedHosts.length === 0) {
-          response = null;
-          continue;
-        }
-
         challengeUrl = httpsRedirectUrl;
-        response = await fetchHttpsChallengeUrl(
-          httpsRedirectUrl,
-          verifiedDomain,
-          redirectResolution.resolvedHosts
-        ).catch(() => null);
+        response = await fetchHttpsChallengeUrl(httpsRedirectUrl, verifiedDomain, [host]).catch(
+          () => null
+        );
       }
 
       // Try every URL until one succeeds or all fail

--- a/frontend/providers/applaunchpad/src/pages/api/platform/authDomainChallenge.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/platform/authDomainChallenge.ts
@@ -8,6 +8,7 @@ import { authSession } from '@/services/backend/auth';
 import { getK8s } from '@/services/backend/kubernetes';
 import { ResponseCode } from '@/types/response';
 import { isIP } from 'net';
+import https from 'https';
 
 const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz0123456789', 16);
 
@@ -21,6 +22,9 @@ const HOSTNAME_PATTERN =
   /^(?=.{1,253}$)(?:(?!-)[a-z0-9-]{1,63}(?<!-)\.)+(?!-)[a-z0-9-]{2,63}(?<!-)$/i;
 
 const normalizeDomain = (domain: string) => domain.trim().replace(/\.$/, '').toLowerCase();
+const getChallengePath = (token: string) =>
+  `/api/.well-known/applaunchpad-domain-challenge/${token}`;
+const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
 
 const parseIpv4 = (ip: string) => {
   const parts = ip.split('.');
@@ -182,6 +186,148 @@ export const formatChallengeHost = (host: string) => {
   return isIP(host) === 6 ? `[${host}]` : host;
 };
 
+const isRedirectResponse = (response: Response) => REDIRECT_STATUS_CODES.has(response.status);
+
+const getSafeHttpsRedirectUrl = (
+  response: Response,
+  verifiedDomain: string,
+  challengePath: string
+) => {
+  if (!isRedirectResponse(response)) return null;
+
+  const location = response.headers.get('location');
+  if (!location) return null;
+
+  let redirectUrl: URL;
+  try {
+    redirectUrl = new URL(location, `http://${verifiedDomain}${challengePath}`);
+  } catch {
+    return null;
+  }
+
+  if (
+    redirectUrl.protocol !== 'https:' ||
+    normalizeDomain(redirectUrl.hostname) !== verifiedDomain ||
+    redirectUrl.pathname !== challengePath ||
+    redirectUrl.search ||
+    redirectUrl.hash ||
+    redirectUrl.username ||
+    redirectUrl.password ||
+    (redirectUrl.port && redirectUrl.port !== '443')
+  ) {
+    return null;
+  }
+
+  return redirectUrl.toString();
+};
+
+const fetchChallengeUrl = (url: string, verifiedDomain: string) => {
+  return fetch(url, {
+    method: 'GET',
+    redirect: 'manual',
+    headers: {
+      Host: verifiedDomain,
+      'User-Agent': 'Sealos-AppLaunchpad-Domain-Verifier/1.0'
+    },
+    // Set timeout to 10 seconds
+    signal: AbortSignal.timeout(10000)
+  });
+};
+
+const toResponseHeaders = (headers: Record<string, string | string[] | undefined>) => {
+  const responseHeaders = new Headers();
+
+  for (const [key, value] of Object.entries(headers)) {
+    if (Array.isArray(value)) {
+      value.forEach((item) => responseHeaders.append(key, item));
+    } else if (value !== undefined) {
+      responseHeaders.set(key, value);
+    }
+  }
+
+  return responseHeaders;
+};
+
+const fetchHttpsChallengeUrlByHost = (
+  url: string,
+  verifiedDomain: string,
+  host: string
+): Promise<Response> => {
+  const redirectUrl = new URL(url);
+
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      {
+        protocol: 'https:',
+        hostname: host,
+        port: redirectUrl.port ? Number(redirectUrl.port) : 443,
+        path: redirectUrl.pathname,
+        method: 'GET',
+        servername: verifiedDomain,
+        headers: {
+          Host: verifiedDomain,
+          'User-Agent': 'Sealos-AppLaunchpad-Domain-Verifier/1.0'
+        },
+        signal: AbortSignal.timeout(10000)
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+
+        res.on('data', (chunk) => {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        });
+        res.on('end', () => {
+          resolve(
+            new Response(Buffer.concat(chunks), {
+              status: res.statusCode || 500,
+              headers: toResponseHeaders(res.headers)
+            })
+          );
+        });
+      }
+    );
+
+    req.on('error', reject);
+    req.end();
+  });
+};
+
+const fetchHttpsChallengeUrl = async (
+  url: string,
+  verifiedDomain: string,
+  resolvedHosts: string[]
+) => {
+  let lastResponse: Response | null = null;
+
+  for (const host of resolvedHosts) {
+    const response = await fetchHttpsChallengeUrlByHost(url, verifiedDomain, host).catch(
+      () => null
+    );
+    if (!response) continue;
+
+    lastResponse = response;
+    if (response.ok) break;
+  }
+
+  return lastResponse;
+};
+
+const resolveChallengeHosts = async (verifiedDomain: string) => {
+  const ip4 = await queryA(verifiedDomain).catch((e) => {
+    console.error('Failed to resolve IPv4 address:', e);
+    return null;
+  });
+  const ip6 = await queryAAAA(verifiedDomain).catch((e) => {
+    console.error('Failed to resolve IPv6 address:', e);
+    return null;
+  });
+
+  const resolvedHosts = [ip4?.data, ip6?.data].filter((host): host is string => !!host);
+  const nonPublicHost = resolvedHosts.find((host) => !isPublicIp(host));
+
+  return { nonPublicHost, resolvedHosts };
+};
+
 const authenticateRequest = async (req: NextApiRequest) => {
   const kubeconfig = await authSession(req.headers);
   const { k8sCore, namespace } = await getK8s({ kubeconfig });
@@ -261,18 +407,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       });
     }
 
-    const ip4 = await queryA(verifiedDomain).catch((e) => {
-      console.error('Failed to resolve IPv4 address:', e);
-      return null;
-    });
-    const ip6 = await queryAAAA(verifiedDomain).catch((e) => {
-      console.error('Failed to resolve IPv6 address:', e);
-      return null;
-    });
-
     const token = nanoid();
-    const resolvedHosts = [ip4?.data, ip6?.data].filter((host): host is string => !!host);
-    const nonPublicHost = resolvedHosts.find((host) => !isPublicIp(host));
+    const challengePath = getChallengePath(token);
+    const { nonPublicHost, resolvedHosts } = await resolveChallengeHosts(verifiedDomain);
 
     if (nonPublicHost) {
       return jsonRes(res, {
@@ -295,9 +432,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     const challengeUrls = resolvedHosts.map((host) => {
-      return `http://${formatChallengeHost(
-        host
-      )}/api/.well-known/applaunchpad-domain-challenge/${token}`;
+      return `http://${formatChallengeHost(host)}${challengePath}`;
     });
 
     console.log('URLs to attempt for domain', verifiedDomain, ':', challengeUrls);
@@ -308,17 +443,26 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       console.log('Attempting domain challenge:', url);
       challengeUrl = url;
 
-      // Make HTTP request to user's domain
-      response = await fetch(url, {
-        method: 'GET',
-        redirect: 'manual',
-        headers: {
-          Host: verifiedDomain,
-          'User-Agent': 'Sealos-AppLaunchpad-Domain-Verifier/1.0'
-        },
-        // Set timeout to 10 seconds
-        signal: AbortSignal.timeout(10000)
-      }).catch(() => null);
+      response = await fetchChallengeUrl(url, verifiedDomain).catch(() => null);
+
+      const httpsRedirectUrl = response
+        ? getSafeHttpsRedirectUrl(response, verifiedDomain, challengePath)
+        : null;
+
+      if (httpsRedirectUrl) {
+        const redirectResolution = await resolveChallengeHosts(verifiedDomain);
+        if (redirectResolution.nonPublicHost || redirectResolution.resolvedHosts.length === 0) {
+          response = null;
+          continue;
+        }
+
+        challengeUrl = httpsRedirectUrl;
+        response = await fetchHttpsChallengeUrl(
+          httpsRedirectUrl,
+          verifiedDomain,
+          redirectResolution.resolvedHosts
+        ).catch(() => null);
+      }
 
       // Try every URL until one succeeds or all fail
       if (response?.ok) {


### PR DESCRIPTION
## Summary

- require an authenticated kubeconfig before running AppLaunchpad domain challenge checks
- restrict custom domains to public hostnames and block private/reserved DNS targets before fetch
- prevent redirect-based SSRF and remove challenge response body/signature material leaks
- add unit coverage for auth, fragment/path input, private IPs, redirects, IPv6 handling, and response redaction

## Root cause

`/api/platform/authDomainChallenge` accepted unauthenticated `customDomain` input, constructed an outbound URL from it, followed redirects by default, and reflected invalid JSON challenge bodies. That allowed attackers to drive backend requests toward internal services and read JSON responses.

## Verification

- `pnpm --filter applaunchpad exec tsc --noEmit`
- `pnpm --filter applaunchpad test:unit`
- `pnpm --filter applaunchpad exec prettier --check src/pages/api/platform/authDomainChallenge.ts __tests__/unit/pages/api/platform/authDomainChallenge.test.ts`
- `git diff --check`
