### PR TITLE
feat(template): support managed template repository layout

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -2469,9 +2469,6 @@ importers:
       cron-parser:
         specifier: ^4.9.0
         version: 4.9.0
-      croner:
-        specifier: ^8.1.0
-        version: 8.1.0
       cronstrue:
         specifier: ^2.32.0
         version: 2.44.0
@@ -16172,11 +16169,6 @@ packages:
 
   /croner@8.0.2:
     resolution: {integrity: sha512-HgSdlSUX8mIgDTTiQpWUP4qY4IFRMsduPCYdca34Pelt8MVdxdaDOzreFtCscA6R+cRZd7UbD1CD3uyx6J3X1A==}
-    engines: {node: '>=18.0'}
-    dev: false
-
-  /croner@8.1.0:
-    resolution: {integrity: sha512-sz990XOUPR8dG/r5BRKMBd15MYDDUu8oeSaxFD5DqvNgHSZw8Psd1s689/IGET7ezxRMiNlCIyGeY1Gvxp/MLg==}
     engines: {node: '>=18.0'}
     dev: false
 

--- a/frontend/providers/template/README.md
+++ b/frontend/providers/template/README.md
@@ -12,7 +12,9 @@ The Template App reads app-store templates from a Git repository configured by e
 
 When templates use repository-local README or icon paths such as `README.md`, `./README.md`, or `/shared/logo.svg`, the app serves them through `/api/templateAsset` from the cloned local repository. This keeps private/offline deployments from depending on public raw URLs.
 
-`/api/updateRepo` pulls the configured repository, regenerates `templates.json`, and clears both README and v2 template/detail caches. Admin template-management flows call this endpoint after successful Git pushes so `/api/listTemplate` and `/api/v2alpha/templates` reflect the same repository commit immediately.
+Template read APIs call a TTL-bound repository freshness check before reading `templates.json`. When the TTL has expired, the app pulls the configured repository, regenerates `templates.json`, and clears both README and v2 template/detail caches. This keeps `/api/listTemplate` and `/api/v2alpha/templates` aligned with the data source even when the repository is changed outside Admin. `TEMPLATE_REPO_SYNC_INTERVAL_MS` controls the freshness interval and defaults to `30000`.
+
+`/api/updateRepo` remains available as a manual immediate refresh endpoint.
 
 ## template repository layout
 

--- a/frontend/providers/template/README.md
+++ b/frontend/providers/template/README.md
@@ -1,5 +1,17 @@
 # sealos app launchpad
 
