### PR TITLE
feat(template): support extra resource labels

### DIFF
--- a/frontend/providers/template/__tests__/template-extra-labels.test.ts
+++ b/frontend/providers/template/__tests__/template-extra-labels.test.ts
@@ -1,0 +1,183 @@
+import JsYaml from 'js-yaml';
+import { describe, expect, it } from 'vitest';
+import { templateDeployKey } from '@/constants/keys';
+import { validateExtraLabels } from '@/utils/common';
+import { generateYamlList, handleTemplateToInstanceYaml } from '@/utils/json-yaml';
+import { CreateInstanceRequestSchema } from '@/types/apis/v2alpha/create-instance';
+import { DeployTemplateRequestSchema } from '@/types/apis/v2alpha/deploy-template';
+
+const renderedYaml = `apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: demo
+  labels:
+    app: demo
+spec:
+  selector:
+    matchLabels:
+      app: demo
+  template:
+    metadata:
+      labels:
+        app: demo
+    spec:
+      containers:
+        - name: main
+          image: nginx
+          env:
+            - name: ENABLED
+              value: true
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        resources:
+          requests:
+            storage: 1Gi
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cleanup
+spec:
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            job: cleanup
+        spec:
+          containers:
+            - name: cleanup
+              image: busybox
+          restartPolicy: OnFailure
+---
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: Cluster
+metadata:
+  name: postgres
+spec:
+  componentSpecs:
+    - name: postgresql
+      volumeClaimTemplates:
+        - metadata:
+            name: data
+          spec:
+            resources:
+              requests:
+                storage: 1Gi
+`;
+
+describe('template extraLabels', () => {
+  it('injects extra labels into rendered resource metadata, pod templates, and PVC templates', () => {
+    const output = generateYamlList(renderedYaml, 'demo', {
+      'brain.io/project-id': 'project-uid',
+      'brain.io/resource-kind': 'template'
+    });
+
+    expect(output).toHaveLength(1);
+    const docs = JsYaml.loadAll(output[0].value).filter(Boolean) as any[];
+    const statefulSet = docs.find((doc) => doc.kind === 'StatefulSet');
+    const cronJob = docs.find((doc) => doc.kind === 'CronJob');
+    const cluster = docs.find((doc) => doc.kind === 'Cluster');
+
+    expect(statefulSet.metadata.labels).toMatchObject({
+      [templateDeployKey]: 'demo',
+      'brain.io/project-id': 'project-uid',
+      'brain.io/resource-kind': 'template'
+    });
+    expect(statefulSet.spec.template.metadata.labels).toMatchObject({
+      app: 'demo',
+      'brain.io/project-id': 'project-uid',
+      'brain.io/resource-kind': 'template'
+    });
+    expect(statefulSet.spec.volumeClaimTemplates[0].metadata.labels).toMatchObject({
+      'brain.io/project-id': 'project-uid',
+      'brain.io/resource-kind': 'template'
+    });
+    expect(cronJob.spec.jobTemplate.spec.template.metadata.labels).toMatchObject({
+      job: 'cleanup',
+      'brain.io/project-id': 'project-uid'
+    });
+    expect(cluster.spec.componentSpecs[0].volumeClaimTemplates[0].metadata.labels).toMatchObject({
+      'brain.io/project-id': 'project-uid'
+    });
+  });
+
+  it('keeps Sealos ownership labels reserved', () => {
+    const validation = validateExtraLabels({
+      [templateDeployKey]: 'other'
+    });
+
+    expect(validation.error).toContain(templateDeployKey);
+  });
+
+  it('validates Kubernetes label keys and values', () => {
+    expect(validateExtraLabels({ 'brain.io/project-id': 'project-uid' }).error).toBeUndefined();
+    expect(validateExtraLabels({ 'bad prefix/project-id': 'project-uid' }).error).toContain(
+      'valid Kubernetes label key'
+    );
+    expect(validateExtraLabels({ 'brain.io/project-id': 'has spaces' }).error).toContain(
+      'valid Kubernetes label value'
+    );
+  });
+
+  it('documents extraLabels in v2alpha request schemas', () => {
+    expect(
+      CreateInstanceRequestSchema.safeParse({
+        name: 'demo',
+        template: 'n8n',
+        extraLabels: { 'brain.io/project-id': 'project-uid' }
+      }).success
+    ).toBe(true);
+    expect(
+      DeployTemplateRequestSchema.safeParse({
+        yaml: 'apiVersion: app.sealos.io/v1\nkind: Template\nmetadata:\n  name: demo',
+        extraLabels: { 'brain.io/project-id': 'project-uid' }
+      }).success
+    ).toBe(true);
+  });
+
+  it('strips UI-only input metadata from generated Instance resources', () => {
+    const instance = handleTemplateToInstanceYaml(
+      {
+        apiVersion: 'app.sealos.io/v1',
+        kind: 'Template',
+        metadata: {
+          name: 'n8n'
+        },
+        spec: {
+          fileName: 'n8n.yaml',
+          filePath: 'template/n8n.yaml',
+          templateType: 'inline',
+          gitRepo: '',
+          author: '',
+          title: 'n8n',
+          url: '',
+          readme: '',
+          icon: '',
+          description: '',
+          draft: false,
+          inputs: {
+            timezone: {
+              description: 'Timezone',
+              type: 'choice',
+              default: 'America/New_York',
+              required: true,
+              options: ['America/New_York', 'Asia/Shanghai'],
+              if: 'true'
+            } as any
+          }
+        }
+      },
+      'n8n-demo'
+    );
+
+    expect(instance.spec.inputs.timezone).toEqual({
+      description: 'Timezone',
+      type: 'choice',
+      default: 'America/New_York',
+      required: true
+    });
+  });
+});

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/instances.ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/instances.ts
@@ -1,6 +1,7 @@
 import { authSession } from '@/services/backend/auth';
 import { getK8s } from '@/services/backend/kubernetes';
 import { generateYamlList, parseTemplateString } from '@/utils/json-yaml';
