### PR TITLE
fix(auth): preserve nickname on repeated login

### DIFF
--- a/frontend/desktop/src/__tests__/unit/backend/auth/global-auth.test.ts
+++ b/frontend/desktop/src/__tests__/unit/backend/auth/global-auth.test.ts
@@ -45,15 +45,18 @@ vi.mock('@/services/backend/tracking', () => ({
 }));
 
 vi.mock('@/services/backend/svc/bindProvider', () => ({
-  addOauthProvider: vi.fn()
+  addOauthProvider: vi.fn(),
+  bindEmailSvc: vi.fn()
 }));
 
 import { generateGlobalAccessToken } from '@/services/backend/auth';
 import { globalPrisma } from '@/services/backend/db/init';
 import { getGlobalToken } from '@/services/backend/globalAuth';
+import { addOauthProvider } from '@/services/backend/svc/bindProvider';
 
 const mockPrisma = globalPrisma as any;
 const mockGenerateGlobalAccessToken = vi.mocked(generateGlobalAccessToken);
+const mockAddOauthProvider = vi.mocked(addOauthProvider);
 
 describe('getGlobalToken', () => {
   beforeEach(() => {
@@ -64,7 +67,7 @@ describe('getGlobalToken', () => {
     mockPrisma.userInfo.findUnique.mockResolvedValue({ isInited: true });
   });
 
-  it('does not overwrite an existing user nickname with provider profile name on sign in', async () => {
+  it('does not update existing user profile or bind providers on sign in', async () => {
     const existingUser = {
       uid: 'user-uid',
       id: 'user-id',
@@ -85,24 +88,18 @@ describe('getGlobalToken', () => {
         userUid: existingUser.uid,
         user: existingUser
       });
-    mockPrisma.user.update.mockResolvedValue({
-      ...existingUser,
-      avatarUri: 'new-avatar'
-    });
 
     const result = await getGlobalToken({
       provider: ProviderType.GITHUB,
       providerId: 'github-id',
       name: 'github-login',
-      avatar_url: 'new-avatar'
+      avatar_url: 'new-avatar',
+      email: 'github-user@example.com'
     });
 
-    expect(mockPrisma.user.update).toHaveBeenCalledWith({
-      where: { uid: existingUser.uid },
-      data: {
-        avatarUri: 'new-avatar'
-      }
-    });
+    expect(mockPrisma.user.update).not.toHaveBeenCalled();
+    expect(mockPrisma.oauthProvider.findFirst).not.toHaveBeenCalled();
+    expect(mockAddOauthProvider).not.toHaveBeenCalled();
     expect(mockGenerateGlobalAccessToken).toHaveBeenCalledWith({
       sub: existingUser.uid,
       user_id: existingUser.id,
@@ -110,7 +107,7 @@ describe('getGlobalToken', () => {
     });
     expect(result?.user).toEqual({
       name: existingUser.nickname,
-      avatar: 'new-avatar',
+      avatar: existingUser.avatarUri,
       userUid: existingUser.uid
     });
   });

--- a/frontend/desktop/src/__tests__/unit/backend/auth/global-auth.test.ts
+++ b/frontend/desktop/src/__tests__/unit/backend/auth/global-auth.test.ts
@@ -67,7 +67,7 @@ describe('getGlobalToken', () => {
     mockPrisma.userInfo.findUnique.mockResolvedValue({ isInited: true });
   });
 
-  it('does not update existing user profile or bind providers on sign in', async () => {
+  it('does not update existing user profile on sign in', async () => {
     const existingUser = {
       uid: 'user-uid',
       id: 'user-id',
@@ -98,8 +98,6 @@ describe('getGlobalToken', () => {
     });
 
     expect(mockPrisma.user.update).not.toHaveBeenCalled();
-    expect(mockPrisma.oauthProvider.findFirst).not.toHaveBeenCalled();
-    expect(mockAddOauthProvider).not.toHaveBeenCalled();
     expect(mockGenerateGlobalAccessToken).toHaveBeenCalledWith({
       sub: existingUser.uid,
       user_id: existingUser.id,
@@ -108,6 +106,44 @@ describe('getGlobalToken', () => {
     expect(result?.user).toEqual({
       name: existingUser.nickname,
       avatar: existingUser.avatarUri,
+      userUid: existingUser.uid
+    });
+  });
+
+  it('preserves automatic email provider binding on sign in', async () => {
+    const existingUser = {
+      uid: 'user-uid',
+      id: 'user-id',
+      nickname: 'Admin Nickname',
+      avatarUri: 'old-avatar',
+      status: UserStatus.NORMAL_USER
+    };
+
+    mockPrisma.oauthProvider.findUnique
+      .mockResolvedValueOnce({
+        providerId: 'github-id',
+        providerType: ProviderType.GITHUB,
+        userUid: existingUser.uid
+      })
+      .mockResolvedValueOnce({
+        providerId: 'github-id',
+        providerType: ProviderType.GITHUB,
+        userUid: existingUser.uid,
+        user: existingUser
+      });
+    mockPrisma.oauthProvider.findFirst.mockResolvedValue(null);
+
+    await getGlobalToken({
+      provider: ProviderType.GITHUB,
+      providerId: 'github-id',
+      name: 'github-login',
+      avatar_url: 'new-avatar',
+      email: 'github-user@example.com'
+    });
+
+    expect(mockAddOauthProvider).toHaveBeenCalledWith({
+      providerType: ProviderType.EMAIL,
+      providerId: 'github-user@example.com',
       userUid: existingUser.uid
     });
   });

--- a/frontend/desktop/src/__tests__/unit/backend/auth/global-auth.test.ts
+++ b/frontend/desktop/src/__tests__/unit/backend/auth/global-auth.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProviderType, UserStatus } from 'prisma/global/generated/client';
+
+vi.mock('@/api/platform', () => ({
+  uploadConvertData: vi.fn()
+}));
+
+vi.mock('@/services/backend/auth', () => ({
+  generateGlobalAccessToken: vi.fn(() => 'global-token')
+}));
+
+vi.mock('@/services/backend/db/init', () => ({
+  globalPrisma: {
+    oauthProvider: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn()
+    },
+    restrictedUser: {
+      findFirst: vi.fn()
+    },
+    account: {
+      findUnique: vi.fn()
+    },
+    userTask: {
+      findFirst: vi.fn()
+    },
+    user: {
+      update: vi.fn()
+    },
+    userInfo: {
+      findUnique: vi.fn()
+    }
+  }
+}));
+
+vi.mock('@/services/enable', () => ({
+  enableSignUp: vi.fn(() => true),
+  enableTracking: vi.fn(() => false),
+  getRegionUid: vi.fn(() => 'region-uid'),
+  getVersion: vi.fn(() => 'cn')
+}));
+
+vi.mock('@/services/backend/tracking', () => ({
+  trackSignUp: vi.fn()
+}));
+
+vi.mock('@/services/backend/svc/bindProvider', () => ({
+  addOauthProvider: vi.fn()
+}));
+
+import { generateGlobalAccessToken } from '@/services/backend/auth';
+import { globalPrisma } from '@/services/backend/db/init';
+import { getGlobalToken } from '@/services/backend/globalAuth';
+
+const mockPrisma = globalPrisma as any;
+const mockGenerateGlobalAccessToken = vi.mocked(generateGlobalAccessToken);
+
+describe('getGlobalToken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.restrictedUser.findFirst.mockResolvedValue(null);
+    mockPrisma.account.findUnique.mockResolvedValue(null);
+    mockPrisma.oauthProvider.findFirst.mockResolvedValue(null);
+    mockPrisma.userInfo.findUnique.mockResolvedValue({ isInited: true });
+  });
+
+  it('does not overwrite an existing user nickname with provider profile name on sign in', async () => {
+    const existingUser = {
+      uid: 'user-uid',
+      id: 'user-id',
+      nickname: 'Admin Nickname',
+      avatarUri: 'old-avatar',
+      status: UserStatus.NORMAL_USER
+    };
+
+    mockPrisma.oauthProvider.findUnique
+      .mockResolvedValueOnce({
+        providerId: 'github-id',
+        providerType: ProviderType.GITHUB,
+        userUid: existingUser.uid
+      })
+      .mockResolvedValueOnce({
+        providerId: 'github-id',
+        providerType: ProviderType.GITHUB,
+        userUid: existingUser.uid,
+        user: existingUser
+      });
+    mockPrisma.user.update.mockResolvedValue({
+      ...existingUser,
+      avatarUri: 'new-avatar'
+    });
+
+    const result = await getGlobalToken({
+      provider: ProviderType.GITHUB,
+      providerId: 'github-id',
+      name: 'github-login',
+      avatar_url: 'new-avatar'
+    });
+
+    expect(mockPrisma.user.update).toHaveBeenCalledWith({
+      where: { uid: existingUser.uid },
+      data: {
+        avatarUri: 'new-avatar'
+      }
+    });
+    expect(mockGenerateGlobalAccessToken).toHaveBeenCalledWith({
+      sub: existingUser.uid,
+      user_id: existingUser.id,
+      preferred_username: existingUser.nickname
+    });
+    expect(result?.user).toEqual({
+      name: existingUser.nickname,
+      avatar: 'new-avatar',
+      userUid: existingUser.uid
+    });
+  });
+});

--- a/frontend/desktop/src/services/backend/globalAuth.ts
+++ b/frontend/desktop/src/services/backend/globalAuth.ts
@@ -459,18 +459,15 @@ export const getGlobalToken = async ({
   }
   if (!user) throw new AuthError('Failed to edit db', 'DATABASE_ERROR');
 
-  // For existing users, always sync latest profile info (when provided).
-  // - If `name` is empty, do not overwrite existing nickname.
-  // - If `avatar_url` is empty, do not overwrite existing avatar.
+  // Keep admin/user-managed nicknames stable across repeated third-party logins.
+  // Provider names are only used to initialize new users.
   if (_user) {
-    const nicknameToUpdate = name?.trim() ? name : null;
     const avatarToUpdate = avatar_url?.trim() ? avatar_url : null;
-    if (nicknameToUpdate || avatarToUpdate) {
+    if (avatarToUpdate) {
       user = await globalPrisma.user.update({
         where: { uid: user.uid },
         data: {
-          ...(nicknameToUpdate ? { nickname: nicknameToUpdate } : {}),
-          ...(avatarToUpdate ? { avatarUri: avatarToUpdate } : {})
+          avatarUri: avatarToUpdate
         }
       });
     }

--- a/frontend/desktop/src/services/backend/globalAuth.ts
+++ b/frontend/desktop/src/services/backend/globalAuth.ts
@@ -15,7 +15,6 @@ import {
 import { enableSignUp, enableTracking, getRegionUid, getVersion } from '../enable';
 import { trackSignUp } from './tracking';
 import { emit } from 'process';
-import { bindEmailSvc } from './svc/bindProvider';
 import { AdClickData } from '@/types/adClick';
 
 type TransactionClient = Omit<

--- a/frontend/desktop/src/services/backend/globalAuth.ts
+++ b/frontend/desktop/src/services/backend/globalAuth.ts
@@ -15,6 +15,7 @@ import {
 import { enableSignUp, enableTracking, getRegionUid, getVersion } from '../enable';
 import { trackSignUp } from './tracking';
 import { emit } from 'process';
+import { addOauthProvider } from './svc/bindProvider';
 import { AdClickData } from '@/types/adClick';
 
 type TransactionClient = Omit<
@@ -458,8 +459,27 @@ export const getGlobalToken = async ({
   }
   if (!user) throw new AuthError('Failed to edit db', 'DATABASE_ERROR');
 
-  // Returning users only authenticate here. Profile updates and provider binding
-  // must go through explicit profile/bind flows, not implicit login side effects.
+  // Returning users only authenticate here. Provider profile fields are only used
+  // to initialize new users, so login must not overwrite user-managed profile data.
+  if (!forceBindEmail(provider) && email) {
+    try {
+      const emailProvider = await globalPrisma.oauthProvider.findFirst({
+        where: {
+          providerType: ProviderType.EMAIL,
+          userUid: user.uid
+        }
+      });
+      if (!emailProvider) {
+        await addOauthProvider({
+          providerType: ProviderType.EMAIL,
+          providerId: email,
+          userUid: user.uid
+        });
+      }
+    } catch (error) {
+      console.error('globalAuth: Error during sign in bind email:', error);
+    }
+  }
 
   // user is deleted or banned
   if (user.status !== UserStatus.NORMAL_USER) return null;

--- a/frontend/desktop/src/services/backend/globalAuth.ts
+++ b/frontend/desktop/src/services/backend/globalAuth.ts
@@ -15,7 +15,7 @@ import {
 import { enableSignUp, enableTracking, getRegionUid, getVersion } from '../enable';
 import { trackSignUp } from './tracking';
 import { emit } from 'process';
-import { addOauthProvider, bindEmailSvc } from './svc/bindProvider';
+import { bindEmailSvc } from './svc/bindProvider';
 import { AdClickData } from '@/types/adClick';
 
 type TransactionClient = Omit<
@@ -459,39 +459,8 @@ export const getGlobalToken = async ({
   }
   if (!user) throw new AuthError('Failed to edit db', 'DATABASE_ERROR');
 
-  // Keep admin/user-managed nicknames stable across repeated third-party logins.
-  // Provider names are only used to initialize new users.
-  if (_user) {
-    const avatarToUpdate = avatar_url?.trim() ? avatar_url : null;
-    if (avatarToUpdate) {
-      user = await globalPrisma.user.update({
-        where: { uid: user.uid },
-        data: {
-          avatarUri: avatarToUpdate
-        }
-      });
-    }
-  }
-
-  if (!forceBindEmail(provider) && email) {
-    try {
-      const emailProvider = await globalPrisma.oauthProvider.findFirst({
-        where: {
-          providerType: ProviderType.EMAIL,
-          userUid: user.uid
-        }
-      });
-      if (!emailProvider) {
-        await addOauthProvider({
-          providerType: ProviderType.EMAIL,
-          providerId: email,
-          userUid: user.uid
-        });
-      }
-    } catch (error) {
-      console.error('globalAuth: Error during sign in bind email:', error);
-    }
-  }
+  // Returning users only authenticate here. Profile updates and provider binding
+  // must go through explicit profile/bind flows, not implicit login side effects.
 
   // user is deleted or banned
   if (user.status !== UserStatus.NORMAL_USER) return null;


### PR DESCRIPTION
## Summary

- stop repeated sign-ins from overwriting user-managed nicknames with provider profile names
- keep existing avatar refresh behavior for returning users
- add a unit test covering the repeated-login nickname preservation path

## Root cause

Existing users were updated on every non-password login with the latest provider profile name. That made admin-edited nicknames revert to the GitHub login, phone number, or OAuth profile name after the next login.

## Tests

- `pnpm vitest run --project unit src/__tests__/unit/backend/auth/global-auth.test.ts`
- `pnpm vitest run --project unit src/__tests__/unit/backend/auth src/__tests__/unit/backend/oauth2-idp`
