### PR TITLE
fix(applaunchpad): resolve delegated NS records

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/services/dns-resolver.fixture.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/services/dns-resolver.fixture.ts
@@ -894,6 +894,22 @@ export const dnsFixtures: DNSFixtures = {
 
     // Local DNS resolvers (8.8.8.8, 1.1.1.1) - used by getAuthoritativeNsFromLocal
     '8.8.8.8': {
+      [queryKey('test', 'NS')]: {
+        request: { name: 'test', type: 'NS' },
+        response: createDnsResponse(
+          61000,
+          [{ name: 'test', type: 'NS' }],
+          [
+            { name: 'test', type: 'NS', ttl: 86400, data: 'a.test-servers.example' },
+            { name: 'test', type: 'NS', ttl: 86400, data: 'b.test-servers.example' }
+          ],
+          [],
+          [
+            { name: 'a.test-servers.example', type: 'A', ttl: 172800, data: '192.0.2.1' },
+            { name: 'b.test-servers.example', type: 'A', ttl: 172800, data: '192.0.2.2' }
+          ]
+        )
+      },
       [queryKey('example.org', 'NS')]: {
         request: { name: 'example.org', type: 'NS' },
         response: createDnsResponse(
@@ -1241,6 +1257,45 @@ export const dnsFixtures: DNSFixtures = {
       }
     },
 
+    // NS server: 192.0.2.1 (a.test-servers.example)
+    '192.0.2.1': {
+      [queryKey('example.test', 'NS')]: {
+        request: { name: 'example.test', type: 'NS' },
+        response: createDnsResponse(
+          61001,
+          [{ name: 'example.test', type: 'NS' }],
+          [],
+          [
+            { name: 'example.test', type: 'NS', ttl: 86400, data: 'ns1.example.test' },
+            { name: 'example.test', type: 'NS', ttl: 86400, data: 'ns2.example.test' }
+          ],
+          [
+            { name: 'ns1.example.test', type: 'A', ttl: 172800, data: '198.51.100.1' },
+            { name: 'ns2.example.test', type: 'A', ttl: 172800, data: '198.51.100.2' }
+          ]
+        )
+      }
+    },
+
+    // NS server: 198.51.100.1 (ns1.example.test)
+    '198.51.100.1': {
+      [queryKey('app.platform.example.test', 'NS')]: {
+        request: { name: 'app.platform.example.test', type: 'NS' },
+        response: createDnsResponse(
+          61002,
+          [{ name: 'app.platform.example.test', type: 'NS' }],
+          [
+            {
+              name: 'app.platform.example.test',
+              type: 'CNAME',
+              ttl: 300,
+              data: 'target.platform.example.test'
+            }
+          ]
+        )
+      }
+    },
+
     // For resolveWithNs multi-nameserver test: good nameserver (returns success)
     '10.0.0.1': {
       [queryKey('test.example.org', 'A')]: {
@@ -1264,6 +1319,18 @@ export const dnsFixtures: DNSFixtures = {
     'a.root-servers.net': {
       ipv4: '198.41.0.4',
       ipv6: '2001:503:ba3e::2:30'
+    },
+    'a.test-servers.example': {
+      ipv4: '192.0.2.1'
+    },
+    'b.test-servers.example': {
+      ipv4: '192.0.2.2'
+    },
+    'ns1.example.test': {
+      ipv4: '198.51.100.1'
+    },
+    'ns2.example.test': {
+      ipv4: '198.51.100.2'
     },
     'a0.org.afilias-nst.info': {
       ipv4: '199.19.56.1',

--- a/frontend/providers/applaunchpad/__tests__/unit/services/dns-resolver.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/services/dns-resolver.test.ts
@@ -440,10 +440,11 @@ describe('DNS Resolver', () => {
 
       const result = extractNSServers('example.org', answers);
 
-      expect(result.length).toBe(MAX_NAMESERVERS);
-      expect(result[0].ns).toBe('ns1.example.org');
-      expect(result[1].ns).toBe('ns2.example.org');
-      expect(result[2].ns).toBe('ns3.example.org');
+      expect(result?.zone).toBe('example.org');
+      expect(result?.nameservers.length).toBe(MAX_NAMESERVERS);
+      expect(result?.nameservers[0].ns).toBe('ns1.example.org');
+      expect(result?.nameservers[1].ns).toBe('ns2.example.org');
+      expect(result?.nameservers[2].ns).toBe('ns3.example.org');
     });
 
     it('should return all nameservers if less than MAX_NAMESERVERS', () => {
@@ -456,9 +457,10 @@ describe('DNS Resolver', () => {
 
       const result = extractNSServers('example.org', answers);
 
-      expect(result.length).toBe(2);
-      expect(result[0].ns).toBe('ns1.example.org');
-      expect(result[1].ns).toBe('ns2.example.org');
+      expect(result?.zone).toBe('example.org');
+      expect(result?.nameservers.length).toBe(2);
+      expect(result?.nameservers[0].ns).toBe('ns1.example.org');
+      expect(result?.nameservers[1].ns).toBe('ns2.example.org');
     });
 
     it('should return exactly MAX_NAMESERVERS when there are exactly MAX_NAMESERVERS nameservers', () => {
@@ -473,10 +475,11 @@ describe('DNS Resolver', () => {
 
       const result = extractNSServers('example.org', answers);
 
-      expect(result.length).toBe(MAX_NAMESERVERS);
-      expect(result[0].ns).toBe('ns1.example.org');
-      expect(result[1].ns).toBe('ns2.example.org');
-      expect(result[2].ns).toBe('ns3.example.org');
+      expect(result?.zone).toBe('example.org');
+      expect(result?.nameservers.length).toBe(MAX_NAMESERVERS);
+      expect(result?.nameservers[0].ns).toBe('ns1.example.org');
+      expect(result?.nameservers[1].ns).toBe('ns2.example.org');
+      expect(result?.nameservers[2].ns).toBe('ns3.example.org');
     });
 
     it('should filter by target domain name', () => {
@@ -490,9 +493,24 @@ describe('DNS Resolver', () => {
 
       const result = extractNSServers('example.org', answers);
 
-      expect(result.length).toBe(2);
-      expect(result[0].ns).toBe('ns1.example.org');
-      expect(result[1].ns).toBe('ns2.example.org');
+      expect(result?.zone).toBe('example.org');
+      expect(result?.nameservers.length).toBe(2);
+      expect(result?.nameservers[0].ns).toBe('ns1.example.org');
+      expect(result?.nameservers[1].ns).toBe('ns2.example.org');
+    });
+
+    it('should return the closest parent zone when response contains delegation NS records', () => {
+      const answers = [
+        { name: 'example.test', type: 'NS', ttl: 86400, data: 'ns1.example.test' },
+        { name: 'test', type: 'NS', ttl: 86400, data: 'a.test-servers.example' },
+        { name: 'ns1.example.test', type: 'A', ttl: 172800, data: '198.51.100.1' },
+        { name: 'a.test-servers.example', type: 'A', ttl: 172800, data: '192.0.2.1' }
+      ] as any;
+
+      const result = extractNSServers('app.platform.example.test', answers);
+
+      expect(result?.zone).toBe('example.test');
+      expect(result?.nameservers.map((ns) => ns.ns)).toEqual(['ns1.example.test']);
     });
   });
 
@@ -866,6 +884,17 @@ describe('DNS Resolver', () => {
         expect(result.zone).toBeTruthy();
         expect(result.nameservers.length).toBeGreaterThan(0);
       }
+    }, 2000);
+
+    it('should continue from a parent TLD delegation to the closest authoritative zone', async () => {
+      const result = await getAuthoritativeNsFromLocal('app.platform.example.test');
+
+      expect(result).not.toBeNull();
+      expect(result?.zone).toBe('example.test');
+      expect(result?.nameservers.map((ns) => ns.ns)).toEqual([
+        'ns1.example.test',
+        'ns2.example.test'
+      ]);
     }, 2000);
 
     it('should return null for empty domain', async () => {

--- a/frontend/providers/applaunchpad/src/services/dns-resolver.ts
+++ b/frontend/providers/applaunchpad/src/services/dns-resolver.ts
@@ -22,6 +22,11 @@ export type Nameserver = {
   readonly resolveIPv6: () => Promise<string | null>;
 };
 
+export type NameserverMatch = {
+  readonly zone: string;
+  readonly nameservers: readonly Nameserver[];
+};
+
 export type DNSRecord = {
   readonly name: string;
   readonly type: string;
@@ -205,6 +210,12 @@ const resolveIPv6Address = async (host: string) => {
   }
 };
 
+const getParentZones = (domain: string): readonly string[] => {
+  const parts = domain.split('.').filter((part) => part.length > 0);
+
+  return parts.map((_, index) => parts.slice(index).join('.'));
+};
+
 /**
  * Extract NS servers with their possible IP addresses from DNS answers.
  * @returns a list of NS servers with lazy IP resolution (max MAX_NAMESERVERS).
@@ -212,10 +223,20 @@ const resolveIPv6Address = async (host: string) => {
 export const extractNSServers = (
   target: string,
   allAnswers: readonly dnsPacket.Answer[]
-): readonly Nameserver[] => {
+): NameserverMatch | null => {
+  const candidateZones = getParentZones(target);
+  const zonesWithNs = candidateZones.filter((zone) =>
+    allAnswers.some((answer) => answer.type === 'NS' && answer.name === zone)
+  );
+  const zone = zonesWithNs[0];
+
+  if (!zone) {
+    return null;
+  }
+
   const nsWithPossibleAddresses = allAnswers.reduce(
     (prev, nsRecord) => {
-      if (nsRecord.type !== 'NS' || nsRecord.name !== target) return prev;
+      if (nsRecord.type !== 'NS' || nsRecord.name !== zone) return prev;
 
       const aRecord = allAnswers.find(
         (addrRecord) => addrRecord.type === 'A' && addrRecord.name === nsRecord.data
@@ -249,7 +270,7 @@ export const extractNSServers = (
     >()
   );
 
-  return Array.from(nsWithPossibleAddresses.entries())
+  const nameservers = Array.from(nsWithPossibleAddresses.entries())
     .map(([ns, addresses]): Nameserver => {
       const glueA = addresses.glueA;
       const glueAAAA = addresses.glueAAAA;
@@ -275,6 +296,15 @@ export const extractNSServers = (
       };
     })
     .slice(0, MAX_NAMESERVERS);
+
+  if (nameservers.length === 0) {
+    return null;
+  }
+
+  return {
+    zone,
+    nameservers
+  };
 };
 
 /**
@@ -403,8 +433,8 @@ export const getAuthoritativeNsFromRoot = async (domain: string): Promise<NSInfo
       ...(nsResponse.additionals ?? [])
     ];
 
-    const nsServersWithIP = extractNSServers(testDomain, answers);
-    if (nsServersWithIP.length === 0) {
+    const nsServerMatch = extractNSServers(testDomain, answers);
+    if (!nsServerMatch) {
       // Exhausted input, return last valid NSInfo if available
       if (remainingParts.length === 0) {
         return lastValidNSInfo;
@@ -419,8 +449,8 @@ export const getAuthoritativeNsFromRoot = async (domain: string): Promise<NSInfo
 
     // Valid response, continue...
     const currentNSInfo: NSInfo = {
-      zone: testDomain,
-      nameservers: nsServersWithIP
+      zone: nsServerMatch.zone,
+      nameservers: nsServerMatch.nameservers
     };
 
     if (remainingParts.length === 0) {
@@ -484,11 +514,11 @@ export const getAuthoritativeNsFromLocal = async (domain: string): Promise<NSInf
           ...(response.additionals ?? [])
         ];
 
-        const nsServersWithIP = extractNSServers(target, answers);
-        if (nsServersWithIP.length > 0) {
+        const nsServerMatch = extractNSServers(target, answers);
+        if (nsServerMatch) {
           return {
-            zone: target,
-            nameservers: nsServersWithIP
+            zone: nsServerMatch.zone,
+            nameservers: nsServerMatch.nameservers
           };
         }
       } catch {
@@ -500,16 +530,53 @@ export const getAuthoritativeNsFromLocal = async (domain: string): Promise<NSInf
     return null;
   };
 
+  const queryFromNameservers = async (
+    target: string,
+    nameservers: readonly Nameserver[]
+  ): Promise<NSInfo | null> => {
+    const response = await resolveWithNs(target, 'NS', nameservers, {
+      recursionDesired: true
+    });
+    if (!response) {
+      return null;
+    }
+
+    const answers = [
+      ...(response.answers ?? []),
+      ...(response.authorities ?? []),
+      ...(response.additionals ?? [])
+    ];
+
+    const nsServerMatch = extractNSServers(target, answers);
+    if (!nsServerMatch) {
+      return null;
+    }
+
+    return {
+      zone: nsServerMatch.zone,
+      nameservers: nsServerMatch.nameservers
+    };
+  };
+
+  let result: NSInfo | null = null;
+
   for (let i = 0; i < parts.length; i += 1) {
     const zoneCandidate = parts.slice(i).join('.');
-    const result = await queryFromLocalResolvers(zoneCandidate);
+    if (result && !zoneCandidate.endsWith(result.zone)) {
+      continue;
+    }
 
-    if (result) {
-      return result;
+    const candidateResult: NSInfo | null =
+      result === null
+        ? await queryFromLocalResolvers(zoneCandidate)
+        : await queryFromNameservers(zoneCandidate, result.nameservers);
+
+    if (candidateResult) {
+      result = candidateResult;
     }
   }
 
-  return null;
+  return result;
 };
 
 /**


### PR DESCRIPTION
  ## Summary

  Fix applaunchpad DNS resolver to continue NS delegation lookup when a parent zone returns referral records.

  ## Changes

  - Track the actual delegated zone returned by NS responses.
  - Continue querying discovered nameservers until the closest authoritative zone is found.
  - Add regression coverage using reserved test domains and documentation IP ranges.