### PR TITLE
fix(applaunchpad): mask registry secret yaml export

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/pages/app/edit/index.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/pages/app/edit/index.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'fs';
+import { describe, expect, it } from 'vitest';
+
+describe('EditApp yaml display state', () => {
+  it('keeps custom-domain verification yaml display masked while caching raw yaml', () => {
+    const source = readFileSync(
+      new URL('../../../../../src/pages/app/edit/index.tsx', import.meta.url),
+      'utf8'
+    );
+    const start = source.indexOf('const handleDomainVerified = useCallback');
+    const end = source.indexOf('useQuery(', start);
+
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+
+    const handleDomainVerified = source.slice(start, end);
+
+    expect(handleDomainVerified).toContain('formOldYamls.current = formData2Yamls(data);');
+    expect(handleDomainVerified).toContain('setYamlList(formData2DisplayYamls(data));');
+    expect(handleDomainVerified).not.toContain('setYamlList(formData2Yamls(data));');
+  });
+});

--- a/frontend/providers/applaunchpad/__tests__/unit/utils/deployYaml2Json.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/deployYaml2Json.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   json2DeployCr,
   json2Ingress,
+  json2Secret,
   json2Service,
   yamlString2Objects
 } from '@/utils/deployYaml2Json';
@@ -90,15 +91,9 @@ describe('json2Ingress', () => {
       })
     ) as any[];
 
-    expect(objects[0].spec.rules[0].host).toBe(
-      'codex-ms100066-launch.192.168.13.29.nip.io'
-    );
-    expect(objects[0].spec.tls[0].hosts).toEqual([
-      'codex-ms100066-launch.192.168.13.29.nip.io'
-    ]);
-    expect(objects[2].spec.dnsNames).toEqual([
-      'codex-ms100066-launch.192.168.13.29.nip.io'
-    ]);
+    expect(objects[0].spec.rules[0].host).toBe('codex-ms100066-launch.192.168.13.29.nip.io');
+    expect(objects[0].spec.tls[0].hosts).toEqual(['codex-ms100066-launch.192.168.13.29.nip.io']);
+    expect(objects[2].spec.dnsNames).toEqual(['codex-ms100066-launch.192.168.13.29.nip.io']);
   });
 
   it('normalizes configured app domain before writing generated ingress host', () => {
@@ -351,5 +346,37 @@ describe('json2DeployCr', () => {
 
     expect(portNames).toEqual(['p-t-80-0', 'p-t-80-1', 'p-t-80-2']);
     expect(new Set(portNames).size).toBe(portNames.length);
+  });
+});
+
+describe('json2Secret', () => {
+  it('keeps registry credentials in deploy yaml by default', () => {
+    const app = createApp();
+    app.secret = {
+      use: true,
+      username: 'demo-user',
+      password: 'real-password',
+      serverAddress: 'registry.example.com'
+    };
+
+    const objects = yamlString2Objects(json2Secret(app)) as any[];
+    const dockerconfigjson = Buffer.from(objects[0].data['.dockerconfigjson'], 'base64').toString();
+
+    expect(dockerconfigjson).toContain('real-password');
+  });
+
+  it('masks registry password in display yaml', () => {
+    const app = createApp();
+    app.secret = {
+      use: true,
+      username: 'demo-user',
+      password: 'real-password',
+      serverAddress: 'registry.example.com'
+    };
+
+    const secretYaml = json2Secret(app, undefined, { maskPassword: true });
+
+    expect(secretYaml).toContain('.dockerconfigjson: ********');
+    expect(secretYaml).not.toContain(".dockerconfigjson: '********'");
   });
 });

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/Header.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/Header.tsx
@@ -13,7 +13,7 @@ import { Info, X } from 'lucide-react';
 import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
 import { useCallback } from 'react';
