### PR TITLE
fix(applaunchpad): show permission errors for restricted actions

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/services/backend/response.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/services/backend/response.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { handleK8sError } from '@/services/backend/response';
+import { ResponseCode, ResponseMessages } from '@/types/response';
+
+describe('handleK8sError', () => {
+  it('maps Kubernetes forbidden response bodies to generic insufficient permission errors', () => {
+    expect(
+      handleK8sError(
+        {
+          body: {
+            kind: 'Status',
+            apiVersion: 'v1',
+            status: 'Failure',
+            code: 403,
+            message: 'deployments.apps "demo" is forbidden'
+          }
+        },
+        { forbiddenCode: ResponseCode.FORBIDDEN }
+      )
+    ).toEqual({
+      code: ResponseCode.FORBIDDEN,
+      message: ResponseMessages[ResponseCode.FORBIDDEN]
+    });
+  });
+
+  it('keeps the create-app forbidden code for create flow callers', () => {
+    expect(
+      handleK8sError({
+        body: {
+          kind: 'Status',
+          apiVersion: 'v1',
+          status: 'Failure',
+          code: 403,
+          message: 'deployments.apps "demo" is forbidden'
+        }
+      })
+    ).toEqual({
+      code: ResponseCode.FORBIDDEN_CREATE_APP,
+      message: ResponseMessages[ResponseCode.FORBIDDEN_CREATE_APP]
+    });
+  });
+
+  it('maps permission text errors even when the Kubernetes status shape was lost', () => {
+    expect(
+      handleK8sError(new Error('pods "demo" is forbidden: User cannot create resource pods/exec'), {
+        forbiddenCode: ResponseCode.FORBIDDEN
+      })
+    ).toEqual({
+      code: ResponseCode.FORBIDDEN,
+      message: ResponseMessages[ResponseCode.FORBIDDEN]
+    });
+  });
+
+  it('maps forbidden response status codes when the body code is missing', () => {
+    expect(
+      handleK8sError(
+        {
+          response: { statusCode: 403 },
+          body: { message: 'request failed' }
+        },
+        { forbiddenCode: ResponseCode.FORBIDDEN }
+      )
+    ).toEqual({
+      code: ResponseCode.FORBIDDEN,
+      message: ResponseMessages[ResponseCode.FORBIDDEN]
+    });
+  });
+});

--- a/frontend/providers/applaunchpad/public/locales/en/common.json
+++ b/frontend/providers/applaunchpad/public/locales/en/common.json
@@ -157,6 +157,7 @@
   "Private": "Private",
   "Private Address": "Private Address",
   "Problem Analysis": "Troubleshooting",
+  "Insufficient permissions": "Insufficient permissions",
   "Protocol": "Protocol",
   "Public": "Public",
   "Public Access": "Internet Access",

--- a/frontend/providers/applaunchpad/public/locales/zh/common.json
+++ b/frontend/providers/applaunchpad/public/locales/zh/common.json
@@ -157,6 +157,7 @@
   "Private": "私有",
   "Private Address": "内网地址",
   "Problem Analysis": "问题分析",
+  "Insufficient permissions": "权限不足",
   "Protocol": "协议",
   "Public": "公开",
   "Public Access": "外网访问",

