### PR TITLE
fix(desktop): show private workspace as personal

### DIFF
--- a/frontend/desktop/src/components/team/NsListItem.tsx
+++ b/frontend/desktop/src/components/team/NsListItem.tsx
@@ -25,6 +25,7 @@ const NsListItem = ({
 } & FlexProps) => {
   const queryClient = useQueryClient();
   const { t } = useTranslation();
+  const displayName = isPrivate ? t('common:default_team') : teamName;
 
   return (
     <Flex
@@ -58,10 +59,7 @@ const NsListItem = ({
             />
           </Box>
         )}
-        <Text textTransform={'capitalize'}>
-          {/* {isPrivate ? t('common:default_team') : teamName} */}
-          {teamName}
-        </Text>
+        <Text textTransform={'capitalize'}>{displayName}</Text>
         {isSelected && showCheck && (
           <CheckIcon style={{ marginLeft: 'auto' }} size={16} color={'#1C4EF5'} />
         )}

--- a/frontend/desktop/src/components/team/TeamCenter.tsx
+++ b/frontend/desktop/src/components/team/TeamCenter.tsx
@@ -246,9 +246,7 @@ export default function TeamCenter({
                     <Box mx="10px">
                       <Flex align={'center'} justifyContent={'space-between'}>
                         <Text fontSize={'24px'} fontWeight={'600'} mr="8px">
-                          {isPrivate
-                            ? `${t('common:default_team')} - ${namespace.teamName}`
-                            : namespace.teamName}
+                          {isPrivate ? t('common:default_team') : namespace.teamName}
                         </Text>
                         {curTeamUser?.role === UserRole.Owner && (
                           <HStack>

--- a/frontend/desktop/src/components/team/WorkspaceToggle.tsx
+++ b/frontend/desktop/src/components/team/WorkspaceToggle.tsx
@@ -96,6 +96,8 @@ export default function WorkspaceToggle() {
   });
   const namespaces = data?.data?.namespaces || [];
   const namespace = namespaces.find((x) => x.uid === ns_uid);
+  const workspaceName =
+    namespace?.nstype === NSType.Private ? t('common:default_team') : namespace?.teamName;
 
   const WorkspaceList = ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) => {
     // Prevent unwanted excess events
@@ -240,7 +242,7 @@ export default function WorkspaceToggle() {
                   textOverflow={'ellipsis'}
                   whiteSpace={'nowrap'}
                 >
-                  {namespace?.teamName}
+                  {workspaceName}
                 </Text>
                 <Center
                   transform={isOpen ? 'rotate(-90deg)' : 'rotate(0deg)'}


### PR DESCRIPTION
## Summary
- show private/default workspaces as the localized default workspace label in the desktop workspace switcher
- apply the same display label in the workspace dropdown and workspace management title

## Testing
- pnpm lint

## Notes
- This is a display-only change. The persisted workspace displayName and rename behavior are unchanged.
