### PR TITLE
fix(desktop): block manager owner grants

### DIFF
--- a/frontend/desktop/src/__tests__/unit/backend/auth/namespace/modifyRole.api.test.ts
+++ b/frontend/desktop/src/__tests__/unit/backend/auth/namespace/modifyRole.api.test.ts
@@ -1,0 +1,375 @@
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+import { JoinStatus, Role } from 'prisma/region/generated/client';
+import { UserRole } from '@/types/team';
+
+vi.mock('@/services/backend/auth', () => ({
+  verifyAccessToken: vi.fn()
+}));
+
+vi.mock('@/services/backend/db/init', () => ({
+  globalPrisma: {},
+  prisma: {
+    userWorkspace: {
+      findMany: vi.fn()
+    }
+  }
+}));
+
+vi.mock('@/services/backend/team', () => ({
+  modifyBinding: vi.fn(),
+  modifyWorkspaceRole: vi.fn()
+}));
+
+import handler, {
+  getModifyRolePermissionError,
+  validateModifyRoleRequest
+} from '@/pages/api/auth/namespace/modifyRole';
+import { verifyAccessToken } from '@/services/backend/auth';
+import { prisma } from '@/services/backend/db/init';
+import { modifyBinding, modifyWorkspaceRole } from '@/services/backend/team';
+
+const mockVerifyAccessToken = verifyAccessToken as MockedFunction<typeof verifyAccessToken>;
+const mockPrisma = prisma as any;
+const mockModifyBinding = modifyBinding as MockedFunction<typeof modifyBinding>;
+const mockModifyWorkspaceRole = modifyWorkspaceRole as MockedFunction<typeof modifyWorkspaceRole>;
+
+const createMockRes = () => {
+  const res: any = {
+    body: undefined,
+    json: vi.fn((payload: unknown) => {
+      res.body = payload;
+      return res;
+    })
+  };
+  return res;
+};
+
+describe('namespace modifyRole api handler', () => {
+  const managerUserCrUid = '11111111-1111-4111-8111-111111111111';
+  const developerUserCrUid = '22222222-2222-4222-8222-222222222222';
+  const ownerUserCrUid = '44444444-4444-4444-8444-444444444444';
+  const workspaceUid = '33333333-3333-4333-8333-333333333333';
+  const workspace = {
+    id: 'ns-team'
+  };
+
+  const buildUserWorkspace = ({
+    userCrUid,
+    role,
+    crName
+  }: {
+    userCrUid: string;
+    role: Role;
+    crName: string;
+  }) => ({
+    userCrUid,
+    workspaceUid,
+    role,
+    status: JoinStatus.IN_WORKSPACE,
+    workspace,
+    userCr: {
+      crName
+    }
+  });
+
+  const createModifyRoleReq = ({
+    targetUserCrUid,
+    tRole
+  }: {
+    targetUserCrUid: string;
+    tRole: UserRole;
+  }) => ({
+    method: 'POST',
+    headers: {},
+    body: {
+      ns_uid: workspaceUid,
+      targetUserCrUid,
+      tRole
+    }
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('validateModifyRoleRequest', () => {
+    const buildValidBody = () => ({
+      ns_uid: workspaceUid,
+      targetUserCrUid: developerUserCrUid,
+      tRole: UserRole.Owner
+    });
+
+    it('rejects invalid target user ids', () => {
+      expect(
+        validateModifyRoleRequest(
+          {
+            ...buildValidBody(),
+            targetUserCrUid: 'bad-id'
+          },
+          managerUserCrUid
+        )
+      ).toEqual({
+        ok: false,
+        error: {
+          code: 400,
+          message: 'tUserId is invalid'
+        }
+      });
+    });
+
+    it('rejects missing or invalid target roles', () => {
+      expect(
+        validateModifyRoleRequest(
+          {
+            ...buildValidBody(),
+            tRole: undefined
+          },
+          managerUserCrUid
+        )
+      ).toEqual({
+        ok: false,
+        error: {
+          code: 400,
+          message: 'tRole is required'
+        }
+      });
+
+      expect(
+        validateModifyRoleRequest(
+          {
+            ...buildValidBody(),
+            tRole: 99 as UserRole
+          },
+          managerUserCrUid
+        )
+      ).toEqual({
+        ok: false,
+        error: {
+          code: 400,
+          message: 'tRole is required'
+        }
+      });
+    });
+
+    it('accepts owner as a syntactically valid target role', () => {
+      expect(validateModifyRoleRequest(buildValidBody(), managerUserCrUid)).toEqual({
+        ok: true,
+        data: buildValidBody()
+      });
+    });
+
+    it('rejects invalid namespace ids', () => {
+      expect(
+        validateModifyRoleRequest(
+          {
+            ...buildValidBody(),
+            ns_uid: 'bad-id'
+          },
+          managerUserCrUid
+        )
+      ).toEqual({
+        ok: false,
+        error: {
+          code: 400,
+          message: 'ns_uid is invalid'
+        }
+      });
+    });
+
+    it('rejects changing the requester role', () => {
+      expect(
+        validateModifyRoleRequest(
+          {
+            ...buildValidBody(),
+            targetUserCrUid: managerUserCrUid
+          },
+          managerUserCrUid
+        )
+      ).toEqual({
+        ok: false,
+        error: {
+          code: 403,
+          message: 'target user is not self'
+        }
+      });
+    });
+  });
+
+  describe('getModifyRolePermissionError', () => {
+    it('rejects manager promotion of a developer to owner', () => {
+      expect(
+        getModifyRolePermissionError({
+          requesterRole: UserRole.Manager,
+          targetCurrentRole: UserRole.Developer,
+          requestedRole: UserRole.Owner,
+          isSelf: false
+        })
+      ).toEqual({
+        code: 403,
+        message: 'you are not owner'
+      });
+    });
+
+    it('allows owner promotion of a developer to owner', () => {
+      expect(
+        getModifyRolePermissionError({
+          requesterRole: UserRole.Owner,
+          targetCurrentRole: UserRole.Developer,
+          requestedRole: UserRole.Owner,
+          isSelf: false
+        })
+      ).toBeNull();
+    });
+
+    it('allows manager modification of a developer to a non-owner role', () => {
+      expect(
+        getModifyRolePermissionError({
+          requesterRole: UserRole.Manager,
+          targetCurrentRole: UserRole.Developer,
+          requestedRole: UserRole.Manager,
+          isSelf: false
+        })
+      ).toBeNull();
+    });
+
+    it('rejects manager modification of an owner', () => {
+      expect(
+        getModifyRolePermissionError({
+          requesterRole: UserRole.Manager,
+          targetCurrentRole: UserRole.Owner,
+          requestedRole: UserRole.Developer,
+          isSelf: false
+        })
+      ).toEqual({
+        code: 403,
+        message: 'you are not manager'
+      });
+    });
+  });
+
+  it('rejects a manager promoting a developer to owner when tRole is Owner', async () => {
+    mockVerifyAccessToken.mockResolvedValue({
+      userCrUid: managerUserCrUid
+    } as any);
+    mockPrisma.userWorkspace.findMany.mockResolvedValue([
+      buildUserWorkspace({
+        userCrUid: managerUserCrUid,
+        role: Role.MANAGER,
+        crName: 'manager-cr'
+      }),
+      buildUserWorkspace({
+        userCrUid: developerUserCrUid,
+        role: Role.DEVELOPER,
+        crName: 'developer-cr'
+      })
+    ]);
+    mockModifyWorkspaceRole.mockResolvedValue(undefined as any);
+    mockModifyBinding.mockResolvedValue({} as any);
+
+    const req: any = createModifyRoleReq({
+      targetUserCrUid: developerUserCrUid,
+      tRole: UserRole.Owner
+    });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.body).toMatchObject({
+      code: 403
+    });
+    expect(mockModifyWorkspaceRole).not.toHaveBeenCalled();
+    expect(mockModifyBinding).not.toHaveBeenCalled();
+  });
+
+  it('allows an owner to promote a developer to owner', async () => {
+    mockVerifyAccessToken.mockResolvedValue({
+      userCrUid: ownerUserCrUid
+    } as any);
+    mockPrisma.userWorkspace.findMany.mockResolvedValue([
+      buildUserWorkspace({
+        userCrUid: ownerUserCrUid,
+        role: Role.OWNER,
+        crName: 'owner-cr'
+      }),
+      buildUserWorkspace({
+        userCrUid: developerUserCrUid,
+        role: Role.DEVELOPER,
+        crName: 'developer-cr'
+      })
+    ]);
+    mockModifyWorkspaceRole.mockResolvedValue(undefined as any);
+    mockModifyBinding.mockResolvedValue({} as any);
+
+    const req: any = createModifyRoleReq({
+      targetUserCrUid: developerUserCrUid,
+      tRole: UserRole.Owner
+    });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.body).toEqual({
+      code: 200,
+      message: 'Successfully',
+      data: null
+    });
+    expect(mockModifyWorkspaceRole).toHaveBeenCalledWith({
+      k8s_username: 'developer-cr',
+      role: UserRole.Owner,
+      action: 'Modify',
+      workspaceId: 'ns-team',
+      pre_role: UserRole.Developer
+    });
+    expect(mockModifyBinding).toHaveBeenCalledWith({
+      userCrUid: developerUserCrUid,
+      workspaceUid,
+      role: UserRole.Owner
+    });
+  });
+
+  it('allows a manager to modify a developer to a non-owner role', async () => {
+    mockVerifyAccessToken.mockResolvedValue({
+      userCrUid: managerUserCrUid
+    } as any);
+    mockPrisma.userWorkspace.findMany.mockResolvedValue([
+      buildUserWorkspace({
+        userCrUid: managerUserCrUid,
+        role: Role.MANAGER,
+        crName: 'manager-cr'
+      }),
+      buildUserWorkspace({
+        userCrUid: developerUserCrUid,
+        role: Role.DEVELOPER,
+        crName: 'developer-cr'
+      })
+    ]);
+    mockModifyWorkspaceRole.mockResolvedValue(undefined as any);
+    mockModifyBinding.mockResolvedValue({} as any);
+
+    const req: any = createModifyRoleReq({
+      targetUserCrUid: developerUserCrUid,
+      tRole: UserRole.Manager
+    });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.body).toEqual({
+      code: 200,
+      message: 'Successfully',
+      data: null
+    });
+    expect(mockModifyWorkspaceRole).toHaveBeenCalledWith({
+      k8s_username: 'developer-cr',
+      role: UserRole.Manager,
+      action: 'Modify',
+      workspaceId: 'ns-team',
+      pre_role: UserRole.Developer
+    });
+    expect(mockModifyBinding).toHaveBeenCalledWith({
+      userCrUid: developerUserCrUid,
+      workspaceUid,
+      role: UserRole.Manager
+    });
+  });
+});