--- a/frontend/providers/applaunchpad/src/api/app.ts
+++ b/frontend/providers/applaunchpad/src/api/app.ts
@@ -86,6 +86,9 @@ export const startAppByName = (appName: string) => {
 
 export const restartPodByName = (podName: string) => GET(`/api/restartPod?podName=${podName}`);
 
+export const checkPodExecPermission = (podName: string) =>
+  GET<{ allowed: boolean }>('/api/checkPodExecPermission', { podName });
+
 export const getAppMonitorData = (payload: {
   queryName: string;
   queryKey: keyof MonitorQueryKey;

--- a/frontend/providers/applaunchpad/src/components/app/detail/index/DelModal.tsx
+++ b/frontend/providers/applaunchpad/src/components/app/detail/index/DelModal.tsx
@@ -18,6 +18,7 @@ import { useMessage } from '@sealos/ui';
 import { useTranslation } from 'next-i18next';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { sealosApp } from 'sealos-desktop-sdk/app';
+import { getErrText } from '@/utils/tools';
 
 enum Page {
   REMINDER = 'REMINDER',
@@ -70,7 +71,7 @@ const DelModal = ({
       onClose();
     } catch (error: any) {
       toast({
-        title: typeof error === 'string' ? error : error.message || '删除出现了意外',
+        title: t(getErrText(error, 'Delete Failed')),
         status: 'error'
       });
       console.error(error);

--- a/frontend/providers/applaunchpad/src/components/app/detail/index/Header.tsx
+++ b/frontend/providers/applaunchpad/src/components/app/detail/index/Header.tsx
@@ -11,6 +11,7 @@ import MyIcon from '@/components/Icon';
 import dynamic from 'next/dynamic';
 import { useTranslation } from 'next-i18next';
 import UpdateModal from './UpdateModal';
+import { getErrText } from '@/utils/tools';
 
 const DelModal = dynamic(() => import('./DelModal'));
 
@@ -64,13 +65,13 @@ const Header = ({
       });
     } catch (error: any) {
       toast({
-        title: typeof error === 'string' ? error : error.message || '重启出现了意外',
+        title: t(getErrText(error), 'Restart Failed'),
         status: 'error'
       });
       console.error(error);
     }
     setLoading(false);
-  }, [appName, toast]);
+  }, [appName, t, toast]);
 
   const handlePauseApp = useCallback(async () => {
     try {
@@ -82,14 +83,14 @@ const Header = ({
       });
     } catch (error: any) {
       toast({
-        title: typeof error === 'string' ? error : error.message || '暂停应用出现了意外',
+        title: t(getErrText(error), 'Pause Failed'),
         status: 'error'
       });
       console.error(error);
     }
     setLoading(false);
     refetch();
-  }, [appName, refetch, toast]);
+  }, [appName, refetch, t, toast]);
 
   const handleStartApp = useCallback(async () => {
     try {
@@ -101,14 +102,14 @@ const Header = ({
       });
     } catch (error: any) {
       toast({
-        title: typeof error === 'string' ? error : error.message || '启动应用出现了意外',
+        title: t(getErrText(error), 'Start Failed'),
         status: 'error'
       });
       console.error(error);
     }
     setLoading(false);
     refetch();
-  }, [appName, refetch, toast]);
+  }, [appName, refetch, t, toast]);
 
   return (
     <Flex h={'32px'} my={'14px'} alignItems={'center'}>

--- a/frontend/providers/applaunchpad/src/components/app/detail/index/Pods.tsx
+++ b/frontend/providers/applaunchpad/src/components/app/detail/index/Pods.tsx
@@ -1,4 +1,4 @@
-import { restartPodByName } from '@/api/app';
+import { checkPodExecPermission, restartPodByName } from '@/api/app';
 import MyIcon from '@/components/Icon';
 import { MyTooltip } from '@sealos/ui';
 import PodLineChart from '@/components/PodLineChart';
@@ -30,6 +30,7 @@ import { sealosApp } from 'sealos-desktop-sdk/app';
 import { MOCK_APP_DETAIL } from '@/mock/apps';
 import { useAppStore } from '@/store/app';
 import { track } from '@sealos/gtm';
+import { getErrText } from '@/utils/tools';
 
 const LogsModal = dynamic(() => import('./LogsModal'));
 const DetailModel = dynamic(() => import('./PodDetailModal'));
@@ -68,6 +69,33 @@ const Pods = ({ pods = [], appName }: { pods: PodDetailType[]; appName: string }
       }
     },
     [t, toast]
