### PR TITLE
feat(desktop): make sign-in protocol prompt configurable

### DIFF
--- a/frontend/desktop/data/config.yaml
+++ b/frontend/desktop/data/config.yaml
@@ -53,6 +53,7 @@ desktop:
     forcedLanguage: "en"
     currencySymbol: "usd"
     protocol:
+      enabled: true
       serviceProtocol:
         zh: "https://sealos.io/zh-Hans/docs/msa/terms-of-service"
         en: "https://sealos.io/docs/msa/terms-of-service"

--- a/frontend/desktop/deploy/HELM_VALUES_GUIDE.md
+++ b/frontend/desktop/deploy/HELM_VALUES_GUIDE.md
@@ -125,6 +125,8 @@ desktopConfig:
   layoutBackgroundImage: '/images/bg-light.svg' # 背景图片
   customerServiceURL: '' # 客服 URL
   layoutDocsUrl: 'https://sealos.run/docs/Intro/' # 文档 URL
+  protocol:
+    enabled: true # 是否显示登录页服务条款和隐私政策提示
 ```
 
 ### 11. Meta 标签配置

--- a/frontend/desktop/deploy/HELM_VALUES_GUIDE_CN.md
+++ b/frontend/desktop/deploy/HELM_VALUES_GUIDE_CN.md
@@ -124,6 +124,8 @@ desktopConfig:
   layoutBackgroundImage: "/images/bg-light.svg" # 背景图片
   customerServiceURL: ""                       # 客服 URL
   layoutDocsUrl: "https://sealos.run/docs/Intro/" # 文档 URL
+  protocol:
+    enabled: true                              # 是否显示登录页服务条款和隐私政策提示
 ```
 
 ### 11. Meta 标签配置

--- a/frontend/desktop/deploy/README.md
+++ b/frontend/desktop/deploy/README.md
@@ -212,6 +212,14 @@ desktop:
     discordInviteLink: '' # Auto-configured: shown for "en", empty for "cn"
     gtmId: null
     currencySymbol: 'usd' # Auto-configured based on version: "cn"→"shellCoin", "en"→"usd"
+    protocol:
+      enabled: true
+      serviceProtocol:
+        zh: 'https://sealos.io/zh-Hans/docs/msa/terms-of-service'
+        en: 'https://sealos.io/docs/msa/terms-of-service'
+      privateProtocol:
+        zh: 'https://sealos.io/zh-Hans/docs/msa/privacy-policy'
+        en: 'https://sealos.io/docs/msa/privacy-policy'
     meta:
       title: 'Sealos Cloud'
       description: 'Sealos Cloud'
@@ -427,6 +435,10 @@ All config.yaml settings can be customized via Helm `--set` parameters through t
 sealos run desktop-frontend:latest \
   -e HELM_OPTIONS="--set desktopConfig.layoutTitle=\"My Cloud Platform\" --set desktopConfig.metaTitle=\"My Cloud\""
 
+# Hide sign-in terms and privacy prompt
+sealos run desktop-frontend:latest \
+  -e HELM_OPTIONS="--set desktopConfig.protocol.enabled=false"
+
 # OAuth providers via HELM_OPTIONS
 sealos run desktop-frontend:latest \
   -e HELM_OPTIONS="--set desktopConfig.githubEnabled=true --set desktopConfig.githubClientId=your-client-id --set desktopConfig.githubClientSecret=your-client-secret"
@@ -444,7 +456,7 @@ sealos run desktop-frontend:latest \
 
 **Common customization options:**
 
-- **UI customization**: `layoutTitle`, `layoutLogo`, `metaTitle`, `metaDescription`, `customerServiceURL`
+- **UI customization**: `layoutTitle`, `layoutLogo`, `metaTitle`, `metaDescription`, `customerServiceURL`, `protocol.enabled`
 - **OAuth providers**: `githubEnabled`, `googleEnabled`, `wechatEnabled`, `oauth2Enabled` and their `*ClientId`, `*ClientSecret`
 - **Features**: `guideEnabled`, `rechargeEnabled`, `trackingEnabled`, `apiEnabled`, `realNameAuthEnabled`
 - **Communication**: `smsEnabled`, `emailEnabled`, `emailHost`, `emailPort`, `emailUser`, `emailPassword`