+## template repository configuration
+
+The Template App reads app-store templates from a Git repository configured by environment variables:
+
+- `TEMPLATE_REPO_URL`: Git clone URL, for example an internal Gogs URL.
+- `TEMPLATE_REPO_BRANCH`: branch to clone, default `main`.
+- `TEMPLATE_REPO_FOLDER`: folder inside the repository that contains template YAML files, default `template`.
+- `TEMPLATE_CATEGORIES_PATH`: optional category JSON path inside the cloned repo, default `config/categories.json`.
+- `TEMPLATE_CATEGORIES`: fallback category JSON when the repository category file is missing.
+
+When templates use repository-local README or icon paths such as `README.md`, `./README.md`, or `/shared/logo.svg`, the app serves them through `/api/templateAsset` from the cloned local repository. This keeps private/offline deployments from depending on public raw URLs.
+
 ## project tree
 ```bash
 .

--- a/frontend/providers/template/README.md
+++ b/frontend/providers/template/README.md
@@ -12,6 +12,25 @@ The Template App reads app-store templates from a Git repository configured by e
 
 When templates use repository-local README or icon paths such as `README.md`, `./README.md`, or `/shared/logo.svg`, the app serves them through `/api/templateAsset` from the cloned local repository. This keeps private/offline deployments from depending on public raw URLs.
 
+## template repository layout
+
+The app keeps backward compatibility with legacy single-file templates such as:
+
+```text
+template/wordpress.yaml
+```
+
+Managed templates may also use the split layout produced by Sealos Admin:
+
+```text
+template/<name>/index.yaml
+template/<name>/manifests/001-app.yaml
+template/<name>/README.md
+template/<name>/logo.svg
+```
+
+`index.yaml` must start with the `Template` document. App resources can either remain as following YAML documents in `index.yaml` or live in sibling `manifests/*.yaml` files. Catalog refresh skips `manifests/` so resource YAML files are not listed as templates. Template detail/source reads append sibling manifest files in lexical order.
+
 ## project tree
 ```bash
 .

--- a/frontend/providers/template/README.md
+++ b/frontend/providers/template/README.md
@@ -12,6 +12,8 @@ The Template App reads app-store templates from a Git repository configured by e
 
 When templates use repository-local README or icon paths such as `README.md`, `./README.md`, or `/shared/logo.svg`, the app serves them through `/api/templateAsset` from the cloned local repository. This keeps private/offline deployments from depending on public raw URLs.
 
+`/api/updateRepo` pulls the configured repository, regenerates `templates.json`, and clears both README and v2 template/detail caches. Admin template-management flows call this endpoint after successful Git pushes so `/api/listTemplate` and `/api/v2alpha/templates` reflect the same repository commit immediately.
+
 ## template repository layout
 
 The app keeps backward compatibility with legacy single-file templates such as:

--- a/frontend/providers/template/deploy/charts/template-frontend/templates/configmap.yaml
+++ b/frontend/providers/template/deploy/charts/template-frontend/templates/configmap.yaml
@@ -13,6 +13,7 @@ data:
     SEALOS_CERT_SECRET_NAME={{ .Values.templateConfig.certSecretName }}
     TEMPLATE_REPO_URL={{ .Values.templateConfig.templateRepoUrl }}
     TEMPLATE_REPO_BRANCH={{ .Values.templateConfig.templateRepoBranch }}
+    TEMPLATE_REPO_FOLDER={{ .Values.templateConfig.templateRepoPath }}
     SHOW_AUTHOR={{ .Values.templateConfig.showAuthor }}
     ACCOUNT_URL={{ .Values.templateConfig.accountUrl }}
     GUIDE_ENABLED={{ .Values.templateConfig.guideEnabled }}

--- a/frontend/providers/template/package.json
+++ b/frontend/providers/template/package.json
@@ -33,7 +33,6 @@
     "axios": "^1.5.1",
     "codemirror": "^6.0.1",
     "cron-parser": "^4.9.0",
-    "croner": "^8.1.0",
     "cronstrue": "^2.32.0",
     "dayjs": "^1.11.10",
     "echarts": "^5.4.3",

--- a/frontend/providers/template/src/pages/api/getTemplateSource.ts
+++ b/frontend/providers/template/src/pages/api/getTemplateSource.ts
@@ -23,6 +23,7 @@ import {
   readTemplateAssetFile,
   rewriteTemplateAssetsToLocalApi
 } from '@/utils/templateAssets';
+import { ensureRepoFresh } from '@/services/backend/template-repo';
 
 const TEMPLATE_MANIFESTS_DIR = 'manifests';
 
@@ -156,6 +157,8 @@ export async function GetTemplateByName({
   locale?: string;
   includeReadme?: string;
 }) {
+  await ensureRepoFresh();
+
   const cdnUrl = process.env.CDN_URL;
   const targetFolder = process.env.TEMPLATE_REPO_FOLDER || 'template';
 

--- a/frontend/providers/template/src/pages/api/getTemplateSource.ts
+++ b/frontend/providers/template/src/pages/api/getTemplateSource.ts
@@ -24,6 +24,39 @@ import {
   rewriteTemplateAssetsToLocalApi
 } from '@/utils/templateAssets';
 
+const TEMPLATE_MANIFESTS_DIR = 'manifests';
+
+const isTemplateIndexFile = (filePath: string) => {
+  const filename = path.basename(filePath).toLowerCase();
+  return filename === 'index.yaml' || filename === 'index.yml';
+};
+
+const joinYamlDocuments = (items: string[]) =>
+  items
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .join('\n---\n');
+
+const readSiblingManifestYaml = (templateFilePath: string) => {
+  if (!isTemplateIndexFile(templateFilePath)) return '';
+
+  const manifestsDir = path.join(path.dirname(templateFilePath), TEMPLATE_MANIFESTS_DIR);
+  if (!fs.existsSync(manifestsDir) || !fs.statSync(manifestsDir).isDirectory()) {
+    return '';
+  }
+
+  const manifestContents = fs
+    .readdirSync(manifestsDir)
+    .filter((item) => {
+      const ext = path.extname(item).toLowerCase();
+      return ext === '.yaml' || ext === '.yml';
+    })
+    .sort((left, right) => left.localeCompare(right))
+    .map((item) => fs.readFileSync(path.join(manifestsDir, item), 'utf-8'));
+
+  return joinYamlDocuments(manifestContents);
+};
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
     const envEnableReadme = process.env.ENABLE_README_FETCH;
@@ -140,6 +173,7 @@ export async function GetTemplateByName({
   const yamlString = fs.readFileSync(templateFilePath, 'utf-8');
 
   let { appYaml, templateYaml } = getYamlTemplate(yamlString);
+  appYaml = joinYamlDocuments([appYaml, readSiblingManifestYaml(templateFilePath)]);
 
   if (!templateYaml) {
     return {

--- a/frontend/providers/template/src/pages/api/getTemplateSource.ts
+++ b/frontend/providers/template/src/pages/api/getTemplateSource.ts
@@ -18,6 +18,11 @@ import { getResourceUsage, ResourceUsage } from '@/utils/usage';
 import { generateYamlData, getTemplateDefaultValues } from '@/utils/template';
 import { readmeCache } from '@/utils/readmeCache';
 import { resolveTemplateAssetUrls } from '@/utils/templateAsset';
+import {
+  hasLocalTemplateAssets,
+  readTemplateAssetFile,
+  rewriteTemplateAssetsToLocalApi
+} from '@/utils/templateAssets';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
@@ -143,14 +148,16 @@ export async function GetTemplateByName({
     };
   }
   templateYaml.spec.deployCount = _tempalte?.spec?.deployCount;
-  templateYaml = resolveTemplateAssetUrls(templateYaml, {
-    repo: {
-      url: TemplateEnvs.TEMPLATE_REPO_URL,
-      branch: TemplateEnvs.TEMPLATE_REPO_BRANCH
-    },
-    templateFilePath,
-    repoRootPath
-  });
+  templateYaml = hasLocalTemplateAssets(templateYaml)
+    ? rewriteTemplateAssetsToLocalApi(templateYaml)
+    : resolveTemplateAssetUrls(templateYaml, {
+        repo: {
+          url: TemplateEnvs.TEMPLATE_REPO_URL,
+          branch: TemplateEnvs.TEMPLATE_REPO_BRANCH
+        },
+        templateFilePath,
+        repoRootPath
+      });
 
   if (cdnUrl) {
     templateYaml.spec.readme = replaceRawWithCDN(templateYaml.spec.readme, cdnUrl);
@@ -187,7 +194,17 @@ export async function GetTemplateByName({
     readUrl = templateYaml?.spec?.i18n?.[locale]?.readme || templateYaml?.spec?.readme || '';
     if (readUrl) {
       try {
-        readmeContent = await fetchReadmeContentWithRetry(readUrl);
+        if (readUrl.startsWith('/api/templateAsset?')) {
+          const asset = new URLSearchParams(readUrl.split('?')[1] || '').get('asset') || '';
+          readmeContent = readTemplateAssetFile({
+            jsonPath,
+            templateName,
+            assetUrl: asset,
+            repoRootPath
+          }).content.toString('utf8');
+        } else {
+          readmeContent = await fetchReadmeContentWithRetry(readUrl);
+        }
       } catch (error) {
         readmeContent = '';
       }

--- a/frontend/providers/template/src/pages/api/listTemplate.ts
+++ b/frontend/providers/template/src/pages/api/listTemplate.ts
@@ -1,10 +1,7 @@
 import { jsonRes } from '@/services/backend/response';
 import { TemplateType } from '@/types/app';
-import {
-  filterConfiguredCategorySlugs,
-  getCategorySlugs,
-  getConfiguredTemplateCategories
-} from '@/utils/template';
+import { filterConfiguredCategorySlugs, getCategorySlugs } from '@/utils/template';
+import { getConfiguredTemplateCategories } from '@/utils/templateCategories.server';
 import type { TemplateCategory } from '@/types/config';
 import { parseGithubUrl } from '@/utils/tools';
 import fs from 'fs';

--- a/frontend/providers/template/src/pages/api/listTemplate.ts
+++ b/frontend/providers/template/src/pages/api/listTemplate.ts
@@ -3,7 +3,7 @@ import { TemplateType } from '@/types/app';
 import {
   filterConfiguredCategorySlugs,
   getCategorySlugs,
-  parseTemplateCategories
+  getConfiguredTemplateCategories
 } from '@/utils/template';
 import type { TemplateCategory } from '@/types/config';
 import { parseGithubUrl } from '@/utils/tools';
@@ -77,7 +77,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const jsonPath = path.resolve(originalPath, 'templates.json');
   const cdnUrl = process.env.CDN_URL;
   const baseurl = `http://${process.env.HOSTNAME || 'localhost'}:${process.env.PORT || 3000}`;
-  const configuredCategories = parseTemplateCategories(process.env.TEMPLATE_CATEGORIES);
+  const repoRootPath = path.resolve(originalPath, 'templates');
+  const configuredCategories = getConfiguredTemplateCategories(repoRootPath);
 
   try {
     if (!global.updateRepoCronJob) {

--- a/frontend/providers/template/src/pages/api/listTemplate.ts
+++ b/frontend/providers/template/src/pages/api/listTemplate.ts
@@ -7,7 +7,7 @@ import { parseGithubUrl } from '@/utils/tools';
 import fs from 'fs';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import path from 'path';
-import { Cron } from 'croner';
+import { ensureRepoFresh } from '@/services/backend/template-repo';
 
 export function replaceRawWithCDN(url: string, cdnUrl: string) {
   let parsedUrl = parseGithubUrl(url);
@@ -73,30 +73,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const originalPath = process.cwd();
   const jsonPath = path.resolve(originalPath, 'templates.json');
   const cdnUrl = process.env.CDN_URL;
-  const baseurl = `http://${process.env.HOSTNAME || 'localhost'}:${process.env.PORT || 3000}`;
   const repoRootPath = path.resolve(originalPath, 'templates');
-  const configuredCategories = getConfiguredTemplateCategories(repoRootPath);
 
   try {
-    if (!global.updateRepoCronJob) {
-      global.updateRepoCronJob = new Cron(
-        '*/5 * * * *',
-        async () => {
-          const result = await (await fetch(`${baseurl}/api/updateRepo`)).json();
-          const now = new Date().toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' });
-          console.log(`[${now}] updateRepoCronJob`);
-        },
-        {
-          timezone: 'Asia/Shanghai'
-        }
-      );
-    }
+    await ensureRepoFresh();
 
-    if (!fs.existsSync(jsonPath)) {
-      console.log(`${baseurl}/api/updateRepo`);
-      await fetch(`${baseurl}/api/updateRepo`);
-    }
-
+    const configuredCategories = getConfiguredTemplateCategories(repoRootPath);
     const templates = readTemplatesFromFile(jsonPath, cdnUrl, configuredCategories, language);
 
     const timestamp = new Date().toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' });

--- a/frontend/providers/template/src/pages/api/platform/getClientAppConfig.ts
+++ b/frontend/providers/template/src/pages/api/platform/getClientAppConfig.ts
@@ -1,6 +1,6 @@
 import { jsonRes } from '@/services/backend/response';
 import { ClientAppConfigSchema } from '@/types/config';