+  );
+
+  const handleOpenTerminal = useCallback(
+    async (podName: string) => {
+      try {
+        await checkPodExecPermission(podName);
+        track('deployment_action', {
+          event_type: 'terminal_open',
+          module: 'applaunchpad'
+        });
+        const defaultCommand = `kubectl exec -it ${podName} -c ${appName} -- sh -c "clear; (bash || ash || sh)"`;
+        sealosApp.runEvents('openDesktopApp', {
+          appKey: 'system-terminal',
+          query: {
+            defaultCommand
+          },
+          messageData: { type: 'new terminal', command: defaultCommand }
+        });
+      } catch (err) {
+        toast({
+          title: t(getErrText(err, 'Insufficient permissions')),
+          status: 'error'
+        });
+        console.log(err);
+      }
+    },
+    [appName, t, toast]
   );
 
   const columns: {
@@ -188,20 +216,7 @@ const Pods = ({ pods = [], appName }: { pods: PodDetailType[]; appName: string }
           <MyTooltip offset={[0, 10]} label={t('Terminal')}>
             <Button
               variant={'square'}
-              onClick={() => {
-                track('deployment_action', {
-                  event_type: 'terminal_open',
-                  module: 'applaunchpad'
-                });
-                const defaultCommand = `kubectl exec -it ${item.podName} -c ${appName} -- sh -c "clear; (bash || ash || sh)"`;
-                sealosApp.runEvents('openDesktopApp', {
-                  appKey: 'system-terminal',
-                  query: {
-                    defaultCommand
-                  },
-                  messageData: { type: 'new terminal', command: defaultCommand }
-                });
-              }}
+              onClick={() => handleOpenTerminal(item.podName)}
             >
               <MyIcon
                 className="driver-detail-terminal"

--- a/frontend/providers/applaunchpad/src/pages/api/checkPodExecPermission.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/checkPodExecPermission.ts
@@ -1,0 +1,50 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import * as k8s from '@kubernetes/client-node';
+import { ApiResp } from '@/services/kubernet';
+import { authSession } from '@/services/backend/auth';
+import { getK8s } from '@/services/backend/kubernetes';
+import { handleK8sError, jsonRes } from '@/services/backend/response';
+import { ResponseCode } from '@/types/response';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
+  try {
+    const { podName } = req.query as { podName: string };
+    if (!podName) {
+      return jsonRes(res, {
+        code: ResponseCode.BAD_REQUEST,
+        message: 'podName is empty'
+      });
+    }
+
+    const { kc, namespace } = await getK8s({
+      kubeconfig: await authSession(req.headers)
+    });
+    const authorizationApi = kc.makeApiClient(k8s.AuthorizationV1Api);
+    const {
+      body: { status }
+    } = await authorizationApi.createSelfSubjectAccessReview({
+      apiVersion: 'authorization.k8s.io/v1',
+      kind: 'SelfSubjectAccessReview',
+      spec: {
+        resourceAttributes: {
+          namespace,
+          verb: 'create',
+          resource: 'pods',
+          subresource: 'exec',
+          name: podName
+        }
+      }
+    });
+
+    if (!status?.allowed) {
+      return jsonRes(res, {
+        code: ResponseCode.FORBIDDEN,
+        message: 'Insufficient permissions'
+      });
+    }
+
+    jsonRes(res, { data: { allowed: true } });
+  } catch (err: any) {
+    jsonRes(res, handleK8sError(err, { forbiddenCode: ResponseCode.FORBIDDEN }));
+  }
+}

--- a/frontend/providers/applaunchpad/src/pages/api/delApp.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/delApp.ts
@@ -2,8 +2,9 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { ApiResp } from '@/services/kubernet';
 import { authSession } from '@/services/backend/auth';
 import { getK8s } from '@/services/backend/kubernetes';
-import { jsonRes } from '@/services/backend/response';
+import { handleK8sError, jsonRes } from '@/services/backend/response';
 import { appDeployKey, ownerReferencesKey, ownerReferencesReadyValue } from '@/constants/app';
+import { ResponseCode } from '@/types/response';
 
 export type DeleteAppParams = { name: string };
 
@@ -20,10 +21,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       message: 'successfully deleted'
     });
   } catch (err: any) {
-    jsonRes(res, {
-      code: 500,
-      error: err
-    });
+    jsonRes(res, handleK8sError(err, { forbiddenCode: ResponseCode.FORBIDDEN }));
   }
 }
 