+import { validateExtraLabels } from '@/utils/common';
 import { mapValues, reduce } from 'lodash';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { GetTemplateByName } from '../../getTemplateSource';
@@ -12,6 +13,7 @@ interface CreateInstanceRequest {
   name: string;
   template: string;
   args?: Record<string, string>;
+  extraLabels?: Record<string, string>;
 }
 
 interface ResourceQuota {
@@ -122,7 +124,22 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   try {
-    const { name, template: templateName, args = {} } = req.body as CreateInstanceRequest;
+    const {
+      name,
+      template: templateName,
+      args = {},
+      extraLabels: rawExtraLabels
+    } = req.body as CreateInstanceRequest;
+    const extraLabelsValidation = validateExtraLabels(rawExtraLabels);
+    if (extraLabelsValidation.error) {
+      return sendError(res, {
+        status: 400,
+        type: ErrorType.VALIDATION_ERROR,
+        code: ErrorCode.INVALID_VALUE,
+        message: extraLabelsValidation.error
+      });
+    }
+    const extraLabels = extraLabelsValidation.labels;
 
     // Validate required fields
     if (!name || typeof name !== 'string' || name.trim() === '') {
@@ -331,7 +348,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       });
     }
 
-    const correctYaml = generateYamlList(generateStr, trimmedName);
+    const correctYaml = generateYamlList(generateStr, trimmedName, extraLabels);
 
     if (!correctYaml || correctYaml.length === 0) {
       return sendError(res, {

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/raw.ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/raw.ts
@@ -8,7 +8,7 @@ import {
   parseTemplateString,
   parseTemplateVariable
 } from '@/utils/json-yaml';
-import { getTemplateEnvs } from '@/utils/common';
+import { getTemplateEnvs, validateExtraLabels } from '@/utils/common';
 import { mapValues, reduce } from 'lodash';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import JsYaml from 'js-yaml';
@@ -126,12 +126,24 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const {
       yaml,
       args = {},
-      dryRun = false
+      dryRun = false,
+      extraLabels: rawExtraLabels
     } = req.body as {
       yaml?: string;
       args?: Record<string, string>;
       dryRun?: boolean;
+      extraLabels?: Record<string, string>;
     };
+    const extraLabelsValidation = validateExtraLabels(rawExtraLabels);
+    if (extraLabelsValidation.error) {
+      return sendError(res, {
+        status: 400,
+        type: ErrorType.VALIDATION_ERROR,
+        code: ErrorCode.INVALID_VALUE,
+        message: extraLabelsValidation.error
+      });
+    }
+    const extraLabels = extraLabelsValidation.labels;
 
     // Validate required yaml field
     if (!yaml || typeof yaml !== 'string' || yaml.trim() === '') {
@@ -256,7 +268,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     // Generate YAML list with templateDeployKey labels
-    const correctYaml = generateYamlList(generateStr, instanceName);
+    const correctYaml = generateYamlList(generateStr, instanceName, extraLabels);
 
     if (!correctYaml || correctYaml.length === 0) {
       return sendError(res, {

--- a/frontend/providers/template/src/types/apis/v2alpha/create-instance.ts
+++ b/frontend/providers/template/src/types/apis/v2alpha/create-instance.ts
@@ -1,5 +1,13 @@
 import { z } from 'zod';
 
+const ExtraLabelsSchema = z
+  .object({})
+  .catchall(z.string().describe('Kubernetes label value'))
+  .describe(
+    'Optional Kubernetes labels to attach to the Instance and rendered resources. Reserved Sealos ownership labels cannot be overridden.'
+  )
+  .meta({ example: { 'brain.io/project-id': 'project-uid' } });
+
 // Request body schema for creating an instance
 export const CreateInstanceRequestSchema = z.object({
   name: z
@@ -21,7 +29,8 @@ export const CreateInstanceRequestSchema = z.object({
       'Template variable key-value pairs. Only args without a default value are required. Use GET /templates/{name} to see which args are required and their defaults.'
     )
     .meta({ example: { OPENAI_API_KEY: 'sk-xxxxxxxxxxxxxxxxxxxx', OPENAI_MODEL_NAME: 'gpt-4o' } })
-    .optional()
+    .optional(),
+  extraLabels: ExtraLabelsSchema.optional()
 });
 
 // Quota schema for resources with compute/storage requirements

--- a/frontend/providers/template/src/types/apis/v2alpha/deploy-template.ts
+++ b/frontend/providers/template/src/types/apis/v2alpha/deploy-template.ts
@@ -1,6 +1,14 @@
 import { z } from 'zod';
 import { InstanceResourceQuotaSchema, ResourceSchema, InstanceSchema } from './create-instance';
 
+const ExtraLabelsSchema = z
+  .object({})
+  .catchall(z.string().describe('Kubernetes label value'))
+  .describe(
+    'Optional Kubernetes labels to attach to the Instance and rendered resources. Reserved Sealos ownership labels cannot be overridden.'
+  )
+  .meta({ example: { 'brain.io/project-id': 'project-uid' } });
+
 // Request body schema for deploying a template from raw YAML
 export const DeployTemplateRequestSchema = z.object({
   yaml: z
@@ -26,7 +34,8 @@ export const DeployTemplateRequestSchema = z.object({
       'If true, validates the resources against the Kubernetes API but does not create anything. Returns 200 with a preview. Default: false.'
     )
     .meta({ example: true })
-    .optional()
+    .optional(),
+  extraLabels: ExtraLabelsSchema.optional()
 });
 
 // Dry-run preview response

--- a/frontend/providers/template/src/utils/common.ts
+++ b/frontend/providers/template/src/utils/common.ts
@@ -1,7 +1,13 @@
 import { cloneDeep, forEach, isNumber, isBoolean, isObject, has } from 'lodash';
-import { templateDeployKey } from '@/constants/keys';
+import { ownerReferencesKey, templateDeployKey } from '@/constants/keys';
 import { EnvResponse } from '@/types';
 import { Config } from '@/config';
+
+export type ExtraResourceLabels = Record<string, string>;
+
+const labelNameSegmentRegex = /^[A-Za-z0-9]([A-Za-z0-9_.-]{0,61}[A-Za-z0-9])?$/;
+const dnsLabelRegex = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
+const reservedExtraLabelKeys = new Set([templateDeployKey, ownerReferencesKey]);
 
 export const parseGithubUrl = (url: string) => {
   if (!url) return null;
@@ -17,7 +23,96 @@ export const parseGithubUrl = (url: string) => {
   };
 };
 
-export const processEnvValue = (obj: any, labelName: string) => {
+function isValidLabelPrefix(prefix: string) {
+  if (prefix.length > 253) return false;
+  return prefix.split('.').every((part) => dnsLabelRegex.test(part));
+}
+
+export function validateExtraLabels(value: unknown): {
+  error?: string;
+  labels: ExtraResourceLabels;
+} {
+  if (value === undefined || value === null) {
+    return { labels: {} };
+  }
+  if (!isObject(value) || Array.isArray(value)) {
+    return { error: 'extraLabels must be an object.', labels: {} };
+  }
+
+  const labels: ExtraResourceLabels = {};
+  for (const [key, rawValue] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof rawValue !== 'string') {
+      return { error: `extraLabels.${key} must be a string.`, labels: {} };
+    }
+    if (reservedExtraLabelKeys.has(key)) {
+      return { error: `extraLabels.${key} is reserved.`, labels: {} };
+    }
+
+    const keyParts = key.split('/');
+    if (keyParts.length > 2) {
+      return { error: `extraLabels.${key} is not a valid Kubernetes label key.`, labels: {} };
+    }
+    const name = keyParts[keyParts.length - 1] ?? '';
+    const prefix = keyParts.length === 2 ? keyParts[0] : '';
+    if (!labelNameSegmentRegex.test(name) || (prefix && !isValidLabelPrefix(prefix))) {
+      return { error: `extraLabels.${key} is not a valid Kubernetes label key.`, labels: {} };
+    }
+    if (rawValue.length > 63 || (rawValue !== '' && !labelNameSegmentRegex.test(rawValue))) {
+      return { error: `extraLabels.${key} is not a valid Kubernetes label value.`, labels: {} };
+    }
+    labels[key] = rawValue;
+  }
+
+  return { labels };
+}
+
+function mergeLabels(target: any, labels: ExtraResourceLabels) {
+  if (!target || Object.keys(labels).length === 0) return;
+  target.labels = target.labels || {};
+  Object.assign(target.labels, labels);
+}
+
+function ensurePath(root: any, keys: string[]) {
+  let cursor = root;
+  for (const key of keys) {
+    if (!cursor?.[key]) cursor[key] = {};
+    cursor = cursor[key];
+  }
+  return cursor;
+}
+
+function applyExtraLabels(obj: any, extraLabels: ExtraResourceLabels) {
+  if (Object.keys(extraLabels).length === 0) return;
+
+  obj.metadata = obj.metadata || {};
+  mergeLabels(obj.metadata, extraLabels);
+
+  if (obj?.spec?.template) {
+    mergeLabels(ensurePath(obj.spec.template, ['metadata']), extraLabels);
+  }
+
+  if (obj?.spec?.jobTemplate?.spec?.template) {
+    mergeLabels(ensurePath(obj.spec.jobTemplate.spec.template, ['metadata']), extraLabels);
+  }
+
+  forEach(obj?.spec?.volumeClaimTemplates, (claim) => {
+    claim.metadata = claim.metadata || {};
+    mergeLabels(claim.metadata, extraLabels);
+  });
+
+  forEach(obj?.spec?.componentSpecs, (component) => {
+    forEach(component?.volumeClaimTemplates, (claim) => {
+      claim.metadata = claim.metadata || {};
+      mergeLabels(claim.metadata, extraLabels);
+    });
+  });
+}
+
+export const processEnvValue = (
+  obj: any,
+  labelName: string,
+  extraLabels: ExtraResourceLabels = {}
+) => {
   const newDeployment = cloneDeep(obj);
 
   forEach(newDeployment?.spec?.template?.spec?.containers, (container) => {
@@ -29,6 +124,8 @@ export const processEnvValue = (obj: any, labelName: string) => {
       }
     });
   });
+
+  applyExtraLabels(newDeployment, extraLabels);
 
   if (labelName) {
     newDeployment.metadata = newDeployment.metadata || {};

--- a/frontend/providers/template/src/utils/json-yaml.ts
+++ b/frontend/providers/template/src/utils/json-yaml.ts
@@ -9,7 +9,7 @@ import {
 import JsYaml from 'js-yaml';
 import { clone, cloneDeep, mapValues } from 'lodash';
 import { customAlphabet } from 'nanoid';
-import { processEnvValue } from './common';
+import { ExtraResourceLabels, processEnvValue } from './common';
 import { EnvResponse } from '@/types/index';
 import Interpreter from 'js-interpreter';
 const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz');
@@ -17,11 +17,15 @@ function base64(str: string) {
   return Buffer.from(str).toString('base64');
 }
 
-export const generateYamlList = (value: string, labelName: string): YamlItemType[] => {
+export const generateYamlList = (
+  value: string,
+  labelName: string,
+  extraLabels: ExtraResourceLabels = {}
+): YamlItemType[] => {
   try {
     let _value = JsYaml.loadAll(value)
       .filter((i) => i)
-      .map((item: any) => JsYaml.dump(processEnvValue(item, labelName)));
+      .map((item: any) => JsYaml.dump(processEnvValue(item, labelName, extraLabels)));
 
     return [
       {
@@ -35,14 +39,18 @@ export const generateYamlList = (value: string, labelName: string): YamlItemType
   }
 };
 
-export const developGenerateYamlList = (value: string, labelName: string): YamlItemType[] => {
+export const developGenerateYamlList = (
+  value: string,
+  labelName: string,
+  extraLabels: ExtraResourceLabels = {}
+): YamlItemType[] => {
   try {
     return JsYaml.loadAll(value)
       .filter((i) => i)
       .map((item: any) => {
         return {
           filename: `${item?.kind}-${item?.metadata?.name ? item.metadata.name : nanoid(6)}.yaml`,
-          value: JsYaml.dump(processEnvValue(item, labelName))
+          value: JsYaml.dump(processEnvValue(item, labelName, extraLabels))
         };
       });
   } catch (error) {
@@ -134,6 +142,26 @@ export const getTemplateDataSource = (template: TemplateType): ProcessedTemplate
   }
 };
 
+const sanitizeInstanceInputs = (
+  inputs: TemplateType['spec']['inputs'] | undefined
+): TemplateInstanceType['spec']['inputs'] => {
+  if (!inputs) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(inputs).map(([key, item]) => [
+      key,
+      {
+        description: item.description,
+        type: item.type,
+        default: item.default,
+        required: item.required
+      }
+    ])
+  );
+};
+
 export const handleTemplateToInstanceYaml = (
   template: TemplateType,
   instanceName: string
@@ -167,7 +195,7 @@ export const handleTemplateToInstanceYaml = (
       templateType: templateType || template_type,
       categories: categories || [],
       defaults: defaults || {},
-      inputs: inputs || {},
+      inputs: sanitizeInstanceInputs(inputs),
       author: author || '',
       title: title || '',
       url: url || '',

--- a/frontend/providers/template/src/utils/template.ts
+++ b/frontend/providers/template/src/utils/template.ts
@@ -2,6 +2,7 @@ import { EnvResponse, YamlItemType } from '@/types';
 import { TemplateSourceType } from '@/types/app';
 import type { TemplateCategory } from '@/types/config';
 import { reduce, mapValues } from 'lodash';
+import type { ExtraResourceLabels } from './common';
 import { developGenerateYamlList, generateYamlList, parseTemplateString } from './json-yaml';
 
 export function getCategorySlugs(categories: readonly TemplateCategory[] = []) {
@@ -51,7 +52,8 @@ export const generateYamlData = (
   templateSource: TemplateSourceType,
   inputs: Record<string, string>,
   platformEnvs?: EnvResponse,
-  isDevelop: boolean = false
+  isDevelop: boolean = false,
+  extraLabels: ExtraResourceLabels = {}
 ): YamlItemType[] => {
   if (!templateSource) return [];
 
@@ -71,6 +73,6 @@ export const generateYamlData = (
   const generateStr = parseTemplateString(templateSource.appYaml, data);
 
   return isDevelop
-    ? developGenerateYamlList(generateStr, app_name)
-    : generateYamlList(generateStr, app_name);
+    ? developGenerateYamlList(generateStr, app_name, extraLabels)
+    : generateYamlList(generateStr, app_name, extraLabels);
 };


### PR DESCRIPTION
## What

- Add optional `extraLabels` support to the template v2alpha create-instance and raw deploy APIs.
- Apply validated extra labels to rendered resource metadata, pod templates, CronJob pod templates, StatefulSet PVC templates, and KubeBlocks component PVC templates.
- Document `extraLabels` in the v2alpha request schemas and reject reserved Sealos ownership labels.
- Strip UI-only template input metadata from generated Instance resources.

## Why

External orchestrators need a supported way to attach their own ownership labels to resources rendered by template deployment, without overriding Sealos labels used for instance lookup and lifecycle management.

## Validation

- `pnpm --filter template test:ci -- template-extra-labels`
- `git diff --check`
- `pnpm exec prettier --check providers/template/src/pages/api/v2alpha/templates/instances.ts providers/template/src/pages/api/v2alpha/templates/raw.ts providers/template/src/types/apis/v2alpha/create-instance.ts providers/template/src/types/apis/v2alpha/deploy-template.ts providers/template/src/utils/common.ts providers/template/src/utils/json-yaml.ts providers/template/src/utils/template.ts providers/template/__tests__/template-extra-labels.test.ts`
- `pnpm --filter template build`

`pnpm --filter template build` passes with existing React Hook lint warnings in unrelated files.
