### PR TITLE
refactor(applaunchpad): use Quantity resources

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -7,4 +7,6 @@ next-env.d.ts
 .claude
 .agents
 skills-lock.json
-**/test-results/
+.omx
+AGENTS.md
+.sisyphus

--- a/frontend/packages/shared/src/utils/quantities/zod.ts
+++ b/frontend/packages/shared/src/utils/quantities/zod.ts
@@ -4,23 +4,29 @@ import { Quantity } from './quantity';
 import type { QuantityJSON } from './types';
 
 /**
- * Accepts `string | number` (OpenAPI v3 oneOf compatible) and transforms it into an immutable `Quantity`.
+ * Accepts `string | number` JSON values and already-hydrated `Quantity` instances.
  *
  * Note: JSON numbers in JS may already lose precision. Prefer using strings in business code.
  */
-export const QuantitySchema = z.union([z.string(), z.number()]).transform((v, ctx) => {
-  try {
-    return Quantity.fromJSON(v satisfies QuantityJSON);
-  } catch (e) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: e instanceof Error ? e.message : 'Invalid quantity'
-    });
-    return z.NEVER;
-  }
-});
+const HydratedQuantitySchema = z.custom<Quantity>((v) => v instanceof Quantity);
 
-/** Input type accepted by `QuantitySchema` (string | number). */
+export const QuantitySchema = z
+  .union([HydratedQuantitySchema, z.string(), z.number()])
+  .transform((v, ctx) => {
+    if (v instanceof Quantity) return v;
+
+    try {
+      return Quantity.fromJSON(v satisfies QuantityJSON);
+    } catch (e) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: e instanceof Error ? e.message : 'Invalid quantity'
+      });
+      return z.NEVER;
+    }
+  });
+
+/** Input type accepted by `QuantitySchema` (Quantity | string | number). */
 export type QuantitySchemaInput = z.input<typeof QuantitySchema>;
 /** Output type of `QuantitySchema` (Quantity). */
 export type QuantitySchemaOutput = z.output<typeof QuantitySchema>;

--- a/frontend/providers/applaunchpad/__tests__/unit/api/app.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/api/app.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Quantity } from '@sealos/shared';
+import { getAppByName, getAppPodsByAppName } from '@/api/app';
+import { MOCK_APP_DETAIL, MOCK_PODS } from '@/mock/apps';
+import { GET } from '@/services/request';
+
+vi.mock('@/services/request', () => ({
+  GET: vi.fn(),
+  POST: vi.fn(),
+  DELETE: vi.fn()
+}));
+
+vi.mock('@sealos/gtm', () => ({
+  track: vi.fn()
+}));
+
+const mockedGET = vi.mocked(GET);
+
+describe('getAppByName', () => {
+  it('hydrates Quantity fields from the API JSON payload', async () => {
+    const payload = JSON.parse(JSON.stringify(MOCK_APP_DETAIL));
+    payload.storeList = [
+      {
+        name: 'data',
+        path: '/data',
+        value: '2Gi'
+      }
+    ];
+
+    mockedGET.mockResolvedValueOnce(payload);
+
+    const app = await getAppByName('hello-world');
+
+    expect(app.cpu).toBeInstanceOf(Quantity);
+    expect(app.cpu.formatForDisplay({ format: 'DecimalSI' })).toBe('200m');
+    expect(app.memory).toBeInstanceOf(Quantity);
+    expect(app.memory.formatForDisplay({ format: 'BinarySI' })).toBe('256Mi');
+    expect(app.storeList[0]?.value).toBeInstanceOf(Quantity);
+    expect(app.storeList[0]?.value.formatForDisplay({ format: 'BinarySI' })).toBe('2Gi');
+  });
+});
+
+describe('getAppPodsByAppName', () => {
+  it('hydrates pod Quantity fields from the API JSON payload', async () => {
+    const payload = JSON.parse(JSON.stringify(MOCK_PODS));
+    payload[0].cpu = '500m';
+    payload[0].memory = '128Mi';
+
+    mockedGET.mockResolvedValueOnce(payload);
+
+    const pods = await getAppPodsByAppName('hello-world');
+
+    expect(pods[0]?.cpu).toBeInstanceOf(Quantity);
+    expect(pods[0]?.cpu.formatForDisplay({ format: 'DecimalSI' })).toBe('500m');
+    expect(pods[0]?.memory).toBeInstanceOf(Quantity);
+    expect(pods[0]?.memory.formatForDisplay({ format: 'BinarySI' })).toBe('128Mi');
+  });
+});

--- a/frontend/providers/applaunchpad/__tests__/unit/types/request_schema.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/types/request_schema.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import { Quantity } from '@sealos/shared';
+import { transformFromLegacySchema, transformToLegacySchema } from '@/types/request_schema';
+import {
+  transformFromLegacySchema as transformFromLegacySchemaV2,
+  transformToLegacySchema as transformToLegacySchemaV2
+} from '@/types/v2alpha/request_schema';
+import type { AppDetailType } from '@/types/app';
+
+const baseV1Request = {
+  name: 'demo',
+  image: { imageName: 'nginx' },
+  launchCommand: {},
+  resource: {
+    replicas: 1,
+    cpu: 0.5,
+    memory: 1
+  },
+  ports: [],
+  env: [],
+  storage: [],
+  configMap: []
+};
+
+const baseV2Request = {
+  name: 'demo',
+  image: { imageName: 'nginx' },
+  launchCommand: {},
+  quota: {
+    replicas: 1,
+    cpu: 0.5,
+    memory: 1
+  },
+  ports: [],
+  env: [],
+  storage: [],
+  configMap: []
+};
+
+const baseDetail = {
+  appName: 'demo',
+  imageName: 'nginx',
+  runCMD: '',
+  cmdParam: '',
+  replicas: 1,
+  cpu: Quantity.parse('500m'),
+  memory: Quantity.parse('1Gi'),
+  networks: [],
+  envs: [],
+  hpa: {
+    use: false,
+    target: 'cpu',
+    value: 50,
+    minReplicas: 1,
+    maxReplicas: 5
+  },
+  secret: {
+    use: false,
+    username: '',
+    password: '',
+    serverAddress: 'docker.io'
+  },
+  configMapList: [],
+  storeList: [],
+  labels: {},
+  volumes: [],
+  volumeMounts: [],
+  kind: 'deployment',
+  id: 'uid',
+  createTime: '2024-01-01 00:00',
+  status: {
+    label: 'Running',
+    value: 'running',
+    color: '',
+    backgroundColor: '',
+    dotColor: ''
+  },
+  isPause: false,
+  usedCpu: { name: '', xData: [], yData: [] },
+  usedMemory: { name: '', xData: [], yData: [] },
+  crYamlList: [],
+  source: {
+    hasSource: false,
+    sourceName: '',
+    sourceType: 'app_store'
+  },
+  openapi: {
+    status: {
+      observedGeneration: 1,
+      replicas: 1,
+      availableReplicas: 1,
+      updatedReplicas: 1,
+      isPause: false
+    }
+  }
+} satisfies AppDetailType;
+
+describe('v1 public schema transforms', () => {
+  it('converts public numeric resources into internal Quantity values', () => {
+    const legacy = transformToLegacySchema(baseV1Request);
+
+    expect(legacy.cpu.toString()).toBe('500m');
+    expect(legacy.memory.toString()).toBe('1Gi');
+  });
+
+  it('converts internal Quantity resources back to public numbers', () => {
+    const response = transformFromLegacySchema(baseDetail);
+
+    expect(response.resource.cpu).toBe(0.5);
+    expect(response.resource.memory).toBe(1);
+  });
+});
+
+describe('v2alpha public schema transforms', () => {
+  it('converts public numeric quota into internal Quantity values', () => {
+    const legacy = transformToLegacySchemaV2(baseV2Request);
+
+    expect(legacy.cpu.toString()).toBe('500m');
+    expect(legacy.memory.toString()).toBe('1Gi');
+  });
+
+  it('converts internal Quantity quota back to public numbers', () => {
+    const response = transformFromLegacySchemaV2(baseDetail);
+
+    expect(response.quota.cpu).toBe(0.5);
+    expect(response.quota.memory).toBe(1);
+  });
+});

--- a/frontend/providers/applaunchpad/__tests__/unit/utils/deployYaml2Json.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/deployYaml2Json.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { json2Ingress, yamlString2Objects } from '@/utils/deployYaml2Json';
+import { json2DeployCr, json2Ingress, yamlString2Objects } from '@/utils/deployYaml2Json';
 import type { AppEditType } from '@/types/app';