--- a/frontend/providers/applaunchpad/src/pages/api/pauseApp.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/pauseApp.ts
@@ -1,7 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { ApiResp } from '@/services/kubernet';
-import { jsonRes } from '@/services/backend/response';
+import { handleK8sError, jsonRes } from '@/services/backend/response';
 import { pauseApp, createK8sContext } from '@/services/backend';
+import { ResponseCode } from '@/types/response';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
   try {
@@ -22,9 +23,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     });
   } catch (err: any) {
     console.log('Pause app error:', err);
-    jsonRes(res, {
-      code: 500,
-      error: err.message || err
-    });
+    jsonRes(res, handleK8sError(err, { forbiddenCode: ResponseCode.FORBIDDEN }));
   }
 }

--- a/frontend/providers/applaunchpad/src/pages/api/platform/checkPermission.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/platform/checkPermission.ts
@@ -2,7 +2,8 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { ApiResp } from '@/services/kubernet';
 import { authSession } from '@/services/backend/auth';
 import { getK8s } from '@/services/backend/kubernetes';
-import { jsonRes } from '@/services/backend/response';
+import { handleK8sError, jsonRes } from '@/services/backend/response';
+import { ResponseCode } from '@/types/response';
 import * as k8s from '@kubernetes/client-node';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
@@ -71,9 +72,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       });
     }
 
-    jsonRes(res, {
-      code: 500,
-      error: err?.body || err?.message
-    });
+    jsonRes(res, handleK8sError(err, { forbiddenCode: ResponseCode.FORBIDDEN }));
   }
 }

--- a/frontend/providers/applaunchpad/src/pages/api/platform/checkPublicDomain.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/platform/checkPublicDomain.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getPublicDomainErrorResponse, jsonRes } from '@/services/backend/response';
+import { getPublicDomainErrorResponse, handleK8sError, jsonRes } from '@/services/backend/response';
 import { createK8sContext } from '@/services/backend';
 import {
   dryRunPublicDomainIngress,
@@ -10,6 +10,7 @@ import {
   PublicDomainError
 } from '@/services/backend/publicDomain';
 import { isCustomPublicDomainPrefixEnabled } from '@/utils/feature-gates';
+import { ResponseCode } from '@/types/response';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -92,9 +93,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       });
     }
 
-    return jsonRes(res, {
-      code: 500,
-      error: err?.body || err?.message || err
-    });
+    return jsonRes(res, handleK8sError(err, { forbiddenCode: ResponseCode.FORBIDDEN }));
   }
 }

--- a/frontend/providers/applaunchpad/src/pages/api/remark.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/remark.ts
@@ -5,6 +5,7 @@ import { getK8s } from '@/services/backend/kubernetes';
 import { handleK8sError, jsonRes } from '@/services/backend/response';
 import { lauchpadRemarkKey } from '@/constants/account';
 import { PatchUtils } from '@kubernetes/client-node';
+import { ResponseCode } from '@/types/response';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
   try {
@@ -66,6 +67,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
     jsonRes(res, { data: 'success' });
   } catch (err: any) {
-    jsonRes(res, handleK8sError(err));
+    jsonRes(res, handleK8sError(err, { forbiddenCode: ResponseCode.FORBIDDEN }));
   }
 }

--- a/frontend/providers/applaunchpad/src/pages/api/restartApp.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/restartApp.ts
@@ -2,7 +2,8 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { ApiResp } from '@/services/kubernet';
 import { authSession } from '@/services/backend/auth';
 import { getK8s } from '@/services/backend/kubernetes';
-import { jsonRes } from '@/services/backend/response';
+import { handleK8sError, jsonRes } from '@/services/backend/response';
+import { ResponseCode } from '@/types/response';
 import dayjs from 'dayjs';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
@@ -26,9 +27,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
     jsonRes(res);
   } catch (err: any) {
-    jsonRes(res, {
-      code: 500,
-      error: err
-    });
+    jsonRes(res, handleK8sError(err, { forbiddenCode: ResponseCode.FORBIDDEN }));
   }
 }

--- a/frontend/providers/applaunchpad/src/pages/api/restartPod.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/restartPod.ts
@@ -2,7 +2,8 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { ApiResp } from '@/services/kubernet';
 import { authSession } from '@/services/backend/auth';
 import { getK8s } from '@/services/backend/kubernetes';
