### PR TITLE
fix(applaunchpad): prevent partial create for invalid names

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/utils/appNameValidation.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/appNameValidation.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from 'vitest';
 import {
   APP_NAME_BASE_MAX_LENGTH,
   K8S_RFC1035_NAME_MAX_LENGTH,
+  getInvalidGeneratedAppNameMessage,
+  getInvalidRfc1035ServiceNameMessage,
   generateAppName,
   isValidAppNameBase,
-  isValidGeneratedAppName
+  isValidGeneratedAppName,
+  isValidRfc1035Name
 } from '@/utils/appNameValidation';
 
 describe('app name validation', () => {
@@ -53,5 +56,29 @@ describe('app name validation', () => {
     expect(podName).toHaveLength(K8S_RFC1035_NAME_MAX_LENGTH);
     expect(isValidGeneratedAppName(podName)).toBe(false);
     expect(/^[a-z]([-a-z0-9]*[a-z0-9])?$/.test(podName)).toBe(true);
+  });
+
+  it('reports app names that exceed the generated name budget before apply', () => {
+    const tooLongBase = `a${'b'.repeat(APP_NAME_BASE_MAX_LENGTH)}`;
+
+    expect(isValidRfc1035Name(tooLongBase)).toBe(true);
+    expect(getInvalidGeneratedAppNameMessage(tooLongBase)).toContain(
+      `Use ${APP_NAME_BASE_MAX_LENGTH} characters or fewer`
+    );
+  });
+
+  it('reports invalid service names before the Kubernetes apply step', () => {
+    expect(
+      getInvalidRfc1035ServiceNameMessage([
+        {
+          kind: 'Deployment',
+          metadata: { name: '111111hello-world' }
+        },
+        {
+          kind: 'Service',
+          metadata: { name: '111111hello-world-yanexremmrtr' }
+        }
+      ])
+    ).toContain('Service "111111hello-world-yanexremmrtr" has an invalid name');
   });
 });

--- a/frontend/providers/applaunchpad/__tests__/unit/utils/deployYaml2Json.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/deployYaml2Json.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { json2DeployCr, json2Ingress, json2Service, yamlString2Objects } from '@/utils/deployYaml2Json';
+import {
+  json2DeployCr,
+  json2Ingress,
+  json2Service,
+  yamlString2Objects
+} from '@/utils/deployYaml2Json';
 import type { AppEditType } from '@/types/app';
 import { deployPVCResizeKey } from '@/constants/app';
 import {
@@ -151,5 +156,14 @@ describe('json2Service', () => {
 
     expect(serviceName).toMatch(/^demo-nodeport-[a-z]{12}$/);
     expect(serviceName.length - app.appName.length).toBe(22);
+  });
+
+  it('keeps the numeric-prefix app name invalidity visible before apply', () => {
+    const app = createApp('', true);
+    app.appName = '111111hello-world';
+
+    const objects = yamlString2Objects(json2Service(app)) as any[];
+
+    expect(objects[0].metadata.name).toMatch(/^111111hello-world-nodeport-[a-z]{12}$/);
   });
 });

--- a/frontend/providers/applaunchpad/src/pages/api/applyApp.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/applyApp.ts
@@ -3,6 +3,12 @@ import { ApiResp } from '@/services/kubernet';
 import { authSession } from '@/services/backend/auth';
 import { getK8s } from '@/services/backend/kubernetes';
 import { handleK8sError, jsonRes } from '@/services/backend/response';
+import yaml from 'js-yaml';
+import {
+  getInvalidGeneratedAppNameMessage,
+  getInvalidRfc1035ServiceNameMessage
+} from '@/utils/appNameValidation';
+import { ResponseCode } from '@/types/response';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
   const { yamlList, mode = 'create' }: { yamlList: string[]; mode?: 'create' | 'replace' } =