--- a/frontend/desktop/deploy/README_CN.md
+++ b/frontend/desktop/deploy/README_CN.md
@@ -212,6 +212,14 @@ desktop:
     discordInviteLink: '' # 自动根据 version 配置: "en"时显示, "cn"时为空
     gtmId: null
     currencySymbol: 'usd' # 自动根据 version 配置: "cn"→"shellCoin", "en"→"usd"
+    protocol:
+      enabled: true
+      serviceProtocol:
+        zh: 'https://sealos.io/zh-Hans/docs/msa/terms-of-service'
+        en: 'https://sealos.io/docs/msa/terms-of-service'
+      privateProtocol:
+        zh: 'https://sealos.io/zh-Hans/docs/msa/privacy-policy'
+        en: 'https://sealos.io/docs/msa/privacy-policy'
     meta:
       title: 'Sealos Cloud'
       description: 'Sealos Cloud'
@@ -427,6 +435,10 @@ kubectl logs -n sealos -l app.kubernetes.io/name=desktop-frontend --tail=100 -f
 sealos run desktop-frontend:latest \
   -e HELM_OPTIONS="--set desktopConfig.layoutTitle=\"我的云平台\" --set desktopConfig.metaTitle=\"我的云平台\""
 
+# 隐藏登录页服务条款和隐私政策提示
+sealos run desktop-frontend:latest \
+  -e HELM_OPTIONS="--set desktopConfig.protocol.enabled=false"
+
 # OAuth 提供商
 sealos run desktop-frontend:latest \
   -e HELM_OPTIONS="--set desktopConfig.githubEnabled=true --set desktopConfig.githubClientId=your-client-id --set desktopConfig.githubClientSecret=your-client-secret"
@@ -444,7 +456,7 @@ sealos run desktop-frontend:latest \
 
 **常用自定义选项：**
 
-- **UI 自定义**: `layoutTitle`, `layoutLogo`, `metaTitle`, `metaDescription`, `customerServiceURL`
+- **UI 自定义**: `layoutTitle`, `layoutLogo`, `metaTitle`, `metaDescription`, `customerServiceURL`, `protocol.enabled`
 - **OAuth 提供商**: `githubEnabled`, `googleEnabled`, `wechatEnabled`, `oauth2Enabled` 及其对应的 `*ClientId`, `*ClientSecret`
 - **功能开关**: `guideEnabled`, `rechargeEnabled`, `trackingEnabled`, `apiEnabled`, `realNameAuthEnabled`
 - **通讯配置**: `smsEnabled`, `emailEnabled`, `emailHost`, `emailPort`, `emailUser`, `emailPassword`

--- a/frontend/desktop/deploy/charts/desktop-frontend/desktop-frontend-values.yaml
+++ b/frontend/desktop/deploy/charts/desktop-frontend/desktop-frontend-values.yaml
@@ -84,6 +84,7 @@ desktopConfig:
     zh: "/images/bg-light.svg"
     en: "/images/bg-light.svg"
   protocol:
+    enabled: true
     serviceProtocol:
       zh: https://sealos.io/zh-Hans/docs/msa/terms-of-service
       en: https://sealos.io/docs/msa/terms-of-service

--- a/frontend/desktop/deploy/charts/desktop-frontend/templates/configmap.yaml
+++ b/frontend/desktop/deploy/charts/desktop-frontend/templates/configmap.yaml
@@ -61,6 +61,7 @@ data:
           zh: "{{.Values.desktopConfig.authBackgroundImage.zh}}"
           en: "{{.Values.desktopConfig.authBackgroundImage.en}}"
         protocol:
+          enabled: {{ .Values.desktopConfig.protocol.enabled }}
           serviceProtocol:
             zh: "{{.Values.desktopConfig.protocol.serviceProtocol.zh}}"
             en: "{{.Values.desktopConfig.protocol.serviceProtocol.en}}"

--- a/frontend/desktop/deploy/charts/desktop-frontend/values.yaml
+++ b/frontend/desktop/deploy/charts/desktop-frontend/values.yaml
@@ -77,6 +77,7 @@ desktopConfig:
     zh: "/images/bg-light.svg"
     en: "/images/bg-light.svg"
   protocol:
+    enabled: true
     serviceProtocol:
       zh: https://sealos.io/zh-Hans/docs/msa/terms-of-service
       en: https://sealos.io/docs/msa/terms-of-service