+import { deployPVCResizeKey } from '@/constants/app';
+import {
+  cpuMillicoresToQuantity,
+  memoryMiToQuantity,
+  storageGiToQuantity
+} from '@/utils/resourceQuantity';
 
 const createApp = (customDomain = ''): AppEditType =>
   ({
@@ -9,8 +15,8 @@ const createApp = (customDomain = ''): AppEditType =>
     runCMD: '',
     cmdParam: '',
     replicas: 1,
-    cpu: 100,
-    memory: 128,
+    cpu: cpuMillicoresToQuantity(100),
+    memory: memoryMiToQuantity(128),
     networks: [
       {
         networkName: 'demo-web',
@@ -78,5 +84,52 @@ describe('json2Ingress', () => {
     expect(
       objects[0].metadata.annotations['nginx.ingress.kubernetes.io/ssl-redirect']
     ).toBeUndefined();
+  });
+});
+
+describe('json2DeployCr', () => {
+  it('emits Quantity CPU and memory limits with 10 percent requests', () => {
+    const objects = yamlString2Objects(
+      json2DeployCr(
+        {
+          ...createApp(),
+          cpu: cpuMillicoresToQuantity(500),
+          memory: memoryMiToQuantity(1024)
+        },
+        'deployment'
+      )
+    ) as any[];
+
+    const resources = objects[0].spec.template.spec.containers[0].resources;
+
+    expect(resources.limits.cpu).toBe('500m');
+    expect(resources.requests.cpu).toBe('50m');
+    expect(resources.limits.memory).toBe('1Gi');
+    expect(resources.requests.memory).toBe('102Mi');
+  });
+
+  it('emits PVC storage from Quantity values', () => {
+    const objects = yamlString2Objects(
+      json2DeployCr(
+        {
+          ...createApp(),
+          storeList: [
+            {
+              name: 'data',
+              path: '/data',
+              value: storageGiToQuantity(2)
+            }
+          ],
+          kind: 'statefulset'
+        },
+        'statefulset'
+      )
+    ) as any[];
+
+    const template = objects[0].spec.volumeClaimTemplates[0];
+
+    expect(template.metadata.annotations.value).toBe('2Gi');
+    expect(template.spec.resources.requests.storage).toBe('2Gi');
+    expect(objects[0].metadata.annotations[deployPVCResizeKey]).toBe('2Gi');
   });
 });

--- a/frontend/providers/applaunchpad/__tests__/unit/utils/resourceQuantity.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/resourceQuantity.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { Quantity } from '@sealos/shared';
+import {
+  cpuMillicoresToQuantity,
+  parseK8sQuantityOrZero,
+  publicCpuCoresToQuantity,
+  publicMemoryGiToQuantity,
+  quantityToCpuMillicores,
+  quantityToMemoryMi,
+  quantityToPublicCpuCores,
+  quantityToPublicMemoryGi,
+  quantityToStorageGi,
+  storageGiToQuantity,
+  memoryMiToQuantity,
+  storageAnnotationToQuantity
+} from '@/utils/resourceQuantity';
+
+describe('resourceQuantity helpers', () => {
+  it('converts public CPU cores to Quantity and back', () => {
+    const quantity = publicCpuCoresToQuantity(0.5);
+
+    expect(quantity.toString()).toBe('500m');
+    expect(quantityToPublicCpuCores(quantity)).toBe(0.5);
+  });
+
+  it('converts CPU millicores to Quantity and back', () => {
+    const quantity = cpuMillicoresToQuantity(200);
+
+    expect(quantity.toString()).toBe('200m');
+    expect(quantityToCpuMillicores(quantity)).toBe(200);
+  });
+
+  it('converts public memory Gi values to BinarySI Quantity and back', () => {
+    const quantity = publicMemoryGiToQuantity(1);
+
+    expect(quantity.toString()).toBe('1Gi');
+    expect(quantityToPublicMemoryGi(quantity)).toBe(1);
+  });
+
+  it('converts memory Mi values to Quantity and back', () => {
+    const quantity = memoryMiToQuantity(256);
+
+    expect(quantity.toString()).toBe('256Mi');
+    expect(quantityToMemoryMi(quantity)).toBe(256);
+  });
+
+  it('converts fractional public memory values through Mi precision', () => {
+    const quantity = publicMemoryGiToQuantity(0.5);
+
+    expect(quantity.toString()).toBe('512Mi');
+    expect(quantityToPublicMemoryGi(quantity)).toBe(0.5);
+  });
+
+  it('returns zero for empty, missing, or invalid Kubernetes quantities', () => {
+    expect(parseK8sQuantityOrZero(undefined).equals(Quantity.ZERO)).toBe(true);
+    expect(parseK8sQuantityOrZero('').equals(Quantity.ZERO)).toBe(true);
+    expect(parseK8sQuantityOrZero('invalid').equals(Quantity.ZERO)).toBe(true);
+  });
+
+  it('converts storage Gi values to Quantity and back', () => {
+    const quantity = storageGiToQuantity(2);
+
+    expect(quantity.toString()).toBe('2Gi');
+    expect(quantityToStorageGi(quantity)).toBe(2);
+  });
+
+  it('parses legacy and Quantity PVC storage annotations', () => {
+    expect(storageAnnotationToQuantity('2').toString()).toBe('2Gi');
+    expect(storageAnnotationToQuantity('2Gi').toString()).toBe('2Gi');
+    expect(
+      storageAnnotationToQuantity('1536Mi').formatForDisplay({
+        format: 'BinarySI',
+        scale: 'auto',
+        digits: 4
+      })
+    ).toBe('1.5Gi');
+    expect(storageAnnotationToQuantity(undefined).equals(Quantity.ZERO)).toBe(true);
+  });
+});

--- a/frontend/providers/applaunchpad/src/api/app.ts
+++ b/frontend/providers/applaunchpad/src/api/app.ts
@@ -7,6 +7,8 @@ import { LogQueryPayload } from '@/pages/api/log/queryLogs';
 import { PodListQueryPayload } from '@/pages/api/log/queryPodList';
 import { NetworkMonitorDataResult } from '@/services/networkMonitorFetch';
 import { track } from '@sealos/gtm';
+import { Quantity } from '@sealos/shared';
+import { quantityFromJSONOrZero } from '@/utils/resourceQuantity';
 
 export const postDeployApp = (yamlList: string[], mode: 'create' | 'replace' = 'create') =>
   POST('/api/applyApp', { yamlList, mode });
@@ -34,11 +36,32 @@ export const delAppByName = (name: string) => {
   return DELETE('/api/delApp', { name });
 };
 
+const hydrateQuantity = (value: unknown): Quantity =>
+  value instanceof Quantity ? value : quantityFromJSONOrZero(value);
+
+const hydrateAppDetail = (app: AppDetailType): AppDetailType => ({
+  ...app,
+  cpu: hydrateQuantity(app.cpu),
+  memory: hydrateQuantity(app.memory),
+  storeList: app.storeList.map((store) => ({
+    ...store,
+    value: hydrateQuantity(store.value)
+  }))
+});
+
+const hydratePodDetail = (pod: PodDetailType): PodDetailType => ({
+  ...pod,
+  cpu: hydrateQuantity(pod.cpu),
+  memory: hydrateQuantity(pod.memory)
+});
+
 export const getAppByName = (name: string, mock = false) =>
-  GET<AppDetailType>(`/api/getAppByAppName?appName=${name}&mock=${mock}`);
+  GET<AppDetailType>(`/api/getAppByAppName?appName=${name}&mock=${mock}`).then(hydrateAppDetail);
 
 export const getAppPodsByAppName = (name: string) =>
-  GET<PodDetailType[]>('/api/getAppPodsByAppName', { name });
+  GET<PodDetailType[]>('/api/getAppPodsByAppName', { name }).then((pods) =>
+    pods.map(hydratePodDetail)
+  );
 
 export const getPodsMetrics = (podsName: string[]) =>
   POST<SinglePodMetrics[]>('/api/getPodsMetrics', { podsName }).then((item) =>

--- a/frontend/providers/applaunchpad/src/components/app/detail/index/AdvancedInfo.tsx
+++ b/frontend/providers/applaunchpad/src/components/app/detail/index/AdvancedInfo.tsx
@@ -252,7 +252,13 @@ const AdvancedInfo = ({
                 <MyIcon name="storeColor" w="24px" h="24px" color="#a1a1aa" className="shrink-0" />
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium text-zinc-900 truncate">{item.path}</p>
-                  <p className="text-xs text-neutral-500">{item.value} Gi</p>
+                  <p className="text-xs text-neutral-500">
+                    {item.value.formatForDisplay({
+                      format: 'BinarySI',
+                      scale: 'auto',
+                      digits: 4
+                    })}
+                  </p>
                 </div>
               </div>
             ))}

--- a/frontend/providers/applaunchpad/src/components/app/detail/index/AppBaseInfo.tsx
+++ b/frontend/providers/applaunchpad/src/components/app/detail/index/AppBaseInfo.tsx
@@ -2,7 +2,7 @@ import GPUItem from '@/components/GPUItem';
 import { MOCK_APP_DETAIL } from '@/mock/apps';
 import { useUserStore } from '@/store/user';
 import type { AppDetailType } from '@/types/app';
-import { printMemory, useCopyData } from '@/utils/tools';
+import { useCopyData } from '@/utils/tools';
 import { Separator } from '@sealos/shadcn-ui/separator';
 import TruncateTooltip from '@/components/TruncateTooltip';
 import { useTranslation } from 'next-i18next';
@@ -44,10 +44,21 @@ const AppBaseInfo = ({ app = MOCK_APP_DETAIL }: { app: AppDetailType }) => {
             label: `${t('Image Name')} ${app.secret.use ? '(Private)' : ''}`,
             value: app.imageName
           },
-          { label: 'Limit CPU', value: `${app.cpu / 1000} Core` },
+          {
+            label: 'Limit CPU',
+            value: app.cpu.formatForDisplay({
+              format: 'DecimalSI',
+              scale: 'auto',
+              digits: 4
+            })
+          },
           {
             label: 'Limit Memory',
-            value: printMemory(app.memory)
+            value: app.memory.formatForDisplay({
+              format: 'BinarySI',
+              scale: 'auto',
+              digits: 4
+            })
           },
           ...(userSourcePrice?.gpu
             ? [

--- a/frontend/providers/applaunchpad/src/components/app/detail/index/PodFileModal.tsx
+++ b/frontend/providers/applaunchpad/src/components/app/detail/index/PodFileModal.tsx
@@ -64,6 +64,8 @@ import {
 } from '@sealos/shadcn-ui/breadcrumb';
 import { Popover, PopoverContent, PopoverTrigger } from '@sealos/shadcn-ui/popover';
 import { Label } from '@sealos/shadcn-ui/label';
+import { storageGiToQuantity } from '@/utils/resourceQuantity';
+import type { Quantity } from '@sealos/shared';
 
 const PodFile = ({
   isOpen,
@@ -86,8 +88,12 @@ const PodFile = ({
   const [storeDetail, setStoreDetail] = useState<{
     name: string;
     path: string;
-    value: number;
-  }>(appDetail.storeList[0] || { name: '/', path: '/', value: 10 });
+    value: Quantity;
+  }>(
+    appDetail.storeList[0]
+      ? appDetail.storeList[0]
+      : { name: '/', path: '/', value: storageGiToQuantity(10) }
+  );
 
   const [fileProgress, setFileProgress] = useState<number>(0);
   const [appName, setAppName] = useState(appDetail.appName);

--- a/frontend/providers/applaunchpad/src/components/apps/list/columns/Storage.tsx
+++ b/frontend/providers/applaunchpad/src/components/apps/list/columns/Storage.tsx
@@ -2,13 +2,20 @@ import { memo } from 'react';
 import { type CellContext } from '@tanstack/react-table';
 
 import { AppListItemType } from '@/types/app';
+import { storageGiToQuantity } from '@/utils/resourceQuantity';
 
 export const Storage = memo<CellContext<AppListItemType, unknown>>(
   ({ row }) => {
     const item = row.original;
     return (
       <span className="text-sm font-normal text-zinc-600">
-        {item.storeAmount > 0 ? `${item.storeAmount}Gi` : '-'}
+        {item.storeAmount > 0
+          ? storageGiToQuantity(item.storeAmount).formatForDisplay({
+              format: 'BinarySI',
+              scale: 'auto',
+              digits: 4
+            })
+          : '-'}
       </span>
     );
   },

--- a/frontend/providers/applaunchpad/src/constants/editApp.ts
+++ b/frontend/providers/applaunchpad/src/constants/editApp.ts
@@ -1,4 +1,5 @@
 import type { AppEditType } from '@/types/app';
+import { cpuMillicoresToQuantity, memoryMiToQuantity } from '@/utils/resourceQuantity';
 import { customAlphabet } from 'nanoid';
 const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz', 12);
 
@@ -31,8 +32,8 @@ export const defaultEditVal: AppEditType = {
   runCMD: '',
   cmdParam: '',
   replicas: 1,
-  cpu: 200,
-  memory: 256,
+  cpu: cpuMillicoresToQuantity(200),
+  memory: memoryMiToQuantity(256),
   networks: [
     {
       // note: this should not have serviceName

--- a/frontend/providers/applaunchpad/src/mock/apps.ts
+++ b/frontend/providers/applaunchpad/src/mock/apps.ts
@@ -1,5 +1,6 @@
 import { AppListItemType, AppDetailType, PodDetailType, AppEditSyncedFields } from '@/types/app';
 import { appStatusMap, podStatusMap } from '@/constants/app';
+import { cpuMillicoresToQuantity, memoryMiToQuantity } from '@/utils/resourceQuantity';
 import { customAlphabet } from 'nanoid';
 const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz', 12);
 
@@ -9,8 +10,8 @@ export const MOCK_APPS: AppListItemType[] = [
     name: 'string',
     status: appStatusMap.running,
     createTime: 'string',
-    cpu: 100,
-    memory: 100,
+    cpu: cpuMillicoresToQuantity(100),
+    memory: memoryMiToQuantity(100),
     usedCpu: {
       name: '',
       xData: new Array(30).fill(0),
@@ -38,8 +39,8 @@ export const MOCK_APPS: AppListItemType[] = [
     name: 'string',
     status: appStatusMap.running,
     createTime: 'string',
-    cpu: 100,
-    memory: 100,
+    cpu: cpuMillicoresToQuantity(100),
+    memory: memoryMiToQuantity(100),
     isPause: false,
     usedCpu: {
       name: '',
@@ -68,8 +69,8 @@ export const MOCK_APPS: AppListItemType[] = [
     status: appStatusMap.running,
     createTime: 'string',
     isPause: false,
-    cpu: 100,
-    memory: 100,
+    cpu: cpuMillicoresToQuantity(100),
+    memory: memoryMiToQuantity(100),
     usedCpu: {
       name: '',
       xData: new Array(30).fill(0),
@@ -210,8 +211,8 @@ export const MOCK_PODS: PodDetailType[] = [
       xData: new Array(30).fill(0),
       yData: new Array(30).fill('0')
     },
-    cpu: 0,
-    memory: 0,
+    cpu: cpuMillicoresToQuantity(0),
+    memory: memoryMiToQuantity(0),
     containerStatuses: [
       {
         name: 'hello-world',
@@ -236,8 +237,8 @@ export const MOCK_PODS: PodDetailType[] = [
       xData: new Array(30).fill(0),
       yData: new Array(30).fill('0')
     },
-    cpu: 0,
-    memory: 0,
+    cpu: cpuMillicoresToQuantity(0),
+    memory: memoryMiToQuantity(0),
     containerStatuses: [
       {
         name: 'hello-world',
@@ -261,8 +262,8 @@ export const MOCK_APP_DETAIL: AppDetailType = {
   runCMD: '',
   cmdParam: '',
   replicas: 1,
-  cpu: 200,
-  memory: 256,
+  cpu: cpuMillicoresToQuantity(200),
+  memory: memoryMiToQuantity(256),
   gpu: {
     type: '',
     amount: 1,
@@ -323,8 +324,8 @@ export const MockAppEditSyncedFields: AppEditSyncedFields = {
   imageName: 'nginx',
   appName: 'hello-world-test',
   replicas: 1,
-  cpu: 4000,
-  memory: 64,
+  cpu: cpuMillicoresToQuantity(4000),
+  memory: memoryMiToQuantity(64),
   networks: [
     {
       networkName: 'network-atyjahgvtzqm',

--- a/frontend/providers/applaunchpad/src/pages/api/updateApp.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/updateApp.ts
@@ -11,6 +11,7 @@ import { errLog, infoLog, warnLog } from 'sealos-desktop-sdk';
 import type { V1Service } from '@kubernetes/client-node';
 import { buildExternalUrl } from '@/utils/network-url';
 import { Config } from '@/config';
+import { storageAnnotationToQuantity } from '@/utils/resourceQuantity';
 
 export type Props = {
   patch: AppPatchPropsType;
@@ -312,26 +313,37 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
           return k8sCore.deleteNamespacedPersistentVolumeClaim(pvc.metadata?.name || '', namespace);
         }
         // check storage change
+        const currentStorageQuantity = storageAnnotationToQuantity(
+          pvc.metadata?.annotations?.value
+        );
+        const nextStorageQuantity = storageAnnotationToQuantity(
+          volume.metadata?.annotations?.value
+        );
         if (
           pvc.metadata?.name &&
           pvc.metadata?.annotations?.value &&
           pvc.spec?.resources?.requests?.storage &&
-          pvc.metadata?.annotations?.value !== volume.metadata?.annotations?.value
+          !currentStorageQuantity.equals(nextStorageQuantity)
         ) {
+          const nextStorageDisplay = nextStorageQuantity.formatForDisplay({
+            format: 'BinarySI',
+            scale: 'auto',
+            digits: 4
+          });
           const pvcName = pvc.metadata.name;
           const jsonPatch = [
             {
               op: 'replace',
               path: '/spec/resources/requests/storage',
-              value: `${volume.metadata?.annotations?.value}Gi`
+              value: nextStorageQuantity.withFormat('BinarySI').toString()
             },
             {
               op: 'replace',
               path: '/metadata/annotations/value',
-              value: `${volume.metadata?.annotations?.value}`
+              value: nextStorageDisplay
             }
           ];
-          infoLog(`replace ${pvcName} storage: ${volume.metadata?.annotations?.value}Gi`);
+          infoLog(`replace ${pvcName} storage: ${nextStorageDisplay}`);
           return k8sCore
             .patchNamespacedPersistentVolumeClaim(
               pvcName,

--- a/frontend/providers/applaunchpad/src/pages/api/v1/app/[name]/index.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/v1/app/[name]/index.ts
@@ -23,6 +23,12 @@ import {
 } from '@kubernetes/client-node';
 import { mountPathToConfigMapKey } from '@/utils/tools';
 import { json2DeployCr, json2Service, json2Ingress } from '@/utils/deployYaml2Json';
+import {
+  parseK8sQuantityOrZero,
+  publicCpuCoresToQuantity,
+  publicMemoryGiToQuantity,
+  storageAnnotationToQuantity
+} from '@/utils/resourceQuantity';
 import type { AppEditType } from '@/types/app';
 import { appDeployKey } from '@/constants/app';
 
@@ -311,23 +317,10 @@ async function updateStorage(
     updatedAppData.storeList = [];
 
     for (const newStore of storageData) {
-      let numericValue = 1;
-      const sizeMatch = newStore.size.match(/^(\d+(?:\.\d+)?)(Gi|Mi|Ti)$/i);
-      if (sizeMatch) {
-        const [, value, unit] = sizeMatch;
-        numericValue = parseFloat(value);
-
-        if (unit.toLowerCase() === 'mi') {
-          numericValue = numericValue / 1024;
-        } else if (unit.toLowerCase() === 'ti') {
-          numericValue = numericValue * 1024;
-        }
-      }
-
       updatedAppData.storeList.push({
         name: mountPathToConfigMapKey(newStore.path),
         path: newStore.path,
-        value: Math.ceil(numericValue)
+        value: parseK8sQuantityOrZero(newStore.size)
       });
     }
 
@@ -463,23 +456,10 @@ async function updateStorage(
     updatedAppData.storeList = [];
 
     for (const newStore of storageData) {
-      let numericValue = 1;
-      const sizeMatch = newStore.size.match(/^(\d+(?:\.\d+)?)(Gi|Mi|Ti)$/i);
-      if (sizeMatch) {
-        const [, value, unit] = sizeMatch;
-        numericValue = parseFloat(value);
-
-        if (unit.toLowerCase() === 'mi') {
-          numericValue = numericValue / 1024;
-        } else if (unit.toLowerCase() === 'ti') {
-          numericValue = numericValue * 1024;
-        }
-      }
-
       updatedAppData.storeList.push({
         name: mountPathToConfigMapKey(newStore.path),
         path: newStore.path,
-        value: Math.ceil(numericValue)
+        value: parseK8sQuantityOrZero(newStore.size)
       });
     }
 
@@ -557,38 +537,44 @@ async function updateExistingPVCs(
       return;
     }
 
-    let newSizeValue = 1;
-    if (newStorageItem.size) {
-      const match = newStorageItem.size.match(/^(\d+)/);
-      if (match) {
-        newSizeValue = parseInt(match[1]);
-      } else {
-        throw new Error(`Invalid storage size format: ${newStorageItem.size}`);
-      }
-    }
+    const newSizeQuantity = parseK8sQuantityOrZero(newStorageItem.size || '1Gi');
+    const currentSizeQuantity = pvc.spec?.resources?.requests?.storage
+      ? parseK8sQuantityOrZero(pvc.spec.resources.requests.storage)
+      : storageAnnotationToQuantity(pvc.metadata?.annotations?.value || '1');
 
-    const currentSizeValue = parseInt(pvc.metadata?.annotations?.value || '1');
-    if (newSizeValue < currentSizeValue) {
+    if (newSizeQuantity.cmp(currentSizeQuantity) < 0) {
       throw new Error(
-        `Cannot shrink PVC ${pvcName} from ${currentSizeValue}Gi to ${newSizeValue}Gi. PVC can only be expanded.`
+        `Cannot shrink PVC ${pvcName} from ${currentSizeQuantity.formatForDisplay({
+          format: 'BinarySI',
+          scale: 'auto',
+          digits: 4
+        })} to ${newSizeQuantity.formatForDisplay({
+          format: 'BinarySI',
+          scale: 'auto',
+          digits: 4
+        })}. PVC can only be expanded.`
       );
     }
 
     if (
       pvc.metadata?.annotations?.value &&
       pvc.spec?.resources?.requests?.storage &&
-      pvc.metadata?.annotations?.value !== newSizeValue.toString()
+      !currentSizeQuantity.equals(newSizeQuantity)
     ) {
       const jsonPatch = [
         {
           op: 'replace',
           path: '/spec/resources/requests/storage',
-          value: `${newSizeValue}Gi`
+          value: newSizeQuantity.withFormat('BinarySI').toString()
         },
         {
           op: 'replace',
           path: '/metadata/annotations/value',
-          value: newSizeValue.toString()
+          value: newSizeQuantity.formatForDisplay({
+            format: 'BinarySI',
+            scale: 'auto',
+            digits: 4
+          })
         }
       ];
 
@@ -946,6 +932,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
               : undefined;
           const updateResourcesData = {
             ...updateData,
+            resource: updateData.resource
+              ? {
+                  ...updateData.resource,
+                  cpu:
+                    updateData.resource.cpu !== undefined
+                      ? publicCpuCoresToQuantity(updateData.resource.cpu)
+                      : undefined,
+                  memory:
+                    updateData.resource.memory !== undefined
+                      ? publicMemoryGiToQuantity(updateData.resource.memory)
+                      : undefined
+                }
+              : undefined,
             command: updateData.launchCommand?.command,
             args: argsArray,
             image: updateData.image?.imageName,

--- a/frontend/providers/applaunchpad/src/pages/api/v1/app/[name]/storage.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/v1/app/[name]/storage.ts
@@ -6,6 +6,7 @@ import { UpdateStorageSchema } from '@/types/request_schema';
 import { json2DeployCr } from '@/utils/deployYaml2Json';
 import { mountPathToConfigMapKey } from '@/utils/tools';
 import type { AppEditType } from '@/types/app';
+import { parseK8sQuantityOrZero, storageAnnotationToQuantity } from '@/utils/resourceQuantity';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
@@ -88,23 +89,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       });
 
       for (const newStore of storage) {
-        let numericValue = 1;
-        const sizeMatch = newStore.size.match(/^(\d+(?:\.\d+)?)(Gi|Mi|Ti)$/i);
-        if (sizeMatch) {
-          const [, value, unit] = sizeMatch;
-          numericValue = parseFloat(value);
-
-          if (unit.toLowerCase() === 'mi') {
-            numericValue = numericValue / 1024;
-          } else if (unit.toLowerCase() === 'ti') {
-            numericValue = numericValue * 1024;
-          }
-        }
-
         const storeItem = {
           name: mountPathToConfigMapKey(newStore.path),
           path: newStore.path,
-          value: Math.ceil(numericValue)
+          value: parseK8sQuantityOrZero(newStore.size)
         };
 
         if (existingStorageByPath.has(newStore.path)) {
@@ -220,38 +208,44 @@ async function updateExistingPVCs(
         return;
       }
 
-      let newSizeValue = 1;
-      if (newStorageItem.size) {
-        const match = newStorageItem.size.match(/^(\d+)/);
-        if (match) {
-          newSizeValue = parseInt(match[1]);
-        } else {
-          throw new Error(`Invalid storage size format: ${newStorageItem.size}`);
-        }
-      }
+      const newSizeQuantity = parseK8sQuantityOrZero(newStorageItem.size || '1Gi');
+      const currentSizeQuantity = pvc.spec?.resources?.requests?.storage
+        ? parseK8sQuantityOrZero(pvc.spec.resources.requests.storage)
+        : storageAnnotationToQuantity(pvc.metadata?.annotations?.value || '1');
 
-      const currentSizeValue = parseInt(pvc.metadata?.annotations?.value || '1');
-      if (newSizeValue < currentSizeValue) {
+      if (newSizeQuantity.cmp(currentSizeQuantity) < 0) {
         throw new Error(
-          `Cannot shrink PVC ${pvcName} from ${currentSizeValue}Gi to ${newSizeValue}Gi. PVC can only be expanded.`
+          `Cannot shrink PVC ${pvcName} from ${currentSizeQuantity.formatForDisplay({
+            format: 'BinarySI',
+            scale: 'auto',
+            digits: 4
+          })} to ${newSizeQuantity.formatForDisplay({
+            format: 'BinarySI',
+            scale: 'auto',
+            digits: 4
+          })}. PVC can only be expanded.`
         );
       }
 
       if (
         pvc.metadata?.annotations?.value &&
         pvc.spec?.resources?.requests?.storage &&
-        pvc.metadata?.annotations?.value !== newSizeValue.toString()
+        !currentSizeQuantity.equals(newSizeQuantity)
       ) {
         const jsonPatch = [
           {
             op: 'replace',
             path: '/spec/resources/requests/storage',
-            value: `${newSizeValue}Gi`
+            value: newSizeQuantity.withFormat('BinarySI').toString()
           },
           {
             op: 'replace',
             path: '/metadata/annotations/value',
-            value: newSizeValue.toString()
+            value: newSizeQuantity.formatForDisplay({
+              format: 'BinarySI',
+              scale: 'auto',
+              digits: 4
+            })
           }
         ];
 

--- a/frontend/providers/applaunchpad/src/pages/api/v2alpha/apps/[name]/index.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/v2alpha/apps/[name]/index.ts
@@ -25,6 +25,12 @@ import {
 } from '@kubernetes/client-node';
 import { mountPathToConfigMapKey } from '@/utils/tools';
 import { json2DeployCr, json2Service, json2Ingress } from '@/utils/deployYaml2Json';
+import {
+  parseK8sQuantityOrZero,
+  publicCpuCoresToQuantity,
+  publicMemoryGiToQuantity,
+  storageAnnotationToQuantity
+} from '@/utils/resourceQuantity';
 import { appDeployKey } from '@/constants/app';
 
 import {
@@ -44,12 +50,6 @@ import {
 const DELAY_SHORT = 2000;
 const DELAY_LONG = 3000;
 const APPLICATION_PROTOCOLS = ['HTTP', 'GRPC', 'WS'] as const;
-const SIZE_UNITS = {
-  MI: 1 / 1024,
-  GI: 1,
-  TI: 1024
-} as const;
-
 // Custom Error Classes
 class PortError extends Error {
   constructor(message: string, public code: number = 500, public details?: ApiErrorDetails) {
@@ -84,17 +84,6 @@ function isApplicationProtocol(protocol?: string): boolean {
   if (!protocol) return false;
   const upperProtocol = protocol.toUpperCase();
   return APPLICATION_PROTOCOLS.includes(upperProtocol as any);
-}
-
-function convertStorageSize(size: string): number {
-  const sizeMatch = size.match(/^(\d+(?:\.\d+)?)(Gi|Mi|Ti)$/i);
-  if (!sizeMatch) return 1;
-
-  const [, value, unit] = sizeMatch;
-  const numericValue = parseFloat(value);
-  const multiplier = SIZE_UNITS[unit.toUpperCase() as keyof typeof SIZE_UNITS] ?? 1;
-
-  return Math.ceil(numericValue * multiplier);
 }
 
 function validateStorageData(storageData: Array<{ path: string; size: string }>): void {
@@ -410,11 +399,13 @@ async function updateServiceAndIngress(
   }
 }
 
-function createStorageList(storageData: Array<{ path: string; size: string }>): any[] {
+function createStorageList(
+  storageData: Array<{ path: string; size: string }>
+): AppEditType['storeList'] {
   return storageData.map((newStore) => ({
     name: mountPathToConfigMapKey(newStore.path),
     path: newStore.path,
-    value: convertStorageSize(newStore.size)
+    value: parseK8sQuantityOrZero(newStore.size)
   }));
 }
 
@@ -501,30 +492,44 @@ async function updateExistingPVCs(
       return;
     }
 
-    const newSizeValue = convertStorageSize(newStorageItem.size);
-    const currentSizeValue = parseInt(pvc.metadata?.annotations?.value || '1');
+    const newSizeQuantity = parseK8sQuantityOrZero(newStorageItem.size || '1Gi');
+    const currentSizeQuantity = pvc.spec?.resources?.requests?.storage
+      ? parseK8sQuantityOrZero(pvc.spec.resources.requests.storage)
+      : storageAnnotationToQuantity(pvc.metadata?.annotations?.value || '1');
 
-    if (newSizeValue < currentSizeValue) {
+    if (newSizeQuantity.cmp(currentSizeQuantity) < 0) {
       throw new Error(
-        `Cannot shrink PVC ${pvcName} from ${currentSizeValue}Gi to ${newSizeValue}Gi. PVC can only be expanded.`
+        `Cannot shrink PVC ${pvcName} from ${currentSizeQuantity.formatForDisplay({
+          format: 'BinarySI',
+          scale: 'auto',
+          digits: 4
+        })} to ${newSizeQuantity.formatForDisplay({
+          format: 'BinarySI',
+          scale: 'auto',
+          digits: 4
+        })}. PVC can only be expanded.`
       );
     }
 
     if (
       pvc.metadata?.annotations?.value &&
       pvc.spec?.resources?.requests?.storage &&
-      pvc.metadata?.annotations?.value !== newSizeValue.toString()
+      !currentSizeQuantity.equals(newSizeQuantity)
     ) {
       const jsonPatch = [
         {
           op: 'replace',
           path: '/spec/resources/requests/storage',
-          value: `${newSizeValue}Gi`
+          value: newSizeQuantity.withFormat('BinarySI').toString()
         },
         {
           op: 'replace',
           path: '/metadata/annotations/value',
-          value: newSizeValue.toString()
+          value: newSizeQuantity.formatForDisplay({
+            format: 'BinarySI',
+            scale: 'auto',
+            digits: 4
+          })
         }
       ];
 
@@ -991,7 +996,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         ) {
           const updateResourcesData = {
             ...updateData,
-            resource: updateData.quota,
+            resource: updateData.quota
+              ? {
+                  ...updateData.quota,
+                  cpu:
+                    updateData.quota.cpu !== undefined
+                      ? publicCpuCoresToQuantity(updateData.quota.cpu)
+                      : undefined,
+                  memory:
+                    updateData.quota.memory !== undefined
+                      ? publicMemoryGiToQuantity(updateData.quota.memory)
+                      : undefined
+                }
+              : undefined,
             command: updateData.launchCommand?.command,
             args: updateData.launchCommand?.args,
             image: updateData.image?.imageName,

--- a/frontend/providers/applaunchpad/src/pages/api/v2alpha/apps/[name]/storage.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/v2alpha/apps/[name]/storage.ts
@@ -5,6 +5,7 @@ import { UpdateStorageSchema, k8sAppNameSchema } from '@/types/v2alpha/request_s
 import { json2DeployCr } from '@/utils/deployYaml2Json';
 import { mountPathToConfigMapKey } from '@/utils/tools';
 import type { AppEditType } from '@/types/app';
+import { parseK8sQuantityOrZero, storageAnnotationToQuantity } from '@/utils/resourceQuantity';
 
 import { sendError, sendValidationError, ErrorType, ErrorCode } from '@/types/v2alpha/error';
 import {
@@ -94,23 +95,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       });
 
       for (const newStore of storage) {
-        let numericValue = 1;
-        const sizeMatch = newStore.size.match(/^(\d+(?:\.\d+)?)(Gi|Mi|Ti)$/i);
-        if (sizeMatch) {
-          const [, value, unit] = sizeMatch;
-          numericValue = parseFloat(value);
-
-          if (unit.toLowerCase() === 'mi') {
-            numericValue = numericValue / 1024;
-          } else if (unit.toLowerCase() === 'ti') {
-            numericValue = numericValue * 1024;
-          }
-        }
-
         const storeItem = {
           name: mountPathToConfigMapKey(newStore.path),
           path: newStore.path,
-          value: Math.ceil(numericValue)
+          value: parseK8sQuantityOrZero(newStore.size)
         };
 
         if (existingStorageByPath.has(newStore.path)) {
@@ -221,46 +209,44 @@ async function updateExistingPVCs(
         return;
       }
 
-      // Parse size with unit conversion: Mi -> /1024, Gi -> x1, Ti -> x1024
-      const sizeMatch = newStorageItem.size.match(/^(\d+(?:\.\d+)?)(Gi|Mi|Ti)$/i);
-      if (!sizeMatch) {
-        throw new Error(
-          `Invalid storage size format: ${newStorageItem.size}. Use format like "10Gi", "1Ti", etc.`
-        );
-      }
-      const [, sizeVal, unit] = sizeMatch;
-      let newSizeValue: number;
-      const numericValue = parseFloat(sizeVal);
-      if (unit.toLowerCase() === 'mi') {
-        newSizeValue = Math.ceil(numericValue / 1024);
-      } else if (unit.toLowerCase() === 'ti') {
-        newSizeValue = Math.ceil(numericValue * 1024);
-      } else {
-        newSizeValue = Math.ceil(numericValue);
-      }
+      const newSizeQuantity = parseK8sQuantityOrZero(newStorageItem.size || '1Gi');
+      const currentSizeQuantity = pvc.spec?.resources?.requests?.storage
+        ? parseK8sQuantityOrZero(pvc.spec.resources.requests.storage)
+        : storageAnnotationToQuantity(pvc.metadata?.annotations?.value || '1');
 
-      const currentSizeValue = parseInt(pvc.metadata?.annotations?.value || '1');
-      if (newSizeValue < currentSizeValue) {
+      if (newSizeQuantity.cmp(currentSizeQuantity) < 0) {
         throw new Error(
-          `Cannot shrink PVC ${pvcName} from ${currentSizeValue}Gi to ${newSizeValue}Gi. PVC can only be expanded.`
+          `Cannot shrink PVC ${pvcName} from ${currentSizeQuantity.formatForDisplay({
+            format: 'BinarySI',
+            scale: 'auto',
+            digits: 4
+          })} to ${newSizeQuantity.formatForDisplay({
+            format: 'BinarySI',
+            scale: 'auto',
+            digits: 4
+          })}. PVC can only be expanded.`
         );
       }
 
       if (
         pvc.metadata?.annotations?.value &&
         pvc.spec?.resources?.requests?.storage &&
-        pvc.metadata?.annotations?.value !== newSizeValue.toString()
+        !currentSizeQuantity.equals(newSizeQuantity)
       ) {
         const jsonPatch = [
           {
             op: 'replace',
             path: '/spec/resources/requests/storage',
-            value: `${newSizeValue}Gi`
+            value: newSizeQuantity.withFormat('BinarySI').toString()
           },
           {
             op: 'replace',
             path: '/metadata/annotations/value',
-            value: newSizeValue.toString()
+            value: newSizeQuantity.formatForDisplay({
+              format: 'BinarySI',
+              scale: 'auto',
+              digits: 4
+            })
           }
         ];
 

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
@@ -53,6 +53,14 @@ import QuotaBox from './QuotaBox';
 import type { StoreType } from './StoreModal';
 import { NetworkSection } from './NetworkSection';
 import { mountPathToConfigMapKey } from '@/utils/tools';
+import {
+  cpuMillicoresToQuantity,
+  memoryMiToQuantity,
+  quantityToCpuMillicores,
+  quantityToMemoryMi,
+  quantityToStorageGi,
+  storageGiToQuantity
+} from '@/utils/resourceQuantity';
 
 const ConfigmapModal = dynamic(() => import('./ConfigmapModal'));
 const StoreModal = dynamic(() => import('./StoreModal'));
@@ -91,6 +99,16 @@ const Form = ({
     getValues,
     formState: { errors }
   } = formHook;
+
+  const getCpuMillicores = useCallback(
+    () => quantityToCpuMillicores(getValues('cpu')),
+    [getValues]
+  );
+  const getMemoryMi = useCallback(() => quantityToMemoryMi(getValues('memory')), [getValues]);
+  const getStorageGiTotal = useCallback(
+    () => getValues('storeList').reduce((sum, item) => sum + quantityToStorageGi(item.value), 0),
+    [getValues]
+  );
 
   const { fields: envs, replace: replaceEnvs } = useFieldArray({
     control,
@@ -164,8 +182,8 @@ const Form = ({
     if (!storageQuota) return 0;
 
     const newlyUsedStorage =
-      storeList.reduce((sum, item) => sum + item.value, 0) -
-      existingStores.reduce((sum, item) => sum + item.value, 0);
+      storeList.reduce((sum, item) => sum + quantityToStorageGi(item.value), 0) -
+      existingStores.reduce((sum, item) => sum + quantityToStorageGi(item.value), 0);
 
     return (
       (storageQuota.limit - storageQuota.used) / resourcePropertyMap.storage.scale -
@@ -262,8 +280,8 @@ const Form = ({
       }
     }
 
-    const cpu = getValues('cpu');
-    const memory = getValues('memory');
+    const cpu = getCpuMillicores();
+    const memory = getMemoryMi();
 
     const cpuList = formSliderListConfig[key].cpu;
     const memoryList = formSliderListConfig[key].memory;
@@ -292,7 +310,7 @@ const Form = ({
         gpuAmount: getValues('gpu.amount')
       })
     };
-  }, [formSliderListConfig, getValues]);
+  }, [formSliderListConfig, getCpuMillicores, getMemoryMi, getValues]);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const SliderList = useMemo(() => countSliderList(), [already, refresh]);
@@ -410,9 +428,9 @@ const Form = ({
                       ? [getValues('hpa.minReplicas') || 1, getValues('hpa.maxReplicas') || 2]
                       : [getValues('replicas') || 1, getValues('replicas') || 1]
                   }
-                  cpu={getValues('cpu')}
-                  memory={getValues('memory')}
-                  storage={getValues('storeList').reduce((sum, item) => sum + item.value, 0)}
+                  cpu={getCpuMillicores()}
+                  memory={getMemoryMi()}
+                  storage={getStorageGiTotal()}
                   gpu={
                     !!getValues('gpu.type')
                       ? {
@@ -830,8 +848,8 @@ const Form = ({
                         if (actualType === '' || (selected && inventory > 0)) {
                           setValue('gpu.type', actualType);
                           const sliderList = countSliderList();
-                          setValue('cpu', sliderList.cpu[1].value);
-                          setValue('memory', sliderList.memory[1].value);
+                          setValue('cpu', cpuMillicoresToQuantity(sliderList.cpu[1].value));
+                          setValue('memory', memoryMiToQuantity(sliderList.memory[1].value));
                         }
                       }}
                     >
@@ -886,8 +904,14 @@ const Form = ({
                                         onClick={() => {
                                           setValue('gpu.amount', item.value);
                                           const sliderList = countSliderList();
-                                          setValue('cpu', sliderList.cpu[1].value);
-                                          setValue('memory', sliderList.memory[1].value);
+                                          setValue(
+                                            'cpu',
+                                            cpuMillicoresToQuantity(sliderList.cpu[1].value)
+                                          );
+                                          setValue(
+                                            'memory',
+                                            memoryMiToQuantity(sliderList.memory[1].value)
+                                          );
                                         }}
                                         className={`w-10 h-10 rounded-lg border text-sm font-normal transition-all ${
                                           getValues('gpu.amount') === item.value
@@ -936,9 +960,11 @@ const Form = ({
                 <div className="flex-1 flex flex-col gap-3 px-1">
                   <Slider
                     value={[
-                      SliderList.cpu.findIndex((item) => item.value === getValues('cpu')) ?? 0
+                      SliderList.cpu.findIndex((item) => item.value === getCpuMillicores()) ?? 0
                     ]}
-                    onValueChange={([val]) => setValue('cpu', SliderList.cpu[val].value)}
+                    onValueChange={([val]) =>
+                      setValue('cpu', cpuMillicoresToQuantity(SliderList.cpu[val].value))
+                    }
                     max={SliderList.cpu.length - 1}
                     min={0}
                     step={1}
@@ -947,9 +973,9 @@ const Form = ({
                     {SliderList.cpu.map((item, i) => (
                       <span
                         key={i}
-                        onClick={() => setValue('cpu', item.value)}
+                        onClick={() => setValue('cpu', cpuMillicoresToQuantity(item.value))}
                         className={`absolute w-10 text-center -translate-x-1/2 cursor-pointer hover:text-zinc-700 ${
-                          getValues('cpu') === item.value ? 'text-zinc-900 font-medium' : ''
+                          getCpuMillicores() === item.value ? 'text-zinc-900 font-medium' : ''
                         }`}
                         style={{
                           left:
@@ -967,7 +993,7 @@ const Form = ({
                   {exceededQuotas.some(({ type }) => type === 'cpu') && (
                     <p className="text-sm text-red-500">
                       {t('cpu_exceeds_quota', {
-                        requested: getValues('cpu') / resourcePropertyMap.cpu.scale,
+                        requested: getCpuMillicores() / resourcePropertyMap.cpu.scale,
                         limit:
                           (exceededQuotas.find(({ type }) => type === 'cpu')?.limit ?? 0) /
                           resourcePropertyMap.cpu.scale,
@@ -986,9 +1012,11 @@ const Form = ({
                 <div className="flex-1 flex flex-col gap-3 px-1">
                   <Slider
                     value={[
-                      SliderList.memory.findIndex((item) => item.value === getValues('memory')) ?? 0
+                      SliderList.memory.findIndex((item) => item.value === getMemoryMi()) ?? 0
                     ]}
-                    onValueChange={([val]) => setValue('memory', SliderList.memory[val].value)}
+                    onValueChange={([val]) =>
+                      setValue('memory', memoryMiToQuantity(SliderList.memory[val].value))
+                    }
                     max={SliderList.memory.length - 1}
                     min={0}
                     step={1}
@@ -997,9 +1025,9 @@ const Form = ({
                     {SliderList.memory.map((item, i) => (
                       <span
                         key={i}
-                        onClick={() => setValue('memory', item.value)}
+                        onClick={() => setValue('memory', memoryMiToQuantity(item.value))}
                         className={`absolute w-10 text-center -translate-x-1/2 cursor-pointer hover:text-zinc-700 ${
-                          getValues('memory') === item.value ? 'text-zinc-900 font-medium' : ''
+                          getMemoryMi() === item.value ? 'text-zinc-900 font-medium' : ''
                         }`}
                         style={{
                           left:
@@ -1017,7 +1045,7 @@ const Form = ({
                   {exceededQuotas.some(({ type }) => type === 'memory') && (
                     <p className="text-sm text-red-500">
                       {t('memory_exceeds_quota', {
-                        requested: getValues('memory') / resourcePropertyMap.memory.scale,
+                        requested: getMemoryMi() / resourcePropertyMap.memory.scale,
                         limit:
                           (exceededQuotas.find(({ type }) => type === 'memory')?.limit ?? 0) /
                           resourcePropertyMap.memory.scale,
@@ -1247,7 +1275,9 @@ const Form = ({
                       type="button"
                       variant="outline"
                       className="h-10 min-w-[86px] shadow-none hover:bg-zinc-50"
-                      onClick={() => setStoreEdit({ name: '', path: '', value: 1 })}
+                      onClick={() =>
+                        setStoreEdit({ name: '', path: '', value: storageGiToQuantity(1) })
+                      }
                     >
                       <Plus className="w-4 h-4" />
                       {t('Add')}
@@ -1273,7 +1303,11 @@ const Form = ({
                               {item.path}
                             </p>
                             <p className="text-xs text-neutral-500 truncate block w-full">
-                              {item.value} Gi
+                              {item.value.formatForDisplay({
+                                format: 'BinarySI',
+                                scale: 'auto',
+                                digits: 4
+                              })}
                             </p>
                           </div>
                           <Button
@@ -1361,10 +1395,18 @@ const Form = ({
         <StoreModal
           defaultValue={storeEdit}
           isEditStore={!!existingStores.find((item) => storeEdit.path === item.path)}
-          minValue={existingStores.find((item) => storeEdit.path === item.path)?.value ?? 1}
+          minValue={
+            quantityToStorageGi(
+              existingStores.find((item) => storeEdit.path === item.path)?.value ??
+                storageGiToQuantity(1)
+            ) || 1
+          }
           maxValue={Math.min(
             // left quota - this one
-            storageQuotaLeft + (storeList.find((item) => item.id === storeEdit.id)?.value ?? 0),
+            storageQuotaLeft +
+              quantityToStorageGi(
+                storeList.find((item) => item.id === storeEdit.id)?.value ?? storageGiToQuantity(0)
+              ),
             // But not exceed the size cap
             config.pvcStorageMax
           )}

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/StoreModal.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/StoreModal.tsx
@@ -19,19 +19,21 @@ import {
   TooltipProvider,
   TooltipTrigger
 } from '@sealos/shadcn-ui/tooltip';
+import type { Quantity } from '@sealos/shared';
+import { quantityToStorageGi, storageGiToQuantity } from '@/utils/resourceQuantity';
 
 export type StoreType = {
   id?: string;
   name: string;
   path: string;
-  value: number;
+  value: Quantity;
 };
 
 const StoreModal = ({
   defaultValue = {
     name: '',
     path: '',
-    value: 1
+    value: storageGiToQuantity(1)
   },
   minValue,
   maxValue,
@@ -62,7 +64,17 @@ const StoreModal = ({
     defaultValues: defaultValue
   });
 
-  const currentValue = watch('value');
+  const currentValue = quantityToStorageGi(watch('value'));
+  const minValueDisplay = storageGiToQuantity(minValue).formatForDisplay({
+    format: 'BinarySI',
+    scale: 'auto',
+    digits: 4
+  });
+  const maxValueDisplay = storageGiToQuantity(maxValue).formatForDisplay({
+    format: 'BinarySI',
+    scale: 'auto',
+    digits: 4
+  });
 
   const textMap = {
     create: {
@@ -74,23 +86,27 @@ const StoreModal = ({
   };
 
   const clampValue = useCallback(
-    (value: number) => {
-      return Number.isSafeInteger(value) ? Math.min(maxValue, Math.max(value, minValue)) : minValue;
+    (value: Quantity) => {
+      const storageValue = quantityToStorageGi(value);
+      const clampedValue = Number.isSafeInteger(storageValue)
+        ? Math.min(maxValue, Math.max(storageValue, minValue))
+        : minValue;
+      return storageGiToQuantity(clampedValue);
     },
     [minValue, maxValue]
   );
 
   const handleIncrement = () => {
-    const current = getValues('value');
+    const current = quantityToStorageGi(getValues('value'));
     if (current < maxValue) {
-      setValue('value', current + 1);
+      setValue('value', storageGiToQuantity(current + 1));
     }
   };
 
   const handleDecrement = () => {
-    const current = getValues('value');
+    const current = quantityToStorageGi(getValues('value'));
     if (current > minValue) {
-      setValue('value', current - 1);
+      setValue('value', storageGiToQuantity(current - 1));
     }
   };
 
@@ -122,19 +138,18 @@ const StoreModal = ({
                         type="number"
                         disabled={maxValue === 0}
                         className="w-20 h-10 text-center border-t border-b border-zinc-200 bg-white text-sm font-medium focus:outline-none focus:ring-0 disabled:opacity-50 disabled:cursor-not-allowed [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                        {...register('value', {
-                          required:
-                            t('Storage Value can not empty') || 'Storage Value can not empty',
-                          min: {
-                            value: minValue,
-                            message: `${t('Min Storage Value')} ${minValue} Gi`
-                          },
-                          max: {
-                            value: maxValue,
-                            message: `${t('Max Storage Value')} ${maxValue} Gi`
-                          },
-                          valueAsNumber: true
-                        })}
+                        value={currentValue}
+                        onChange={(event) => {
+                          const nextValue = Number(event.target.value);
+                          setValue(
+                            'value',
+                            storageGiToQuantity(Number.isFinite(nextValue) ? nextValue : minValue),
+                            {
+                              shouldDirty: true,
+                              shouldValidate: true
+                            }
+                          );
+                        }}
                       />
                     </div>
                     <button
@@ -152,12 +167,21 @@ const StoreModal = ({
                   <p className="text-sm text-zinc-900 font-normal p-2">
                     {maxValue === 0
                       ? t('Storage limit reached')
-                      : `${t('Storage Range')}: ${minValue}~${maxValue} Gi`}
+                      : `${t('Storage Range')}: ${minValueDisplay}~${maxValueDisplay}`}
                   </p>
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
-            {errors.value && <p className="text-sm text-red-500">{errors.value.message}</p>}
+            {currentValue < minValue && (
+              <p className="text-sm text-red-500">
+                {`${t('Min Storage Value')} ${minValueDisplay}`}
+              </p>
+            )}
+            {currentValue > maxValue && (
+              <p className="text-sm text-red-500">
+                {`${t('Max Storage Value')} ${maxValueDisplay}`}
+              </p>
+            )}
           </div>
 
           {/* Mount Path */}

--- a/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
@@ -37,6 +37,14 @@ import { useGuideStore } from '@/store/guide';
 import { track } from '@sealos/gtm';
 import { useQuotaGuarded, useUserQuota, resourcePropertyMap } from '@sealos/shared';
 import { useClientAppConfig } from '@/hooks/useClientAppConfig';
+import {
+  cpuMillicoresToQuantity,
+  memoryMiToQuantity,
+  quantityFromJSONOrZero,
+  quantityToCpuMillicores,
+  quantityToMemoryMi,
+  quantityToStorageGi
+} from '@/utils/resourceQuantity';
 
 const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz', 12);
 
@@ -286,8 +294,8 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
       if (!appName) {
         const defaultApp = {
           ...defaultEditVal,
-          cpu: formSliderListConfig[defaultSliderKey].cpu[0],
-          memory: formSliderListConfig[defaultSliderKey].memory[0]
+          cpu: cpuMillicoresToQuantity(formSliderListConfig[defaultSliderKey].cpu[0]),
+          memory: memoryMiToQuantity(formSliderListConfig[defaultSliderKey].memory[0])
         };
         setAlready(true);
         setYamlList([
@@ -418,13 +426,23 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
 
     return {
       cpu: isEdit
-        ? realTimeForm.current.cpu * newReplicas -
-          (formHook.formState.defaultValues?.cpu ?? 0) * oldReplicas
-        : realTimeForm.current.cpu * newReplicas,
+        ? quantityToCpuMillicores(realTimeForm.current.cpu) * newReplicas -
+          quantityToCpuMillicores(
+            formHook.formState.defaultValues?.cpu
+              ? quantityFromJSONOrZero(String(formHook.formState.defaultValues.cpu))
+              : defaultEditVal.cpu
+          ) *
+            oldReplicas
+        : quantityToCpuMillicores(realTimeForm.current.cpu) * newReplicas,
       memory: isEdit
-        ? realTimeForm.current.memory * newReplicas -
-          (formHook.formState.defaultValues?.memory ?? 0) * oldReplicas
-        : realTimeForm.current.memory * newReplicas,
+        ? quantityToMemoryMi(realTimeForm.current.memory) * newReplicas -
+          quantityToMemoryMi(
+            formHook.formState.defaultValues?.memory
+              ? quantityFromJSONOrZero(String(formHook.formState.defaultValues.memory))
+              : defaultEditVal.memory
+          ) *
+            oldReplicas
+        : quantityToMemoryMi(realTimeForm.current.memory) * newReplicas,
       gpu: isEdit
         ? newGpuCount * newReplicas - oldGpuCount * oldReplicas
         : newGpuCount * newReplicas,
@@ -437,10 +455,18 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
         : (realTimeForm.current.networks?.filter((item) => item.openNodePort)?.length ?? 0) *
           newReplicas,
       storage: isEdit
-        ? (realTimeForm.current.storeList.reduce((sum, item) => sum + item.value, 0) * newReplicas -
-            existingStores.reduce((sum, item) => sum + item.value, 0) * oldReplicas) *
+        ? (realTimeForm.current.storeList.reduce(
+            (sum, item) => sum + quantityToStorageGi(item.value),
+            0
+          ) *
+            newReplicas -
+            existingStores.reduce((sum, item) => sum + quantityToStorageGi(item.value), 0) *
+              oldReplicas) *
           resourcePropertyMap.storage.scale
-        : realTimeForm.current.storeList.reduce((sum, item) => sum + item.value, 0) *
+        : realTimeForm.current.storeList.reduce(
+            (sum, item) => sum + quantityToStorageGi(item.value),
+            0
+          ) *
           newReplicas *
           resourcePropertyMap.storage.scale,
       traffic: true as const
@@ -505,8 +531,8 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
             template_version: data.imageName.split(':')?.[1] ?? 'latest'
           },
           resources: {
-            cpu_cores: data.cpu,
-            ram_mb: data.memory,
+            cpu_cores: quantityToCpuMillicores(data.cpu) / 1000,
+            ram_mb: quantityToMemoryMi(data.memory),
             replicas: data.hpa.use ? data.hpa.maxReplicas : Number(data.replicas),
             scaling: data.hpa.use
               ? {

--- a/frontend/providers/applaunchpad/src/services/backend/appService.ts
+++ b/frontend/providers/applaunchpad/src/services/backend/appService.ts
@@ -7,10 +7,12 @@ import { str2Num } from '@/utils/tools';
 import { adaptAppDetail } from '@/utils/adapt';
 import { DeployKindsType, AppDetailType } from '@/types/app';
 import { z } from 'zod';
-import { LaunchpadApplicationSchema, resourceConverters } from '@/types/schema';
+import { LaunchpadApplicationSchema } from '@/types/schema';
 import { transformFromLegacySchema } from '@/types/request_schema';
 import { LaunchpadApplicationSchema as LaunchpadApplicationSchemaV2 } from '@/types/v2alpha/schema';
 import { transformFromLegacySchema as transformFromLegacySchemaV2 } from '@/types/v2alpha/request_schema';
+import type { Quantity } from '@sealos/shared';
+import { cpuRequestQuantity, memoryRequestQuantity } from '@/utils/resourceQuantity';
 import {
   PatchUtils,
   KubeConfig,
@@ -549,8 +551,8 @@ export async function updateAppResources(
   appName: string,
   updateData: {
     resource?: {
-      cpu?: number;
-      memory?: number;
+      cpu?: Quantity;
+      memory?: Quantity;
       replicas?: number;
       hpa?: {
         target: 'cpu' | 'memory' | 'gpu';
@@ -699,33 +701,31 @@ export async function updateAppResources(
     }> = [];
 
     if (updateData.resource?.cpu !== undefined) {
-      const millicores = resourceConverters.cpuToMillicores(updateData.resource.cpu);
       jsonPatch.push(
         {
           op: 'replace',
           path: '/spec/template/spec/containers/0/resources/requests/cpu',
-          value: `${str2Num(Math.floor(millicores * 0.1))}m`
+          value: cpuRequestQuantity(updateData.resource.cpu).withFormat('DecimalSI').toString()
         },
         {
           op: 'replace',
           path: '/spec/template/spec/containers/0/resources/limits/cpu',
-          value: `${str2Num(millicores)}m`
+          value: updateData.resource.cpu.withFormat('DecimalSI').toString()
         }
       );
     }
 
     if (updateData.resource?.memory !== undefined) {
-      const memoryMB = resourceConverters.memoryToMB(updateData.resource.memory);
       jsonPatch.push(
         {
           op: 'replace',
           path: '/spec/template/spec/containers/0/resources/requests/memory',
-          value: `${str2Num(Math.floor(memoryMB * 0.1))}Mi`
+          value: memoryRequestQuantity(updateData.resource.memory).withFormat('BinarySI').toString()
         },
         {
           op: 'replace',
           path: '/spec/template/spec/containers/0/resources/limits/memory',
-          value: `${str2Num(memoryMB)}Mi`
+          value: updateData.resource.memory.withFormat('BinarySI').toString()
         }
       );
     }

--- a/frontend/providers/applaunchpad/src/types/app.d.ts
+++ b/frontend/providers/applaunchpad/src/types/app.d.ts
@@ -13,6 +13,7 @@ import type {
   V1Volume,
   V1VolumeMount
 } from '@kubernetes/client-node';
+import type { Quantity } from '@sealos/shared';
 import { MonitorDataResult } from './monitor';
 
 export type HpaTarget = 'cpu' | 'memory' | 'gpu';
@@ -48,8 +49,8 @@ export interface AppListItemType {
   status: AppStatusMapType;
   isPause: boolean;
   createTime: string;
-  cpu: number;
-  memory: number;
+  cpu: Quantity;
+  memory: Quantity;
   gpu?: GpuType;
   usedCpu: MonitorDataResult;
   usedMemory: MonitorDataResult; // average value
@@ -73,8 +74,8 @@ export interface AppEditType {
   runCMD: string;
   cmdParam: string;
   replicas: number | '';
-  cpu: number;
-  memory: number;
+  cpu: Quantity;
+  memory: Quantity;
   gpu?: GpuType;
   networks: {
     serviceName?: string;
@@ -118,7 +119,7 @@ export interface AppEditType {
   storeList: {
     name: string;
     path: string;
-    value: number;
+    value: Quantity;
   }[];
   labels: { [key: string]: string };
   volumes: V1Volume[];
@@ -194,16 +195,16 @@ export interface PodDetailType extends V1Pod {
   age: string;
   usedCpu: MonitorDataResult;
   usedMemory: MonitorDataResult;
-  cpu: number;
-  memory: number;
+  cpu: Quantity;
+  memory: Quantity;
   podReason?: string;
   podMessage?: string;
   containerStatuses: ContainerStatusType[];
 }
 export interface PodMetrics {
   podName: string;
-  cpu: number;
-  memory: number;
+  cpu: Quantity;
+  memory: Quantity;
 }
 
 export interface PodEvent {

--- a/frontend/providers/applaunchpad/src/types/request_schema.ts
+++ b/frontend/providers/applaunchpad/src/types/request_schema.ts
@@ -38,9 +38,15 @@ import {
   LaunchpadApplicationSchema,
   LaunchCommandSchema,
   ImageSchema,
-  imageRegistrySchema,
-  resourceConverters
+  imageRegistrySchema
 } from './schema';
+import {
+  parseK8sQuantityOrZero,
+  publicCpuCoresToQuantity,
+  publicMemoryGiToQuantity,
+  quantityToPublicCpuCores,
+  quantityToPublicMemoryGi
+} from '@/utils/resourceQuantity';
 
 export const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz', 12);
 
@@ -358,8 +364,8 @@ export const CreateLaunchpadRequestSchema = z
 export function transformToLegacySchema(
   standardRequest: z.infer<typeof CreateLaunchpadRequestSchema>
 ): AppEditType {
-  const cpuValue = resourceConverters.cpuToMillicores(standardRequest.resource.cpu);
-  const memoryValue = resourceConverters.memoryToMB(standardRequest.resource.memory);
+  const cpuValue = publicCpuCoresToQuantity(standardRequest.resource.cpu);
+  const memoryValue = publicMemoryGiToQuantity(standardRequest.resource.memory);
 
   const networks = standardRequest.ports?.map((port) => {
     const isApplicationProtocol = ['HTTP', 'GRPC', 'WS'].includes(port.protocol);
@@ -446,13 +452,9 @@ export function transformToLegacySchema(
 
   const storeList =
     standardRequest.storage?.map((storage) => {
-      let sizeValue = 1;
-      if (storage.size) {
-        const match = storage.size.match(/^(\d+)/);
-        if (match) {
-          sizeValue = parseInt(match[1]);
-        }
-      }
+      const sizeValue = storage.size
+        ? parseK8sQuantityOrZero(storage.size)
+        : parseK8sQuantityOrZero('1Gi');
       return {
         name: storage.name,
         path: storage.path,
@@ -510,8 +512,8 @@ export function transformFromLegacySchema(
     },
     resource: {
       replicas: legacyData.hpa?.use ? undefined : legacyData.replicas || 1,
-      cpu: resourceConverters.millicoresToCpu(legacyData.cpu || 200),
-      memory: resourceConverters.mbToMemory(legacyData.memory || 256),
+      cpu: quantityToPublicCpuCores(legacyData.cpu),
+      memory: quantityToPublicMemoryGi(legacyData.memory),
       gpu: legacyData.gpu
         ? {
             vendor: legacyData.gpu.manufacturers,
@@ -564,7 +566,11 @@ export function transformFromLegacySchema(
       legacyData.storeList?.map((store) => ({
         name: store.name,
         path: store.path,
-        size: `${store.value || 1}Gi`
+        size: (store.value || parseK8sQuantityOrZero('1Gi')).formatForDisplay({
+          format: 'BinarySI',
+          scale: 'auto',
+          digits: 4
+        })
       })) || [],
     kind: legacyData.kind || 'deployment',
 

--- a/frontend/providers/applaunchpad/src/types/schema.ts
+++ b/frontend/providers/applaunchpad/src/types/schema.ts
@@ -22,16 +22,6 @@ import { customAlphabet } from 'nanoid';
 
 export const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz', 12);
 
-export const resourceConverters = {
-  cpuToMillicores: (cores: number): number => cores * 1000,
-
-  memoryToMB: (gb: number): number => gb * 1024,
-
-  millicoresToCpu: (millicores: number): number => millicores / 1000,
-
-  mbToMemory: (mb: number): number => mb / 1024
-};
-
 export const ResourceSchema = z
   .object({
     replicas: z

--- a/frontend/providers/applaunchpad/src/types/v2alpha/request_schema.ts
+++ b/frontend/providers/applaunchpad/src/types/v2alpha/request_schema.ts
@@ -15,10 +15,16 @@ import {
   PortConfigSchema,
   LaunchpadApplicationSchema,
   LaunchCommandSchema,
-  ImageSchema,
-  resourceConverters
+  ImageSchema
 } from './schema';
 import { buildExternalUrl } from '@/utils/network-url';
+import {
+  parseK8sQuantityOrZero,
+  publicCpuCoresToQuantity,
+  publicMemoryGiToQuantity,
+  quantityToPublicCpuCores,
+  quantityToPublicMemoryGi
+} from '@/utils/resourceQuantity';
 
 export const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz', 12);
 
@@ -357,8 +363,8 @@ export const CreateLaunchpadRequestSchema = z
 export function transformToLegacySchema(
   standardRequest: z.infer<typeof CreateLaunchpadRequestSchema>
 ): AppEditType {
-  const cpuValue = resourceConverters.cpuToMillicores(standardRequest.quota.cpu);
-  const memoryValue = resourceConverters.memoryToMB(standardRequest.quota.memory);
+  const cpuValue = publicCpuCoresToQuantity(standardRequest.quota.cpu);
+  const memoryValue = publicMemoryGiToQuantity(standardRequest.quota.memory);
 
   const ports = standardRequest.ports || [];
   const defaultPort = ports.length > 0 ? ports[0].number : 80;
@@ -455,13 +461,9 @@ export function transformToLegacySchema(
 
   const storeList =
     standardRequest.storage?.map((storage) => {
-      let sizeValue = 1;
-      if (storage.size) {
-        const match = storage.size.match(/^(\d+)/);
-        if (match) {
-          sizeValue = parseInt(match[1]);
-        }
-      }
+      const sizeValue = storage.size
+        ? parseK8sQuantityOrZero(storage.size)
+        : parseK8sQuantityOrZero('1Gi');
       return {
         name: storage.name,
         path: storage.path,
@@ -531,8 +533,8 @@ export function transformFromLegacySchema(
     },
     quota: {
       replicas: legacyData.hpa?.use ? undefined : legacyData.replicas || 1,
-      cpu: resourceConverters.millicoresToCpu(legacyData.cpu || 200),
-      memory: resourceConverters.mbToMemory(legacyData.memory || 256),
+      cpu: quantityToPublicCpuCores(legacyData.cpu),
+      memory: quantityToPublicMemoryGi(legacyData.memory),
       hpa: legacyData.hpa?.use
         ? {
             target: legacyData.hpa.target,
@@ -609,7 +611,11 @@ export function transformFromLegacySchema(
       legacyData.storeList?.map((store) => ({
         name: store.name,
         path: store.path,
-        size: `${store.value || 1}Gi`
+        size: (store.value || parseK8sQuantityOrZero('1Gi')).formatForDisplay({
+          format: 'BinarySI',
+          scale: 'auto',
+          digits: 4
+        })
       })) || [],
     resourceType: 'launchpad',
     kind: legacyData.kind,

--- a/frontend/providers/applaunchpad/src/types/v2alpha/schema.ts
+++ b/frontend/providers/applaunchpad/src/types/v2alpha/schema.ts
@@ -4,16 +4,6 @@ import { customAlphabet } from 'nanoid';
 
 export const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz', 12);
 
-export const resourceConverters = {
-  cpuToMillicores: (cores: number): number => cores * 1000,
-
-  memoryToMB: (gb: number): number => gb * 1024,
-
-  millicoresToCpu: (millicores: number): number => millicores / 1000,
-
-  mbToMemory: (mb: number): number => mb / 1024
-};
-
 export const ResourceSchema = z
   .object({
     replicas: z

--- a/frontend/providers/applaunchpad/src/utils/adapt.ts
+++ b/frontend/providers/applaunchpad/src/utils/adapt.ts
@@ -44,7 +44,11 @@ import { defaultEditVal } from '@/constants/editApp';
 import { customAlphabet } from 'nanoid';
 import { has } from 'lodash';
 import { lauchpadRemarkKey } from '@/constants/account';
-import { cpuFormatToM, memoryFormatToMi } from '@sealos/shared';
+import {
+  parseK8sQuantityOrZero,
+  quantityToStorageGi,
+  storageAnnotationToQuantity
+} from '@/utils/resourceQuantity';
 
 const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz', 12);
 
@@ -113,10 +117,12 @@ export const getAppSource = (
 export const adaptAppListItem = (app: V1Deployment & V1StatefulSet): AppListItemType => {
   // compute store amount
   const storeAmount = app.spec?.volumeClaimTemplates
-    ? app.spec?.volumeClaimTemplates.reduce(
-        (sum, item) => sum + Number(item?.metadata?.annotations?.value),
-        0
-      )
+    ? app.spec?.volumeClaimTemplates.reduce((sum, item) => {
+        const storage = item?.spec?.resources?.requests?.storage
+          ? parseK8sQuantityOrZero(item.spec.resources.requests.storage)
+          : storageAnnotationToQuantity(item?.metadata?.annotations?.value);
+        return sum + quantityToStorageGi(storage);
+      }, 0)
     : 0;
 
   const gpuNodeSelector = app?.spec?.template?.spec?.nodeSelector;
@@ -127,8 +133,10 @@ export const adaptAppListItem = (app: V1Deployment & V1StatefulSet): AppListItem
     status: appStatusMap.waiting,
     isPause: !!app?.metadata?.annotations?.[pauseKey],
     createTime: dayjs(app.metadata?.creationTimestamp).format('YYYY/MM/DD HH:mm'),
-    cpu: cpuFormatToM(app.spec?.template?.spec?.containers?.[0]?.resources?.limits?.cpu || '0'),
-    memory: memoryFormatToMi(
+    cpu: parseK8sQuantityOrZero(
+      app.spec?.template?.spec?.containers?.[0]?.resources?.limits?.cpu || '0'
+    ),
+    memory: parseK8sQuantityOrZero(
       app.spec?.template?.spec?.containers?.[0]?.resources?.limits?.memory || '0'
     ),
     gpu: {
@@ -227,16 +235,16 @@ export const adaptPod = (pod: V1Pod): PodDetailType => {
       xData: new Array(30).fill(0),
       yData: new Array(30).fill('0')
     },
-    cpu: cpuFormatToM(pod.spec?.containers?.[0]?.resources?.limits?.cpu || '0'),
-    memory: memoryFormatToMi(pod.spec?.containers?.[0]?.resources?.limits?.memory || '0')
+    cpu: parseK8sQuantityOrZero(pod.spec?.containers?.[0]?.resources?.limits?.cpu || '0'),
+    memory: parseK8sQuantityOrZero(pod.spec?.containers?.[0]?.resources?.limits?.memory || '0')
   };
 };
 
 export const adaptMetrics = (metrics: SinglePodMetrics): PodMetrics => {
   return {
     podName: metrics.metadata.name,
-    cpu: cpuFormatToM(metrics?.containers?.[0]?.usage?.cpu),
-    memory: memoryFormatToMi(metrics?.containers?.[0]?.usage?.memory)
+    cpu: parseK8sQuantityOrZero(metrics?.containers?.[0]?.usage?.cpu),
+    memory: parseK8sQuantityOrZero(metrics?.containers?.[0]?.usage?.memory)
   };
 };
 
@@ -431,10 +439,10 @@ export const adaptAppDetail = async (
         ? appDeploy.spec?.template?.spec?.containers?.[0]?.args.join(' ')
         : JSON.stringify(appDeploy.spec?.template?.spec?.containers?.[0]?.args)) || '',
     replicas: appDeploy.spec?.replicas || 0,
-    cpu: cpuFormatToM(
+    cpu: parseK8sQuantityOrZero(
       appDeploy.spec?.template?.spec?.containers?.[0]?.resources?.limits?.cpu || '0'
     ),
-    memory: memoryFormatToMi(
+    memory: parseK8sQuantityOrZero(
       appDeploy.spec?.template?.spec?.containers?.[0]?.resources?.limits?.memory || '0'
     ),
     gpu: {
@@ -538,11 +546,16 @@ export const adaptAppDetail = async (
     configMapList: getConfigMapList(),
     secret: atobSecretYaml(deployKindsMap?.Secret?.data?.['.dockerconfigjson']),
     storeList: deployKindsMap.StatefulSet?.spec?.volumeClaimTemplates
-      ? deployKindsMap.StatefulSet?.spec?.volumeClaimTemplates.map((item) => ({
-          name: item.metadata?.name || '',
-          path: item.metadata?.annotations?.path || '',
-          value: Number(item.metadata?.annotations?.value || 0)
-        }))
+      ? deployKindsMap.StatefulSet?.spec?.volumeClaimTemplates.map((item) => {
+          const storage = item.spec?.resources?.requests?.storage;
+          return {
+            name: item.metadata?.name || '',
+            path: item.metadata?.annotations?.path || '',
+            value: storage
+              ? parseK8sQuantityOrZero(storage)
+              : storageAnnotationToQuantity(item.metadata?.annotations?.value)
+          };
+        })
       : [],
     volumeMounts: getFilteredVolumeMounts(),
     volumes: getFilteredVolumes(),

--- a/frontend/providers/applaunchpad/src/utils/deployYaml2Json.ts
+++ b/frontend/providers/applaunchpad/src/utils/deployYaml2Json.ts
@@ -13,6 +13,12 @@ import dayjs from 'dayjs';
 import yaml from 'js-yaml';
 import { customAlphabet, customRandom } from 'nanoid';
 import crypto from 'crypto';
+import {
+  cpuRequestQuantity,
+  memoryRequestQuantity,
+  quantityToStorageGi,
+  storageGiToQuantity
+} from '@/utils/resourceQuantity';
 
 // Create deterministic nanoid based on seed
 const createDeterministicNanoid = (seed: string): string => {
@@ -54,7 +60,10 @@ export const yamlString2Objects = (yamlString: string): object[] => {
 };
 
 export const json2DeployCr = (data: AppEditType, type: 'deployment' | 'statefulset') => {
-  const totalStorage = data.storeList.reduce((acc, item) => acc + item.value, 0);
+  const totalStorage = data.storeList.reduce(
+    (acc, item) => acc + quantityToStorageGi(item.value),
+    0
+  );
 
   const metadata = {
     name: data.appName,
@@ -62,7 +71,11 @@ export const json2DeployCr = (data: AppEditType, type: 'deployment' | 'statefuls
       originImageName: data.imageName,
       [minReplicasKey]: `${data.hpa.use ? data.hpa.minReplicas : data.replicas}`,
       [maxReplicasKey]: `${data.hpa.use ? data.hpa.maxReplicas : data.replicas}`,
-      [deployPVCResizeKey]: `${totalStorage}Gi`
+      [deployPVCResizeKey]: storageGiToQuantity(totalStorage).formatForDisplay({
+        format: 'BinarySI',
+        scale: 'auto',
+        digits: 4
+      })
     },
     labels: {
       ...(data.labels || {}),
@@ -105,13 +118,13 @@ export const json2DeployCr = (data: AppEditType, type: 'deployment' | 'statefuls
         : [],
     resources: {
       requests: {
-        cpu: `${str2Num(Math.floor(data.cpu * 0.1))}m`,
-        memory: `${str2Num(Math.floor(data.memory * 0.1))}Mi`,
+        cpu: cpuRequestQuantity(data.cpu).withFormat('DecimalSI').toString(),
+        memory: memoryRequestQuantity(data.memory).withFormat('BinarySI').toString(),
         ...(!!data.gpu?.type ? { [gpuResourceKey]: data.gpu.amount } : {})
       },
       limits: {
-        cpu: `${str2Num(data.cpu)}m`,
-        memory: `${str2Num(data.memory)}Mi`,
+        cpu: data.cpu.withFormat('DecimalSI').toString(),
+        memory: data.memory.withFormat('BinarySI').toString(),
         ...(!!data.gpu?.type ? { [gpuResourceKey]: data.gpu.amount } : {})
       }
     },
@@ -168,7 +181,11 @@ export const json2DeployCr = (data: AppEditType, type: 'deployment' | 'statefuls
     metadata: {
       annotations: {
         path: store.path,
-        value: `${store.value}`
+        value: store.value.formatForDisplay({
+          format: 'BinarySI',
+          scale: 'auto',
+          digits: 4
+        })
       },
       name: store.name
     },
@@ -176,7 +193,7 @@ export const json2DeployCr = (data: AppEditType, type: 'deployment' | 'statefuls
       accessModes: ['ReadWriteOnce'],
       resources: {
         requests: {
-          storage: `${store.value}Gi`
+          storage: store.value.withFormat('BinarySI').toString()
         }
       }
     }

--- a/frontend/providers/applaunchpad/src/utils/resourceQuantity.ts
+++ b/frontend/providers/applaunchpad/src/utils/resourceQuantity.ts
@@ -1,0 +1,84 @@
+import { BinaryScale, Quantity } from '@sealos/shared';
+
+const roundTo = (value: number, digits = 4): number => {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+};
+
+const quantityToBinaryNumber = (quantity: Quantity, scale: BinaryScale, digits = 4): number =>
+  Number.parseFloat(
+    quantity.formatForDisplay({
+      format: 'BinarySI',
+      scale,
+      digits
+    })
+  );
+
+export const parseK8sQuantityOrZero = (value?: string | null): Quantity => {
+  if (!value || value === '0') return Quantity.ZERO;
+
+  try {
+    return Quantity.parse(value);
+  } catch {
+    return Quantity.ZERO;
+  }
+};
+
+export const quantityFromJSONOrZero = (value: unknown): Quantity => {
+  if (value === undefined || value === null || value === '') return Quantity.ZERO;
+
+  try {
+    return Quantity.fromJSON(value);
+  } catch {
+    return Quantity.ZERO;
+  }
+};
+
+export const cpuMillicoresToQuantity = (value: number): Quantity =>
+  Quantity.newMilliQuantity(BigInt(Math.round(value)), 'DecimalSI');
+
+export const quantityToCpuMillicores = (quantity: Quantity): number =>
+  Number(quantity.milliValue());
+
+export const publicCpuCoresToQuantity = (value: number): Quantity =>
+  cpuMillicoresToQuantity(value * 1000);
+
+export const quantityToPublicCpuCores = (quantity: Quantity): number =>
+  roundTo(quantityToCpuMillicores(quantity) / 1000);
+
+export const memoryMiToQuantity = (value: number): Quantity =>
+  Number.isInteger(value)
+    ? Quantity.newBinaryScaledQuantity(BigInt(value), BinaryScale.Mebi)
+    : Quantity.newBinaryScaledQuantity(BigInt(Math.ceil(value * 1024)), BinaryScale.Kibi);
+
+export const quantityToMemoryMi = (quantity: Quantity): number =>
+  quantityToBinaryNumber(quantity, BinaryScale.Mebi, 4);
+
+export const publicMemoryGiToQuantity = (value: number): Quantity =>
+  memoryMiToQuantity(value * 1024);
+
+export const quantityToPublicMemoryGi = (quantity: Quantity): number =>
+  roundTo(quantityToMemoryMi(quantity) / 1024);
+
+export const storageGiToQuantity = (value: number): Quantity =>
+  Number.isInteger(value)
+    ? Quantity.newBinaryScaledQuantity(BigInt(value), BinaryScale.Gibi)
+    : memoryMiToQuantity(value * 1024);
+
+export const quantityToStorageGi = (quantity: Quantity): number =>
+  roundTo(quantityToMemoryMi(quantity) / 1024);
+
+export const storageAnnotationToQuantity = (value?: string | null): Quantity => {
+  const annotationValue = value?.trim();
+  if (!annotationValue) return Quantity.ZERO;
+
+  return /^\d+(?:\.\d+)?$/.test(annotationValue)
+    ? storageGiToQuantity(Number(annotationValue))
+    : parseK8sQuantityOrZero(annotationValue);
+};
+
+export const cpuRequestQuantity = (limit: Quantity): Quantity =>
+  cpuMillicoresToQuantity(Math.floor(quantityToCpuMillicores(limit) * 0.1));
+
+export const memoryRequestQuantity = (limit: Quantity): Quantity =>
+  memoryMiToQuantity(Math.floor(quantityToMemoryMi(limit) * 0.1));

--- a/frontend/providers/applaunchpad/src/utils/tools.ts
+++ b/frontend/providers/applaunchpad/src/utils/tools.ts
@@ -138,13 +138,6 @@ export const atobSecretYaml = (secret?: string): AppEditType['secret'] => {
 };
 
 /**
- * print memory to Mi of Gi
- */
-export const printMemory = (val: number) => {
-  return val >= 1024 ? `${val / 1024} Gi` : `${val} Mi`;
-};
-
-/**
  * format pod createTime
  */
 export const formatPodTime = (createTimeStamp: Date = new Date()) => {

--- a/frontend/providers/costcenter/__tests__/unit/api/workspace.test.ts
+++ b/frontend/providers/costcenter/__tests__/unit/api/workspace.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Quantity } from '@sealos/shared';
+import { getWorkspaceQuota } from '@/api/workspace';
+import request from '@/service/request';
+import { WorkspaceQuotaResponseSchema } from '@/types/workspace';
+
+vi.mock('@/service/request', () => ({
+  default: vi.fn()
+}));
+
+const mockedRequest = vi.mocked(request);
+
+describe('getWorkspaceQuota', () => {
+  it('hydrates workspace quota Quantity fields from the API JSON payload', async () => {
+    mockedRequest.mockResolvedValueOnce({
+      code: 200,
+      data: {
+        quota: [
+          {
+            type: 'cpu',
+            used: '500m',
+            limit: '2'
+          }
+        ]
+      }
+    });
+
+    const response = await getWorkspaceQuota({
+      regionUid: 'region-1',
+      workspace: 'ns-demo'
+    });
+
+    const item = response.data?.quota[0];
+    expect(item?.used).toBeInstanceOf(Quantity);
+    expect(item?.used.formatForDisplay({ format: 'DecimalSI' })).toBe('500m');
+    expect(item?.limit).toBeInstanceOf(Quantity);
+    expect(item?.limit.formatForDisplay({ format: 'DecimalSI' })).toBe('2');
+
+    const parsedAgain = WorkspaceQuotaResponseSchema.safeParse(response.data);
+    expect(parsedAgain.success).toBe(true);
+  });
+});

--- a/frontend/providers/costcenter/src/api/workspace.ts
+++ b/frontend/providers/costcenter/src/api/workspace.ts
@@ -1,9 +1,19 @@
 import request from '@/service/request';
 import { ApiResp } from '@/types/api';
-import { WorkspaceQuotaRequest, WorkspaceQuotaResponse } from '@/types/workspace';
+import {
+  WorkspaceQuotaRequest,
+  WorkspaceQuotaResponse,
+  WorkspaceQuotaResponseSchema
+} from '@/types/workspace';
 
-export const getWorkspaceQuota = (data: WorkspaceQuotaRequest) =>
-  request<any, ApiResp<WorkspaceQuotaResponse>>('/api/workspace/get-workspace-quota', {
+export const getWorkspaceQuota = async (data: WorkspaceQuotaRequest) => {
+  const res = await request<any, ApiResp<unknown>>('/api/workspace/get-workspace-quota', {
     method: 'POST',
     data
   });
+
+  const parsed = WorkspaceQuotaResponseSchema.safeParse(res?.data);
+  if (!parsed.success) throw parsed.error;
+
+  return { ...res, data: parsed.data } as ApiResp<WorkspaceQuotaResponse>;
+};


### PR DESCRIPTION
Migrate to new `Quantity` utility.

Ref: https://github.com/labring/sealos/pull/6670

## Scope

- Frontend pages
- Private APIs

Public APIs behaviors are not changed, they are still using the legacy number presentation.