@@ -15,6 +21,33 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     return;
   }
   try {
+    const allResources = yamlList.flatMap((yamlStr) =>
+      yaml.loadAll(yamlStr).filter((item) => item)
+    );
+    const mainWorkload = allResources.find(
+      (resource: any) => resource.kind === 'Deployment' || resource.kind === 'StatefulSet'
+    ) as any;
+
+    const invalidAppNameMessage = mainWorkload
+      ? getInvalidGeneratedAppNameMessage(mainWorkload.metadata?.name)
+      : undefined;
+    if (mode === 'create' && invalidAppNameMessage) {
+      jsonRes(res, {
+        code: ResponseCode.BAD_REQUEST,
+        message: invalidAppNameMessage
+      });
+      return;
+    }
+
+    const invalidServiceNameMessage = getInvalidRfc1035ServiceNameMessage(allResources as any[]);
+    if (invalidServiceNameMessage) {
+      jsonRes(res, {
+        code: ResponseCode.BAD_REQUEST,
+        message: invalidServiceNameMessage
+      });
+      return;
+    }
+
     const { applyYamlList } = await getK8s({
       kubeconfig: await authSession(req.headers)
     });

--- a/frontend/providers/applaunchpad/src/utils/appNameValidation.ts
+++ b/frontend/providers/applaunchpad/src/utils/appNameValidation.ts
@@ -21,3 +21,34 @@ export const isValidGeneratedAppName = (appName: string) =>
   APP_GENERATED_NAME_PATTERN.test(appName);
 
 export const generateAppName = (baseName: string) => baseName;
+
+export const isValidRfc1035Name = (name: string) =>
+  name.length > 0 &&
+  name.length <= K8S_RFC1035_NAME_MAX_LENGTH &&
+  APP_GENERATED_NAME_PATTERN.test(name);
+
+type NamedKubernetesResource = {
+  kind?: string;
+  metadata?: {
+    name?: unknown;
+  };
+};
+
+export const getInvalidGeneratedAppNameMessage = (name: unknown) => {
+  if (typeof name !== 'string' || isValidGeneratedAppName(name)) return;
+
+  return `Application name "${name}" is invalid. Use ${APP_GENERATED_NAME_MAX_LENGTH} characters or fewer, start with a lowercase letter, use only lowercase letters, numbers, or hyphens, and end with a lowercase letter or number.`;
+};
+
+export const getInvalidRfc1035ServiceNameMessage = (resources: NamedKubernetesResource[]) => {
+  const invalidResource = resources.find((resource) => {
+    const name = resource?.metadata?.name;
+    return resource.kind === 'Service' && typeof name === 'string' && !isValidRfc1035Name(name);
+  });
+
+  if (!invalidResource) return;
+
+  return `${invalidResource.kind || 'Resource'} "${
+    invalidResource.metadata?.name
+  }" has an invalid name. Names must start with a lowercase letter, contain only lowercase letters, numbers, or hyphens, and end with a lowercase letter or number.`;
+};


### PR DESCRIPTION
## Summary

- Add shared preflight validation for generated AppLaunchpad app names and Service names.
- Reject invalid names in `/api/applyApp` before any Kubernetes resource is applied, preventing partially-created apps.
- Add regression coverage for the numeric-prefix YAML apply path that triggered labring-sigs/sealos-issues#207.

Fixes labring-sigs/sealos-issues#207.
Follow-up to labring/sealos#6994.

## Verification

- `pnpm --filter ./providers/applaunchpad lint`
- `./node_modules/.bin/prettier --check providers/applaunchpad/src/pages/api/applyApp.ts providers/applaunchpad/src/utils/appNameValidation.ts providers/applaunchpad/__tests__/unit/utils/appNameValidation.test.ts providers/applaunchpad/__tests__/unit/utils/deployYaml2Json.test.ts`
- `git diff --check`
- `docker build --platform=linux/amd64 -t hub.192.168.13.209.nip.io/labring/sealos-applaunchpad-frontend:invalid-name-e51c77580481-20260617155951 --build-arg path=providers/applaunchpad --build-arg name=applaunchpad .`

`vitest` was not available in the local sparse worktree (`Command "vitest" not found`), so the regression tests were added but not executed locally.

## 209 deployment

Cluster 209 currently uses the older AppLaunchpad ConfigMap schema, so the current-main PR image is not runtime-compatible with that cluster config. I restored 209 after that check, then deployed a 209-compatible backport image from the currently running code line:

- Image: `hub.192.168.13.209.nip.io/labring/sealos-applaunchpad-frontend:invalid-name-209-325bd355-20260617162731`
- Rollout: `kubectl --kubeconfig ~/.kube/209 -n applaunchpad-frontend rollout status deploy/applaunchpad-frontend --timeout=300s`
- Current status: `1/1 ready`, pod `Running`, `0` restarts