-import { parseTemplateCategories } from '@/utils/template';
+import { getConfiguredTemplateCategories } from '@/utils/template';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 export function getClientAppConfigServer() {
@@ -11,7 +11,7 @@ export function getClientAppConfigServer() {
       process.env.CURRENCY_SYMBOL === 'cny' || process.env.CURRENCY_SYMBOL === 'usd'
         ? process.env.CURRENCY_SYMBOL
         : 'shellCoin',
-    categories: parseTemplateCategories(process.env.TEMPLATE_CATEGORIES),
+    categories: getConfiguredTemplateCategories(),
     showAuthor: process.env.SHOW_AUTHOR === 'true',
     carousel: {
       enabled: false,

--- a/frontend/providers/template/src/pages/api/platform/getClientAppConfig.ts
+++ b/frontend/providers/template/src/pages/api/platform/getClientAppConfig.ts
@@ -1,6 +1,6 @@
 import { jsonRes } from '@/services/backend/response';
 import { ClientAppConfigSchema } from '@/types/config';
-import { getConfiguredTemplateCategories } from '@/utils/template';
+import { getConfiguredTemplateCategories } from '@/utils/templateCategories.server';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 export function getClientAppConfigServer() {

--- a/frontend/providers/template/src/pages/api/templateAsset.ts
+++ b/frontend/providers/template/src/pages/api/templateAsset.ts
@@ -2,6 +2,7 @@ import { jsonRes } from '@/services/backend/response';
 import { readTemplateAssetFile } from '@/utils/templateAssets';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import path from 'path';
+import { ensureRepoFresh } from '@/services/backend/template-repo';
 
 const MIME_BY_EXT: Record<string, string> = {
   '.svg': 'image/svg+xml',
@@ -14,7 +15,7 @@ const MIME_BY_EXT: Record<string, string> = {
   '.txt': 'text/plain; charset=utf-8'
 };
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { templateName, asset } = req.query as {
     templateName?: string;
     asset?: string;
@@ -25,6 +26,8 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   try {
+    await ensureRepoFresh();
+
     const originalPath = process.cwd();
     const jsonPath = path.resolve(originalPath, 'templates.json');
     const result = readTemplateAssetFile({ jsonPath, templateName, assetUrl: asset });

--- a/frontend/providers/template/src/pages/api/templateAsset.ts
+++ b/frontend/providers/template/src/pages/api/templateAsset.ts
@@ -1,0 +1,41 @@
+import { jsonRes } from '@/services/backend/response';
+import { readTemplateAssetFile } from '@/utils/templateAssets';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import path from 'path';
+
+const MIME_BY_EXT: Record<string, string> = {
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif',
+  '.md': 'text/markdown; charset=utf-8',
+  '.txt': 'text/plain; charset=utf-8'
+};
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { templateName, asset } = req.query as {
+    templateName?: string;
+    asset?: string;
+  };
+
+  if (!templateName || !asset) {
+    return jsonRes(res, { code: 400, message: 'templateName and asset are required.' });
+  }
+
+  try {
+    const originalPath = process.cwd();
+    const jsonPath = path.resolve(originalPath, 'templates.json');
+    const result = readTemplateAssetFile({ jsonPath, templateName, assetUrl: asset });
+    const ext = path.extname(result.path).toLowerCase();
+    res.setHeader('Content-Type', MIME_BY_EXT[ext] || 'application/octet-stream');
+    res.setHeader('Cache-Control', 'public, max-age=300');
+    res.status(200).send(result.content);
+  } catch (error) {
+    jsonRes(res, {
+      code: 404,
+      message: error instanceof Error ? error.message : 'Template asset not found.'
+    });
+  }
+}

--- a/frontend/providers/template/src/pages/api/updateRepo.ts
+++ b/frontend/providers/template/src/pages/api/updateRepo.ts
@@ -3,11 +3,13 @@ import { jsonRes } from '@/services/backend/response';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { updateRepo } from '@/services/backend/template-repo';
 import { readmeCache } from '@/utils/readmeCache';
+import { clearTemplateCache } from './v2alpha/templates/templateCache';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
     await updateRepo();
     readmeCache.clear();
+    clearTemplateCache();
 
     jsonRes(res, {
       data: `success update template`,

--- a/frontend/providers/template/src/pages/api/updateRepo.ts
+++ b/frontend/providers/template/src/pages/api/updateRepo.ts
@@ -2,14 +2,10 @@ import { jsonRes } from '@/services/backend/response';
 
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { updateRepo } from '@/services/backend/template-repo';
-import { readmeCache } from '@/utils/readmeCache';
-import { clearTemplateCache } from './v2alpha/templates/templateCache';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
     await updateRepo();
-    readmeCache.clear();
-    clearTemplateCache();
 
     jsonRes(res, {
       data: `success update template`,

--- a/frontend/providers/template/src/pages/api/v1/template/[name].ts
+++ b/frontend/providers/template/src/pages/api/v1/template/[name].ts
@@ -6,7 +6,7 @@ import path from 'path';
 import { getResourceUsage, ResourceUsage } from '@/utils/usage';
 import { readTemplatesFromFile } from '../../listTemplate';
 import { GetTemplateByName } from '../../getTemplateSource';
-import { getConfiguredTemplateCategories } from '@/utils/template';
+import { getConfiguredTemplateCategories } from '@/utils/templateCategories.server';
 
 function simplifyResourceValue(
   resource: { min: number; max: number },

--- a/frontend/providers/template/src/pages/api/v1/template/[name].ts
+++ b/frontend/providers/template/src/pages/api/v1/template/[name].ts
@@ -6,7 +6,7 @@ import path from 'path';
 import { getResourceUsage, ResourceUsage } from '@/utils/usage';
 import { readTemplatesFromFile } from '../../listTemplate';
 import { GetTemplateByName } from '../../getTemplateSource';
-import { parseTemplateCategories } from '@/utils/template';
+import { getConfiguredTemplateCategories } from '@/utils/template';
 
 function simplifyResourceValue(
   resource: { min: number; max: number },
@@ -52,7 +52,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const templates = readTemplatesFromFile(
       jsonPath,
       process.env.CDN_URL,
-      parseTemplateCategories(process.env.TEMPLATE_CATEGORIES),
+      getConfiguredTemplateCategories(path.resolve(originalPath, 'templates')),
       language
     );
     const template = templates.find((t) => t.metadata.name === templateName);

--- a/frontend/providers/template/src/pages/api/v1/template/[name].ts
+++ b/frontend/providers/template/src/pages/api/v1/template/[name].ts
@@ -7,6 +7,7 @@ import { getResourceUsage, ResourceUsage } from '@/utils/usage';
 import { readTemplatesFromFile } from '../../listTemplate';
 import { GetTemplateByName } from '../../getTemplateSource';
 import { getConfiguredTemplateCategories } from '@/utils/templateCategories.server';
+import { ensureRepoFresh } from '@/services/backend/template-repo';
 
 function simplifyResourceValue(
   resource: { min: number; max: number },
@@ -41,6 +42,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   try {
     const originalPath = process.cwd();
     const jsonPath = path.resolve(originalPath, 'templates.json');
+    await ensureRepoFresh();
 
     if (!fs.existsSync(jsonPath)) {
       return jsonRes(res, {

--- a/frontend/providers/template/src/pages/api/v1/template/index.ts
+++ b/frontend/providers/template/src/pages/api/v1/template/index.ts
@@ -5,6 +5,7 @@ import { getConfiguredTemplateCategories } from '@/utils/templateCategories.serv
 import type { NextApiRequest, NextApiResponse } from 'next';
 import path from 'path';
 import { readTemplatesFromFile } from '../../listTemplate';
+import { ensureRepoFresh } from '@/services/backend/template-repo';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const language = (req.query.language as string) || 'en';
@@ -12,6 +13,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const jsonPath = path.resolve(originalPath, 'templates.json');
 
   try {
+    await ensureRepoFresh();
+
     const configuredCategories = getConfiguredTemplateCategories(
       path.resolve(originalPath, 'templates')
     );

--- a/frontend/providers/template/src/pages/api/v1/template/index.ts
+++ b/frontend/providers/template/src/pages/api/v1/template/index.ts
@@ -1,6 +1,7 @@
 import { jsonRes } from '@/services/backend/response';
 import { TemplateType } from '@/types/app';
-import { getCategorySlugs, getConfiguredTemplateCategories } from '@/utils/template';
+import { getCategorySlugs } from '@/utils/template';
+import { getConfiguredTemplateCategories } from '@/utils/templateCategories.server';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import path from 'path';
 import { readTemplatesFromFile } from '../../listTemplate';

--- a/frontend/providers/template/src/pages/api/v1/template/index.ts
+++ b/frontend/providers/template/src/pages/api/v1/template/index.ts
@@ -1,6 +1,6 @@
 import { jsonRes } from '@/services/backend/response';
 import { TemplateType } from '@/types/app';
-import { getCategorySlugs, parseTemplateCategories } from '@/utils/template';
+import { getCategorySlugs, getConfiguredTemplateCategories } from '@/utils/template';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import path from 'path';
 import { readTemplatesFromFile } from '../../listTemplate';
@@ -11,7 +11,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const jsonPath = path.resolve(originalPath, 'templates.json');
 
   try {
-    const configuredCategories = parseTemplateCategories(process.env.TEMPLATE_CATEGORIES);
+    const configuredCategories = getConfiguredTemplateCategories(
+      path.resolve(originalPath, 'templates')
+    );
     const templates = readTemplatesFromFile(
       jsonPath,
       process.env.CDN_URL,

--- a/frontend/providers/template/src/pages/api/v1alpha/listTemplate.ts
+++ b/frontend/providers/template/src/pages/api/v1alpha/listTemplate.ts
@@ -4,12 +4,15 @@ import { TemplateType } from '@/types/app';
 import fs from 'fs';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import path from 'path';
+import { ensureRepoFresh } from '@/services/backend/template-repo';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const originalPath = process.cwd();
   const jsonPath = path.resolve(originalPath, 'templates.json');
 
   try {
+    await ensureRepoFresh();
+
     if (fs.existsSync(jsonPath)) {
       const jsonData = fs.readFileSync(jsonPath, 'utf8');
       const _templates: TemplateType[] = JSON.parse(jsonData);

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/[name].ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/[name].ts
@@ -12,6 +12,7 @@ import {
 } from './templateCache';
 import { getConfiguredTemplateCategories } from '@/utils/templateCategories.server';
 import { sendError, ErrorType, ErrorCode } from '@/types/v2alpha/error';
+import { ensureRepoFresh } from '@/services/backend/template-repo';
 
 // estimate min—max equality
 function simplifyResourceValue(
@@ -96,7 +97,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   // Add caching headers for GET requests
   if (req.method === 'GET') {
-    res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=600');
+    res.setHeader('Cache-Control', 'no-cache');
     res.setHeader('ETag', `"${templateName}-${language}"`);
     return handleTemplateDetails(req, res, templateName, language);
   }
@@ -119,6 +120,7 @@ async function handleTemplateDetails(
   try {
     const originalPath = process.cwd();
     const jsonPath = path.resolve(originalPath, 'templates.json');
+    await ensureRepoFresh();
 
     if (!fs.existsSync(jsonPath)) {
       return sendError(res, {

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/[name].ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/[name].ts
@@ -10,7 +10,7 @@ import {
   getCachedTemplateDetail,
   setCachedTemplateDetail
 } from './templateCache';
-import { getConfiguredTemplateCategories } from '@/utils/template';
+import { getConfiguredTemplateCategories } from '@/utils/templateCategories.server';
 import { sendError, ErrorType, ErrorCode } from '@/types/v2alpha/error';
 
 // estimate min—max equality

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/[name].ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/[name].ts
@@ -10,7 +10,7 @@ import {
   getCachedTemplateDetail,
   setCachedTemplateDetail
 } from './templateCache';
-import { parseTemplateCategories } from '@/utils/template';
+import { getConfiguredTemplateCategories } from '@/utils/template';
 import { sendError, ErrorType, ErrorCode } from '@/types/v2alpha/error';
 
 // estimate min—max equality
@@ -131,7 +131,7 @@ async function handleTemplateDetails(
     getCachedTemplates(
       jsonPath,
       process.env.CDN_URL,
-      parseTemplateCategories(process.env.TEMPLATE_CATEGORIES),
+      getConfiguredTemplateCategories(path.resolve(originalPath, 'templates')),
       language
     );
     const template = getTemplateFromCache(templateName);

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/index.ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/index.ts
@@ -5,6 +5,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import path from 'path';
 import { getCachedTemplates } from './templateCache';
 import { sendError, ErrorType, ErrorCode } from '@/types/v2alpha/error';
+import { ensureRepoFresh } from '@/services/backend/template-repo';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
@@ -20,12 +21,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const originalPath = process.cwd();
   const jsonPath = path.resolve(originalPath, 'templates.json');
 
-  // Add caching headers for GET requests
-  res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=600'); // 5min client, 10min CDN
+  res.setHeader('Cache-Control', 'no-cache');
   res.setHeader('ETag', `"template-list-${language}"`);
 
   try {
-    // Use shared cache instead of directly reading templates
+    await ensureRepoFresh();
+
     const configuredCategories = getConfiguredTemplateCategories(
       path.resolve(originalPath, 'templates')
     );

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/index.ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/index.ts
@@ -1,5 +1,6 @@
 import { TemplateType } from '@/types/app';
-import { getCategorySlugs, getConfiguredTemplateCategories } from '@/utils/template';
+import { getCategorySlugs } from '@/utils/template';
+import { getConfiguredTemplateCategories } from '@/utils/templateCategories.server';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import path from 'path';
 import { getCachedTemplates } from './templateCache';

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/index.ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/index.ts
@@ -1,5 +1,5 @@
 import { TemplateType } from '@/types/app';
-import { getCategorySlugs, parseTemplateCategories } from '@/utils/template';
+import { getCategorySlugs, getConfiguredTemplateCategories } from '@/utils/template';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import path from 'path';
 import { getCachedTemplates } from './templateCache';
@@ -25,7 +25,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   try {
     // Use shared cache instead of directly reading templates
-    const configuredCategories = parseTemplateCategories(process.env.TEMPLATE_CATEGORIES);
+    const configuredCategories = getConfiguredTemplateCategories(
+      path.resolve(originalPath, 'templates')
+    );
     const cacheResult = getCachedTemplates(
       jsonPath,
       process.env.CDN_URL,

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/templateCache.ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/templateCache.ts
@@ -1,6 +1,7 @@
 import { readTemplatesFromFile } from '../../listTemplate';
 import { TemplateType } from '@/types/app';
 import type { TemplateCategory } from '@/types/config';
+import { registerTemplateCatalogCacheClearer } from '@/services/backend/template-runtime-cache';
 
 interface TemplatesCache {
   data: TemplateType[];
@@ -89,3 +90,5 @@ export function clearTemplateCache(): void {
   templatesCache = null;
   templateDetailCache.clear();
 }
+
+registerTemplateCatalogCacheClearer(clearTemplateCache);

--- a/frontend/providers/template/src/pages/deploy/components/ReadMe.tsx
+++ b/frontend/providers/template/src/pages/deploy/components/ReadMe.tsx
@@ -13,6 +13,13 @@ const ReadMe = ({ readUrl, readmeContent }: { readUrl: string; readmeContent: st
   const myRewrite = (node, index, parent) => {
     if (node.tagName === 'img' && !node.properties.src.startsWith('http')) {
       const imgSrc = node.properties.src.replace(/^\.\/|^\//, '');
+      if (readUrl?.startsWith('/api/templateAsset?')) {
+        const params = new URLSearchParams(readUrl.split('?')[1] || '');
+        params.set('asset', imgSrc);
+        node.properties.referrerPolicy = 'no-referrer';
+        node.properties.src = `/api/templateAsset?${params.toString()}`;
+        return;
+      }
       const baseUrl = readUrl?.substring(0, readUrl?.lastIndexOf('/') + 1);
       node.properties.referrerPolicy = 'no-referrer';
       node.properties.src = `${baseUrl}${imgSrc}`;

--- a/frontend/providers/template/src/pages/index.tsx
+++ b/frontend/providers/template/src/pages/index.tsx
@@ -9,6 +9,7 @@ import type { TemplateCategory } from '@/types/config';
 import { serviceSideProps } from '@/utils/i18n';
 import { getCategoryLabel } from '@/utils/template';
 import { compareFirstLanguages, formatStarNumber } from '@/utils/tools';
+import { getAppListContentState, hasAppListTemplates } from '@/utils/appListState';
 import {
   Avatar,
   AvatarGroup,
@@ -80,6 +81,11 @@ export default function AppList({
 
     return searchResults;
   }, [data?.templates, appType, searchValue]);
+  const contentState = getAppListContentState({
+    hasLoadedData: Boolean(data),
+    filteredTemplates: filterData
+  });
+  const showCarousel = hasAppListTemplates(data?.templates);
 
   const goDeploy = (name: string) => {
     if (!name) return;
@@ -118,7 +124,7 @@ export default function AppList({
     }
   }, [router.query?.action, isClientSide]);
 
-  if (!data) {
+  if (contentState === 'loading') {
     return (
       <Flex alignItems={'center'} justifyContent={'center'} w="full" h="100vh">
         <Spinner size="xl" color="#219BF4" />
@@ -157,161 +163,155 @@ export default function AppList({
         <meta name="twitter:image" content={`${canonicalUrl}/og.png`} />
       </Head>
 
-      {!!data?.templates?.length ? (
-        <>
-          {systemConfig?.showCarousel && <Banner />}
-          {filterData?.length && filterData?.length > 0 ? (
-            <Grid
-              justifyContent={'center'}
-              w={'100%'}
-              gridTemplateColumns="repeat(auto-fill,minmax(320px,1fr))"
-              gridGap={'24px'}
-              minW={'480px'}
-            >
-              {filterData?.map((item: TemplateType) => {
-                return (
-                  <Flex
-                    position={'relative'}
-                    cursor={'pointer'}
-                    onClick={() => goDeploy(item?.metadata?.name)}
-                    _hover={{
-                      borderColor: '#36ADEF',
-                      boxShadow: '0px 4px 5px 0px rgba(185, 196, 205, 0.25)'
-                    }}
-                    key={item?.metadata?.name}
-                    flexDirection={'column'}
-                    h={'184px'}
-                    p={'24px'}
-                    borderRadius={'8px'}
-                    backgroundColor={'#fff'}
-                    boxShadow={'0px 2px 4px 0px rgba(187, 196, 206, 0.25)'}
-                    border={'1px solid #EAEBF0'}
-                  >
-                    <Flex alignItems={'center'}>
-                      <Box
-                        p={'6px'}
-                        w={'48px'}
-                        h={'48px'}
-                        boxShadow={'0px 1px 2px 0.5px rgba(84, 96, 107, 0.20)'}
-                        borderRadius={'4px'}
-                        backgroundColor={'#fff'}
-                        border={' 1px solid rgba(255, 255, 255, 0.50)'}
-                        aspectRatio={'1 / 1'}
+      <>
+        {showCarousel && systemConfig?.showCarousel && <Banner />}
+        {contentState === 'grid' ? (
+          <Grid
+            justifyContent={'center'}
+            w={'100%'}
+            gridTemplateColumns="repeat(auto-fill,minmax(320px,1fr))"
+            gridGap={'24px'}
+            minW={'480px'}
+          >
+            {filterData?.map((item: TemplateType) => {
+              return (
+                <Flex
+                  position={'relative'}
+                  cursor={'pointer'}
+                  onClick={() => goDeploy(item?.metadata?.name)}
+                  _hover={{
+                    borderColor: '#36ADEF',
+                    boxShadow: '0px 4px 5px 0px rgba(185, 196, 205, 0.25)'
+                  }}
+                  key={item?.metadata?.name}
+                  flexDirection={'column'}
+                  h={'184px'}
+                  p={'24px'}
+                  borderRadius={'8px'}
+                  backgroundColor={'#fff'}
+                  boxShadow={'0px 2px 4px 0px rgba(187, 196, 206, 0.25)'}
+                  border={'1px solid #EAEBF0'}
+                >
+                  <Flex alignItems={'center'}>
+                    <Box
+                      p={'6px'}
+                      w={'48px'}
+                      h={'48px'}
+                      boxShadow={'0px 1px 2px 0.5px rgba(84, 96, 107, 0.20)'}
+                      borderRadius={'4px'}
+                      backgroundColor={'#fff'}
+                      border={' 1px solid rgba(255, 255, 255, 0.50)'}
+                      aspectRatio={'1 / 1'}
+                    >
+                      <Image
+                        src={item.spec.i18n?.[i18n.language]?.icon ?? item?.spec?.icon}
+                        alt="logo"
+                        width={'36px'}
+                        height={'36px'}
+                        loading="lazy"
+                      />
+                    </Box>
+                    <Flex ml="16px" noOfLines={2} flexDirection={'column'}>
+                      <Text
+                        fontSize={'18px'}
+                        fontWeight={600}
+                        color={'#111824'}
+                        textOverflow={'ellipsis'}
+                        overflow={'hidden'}
+                        whiteSpace={'nowrap'}
+                        style={{
+                          textWrap: 'nowrap'
+                        }}
                       >
-                        <Image
-                          src={item.spec.i18n?.[i18n.language]?.icon ?? item?.spec?.icon}
-                          alt="logo"
-                          width={'36px'}
-                          height={'36px'}
-                          loading="lazy"
-                        />
-                      </Box>
-                      <Flex ml="16px" noOfLines={2} flexDirection={'column'}>
-                        <Text
-                          fontSize={'18px'}
-                          fontWeight={600}
-                          color={'#111824'}
-                          textOverflow={'ellipsis'}
-                          overflow={'hidden'}
-                          whiteSpace={'nowrap'}
-                          style={{
-                            textWrap: 'nowrap'
-                          }}
-                        >
-                          {item.spec.i18n?.[i18n.language]?.title ?? item.spec.title}
+                        {item.spec.i18n?.[i18n.language]?.title ?? item.spec.title}
+                      </Text>
+                      {envs?.SHOW_AUTHOR === 'true' && (
+                        <Text fontSize={'12px'} fontWeight={400} color={'#5A646E'}>
+                          By {item.spec.author}
                         </Text>
-                        {envs?.SHOW_AUTHOR === 'true' && (
-                          <Text fontSize={'12px'} fontWeight={400} color={'#5A646E'}>
-                            By {item.spec.author}
-                          </Text>
-                        )}
-                      </Flex>
-                      {item.spec?.deployCount && item.spec?.deployCount > 6 && (
-                        <Tooltip
-                          label={t('users installed the app', { count: item.spec.deployCount })}
-                          hasArrow
-                          bg="#FFF"
-                          placement="bottom-end"
-                        >
-                          <Flex gap={'6px'} ml={'auto'}>
-                            <AvatarGroup size={'xs'} max={3}>
-                              <Avatar name={nanoid(6)} />
-                              <Avatar name={nanoid(6)} />
-                              <Avatar name={nanoid(6)} />
-                            </AvatarGroup>
-                            <Text>+{formatStarNumber(item.spec.deployCount)}</Text>
-                          </Flex>
-                        </Tooltip>
                       )}
                     </Flex>
-                    <Text
-                      css={`
-                        display: -webkit-box;
-                        -webkit-line-clamp: 2;
-                        -webkit-box-orient: vertical;
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                      `}
-                      my={'16px'}
-                      fontSize={'12px'}
-                      color={'5A646E'}
-                      fontWeight={400}
-                    >
-                      {item.spec.i18n?.[i18n.language]?.description ?? item.spec.description}
-                    </Text>
-                    <Flex
-                      mt="auto"
-                      justifyContent={'space-between'}
-                      alignItems={'center'}
-                      gap={'20px'}
-                    >
-                      <Flex alignItems={'center'} gap={'10px'} overflow={'hidden'}>
-                        {item?.spec?.categories
-                          ?.map((slug) => categoryBySlug.get(slug))
-                          .filter((category): category is TemplateCategory => Boolean(category))
-                          .map((category) => (
-                            <Tag
-                              flexShrink={0}
-                              key={category.slug}
-                              bg="#F4F4F7"
-                              border={'1px solid #E8EBF0'}
-                              fontSize={'10px'}
-                              color={'5A646E'}
-                              fontWeight={400}
-                            >
-                              {getCategoryLabel(category, i18n.language)}
-                            </Tag>
-                          ))}
-                      </Flex>
-                      <Center
-                        cursor={'pointer'}
-                        onClick={(e) =>
-                          goGithub(
-                            e,
-                            item.spec?.i18n?.[i18n.language]?.gitRepo ?? item?.spec?.gitRepo
-                          )
-                        }
+                    {item.spec?.deployCount && item.spec?.deployCount > 6 && (
+                      <Tooltip
+                        label={t('users installed the app', { count: item.spec.deployCount })}
+                        hasArrow
+                        bg="#FFF"
+                        placement="bottom-end"
                       >
-                        <ShareIcon color={'#667085'} />
-                      </Center>
-                    </Flex>
+                        <Flex gap={'6px'} ml={'auto'}>
+                          <AvatarGroup size={'xs'} max={3}>
+                            <Avatar name={nanoid(6)} />
+                            <Avatar name={nanoid(6)} />
+                            <Avatar name={nanoid(6)} />
+                          </AvatarGroup>
+                          <Text>+{formatStarNumber(item.spec.deployCount)}</Text>
+                        </Flex>
+                      </Tooltip>
+                    )}
                   </Flex>
-                );
-              })}
-            </Grid>
-          ) : (
-            <Center w="full" h="calc(100% - 285px)">
-              <Center border={'1px dashed #9CA2A8'} borderRadius="50%" w={'48px'} h={'48px'}>
-                <MyIcon color={'#7B838B'} name="empty"></MyIcon>
-              </Center>
+                  <Text
+                    css={`
+                      display: -webkit-box;
+                      -webkit-line-clamp: 2;
+                      -webkit-box-orient: vertical;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                    `}
+                    my={'16px'}
+                    fontSize={'12px'}
+                    color={'5A646E'}
+                    fontWeight={400}
+                  >
+                    {item.spec.i18n?.[i18n.language]?.description ?? item.spec.description}
+                  </Text>
+                  <Flex
+                    mt="auto"
+                    justifyContent={'space-between'}
+                    alignItems={'center'}
+                    gap={'20px'}
+                  >
+                    <Flex alignItems={'center'} gap={'10px'} overflow={'hidden'}>
+                      {item?.spec?.categories
+                        ?.map((slug) => categoryBySlug.get(slug))
+                        .filter((category): category is TemplateCategory => Boolean(category))
+                        .map((category) => (
+                          <Tag
+                            flexShrink={0}
+                            key={category.slug}
+                            bg="#F4F4F7"
+                            border={'1px solid #E8EBF0'}
+                            fontSize={'10px'}
+                            color={'5A646E'}
+                            fontWeight={400}
+                          >
+                            {getCategoryLabel(category, i18n.language)}
+                          </Tag>
+                        ))}
+                    </Flex>
+                    <Center
+                      cursor={'pointer'}
+                      onClick={(e) =>
+                        goGithub(
+                          e,
+                          item.spec?.i18n?.[i18n.language]?.gitRepo ?? item?.spec?.gitRepo
+                        )
+                      }
+                    >
+                      <ShareIcon color={'#667085'} />
+                    </Center>
+                  </Flex>
+                </Flex>
+              );
+            })}
+          </Grid>
+        ) : (
+          <Center w="full" h="calc(100% - 285px)">
+            <Center border={'1px dashed #9CA2A8'} borderRadius="50%" w={'48px'} h={'48px'}>
+              <MyIcon color={'#7B838B'} name="empty"></MyIcon>
             </Center>
-          )}
-        </>
-      ) : (
-        <Flex alignItems={'center'} justifyContent={'center'} w="full" h="full">
-          <Spinner size="xl" color="#219BF4" />
-        </Flex>
-      )}
+          </Center>
+        )}
+      </>
     </Box>
   );
 }

--- a/frontend/providers/template/src/pages/index.tsx
+++ b/frontend/providers/template/src/pages/index.tsx
@@ -51,7 +51,7 @@ export default function AppList({
 
   const { data } = useQuery(['listTemplate', i18n.language], () => getTemplates(i18n.language), {
     refetchInterval: 5 * 60 * 1000,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
     retry: 3
   });
 

--- a/frontend/providers/template/src/services/backend/template-repo.ts
+++ b/frontend/providers/template/src/services/backend/template-repo.ts
@@ -13,8 +13,9 @@ import { resolveTemplateAssetUrls } from '@/utils/templateAsset';
 import { hasLocalTemplateAssets, rewriteTemplateAssetsToLocalApi } from '@/utils/templateAssets';
 
 const execAsync = util.promisify(exec);
+const TEMPLATE_MANIFESTS_DIR = 'manifests';
 
-const readFileList = (targetPath: string, fileList: unknown[] = []) => {
+const readFileList = (targetPath: string, fileList: string[] = []) => {
   // fix ci
   const sanitizePath = (inputPath: string) => {
     if (typeof inputPath !== 'string') {
@@ -32,6 +33,7 @@ const readFileList = (targetPath: string, fileList: unknown[] = []) => {
     if (stats.isFile() && isYamlFile && item !== 'template.yaml') {
       fileList.push(filePath);
     } else if (stats.isDirectory()) {
+      if (item === TEMPLATE_MANIFESTS_DIR) return;
       readFileList(filePath, fileList);
     }
   });
@@ -95,7 +97,7 @@ export async function updateRepo() {
     throw new Error('missing template repository file');
   }
 
-  let fileList: unknown[] = [];
+  let fileList: string[] = [];
   const _targetPath = path.join(targetPath, targetFolder);
   readFileList(_targetPath, fileList);
 

--- a/frontend/providers/template/src/services/backend/template-repo.ts
+++ b/frontend/providers/template/src/services/backend/template-repo.ts
@@ -10,6 +10,7 @@ import * as k8s from '@kubernetes/client-node';
 import { getYamlTemplate } from '@/utils/json-yaml';
 import { getTemplateEnvs } from '@/utils/tools';
 import { resolveTemplateAssetUrls } from '@/utils/templateAsset';
+import { hasLocalTemplateAssets, rewriteTemplateAssetsToLocalApi } from '@/utils/templateAssets';
 
 const execAsync = util.promisify(exec);
 
@@ -108,14 +109,16 @@ export async function updateRepo() {
       const content = fs.readFileSync(item, 'utf-8');
       let { templateYaml } = getYamlTemplate(content);
       if (!!templateYaml) {
-        templateYaml = resolveTemplateAssetUrls(templateYaml, {
-          repo: {
-            url: TemplateEnvs.TEMPLATE_REPO_URL,
-            branch: TemplateEnvs.TEMPLATE_REPO_BRANCH
-          },
-          templateFilePath: item,
-          repoRootPath: targetPath
-        });
+        templateYaml = hasLocalTemplateAssets(templateYaml)
+          ? rewriteTemplateAssetsToLocalApi(templateYaml)
+          : resolveTemplateAssetUrls(templateYaml, {
+              repo: {
+                url: TemplateEnvs.TEMPLATE_REPO_URL,
+                branch: TemplateEnvs.TEMPLATE_REPO_BRANCH
+              },
+              templateFilePath: item,
+              repoRootPath: targetPath
+            });
         const appTitle = templateYaml.spec.title.toUpperCase();
         const currentCount = templateStaticMap[appTitle] || 0;
         const randomFactor = 11 + Math.floor(Math.random() * 5); // [11,12,13,14,15]

--- a/frontend/providers/template/src/services/backend/template-repo.ts
+++ b/frontend/providers/template/src/services/backend/template-repo.ts
@@ -11,9 +11,20 @@ import { getYamlTemplate } from '@/utils/json-yaml';
 import { getTemplateEnvs } from '@/utils/tools';
 import { resolveTemplateAssetUrls } from '@/utils/templateAsset';
 import { hasLocalTemplateAssets, rewriteTemplateAssetsToLocalApi } from '@/utils/templateAssets';
+import { clearTemplateRuntimeCaches } from './template-runtime-cache';
 
 const execAsync = util.promisify(exec);
 const TEMPLATE_MANIFESTS_DIR = 'manifests';
+const DEFAULT_REPO_SYNC_INTERVAL_MS = 30_000;
+
+let lastRepoSyncAt = 0;
+let pendingRepoSync: Promise<void> | null = null;
+
+function getRepoSyncIntervalMs() {
+  const parsed = Number(process.env.TEMPLATE_REPO_SYNC_INTERVAL_MS);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_REPO_SYNC_INTERVAL_MS;
+  return parsed;
+}
 
 const readFileList = (targetPath: string, fileList: string[] = []) => {
   // fix ci
@@ -138,4 +149,33 @@ export async function updateRepo() {
 
   const jsonContent = JSON.stringify(jsonObjArr, null, 2);
   fs.writeFileSync(jsonPath, jsonContent, 'utf-8');
+  lastRepoSyncAt = Date.now();
+  clearTemplateRuntimeCaches();
+}
+
+export async function ensureRepoFresh({ force = false }: { force?: boolean } = {}) {
+  const jsonPath = path.resolve(process.cwd(), 'templates.json');
+  const now = Date.now();
+  const syncIntervalMs = getRepoSyncIntervalMs();
+
+  if (!force && fs.existsSync(jsonPath) && now - lastRepoSyncAt < syncIntervalMs) {
+    return;
+  }
+
+  if (!pendingRepoSync) {
+    pendingRepoSync = updateRepo().finally(() => {
+      pendingRepoSync = null;
+    });
+  }
+
+  try {
+    await pendingRepoSync;
+  } catch (error) {
+    if (fs.existsSync(jsonPath)) {
+      console.error('[template-repo] Failed to refresh repository, using local catalog:', error);
+      lastRepoSyncAt = Date.now();
+      return;
+    }
+    throw error;
+  }
 }

--- a/frontend/providers/template/src/services/backend/template-runtime-cache.ts
+++ b/frontend/providers/template/src/services/backend/template-runtime-cache.ts
@@ -1,0 +1,23 @@
+import { readmeCache } from '@/utils/readmeCache';
+
+type CacheClearer = () => void;
+
+const catalogCacheClearers = new Set<CacheClearer>();
+
+export function registerTemplateCatalogCacheClearer(clearer: CacheClearer) {
+  catalogCacheClearers.add(clearer);
+  return () => {
+    catalogCacheClearers.delete(clearer);
+  };
+}
+
+export function clearTemplateRuntimeCaches() {
+  readmeCache.clear();
+  for (const clearer of catalogCacheClearers) {
+    try {
+      clearer();
+    } catch (error) {
+      console.error('[template-repo] Failed to clear template cache:', error);
+    }
+  }
+}

--- a/frontend/providers/template/src/types/apis/v2alpha/index.ts
+++ b/frontend/providers/template/src/types/apis/v2alpha/index.ts
@@ -105,7 +105,7 @@ export const document = createDocument({
         tags: ['Query'],
         summary: 'List all templates',
         description:
-          'Returns metadata only (no resource calculation). Response headers: `Cache-Control` (public, max-age=300, s-maxage=600), `ETag`. When categories exist, top category keys are returned in `X-Menu-Keys` (comma-separated). For full details including resource requirements, use `/templates/{name}`.',
+          'Returns metadata only (no resource calculation). The handler first runs a TTL-bound repository freshness check, then responds with `Cache-Control: no-cache` and `ETag`. When categories exist, top category keys are returned in `X-Menu-Keys` (comma-separated). For full details including resource requirements, use `/templates/{name}`.',
         operationId: 'listTemplates',
         security: [],
         requestParams: {
@@ -116,8 +116,8 @@ export const document = createDocument({
             description: 'Successfully retrieved template list',
             headers: {
               'Cache-Control': {
-                description: 'Caching directive: public, max-age=300, s-maxage=600',
-                schema: { type: 'string', example: 'public, max-age=300, s-maxage=600' }
+                description: 'Caching directive: no-cache',
+                schema: { type: 'string', example: 'no-cache' }
               },
               ETag: {
                 description: 'Entity tag for caching, format: "template-list-{language}"',
@@ -188,7 +188,7 @@ export const document = createDocument({
         tags: ['Query'],
         summary: 'Get template details',
         description:
-          'Returns complete template metadata with dynamically calculated resource requirements (CPU, memory, storage, NodePort count) derived from the template YAML. Falls back to static configuration if calculation fails. Response headers: `Cache-Control` (public, max-age=300, s-maxage=600), `ETag`.',
+          'Returns complete template metadata with dynamically calculated resource requirements (CPU, memory, storage, NodePort count) derived from the template YAML. Falls back to static configuration if calculation fails. The handler first runs a TTL-bound repository freshness check, then responds with `Cache-Control: no-cache` and `ETag`.',
         operationId: 'getTemplate',
         security: [],
         requestParams: {
@@ -200,8 +200,8 @@ export const document = createDocument({
             description: 'Successfully retrieved template details',
             headers: {
               'Cache-Control': {
-                description: 'Caching directive: public, max-age=300, s-maxage=600',
-                schema: { type: 'string', example: 'public, max-age=300, s-maxage=600' }
+                description: 'Caching directive: no-cache',
+                schema: { type: 'string', example: 'no-cache' }
               },
               ETag: {
                 description: 'Entity tag for caching, format: "{name}-{language}"',

--- a/frontend/providers/template/src/types/index.ts
+++ b/frontend/providers/template/src/types/index.ts
@@ -1,9 +1,3 @@
-import Cron from 'croner';
-
-declare global {
-  var updateRepoCronJob: Cron;
-}
-
 export type QueryType = {
   name: string;
   templateName: string;

--- a/frontend/providers/template/src/utils/appListState.test.js
+++ b/frontend/providers/template/src/utils/appListState.test.js
@@ -1,0 +1,59 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const ts = require('typescript');
+
+function loadAppListState() {
+  const sourcePath = path.join(__dirname, 'appListState.ts');
+  const source = fs.readFileSync(sourcePath, 'utf8');
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020
+    }
+  });
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'app-list-state-'));
+  const tempFile = path.join(tempDir, 'appListState.cjs');
+  fs.writeFileSync(tempFile, compiled.outputText);
+  return require(tempFile);
+}
+
+const { getAppListContentState, hasAppListTemplates } = loadAppListState();
+
+test('keeps the app list loading before data arrives', () => {
+  assert.equal(
+    getAppListContentState({
+      hasLoadedData: false,
+      filteredTemplates: undefined
+    }),
+    'loading'
+  );
+});
+
+test('shows the empty state when a loaded catalog has no templates', () => {
+  assert.equal(
+    getAppListContentState({
+      hasLoadedData: true,
+      filteredTemplates: []
+    }),
+    'empty'
+  );
+});
+
+test('shows the grid when filtered templates are available', () => {
+  assert.equal(
+    getAppListContentState({
+      hasLoadedData: true,
+      filteredTemplates: [{}]
+    }),
+    'grid'
+  );
+});
+
+test('shows carousel only when the catalog has templates', () => {
+  assert.equal(hasAppListTemplates([]), false);
+  assert.equal(hasAppListTemplates([{}]), true);
+});

--- a/frontend/providers/template/src/utils/appListState.ts
+++ b/frontend/providers/template/src/utils/appListState.ts
@@ -1,0 +1,16 @@
+export type AppListContentState = 'loading' | 'empty' | 'grid';
+
+export function getAppListContentState({
+  hasLoadedData,
+  filteredTemplates
+}: {
+  hasLoadedData: boolean;
+  filteredTemplates?: readonly unknown[] | null;
+}): AppListContentState {
+  if (!hasLoadedData) return 'loading';
+  return (filteredTemplates?.length ?? 0) > 0 ? 'grid' : 'empty';
+}
+
+export function hasAppListTemplates(templates?: readonly unknown[] | null) {
+  return (templates?.length ?? 0) > 0;
+}

--- a/frontend/providers/template/src/utils/template.ts
+++ b/frontend/providers/template/src/utils/template.ts
@@ -3,6 +3,8 @@ import { TemplateSourceType } from '@/types/app';
 import type { TemplateCategory } from '@/types/config';
 import { reduce, mapValues } from 'lodash';
 import { developGenerateYamlList, generateYamlList, parseTemplateString } from './json-yaml';
+import fs from 'fs';
+import path from 'path';
 
 export const DEFAULT_TEMPLATE_CATEGORIES: TemplateCategory[] = [
   { slug: 'ai', i18n: { en: 'AI', zh: 'AI' } },
@@ -36,6 +38,22 @@ export function parseTemplateCategories(value?: string): TemplateCategory[] {
     console.error('[Template Categories] Failed to parse TEMPLATE_CATEGORIES:', error);
     return DEFAULT_TEMPLATE_CATEGORIES;
   }
+}
+
+export function getConfiguredTemplateCategories(repoRootPath?: string): TemplateCategory[] {
+  const configuredPath = process.env.TEMPLATE_CATEGORIES_PATH || 'config/categories.json';
+  const rootPath = repoRootPath || path.resolve(process.cwd(), 'templates');
+  const categoryPath = path.resolve(rootPath, configuredPath);
+
+  if (categoryPath.startsWith(rootPath) && fs.existsSync(categoryPath)) {
+    try {
+      return parseTemplateCategories(fs.readFileSync(categoryPath, 'utf8'));
+    } catch (error) {
+      console.error('[Template Categories] Failed to read categories from repository:', error);
+    }
+  }
+
+  return parseTemplateCategories(process.env.TEMPLATE_CATEGORIES);
 }
 
 export function getCategorySlugs(categories: readonly TemplateCategory[] = []) {

--- a/frontend/providers/template/src/utils/template.ts
+++ b/frontend/providers/template/src/utils/template.ts
@@ -3,8 +3,6 @@ import { TemplateSourceType } from '@/types/app';
 import type { TemplateCategory } from '@/types/config';
 import { reduce, mapValues } from 'lodash';
 import { developGenerateYamlList, generateYamlList, parseTemplateString } from './json-yaml';
-import fs from 'fs';
-import path from 'path';
 
 export const DEFAULT_TEMPLATE_CATEGORIES: TemplateCategory[] = [
   { slug: 'ai', i18n: { en: 'AI', zh: 'AI' } },
@@ -38,22 +36,6 @@ export function parseTemplateCategories(value?: string): TemplateCategory[] {
     console.error('[Template Categories] Failed to parse TEMPLATE_CATEGORIES:', error);
     return DEFAULT_TEMPLATE_CATEGORIES;
   }
-}
-
-export function getConfiguredTemplateCategories(repoRootPath?: string): TemplateCategory[] {
-  const configuredPath = process.env.TEMPLATE_CATEGORIES_PATH || 'config/categories.json';
-  const rootPath = repoRootPath || path.resolve(process.cwd(), 'templates');
-  const categoryPath = path.resolve(rootPath, configuredPath);
-
-  if (categoryPath.startsWith(rootPath) && fs.existsSync(categoryPath)) {
-    try {
-      return parseTemplateCategories(fs.readFileSync(categoryPath, 'utf8'));
-    } catch (error) {
-      console.error('[Template Categories] Failed to read categories from repository:', error);
-    }
-  }
-
-  return parseTemplateCategories(process.env.TEMPLATE_CATEGORIES);
 }
 
 export function getCategorySlugs(categories: readonly TemplateCategory[] = []) {

--- a/frontend/providers/template/src/utils/templateAssets.ts
+++ b/frontend/providers/template/src/utils/templateAssets.ts
@@ -1,0 +1,136 @@
+import { TemplateType } from '@/types/app';
+import fs from 'fs';
+import path from 'path';
+
+function hasUrlScheme(value: string) {
+  return /^[a-z][a-z0-9+.-]*:/i.test(value);
+}
+
+function isLocalAssetUrl(value: string) {
+  return Boolean(value) && !hasUrlScheme(value) && !value.startsWith('//');
+}
+
+function hasLocalAsset(template: TemplateType, field: 'readme' | 'icon') {
+  const value = template.spec[field];
+  if (value && isLocalAssetUrl(value)) return true;
+
+  if (!template.spec.i18n) return false;
+  return Object.values(template.spec.i18n).some((data) => {
+    const nextValue = data[field];
+    return Boolean(nextValue && isLocalAssetUrl(nextValue));
+  });
+}
+
+export function hasLocalTemplateAssets(template: TemplateType) {
+  return hasLocalAsset(template, 'readme') || hasLocalAsset(template, 'icon');
+}
+
+export function getTemplateRepoRootPath() {
+  return path.resolve(process.cwd(), 'templates');
+}
+
+function assertInRepo(repoRootPath: string, targetPath: string) {
+  const root = path.resolve(repoRootPath);
+  const target = path.resolve(targetPath);
+  if (target !== root && !target.startsWith(`${root}${path.sep}`)) {
+    throw new Error('Template asset path escapes repository root.');
+  }
+  return target;
+}
+
+export function resolveTemplateRelativeAssetPath(
+  templateFilePath: string,
+  assetUrl: string,
+  repoRootPath = getTemplateRepoRootPath()
+) {
+  if (!isLocalAssetUrl(assetUrl)) return '';
+
+  const normalizedTemplateFile = path.resolve(templateFilePath);
+  assertInRepo(repoRootPath, normalizedTemplateFile);
+  const baseDir = path.dirname(normalizedTemplateFile);
+  const assetPath = assetUrl.startsWith('/')
+    ? path.resolve(repoRootPath, assetUrl.replace(/^\//, ''))
+    : path.resolve(baseDir, assetUrl.replace(/^\.\//, ''));
+
+  return assertInRepo(repoRootPath, assetPath);
+}
+
+export function resolveTemplateAssetApiUrl(
+  templateName: string,
+  assetUrl: string,
+  locale?: string
+) {
+  if (!isLocalAssetUrl(assetUrl)) return assetUrl || '';
+
+  const query = new URLSearchParams({
+    templateName,
+    asset: assetUrl
+  });
+  if (locale) query.set('locale', locale);
+  return `/api/templateAsset?${query.toString()}`;
+}
+
+export function rewriteTemplateAssetsToLocalApi(template: TemplateType) {
+  const templateName = template.metadata.name;
+  const resolved = {
+    ...template,
+    spec: {
+      ...template.spec,
+      i18n: template.spec.i18n ? { ...template.spec.i18n } : template.spec.i18n
+    }
+  };
+
+  resolved.spec.readme = resolveTemplateAssetApiUrl(templateName, resolved.spec.readme);
+  resolved.spec.icon = resolveTemplateAssetApiUrl(templateName, resolved.spec.icon);
+
+  if (resolved.spec.i18n) {
+    Object.entries(resolved.spec.i18n).forEach(([lang, data]) => {
+      const nextData = { ...data };
+      if (nextData.readme) {
+        nextData.readme = resolveTemplateAssetApiUrl(templateName, nextData.readme, lang);
+      }
+      if (nextData.icon) {
+        nextData.icon = resolveTemplateAssetApiUrl(templateName, nextData.icon, lang);
+      }
+      resolved.spec.i18n![lang] = nextData;
+    });
+  }
+
+  return resolved;
+}
+
+export function findTemplateByName(jsonPath: string, templateName: string) {
+  const jsonData: TemplateType[] = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+  return jsonData.find((item) => item.metadata.name === templateName);
+}
+
+export function readTemplateAssetFile({
+  jsonPath,
+  templateName,
+  assetUrl,
+  repoRootPath = getTemplateRepoRootPath()
+}: {
+  jsonPath: string;
+  templateName: string;
+  assetUrl: string;
+  repoRootPath?: string;
+}) {
+  const template = findTemplateByName(jsonPath, templateName);
+  if (!template?.spec?.filePath) {
+    throw new Error('Template not found.');
+  }
+
+  const targetPath = resolveTemplateRelativeAssetPath(
+    template.spec.filePath,
+    assetUrl,
+    repoRootPath
+  );
+  if (!targetPath || !fs.existsSync(targetPath)) {
+    throw new Error('Template asset not found.');
+  }
+
+  return {
+    path: targetPath,
+    content: fs.readFileSync(targetPath)
+  };
+}

--- a/frontend/providers/template/src/utils/templateCategories.server.ts
+++ b/frontend/providers/template/src/utils/templateCategories.server.ts
@@ -1,0 +1,31 @@
+import fs from 'fs';
+import path from 'path';
+import { parseTemplateCategories } from './template';
+
+function resolveRepoCategoryPath(repoRootPath: string) {
+  const configuredPath = process.env.TEMPLATE_CATEGORIES_PATH || 'config/categories.json';
+  const rootPath = path.resolve(repoRootPath);
+  const categoryPath = path.resolve(rootPath, configuredPath);
+
+  if (categoryPath !== rootPath && !categoryPath.startsWith(`${rootPath}${path.sep}`)) {
+    return '';
+  }
+
+  return categoryPath;
+}
+
+export function getConfiguredTemplateCategories(
+  repoRootPath = path.resolve(process.cwd(), 'templates')
+) {
+  const categoryPath = resolveRepoCategoryPath(repoRootPath);
+
+  if (categoryPath && fs.existsSync(categoryPath)) {
+    try {
+      return parseTemplateCategories(fs.readFileSync(categoryPath, 'utf8'));
+    } catch (error) {
+      console.error('[Template Categories] Failed to read categories from repository:', error);
+    }
+  }
+
+  return parseTemplateCategories(process.env.TEMPLATE_CATEGORIES);
+}


### PR DESCRIPTION
## What this PR does

This PR adds Template App support for the managed template repository layout produced by Sealos Admin.

- Reads category metadata from `config/categories.json` in the cloned template repository, with the existing env fallback kept server-side.
- Serves repository-local README/icon assets through `/api/templateAsset` so private or offline stores do not depend on public raw URLs.
- Supports split template manifests such as `template/<name>/index.yaml` plus `template/<name>/manifests/*.yaml` while keeping legacy single-file templates compatible.

## Why this is needed

The paired Admin template-management flow writes templates, categories, README files, icons, and manifests into an internal Git/Gogs repository. Template App needs to consume that same repository format for the store and deploy flows.

## Test

- `pnpm -C frontend/providers/template build`

Note: the build completed successfully with existing React Hook lint warnings.