-import { jsonRes } from '@/services/backend/response';
+import { handleK8sError, jsonRes } from '@/services/backend/response';
+import { ResponseCode } from '@/types/response';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
   try {
@@ -18,9 +19,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
     jsonRes(res);
   } catch (err: any) {
-    jsonRes(res, {
-      code: 500,
-      error: err
-    });
+    jsonRes(res, handleK8sError(err, { forbiddenCode: ResponseCode.FORBIDDEN }));
   }
 }

--- a/frontend/providers/applaunchpad/src/pages/api/updateApp.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/updateApp.ts
@@ -11,6 +11,7 @@ import { errLog, infoLog, warnLog } from 'sealos-desktop-sdk';
 import type { V1Service } from '@kubernetes/client-node';
 import { generateOwnerReference, shouldHaveOwnerReference } from '@/utils/deployYaml2Json';
 import { buildExternalUrl } from '@/utils/network-url';
+import { ResponseCode } from '@/types/response';
 
 export type Props = {
   patch: AppPatchPropsType;
@@ -489,6 +490,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
     return jsonRes(res);
   } catch (err: any) {
-    return jsonRes(res, handleK8sError(err?.body || err));
+    return jsonRes(res, handleK8sError(err, { forbiddenCode: ResponseCode.FORBIDDEN }));
   }
 }

--- a/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
@@ -184,6 +184,13 @@ async function validatePublicDomainAvailabilityBeforeSubmit(
         appName: data.appName
       });
     } catch (error: any) {
+      if (
+        error?.code === ResponseCode.FORBIDDEN ||
+        /forbidden|permission denied|insufficient permissions/i.test(error?.message || '')
+      ) {
+        return t('Insufficient permissions');
+      }
+
       if (error?.error?.code !== 'PUBLIC_DOMAIN_CONFLICT') {
         throw error;
       }
@@ -436,6 +443,14 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
           track('error_occurred', {
             module: 'applaunchpad',
             error_code: 'FORBIDDEN_CREATE_APP'
+          });
+        } else if (error?.code === ResponseCode.FORBIDDEN) {
+          setErrorMessage(t('Insufficient permissions'));
+          setErrorCode(ResponseCode.FORBIDDEN);
+
+          track('error_occurred', {
+            module: 'applaunchpad',
+            error_code: 'FORBIDDEN'
           });
         } else if (error?.code === ResponseCode.QUOTA_EXCEEDED) {
           setErrorMessage(t('quota_exceeded'));
@@ -883,7 +898,13 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
                 } catch (error: any) {
                   return toast({
                     status: 'warning',
-                    title: error?.message || 'Check Error'
+                    title:
+                      error?.code === ResponseCode.FORBIDDEN ||
+                      /forbidden|permission denied|insufficient permissions/i.test(
+                        error?.message || ''
+                      )
+                        ? t('Insufficient permissions')
+                        : error?.message || 'Check Error'
                   });
                 }
               }

--- a/frontend/providers/applaunchpad/src/services/backend/response.ts
+++ b/frontend/providers/applaunchpad/src/services/backend/response.ts
@@ -29,7 +29,27 @@ export function getPublicDomainErrorResponse(err: PublicDomainError) {
   };
 }
 