-import { formData2Yamls } from '../index';
+import { formData2DisplayYamls } from '../index';
 
 const Header = ({
   appName,
@@ -39,7 +39,7 @@ const Header = ({
     let exportYamlList: YamlItemType[];
     if (getFormData) {
       const formData = getFormData();
-      exportYamlList = formData2Yamls(formData);
+      exportYamlList = formData2DisplayYamls(formData);
     } else {
       exportYamlList = yamlList;
     }

--- a/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
@@ -45,7 +45,8 @@ const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz', 12);
 const ErrorModal = dynamic(() => import('./components/ErrorModal'));
 
 export const formData2Yamls = (
-  data: AppEditType
+  data: AppEditType,
+  options?: { maskSecret?: boolean }
   // handleType: 'edit' | 'create' = 'create',
   // crYamlList?: DeployKindsType[]
 ) => [
@@ -90,11 +91,14 @@ export const formData2Yamls = (
     ? [
         {
           filename: 'secret.yaml',
-          value: json2Secret(data)
+          value: json2Secret(data, undefined, { maskPassword: options?.maskSecret })
         }
       ]
     : [])
 ];
+
+export const formData2DisplayYamls = (data: AppEditType) =>
+  formData2Yamls(data, { maskSecret: true });
 
 const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) => {
   const { t } = useTranslation();
@@ -376,7 +380,7 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
         setDefaultGpuSource(res.gpu);
         formHook.reset(adaptEditAppData(res));
         setAlready(true);
-        setYamlList(formData2Yamls(realTimeForm.current));
+        setYamlList(formData2DisplayYamls(realTimeForm.current));
       },
       onError(err) {
         toast({
@@ -393,7 +397,7 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
   useEffect(() => {
     if (tabType === 'yaml') {
       try {
-        setYamlList(formData2Yamls(realTimeForm.current));
+        setYamlList(formData2DisplayYamls(realTimeForm.current));
       } catch (error) {}
     }
   }, [router.query.name, tabType]);
@@ -540,7 +544,7 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
               console.log('data', data);
 
               const parseYamls = formData2Yamls(data);
-              setYamlList(parseYamls);
+              setYamlList(formData2DisplayYamls(data));
 
               // gpu inventory check
               if (data.gpu?.type) {

--- a/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
@@ -331,7 +331,7 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
           .then(() => {
             toast({ status: 'success', title: t('Deployment Successful') });
             formOldYamls.current = formData2Yamls(data);
-            setYamlList(formData2Yamls(data));
+            setYamlList(formData2DisplayYamls(data));
           })
           .catch((err) => {
             toast({ status: 'error', title: getErrText(err) });

--- a/frontend/providers/applaunchpad/src/utils/deployYaml2Json.ts
+++ b/frontend/providers/applaunchpad/src/utils/deployYaml2Json.ts
@@ -711,7 +711,15 @@ export const json2ConfigMap = (data: AppEditType, ownerReferences?: V1OwnerRefer
   return yaml.dump(template);
 };
 
-export const json2Secret = (data: AppEditType, ownerReferences?: V1OwnerReference[]) => {
+const maskedDockerConfigJson = '********';
+const quotedMaskedDockerConfigJson = `.dockerconfigjson: '${maskedDockerConfigJson}'`;
+const unquotedMaskedDockerConfigJson = `.dockerconfigjson: ${maskedDockerConfigJson}`;
+
+export const json2Secret = (
+  data: AppEditType,
+  ownerReferences?: V1OwnerReference[],
+  options?: { maskPassword?: boolean }
+) => {
   const auth = strToBase64(`${data.secret.username}:${data.secret.password}`);
   const dockerconfigjson = strToBase64(
     JSON.stringify({
@@ -733,11 +741,14 @@ export const json2Secret = (data: AppEditType, ownerReferences?: V1OwnerReferenc
       ...(ownerReferences ? { ownerReferences } : {})
     },
     data: {
-      '.dockerconfigjson': dockerconfigjson
+      '.dockerconfigjson': options?.maskPassword ? maskedDockerConfigJson : dockerconfigjson
     },
     type: 'kubernetes.io/dockerconfigjson'
   };
-  return yaml.dump(template);
+  const secretYaml = yaml.dump(template);
+  return options?.maskPassword
+    ? secretYaml.replace(quotedMaskedDockerConfigJson, unquotedMaskedDockerConfigJson)
+    : secretYaml;
 };
 export const json2HPA = (data: AppEditType, ownerReferences?: V1OwnerReference[]) => {
   const isDeployment = data.storeList?.length === 0;


### PR DESCRIPTION
## Summary
- mask private registry credentials in App Launchpad YAML display/export output
- keep deploy/apply YAML generation unchanged so private image pulls still receive real credentials
- add coverage for raw versus masked dockerconfigjson secret generation

## Verification
- `pnpm --dir frontend --filter applaunchpad exec prettier --check src/utils/deployYaml2Json.ts src/pages/app/edit/index.tsx src/pages/app/edit/components/Header.tsx __tests__/unit/utils/deployYaml2Json.test.ts`
- `pnpm --dir frontend --filter applaunchpad exec tsc --noEmit`
- `pnpm --dir frontend --filter applaunchpad run lint`

## Notes
- `pnpm --dir frontend dlx vitest run providers/applaunchpad/__tests__/unit/utils/deployYaml2Json.test.ts` is blocked by the existing test runner setup not resolving the `@/` path alias for this package.

Fixes labring-sigs/sealos-issues#320