--- a/frontend/desktop/src/__tests__/unit/backend/auth/namespace/modifyRole.api.test.ts
+++ b/frontend/desktop/src/__tests__/unit/backend/auth/namespace/modifyRole.api.test.ts
@@ -221,10 +221,24 @@ describe('namespace modifyRole api handler', () => {
       ).toBeNull();
     });
 
-    it('allows manager modification of a developer to a non-owner role', () => {
+    it('rejects manager modification of a developer to a non-owner role', () => {
       expect(
         getModifyRolePermissionError({
           requesterRole: UserRole.Manager,
+          targetCurrentRole: UserRole.Developer,
+          requestedRole: UserRole.Manager,
+          isSelf: false
+        })
+      ).toEqual({
+        code: 403,
+        message: 'you are not owner'
+      });
+    });
+
+    it('allows owner modification of a developer to a non-owner role', () => {
+      expect(
+        getModifyRolePermissionError({
+          requesterRole: UserRole.Owner,
           targetCurrentRole: UserRole.Developer,
           requestedRole: UserRole.Manager,
           isSelf: false
@@ -242,7 +256,7 @@ describe('namespace modifyRole api handler', () => {
         })
       ).toEqual({
         code: 403,
-        message: 'you are not manager'
+        message: 'you are not owner'
       });
     });
   });
@@ -327,7 +341,7 @@ describe('namespace modifyRole api handler', () => {
     });
   });
 