-export const handleK8sError = (err: any): Partial<ApiResponse> => {
+const getErrorBody = (err: any) => err?.body || err?.response?.body || err;
+
+const getErrorStatusCode = (err: any) => {
+  const body = getErrorBody(err);
+  const code = body?.code ?? err?.response?.statusCode ?? err?.response?.status ?? err?.statusCode;
+  return typeof code === 'number' ? code : undefined;
+};
+
+const getErrorMessage = (err: any) => {
+  const body = getErrorBody(err);
+  if (typeof err === 'string') return err;
+  if (typeof body === 'string') return body;
+  return body?.message || err?.message || body?.reason || err?.reason || '';
+};
+
+export const handleK8sError = (
+  err: any,
+  options: {
+    forbiddenCode?: ResponseCode.FORBIDDEN | ResponseCode.FORBIDDEN_CREATE_APP;
+  } = {}
+): Partial<ApiResponse> => {
   if (isIngressPublicDomainConflictError(err)) {
     const conflict = getPublicDomainConflictResponse(err);
     return {
@@ -39,27 +59,37 @@ export const handleK8sError = (err: any): Partial<ApiResponse> => {
     };
   }
 
-  if (err?.kind === 'Status' && err?.apiVersion === 'v1' && err?.status) {
-    const k8sApiErr = err as V1Status;
-    if (k8sApiErr.code === 403) {
-      if (k8sApiErr.message?.includes('account balance less than 0')) {
+  const body = getErrorBody(err);
+  const statusCode = getErrorStatusCode(err);
+  const errMessage = getErrorMessage(err);
+  const forbiddenCode = options.forbiddenCode ?? ResponseCode.FORBIDDEN_CREATE_APP;
+
+  if (
+    body?.kind === 'Status' ||
+    body?.apiVersion === 'v1' ||
+    body?.status ||
+    typeof statusCode === 'number'
+  ) {
+    const k8sApiErr = body as V1Status;
+    if ((k8sApiErr.code ?? statusCode) === 403) {
+      if (errMessage.includes('account balance less than 0')) {
         return {
           code: ResponseCode.BALANCE_NOT_ENOUGH,
           message: ResponseMessages[ResponseCode.BALANCE_NOT_ENOUGH]
         };
       }
-      if (k8sApiErr.message?.includes('exceeded quota')) {
+      if (errMessage.includes('exceeded quota')) {
         return {
           code: ResponseCode.QUOTA_EXCEEDED,
           message: ResponseMessages[ResponseCode.QUOTA_EXCEEDED]
         };
       }
       return {
-        code: ResponseCode.FORBIDDEN_CREATE_APP,
-        message: ResponseMessages[ResponseCode.FORBIDDEN_CREATE_APP]
+        code: forbiddenCode,
+        message: ResponseMessages[forbiddenCode]
       };
     }
-    if (k8sApiErr.code === 409 && k8sApiErr.message?.includes('already exists')) {
+    if ((k8sApiErr.code ?? statusCode) === 409 && errMessage.includes('already exists')) {
       return {
         code: ResponseCode.APP_ALREADY_EXISTS,
         message: ResponseMessages[ResponseCode.APP_ALREADY_EXISTS]
@@ -67,8 +97,15 @@ export const handleK8sError = (err: any): Partial<ApiResponse> => {
     }
   }
 
+  if (/forbidden|permission denied/i.test(errMessage)) {
+    return {
+      code: forbiddenCode,
+      message: ResponseMessages[forbiddenCode]
+    };
+  }
+
   return {
-    code: err?.code || ResponseCode.SERVER_ERROR,
-    message: err?.message || ResponseMessages[ResponseCode.SERVER_ERROR]
+    code: typeof body?.code === 'number' ? body.code : ResponseCode.SERVER_ERROR,
+    message: errMessage || ResponseMessages[ResponseCode.SERVER_ERROR]
   };
 };


### PR DESCRIPTION
## Summary
- Normalize Kubernetes forbidden errors from restricted AppLaunchpad operations into a clear insufficient-permission response.
- Show the permission message in edit/detail/list toasts instead of falling back to generic server errors.
- Add a pod exec permission preflight before opening the terminal app, plus locale keys and a regression test for forbidden error mapping.

## Related Issue
Fixes labring-sigs/sealos-issues#319

## Tests
- `docker buildx build --platform linux/amd64 --target builder --output=type=cacheonly --build-arg path=providers/applaunchpad --build-arg name=applaunchpad .` from `frontend`
- `node -e "const fs=require('fs'); ['frontend/providers/applaunchpad/public/locales/en/common.json','frontend/providers/applaunchpad/public/locales/zh/common.json'].forEach((f)=>JSON.parse(fs.readFileSync(f,'utf8'))); console.log('locale json ok')"`

Note: the workspace has existing Vitest tests, but Vitest is not declared as a runnable dependency in this package, so the new regression test is included for CI/regression coverage but was not executed locally.