--- a/frontend/desktop/src/components/v2/Sign.tsx
+++ b/frontend/desktop/src/components/v2/Sign.tsx
@@ -27,6 +27,7 @@ export default function SigninComponent() {
 
   // State to control password login mode
   const [isPasswordMode, setIsPasswordMode] = useState(false);
+  const showProtocol = conf.layoutConfig?.protocol?.enabled !== false;
 
   let protocol_data: Parameters<typeof useProtocol>[0];
   if (['zh', 'zh-Hans'].includes(i18n.language))
@@ -308,33 +309,35 @@ export default function SigninComponent() {
           )}
         </Stack>
 
-        <Box
-          mt={'8px'}
-          fontSize="14px"
-          color="gray.500"
-          width={'full'}
-          textAlign={'center'}
-          mr="2px"
-        >
-          {t('v2:terms_and_privacy_policy_text')}{' '}
+        {showProtocol && (
           <Box
-            as={Link}
-            href={protocol_data.service_protocol || ''}
-            target="_blank"
-            textDecoration="underline"
+            mt={'8px'}
+            fontSize="14px"
+            color="gray.500"
+            width={'full'}
+            textAlign={'center'}
+            mr="2px"
           >
-            {t('v2:terms_and_conditions')}
+            {t('v2:terms_and_privacy_policy_text')}{' '}
+            <Box
+              as={Link}
+              href={protocol_data.service_protocol || ''}
+              target="_blank"
+              textDecoration="underline"
+            >
+              {t('v2:terms_and_conditions')}
+            </Box>
+            ,
+            <Box
+              as={Link}
+              href={protocol_data.private_protocol || ''}
+              target="_blank"
+              textDecoration="underline"
+            >
+              {t('v2:privacy_policy')}
+            </Box>
           </Box>
-          ,
-          <Box
-            as={Link}
-            href={protocol_data.private_protocol || ''}
-            target="_blank"
-            textDecoration="underline"
-          >
-            {t('v2:privacy_policy')}
-          </Box>
-        </Box>
+        )}
 
         {/* Username/Password Login Button */}
         {passwordSigninEnabled && (

--- a/frontend/desktop/src/components/v2/Sign.tsx
+++ b/frontend/desktop/src/components/v2/Sign.tsx
@@ -27,7 +27,7 @@ export default function SigninComponent() {
 
   // State to control password login mode
   const [isPasswordMode, setIsPasswordMode] = useState(false);
-  const showProtocol = conf.layoutConfig?.protocol?.enabled !== false;
+  const showProtocol = conf.isLoaded && conf.layoutConfig?.protocol?.enabled !== false;
 
   let protocol_data: Parameters<typeof useProtocol>[0];
   if (['zh', 'zh-Hans'].includes(i18n.language))
@@ -318,7 +318,7 @@ export default function SigninComponent() {
             textAlign={'center'}
             mr="2px"
           >
-            {t('v2:terms_and_privacy_policy_text')}{' '}
+            {`${t('v2:terms_and_privacy_policy_text')} `}
             <Box
               as={Link}
               href={protocol_data.service_protocol || ''}

--- a/frontend/desktop/src/types/system.ts
+++ b/frontend/desktop/src/types/system.ts
@@ -54,6 +54,7 @@ export type MetaScriptType = {
 };
 
 export type ProtocolConfigType = {
+  enabled?: boolean;
   serviceProtocol: {
     zh: string;
     en: string;
@@ -305,6 +306,7 @@ export const DefaultLayoutConfig: LayoutConfigType = {
   logo: '/logo.svg',
   backgroundImage: '/images/bg-light.svg',
   protocol: {
+    enabled: true,
     serviceProtocol: {
       zh: '',
       en: ''


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->

## Summary

- Add `desktopConfig.protocol.enabled` to control whether the sign-in terms and privacy prompt is shown.
- Keep the prompt enabled by default and preserve compatibility for configs that do not include the new field.
- Document the new Helm option and keep local/default config examples in sync.

## Verification

- `pnpm lint` from `frontend/desktop` passed with existing warnings.
- `helm template sealos-desktop deploy/charts/desktop-frontend --set desktopConfig.protocol.enabled=false` renders `protocol.enabled: false` in `config.yaml`.