-  it('allows a manager to modify a developer to a non-owner role', async () => {
+  it('rejects a manager modifying a developer to a non-owner role', async () => {
     mockVerifyAccessToken.mockResolvedValue({
       userCrUid: managerUserCrUid
     } as any);
@@ -336,6 +350,40 @@ describe('namespace modifyRole api handler', () => {
         userCrUid: managerUserCrUid,
         role: Role.MANAGER,
         crName: 'manager-cr'
+      }),
+      buildUserWorkspace({
+        userCrUid: developerUserCrUid,
+        role: Role.DEVELOPER,
+        crName: 'developer-cr'
+      })
+    ]);
+    mockModifyWorkspaceRole.mockResolvedValue(undefined as any);
+    mockModifyBinding.mockResolvedValue({} as any);
+
+    const req: any = createModifyRoleReq({
+      targetUserCrUid: developerUserCrUid,
+      tRole: UserRole.Manager
+    });
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.body).toMatchObject({
+      code: 403
+    });
+    expect(mockModifyWorkspaceRole).not.toHaveBeenCalled();
+    expect(mockModifyBinding).not.toHaveBeenCalled();
+  });
+
+  it('allows an owner to modify a developer to a non-owner role', async () => {
+    mockVerifyAccessToken.mockResolvedValue({
+      userCrUid: ownerUserCrUid
+    } as any);
+    mockPrisma.userWorkspace.findMany.mockResolvedValue([
+      buildUserWorkspace({
+        userCrUid: ownerUserCrUid,
+        role: Role.OWNER,
+        crName: 'owner-cr'
       }),
       buildUserWorkspace({
         userCrUid: developerUserCrUid,

--- a/frontend/desktop/src/pages/api/auth/namespace/modifyRole.ts
+++ b/frontend/desktop/src/pages/api/auth/namespace/modifyRole.ts
@@ -43,7 +43,6 @@ export const validateModifyRoleRequest = (
 export const getModifyRolePermissionError = ({
   requesterRole,
   targetCurrentRole,
-  requestedRole,
   isSelf
 }: {
   requesterRole: UserRole;
@@ -51,11 +50,11 @@ export const getModifyRolePermissionError = ({
   requestedRole: UserRole;
   isSelf: boolean;
 }): ModifyRoleError | null => {
+  if (requesterRole !== UserRole.Owner) return { code: 403, message: 'you are not owner' };
+
   const canManageTargetCurrentRole = vaildManage(requesterRole)(targetCurrentRole, isSelf);
 
   if (!canManageTargetCurrentRole) return { code: 403, message: 'you are not manager' };
-  if (requestedRole === UserRole.Owner && requesterRole !== UserRole.Owner)
-    return { code: 403, message: 'you are not owner' };
 
   return null;
 };

--- a/frontend/desktop/src/pages/api/auth/namespace/modifyRole.ts
+++ b/frontend/desktop/src/pages/api/auth/namespace/modifyRole.ts
@@ -8,23 +8,68 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { JoinStatus } from 'prisma/region/generated/client';
 import { validate } from 'uuid';
 
+type ModifyRoleError = {
+  code: number;
+  message: string;
+};
+
+type ModifyRoleBody = {
+  ns_uid: string;
+  targetUserCrUid: string;
+  tRole: UserRole;
+};
+
+export const validateModifyRoleRequest = (
+  body: {
+    ns_uid?: string;
+    targetUserCrUid?: string;
+    tRole?: UserRole;
+  },
+  requesterUserCrUid: string
+): { ok: true; data: ModifyRoleBody } | { ok: false; error: ModifyRoleError } => {
+  const { ns_uid, targetUserCrUid, tRole } = body;
+
+  if (!targetUserCrUid || !validate(targetUserCrUid))
+    return { ok: false, error: { code: 400, message: 'tUserId is invalid' } };
+  if (!isUserRole(tRole)) return { ok: false, error: { code: 400, message: 'tRole is required' } };
+  if (!ns_uid || !validate(ns_uid))
+    return { ok: false, error: { code: 400, message: 'ns_uid is invalid' } };
+  if (targetUserCrUid === requesterUserCrUid)
+    return { ok: false, error: { code: 403, message: 'target user is not self' } };
+
+  return { ok: true, data: { ns_uid, targetUserCrUid, tRole } };
+};
+
+export const getModifyRolePermissionError = ({
+  requesterRole,
+  targetCurrentRole,
+  requestedRole,
+  isSelf
+}: {
+  requesterRole: UserRole;
+  targetCurrentRole: UserRole;
+  requestedRole: UserRole;
+  isSelf: boolean;
+}): ModifyRoleError | null => {
+  const canManageTargetCurrentRole = vaildManage(requesterRole)(targetCurrentRole, isSelf);
+
+  if (!canManageTargetCurrentRole) return { code: 403, message: 'you are not manager' };
+  if (requestedRole === UserRole.Owner && requesterRole !== UserRole.Owner)
+    return { code: 403, message: 'you are not owner' };
+
+  return null;
+};
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
     const payload = await verifyAccessToken(req.headers);
     if (!payload) return jsonRes(res, { code: 401, message: 'token verify error' });
-    //
-    const { ns_uid, targetUserCrUid, tRole } = req.body as {
-      ns_uid?: string;
-      targetUserCrUid?: string;
-      tRole?: UserRole;
-    };
-    if (!targetUserCrUid || !validate(targetUserCrUid))
-      return jsonRes(res, { code: 400, message: 'tUserId is invalid' });
-    if (!isUserRole(tRole)) return jsonRes(res, { code: 400, message: 'tRole is required' });
-    if (!ns_uid || !validate(ns_uid))
-      return jsonRes(res, { code: 400, message: 'ns_uid is invalid' });
-    if (targetUserCrUid === payload.userCrUid)
-      return jsonRes(res, { code: 403, message: 'target user is not self' });
+
+    const requestValidation = validateModifyRoleRequest(req.body, payload.userCrUid);
+    if (!requestValidation.ok) return jsonRes(res, requestValidation.error);
+
+    const { ns_uid, targetUserCrUid, tRole } = requestValidation.data;
+
     //  get utn
     const queryResults = await prisma.userWorkspace.findMany({
       where: {
@@ -41,22 +86,29 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     });
     const own = queryResults.find((x) => x.userCrUid === payload.userCrUid);
     if (!own) return jsonRes(res, { code: 403, message: 'you are not in namespace' });
-    const vaildFn = vaildManage(roleToUserRole(own.role));
     const targetUser = queryResults.find((x) => x.userCrUid === targetUserCrUid);
     if (!targetUser) return jsonRes(res, { code: 404, message: 'target is not in namespace' });
-    if (!vaildFn(roleToUserRole(targetUser.role), targetUser.userCrUid === own.userCrUid))
-      return jsonRes(res, { code: 403, message: 'you are not manager' });
+
+    const ownRole = roleToUserRole(own.role);
+    const targetRole = roleToUserRole(targetUser.role);
+    const permissionError = getModifyRolePermissionError({
+      requesterRole: ownRole,
+      targetCurrentRole: targetRole,
+      requestedRole: tRole,
+      isSelf: targetUser.userCrUid === own.userCrUid
+    });
+
+    if (permissionError) return jsonRes(res, permissionError);
 
     // if role is same, do nothing
-    if (roleToUserRole(targetUser.role) === tRole)
-      return jsonRes(res, { code: 200, message: 'Successfully' });
+    if (targetRole === tRole) return jsonRes(res, { code: 200, message: 'Successfully' });
 
     await modifyWorkspaceRole({
       k8s_username: targetUser.userCr.crName,
       role: tRole,
       action: 'Modify',
       workspaceId: targetUser.workspace.id,
-      pre_role: roleToUserRole(targetUser.role)
+      pre_role: targetRole
     });
     const updateResult = await modifyBinding({
       userCrUid: targetUser.userCrUid,


### PR DESCRIPTION
Fixes namespace role assignment authorization so only Owners can modify member roles, preventing Managers from elevating or changing other users’ roles.