### PR TITLE
fix(dbprovider): hide empty monitor metrics

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -10,3 +10,5 @@ skills-lock.json
 .omx
 AGENTS.md
 .sisyphus
+**/test-results/
+.codegraph/

--- a/frontend/providers/dbprovider/src/pages/api/monitor/getAbortedConnections.ts
+++ b/frontend/providers/dbprovider/src/pages/api/monitor/getAbortedConnections.ts
@@ -19,7 +19,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     const startTime = endTime - 60 * 60 * 1000; // 前向推进1个小时的时间戳
 
     const queryType: { [key: string]: string } = {
-      [DBTypeEnum.mysql]: `sum(rate(mysql_global_status_aborted_connects{$, workloads_kubeblocks_io_instance="${dbName}-mysql}"}[1m])) by (namespace,app_kubernetes_io_instance,pod)`,
+      [DBTypeEnum.mysql]: `sum(rate(mysql_global_status_aborted_connects{$, workloads_kubeblocks_io_instance="${dbName}-mysql"}[1m])) by (namespace,app_kubernetes_io_instance,pod)`,
       [DBTypeEnum.notapemysql]: `sum(rate(mysql_global_status_aborted_connects{$, workloads_kubeblocks_io_instance="${dbName}-mysql"}[1m])) by (namespace,app_kubernetes_io_instance,pod)`
     };
 

--- a/frontend/providers/dbprovider/src/pages/db/detail/components/Monitor/index.tsx
+++ b/frontend/providers/dbprovider/src/pages/db/detail/components/Monitor/index.tsx
@@ -185,20 +185,6 @@ const Monitor = ({ db, dbName, dbType }: { dbName: string; dbType: string; db?: 
           {dbType === DBTypeEnum.postgresql && (
             <>
               <ChartTemplate
-                apiUrl="/api/monitor/getTransactions"
-                chartTitle={'commits_per_second'}
-                dbName={dbName}
-                dbType={dbType}
-                db={db}
-              />
-              <ChartTemplate
-                apiUrl="/api/monitor/getRollback"
-                chartTitle={'rollbacks_per_second'}
-                dbName={dbName}
-                dbType={dbType}
-                db={db}
-              />
-              <ChartTemplate
                 apiUrl="/api/monitor/getDurationTransaction"
                 chartTitle={'duration_of_transaction'}
                 dbName={dbName}
@@ -206,15 +192,6 @@ const Monitor = ({ db, dbName, dbType }: { dbName: string; dbType: string; db?: 
                 db={db}
                 unit="ms"
               />
-              <ChartTemplate
-                apiUrl="/api/monitor/getBlockReadTime"
-                chartTitle={'block_read_time'}
-                dbName={dbName}
-                dbType={dbType}
-                db={db}
-                unit="ms"
-              />
-
               <ChartTemplate
                 apiUrl="/api/monitor/getBlockWriteTime"
                 chartTitle={'block_write_time'}
@@ -298,15 +275,6 @@ const Monitor = ({ db, dbName, dbType }: { dbName: string; dbType: string; db?: 
                 dbType={dbType}
                 db={db}
                 queryKey={'Redis_KeyEvictions'}
-              />
-              <ChartTemplate
-                apiUrl="/api/monitor/getRedisPerformance"
-                chartTitle={'hits_ratio'}
-                dbName={dbName}
-                dbType={dbType}
-                db={db}
-                queryKey={'Redis_HitsRatio'}
-                unit="%"
               />
             </>
           )}


### PR DESCRIPTION
## Summary
- hide DBProvider monitor charts that currently render empty data
- fix the malformed MySQL aborted connections PromQL query
- ignore local CodeGraph index output

## Testing
- Not run; change is limited to chart visibility and query string cleanup.