### PR TITLE
fix(applaunchpad): hydrate form quantities

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/utils/resourceQuantity.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/resourceQuantity.test.ts
@@ -10,6 +10,8 @@ import {
   quantityToPublicCpuCores,
   quantityToPublicMemoryGi,
   quantityToStorageGi,
+  syncedCpuToQuantity,
+  syncedMemoryToQuantity,
   storageGiToQuantity,
   memoryMiToQuantity,
   storageAnnotationToQuantity
@@ -36,6 +38,14 @@ describe('resourceQuantity helpers', () => {
     expect(quantityToCpuMillicores({})).toBe(0);
     expect(quantityToMemoryMi('256Mi')).toBe(256);
     expect(quantityToStorageGi('2Gi')).toBe(2);
+  });
+
+  it('converts synced public resource values to Quantity', () => {
+    expect(syncedCpuToQuantity(2000).toString()).toBe('2');
+    expect(syncedCpuToQuantity('2000').toString()).toBe('2');
+    expect(syncedMemoryToQuantity(4096).toString()).toBe('4Gi');
+    expect(syncedMemoryToQuantity('4096').toString()).toBe('4Gi');
+    expect(syncedMemoryToQuantity('256Mi').toString()).toBe('256Mi');
   });
 
   it('converts public memory Gi values to BinarySI Quantity and back', () => {

--- a/frontend/providers/applaunchpad/__tests__/unit/utils/resourceQuantity.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/resourceQuantity.test.ts
@@ -30,6 +30,14 @@ describe('resourceQuantity helpers', () => {
     expect(quantityToCpuMillicores(quantity)).toBe(200);
   });
 
+  it('converts serialized quantity values back to numbers', () => {
+    expect(quantityToCpuMillicores('200m')).toBe(200);
+    expect(quantityToCpuMillicores(null)).toBe(0);
+    expect(quantityToCpuMillicores({})).toBe(0);
+    expect(quantityToMemoryMi('256Mi')).toBe(256);
+    expect(quantityToStorageGi('2Gi')).toBe(2);
+  });
+
   it('converts public memory Gi values to BinarySI Quantity and back', () => {
     const quantity = publicMemoryGiToQuantity(1);
 

--- a/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
@@ -40,7 +40,7 @@ import { useClientAppConfig } from '@/hooks/useClientAppConfig';
 import {
   cpuMillicoresToQuantity,
   memoryMiToQuantity,
-  quantityFromJSONOrZero,
+  quantityOrZero,
   quantityToCpuMillicores,
   quantityToMemoryMi,
   quantityToStorageGi
@@ -104,6 +104,16 @@ export const formData2Yamls = (
     : [])
 ];
 
+const normalizeFormQuantities = (data: AppEditType): AppEditType => ({
+  ...data,
+  cpu: quantityOrZero(data.cpu),
+  memory: quantityOrZero(data.memory),
+  storeList: data.storeList.map((store) => ({
+    ...store,
+    value: quantityOrZero(store.value)
+  }))
+});
+
 const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) => {
   const { t } = useTranslation();
   const formOldYamls = useRef<YamlItemType[]>([]);
@@ -154,7 +164,7 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
   // watch form change, compute new yaml
   formHook.watch((data) => {
     if (!data) return;
-    realTimeForm.current = data as AppEditType;
+    realTimeForm.current = normalizeFormQuantities(data as AppEditType);
     setForceUpdate(!forceUpdate);
   });
 
@@ -429,7 +439,7 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
         ? quantityToCpuMillicores(realTimeForm.current.cpu) * newReplicas -
           quantityToCpuMillicores(
             formHook.formState.defaultValues?.cpu
-              ? quantityFromJSONOrZero(String(formHook.formState.defaultValues.cpu))
+              ? formHook.formState.defaultValues.cpu
               : defaultEditVal.cpu
           ) *
             oldReplicas
@@ -438,7 +448,7 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
         ? quantityToMemoryMi(realTimeForm.current.memory) * newReplicas -
           quantityToMemoryMi(
             formHook.formState.defaultValues?.memory
-              ? quantityFromJSONOrZero(String(formHook.formState.defaultValues.memory))
+              ? formHook.formState.defaultValues.memory
               : defaultEditVal.memory
           ) *
             oldReplicas
@@ -517,7 +527,7 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
       }
 
       openConfirm(() => {
-        const submitData = data;
+        const submitData = normalizeFormQuantities(data);
         formHook.setValue('appName', submitData.appName);
         realTimeForm.current = submitData;
 
@@ -535,10 +545,10 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
             template_version: submitData.imageName.split(':')?.[1] ?? 'latest'
           },
           resources: {
-            cpu_cores: quantityToCpuMillicores(data.cpu) / 1000,
-            ram_mb: quantityToMemoryMi(data.memory),
-            replicas: data.hpa.use ? data.hpa.maxReplicas : Number(data.replicas),
-            scaling: data.hpa.use
+            cpu_cores: quantityToCpuMillicores(submitData.cpu) / 1000,
+            ram_mb: quantityToMemoryMi(submitData.memory),
+            replicas: submitData.hpa.use ? submitData.hpa.maxReplicas : Number(submitData.replicas),
+            scaling: submitData.hpa.use
               ? {
                   method:
                     submitData.hpa.target === 'cpu'

--- a/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
@@ -43,7 +43,9 @@ import {
   quantityOrZero,
   quantityToCpuMillicores,
   quantityToMemoryMi,
-  quantityToStorageGi
+  quantityToStorageGi,
+  syncedCpuToQuantity,
+  syncedMemoryToQuantity
 } from '@/utils/resourceQuantity';
 
 const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz', 12);
@@ -382,7 +384,13 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
 
       basicFields.forEach((field) => {
         if (parsedData[field] !== undefined) {
-          formHook.setValue(field, parsedData[field] as any);
+          const value =
+            field === 'cpu'
+              ? syncedCpuToQuantity(parsedData[field])
+              : field === 'memory'
+              ? syncedMemoryToQuantity(parsedData[field])
+              : parsedData[field];
+          formHook.setValue(field, value as any);
         }
       });
 

--- a/frontend/providers/applaunchpad/src/utils/adapt.ts
+++ b/frontend/providers/applaunchpad/src/utils/adapt.ts
@@ -114,10 +114,12 @@ export const getAppSource = (
   };
 };
 
-export const adaptAppListItem = (app: V1Deployment & V1StatefulSet): AppListItemType => {
+export const adaptAppListItem = (app: V1Deployment | V1StatefulSet): AppListItemType => {
   // compute store amount
-  const storeAmount = app.spec?.volumeClaimTemplates
-    ? app.spec?.volumeClaimTemplates.reduce((sum, item) => {
+  const volumeClaimTemplates =
+    app.spec && 'volumeClaimTemplates' in app.spec ? app.spec.volumeClaimTemplates : undefined;
+  const storeAmount = volumeClaimTemplates
+    ? volumeClaimTemplates.reduce((sum, item) => {
         const storage = item?.spec?.resources?.requests?.storage
           ? parseK8sQuantityOrZero(item.spec.resources.requests.storage)
           : storageAnnotationToQuantity(item?.metadata?.annotations?.value);

--- a/frontend/providers/applaunchpad/src/utils/resourceQuantity.ts
+++ b/frontend/providers/applaunchpad/src/utils/resourceQuantity.ts
@@ -49,6 +49,13 @@ export const publicCpuCoresToQuantity = (value: number): Quantity =>
 export const quantityToPublicCpuCores = (quantity: unknown): number =>
   roundTo(quantityToCpuMillicores(quantity) / 1000);
 
+export const syncedCpuToQuantity = (value: unknown): Quantity =>
+  typeof value === 'number'
+    ? cpuMillicoresToQuantity(value)
+    : typeof value === 'string' && /^\d+$/.test(value.trim())
+    ? cpuMillicoresToQuantity(Number(value))
+    : quantityOrZero(value);
+
 export const memoryMiToQuantity = (value: number): Quantity =>
   Number.isInteger(value)
     ? Quantity.newBinaryScaledQuantity(BigInt(value), BinaryScale.Mebi)
@@ -62,6 +69,13 @@ export const publicMemoryGiToQuantity = (value: number): Quantity =>
 
 export const quantityToPublicMemoryGi = (quantity: unknown): number =>
   roundTo(quantityToMemoryMi(quantity) / 1024);
+
+export const syncedMemoryToQuantity = (value: unknown): Quantity =>
+  typeof value === 'number'
+    ? memoryMiToQuantity(value)
+    : typeof value === 'string' && /^\d+$/.test(value.trim())
+    ? memoryMiToQuantity(Number(value))
+    : quantityOrZero(value);
 
 export const storageGiToQuantity = (value: number): Quantity =>
   Number.isInteger(value)

--- a/frontend/providers/applaunchpad/src/utils/resourceQuantity.ts
+++ b/frontend/providers/applaunchpad/src/utils/resourceQuantity.ts
@@ -34,16 +34,19 @@ export const quantityFromJSONOrZero = (value: unknown): Quantity => {
   }
 };
 
+export const quantityOrZero = (value: unknown): Quantity =>
+  value instanceof Quantity ? value : quantityFromJSONOrZero(value);
+
 export const cpuMillicoresToQuantity = (value: number): Quantity =>
   Quantity.newMilliQuantity(BigInt(Math.round(value)), 'DecimalSI');
 
-export const quantityToCpuMillicores = (quantity: Quantity): number =>
-  Number(quantity.milliValue());
+export const quantityToCpuMillicores = (quantity: unknown): number =>
+  Number(quantityOrZero(quantity).milliValue());
 
 export const publicCpuCoresToQuantity = (value: number): Quantity =>
   cpuMillicoresToQuantity(value * 1000);
 
-export const quantityToPublicCpuCores = (quantity: Quantity): number =>
+export const quantityToPublicCpuCores = (quantity: unknown): number =>
   roundTo(quantityToCpuMillicores(quantity) / 1000);
 
 export const memoryMiToQuantity = (value: number): Quantity =>
@@ -51,13 +54,13 @@ export const memoryMiToQuantity = (value: number): Quantity =>
     ? Quantity.newBinaryScaledQuantity(BigInt(value), BinaryScale.Mebi)
     : Quantity.newBinaryScaledQuantity(BigInt(Math.ceil(value * 1024)), BinaryScale.Kibi);
 
-export const quantityToMemoryMi = (quantity: Quantity): number =>
-  quantityToBinaryNumber(quantity, BinaryScale.Mebi, 4);
+export const quantityToMemoryMi = (quantity: unknown): number =>
+  quantityToBinaryNumber(quantityOrZero(quantity), BinaryScale.Mebi, 4);
 
 export const publicMemoryGiToQuantity = (value: number): Quantity =>
   memoryMiToQuantity(value * 1024);
 
-export const quantityToPublicMemoryGi = (quantity: Quantity): number =>
+export const quantityToPublicMemoryGi = (quantity: unknown): number =>
   roundTo(quantityToMemoryMi(quantity) / 1024);
 
 export const storageGiToQuantity = (value: number): Quantity =>
@@ -65,7 +68,7 @@ export const storageGiToQuantity = (value: number): Quantity =>
     ? Quantity.newBinaryScaledQuantity(BigInt(value), BinaryScale.Gibi)
     : memoryMiToQuantity(value * 1024);
 
-export const quantityToStorageGi = (quantity: Quantity): number =>
+export const quantityToStorageGi = (quantity: unknown): number =>
   roundTo(quantityToMemoryMi(quantity) / 1024);
 
 export const storageAnnotationToQuantity = (value?: string | null): Quantity => {
@@ -77,8 +80,8 @@ export const storageAnnotationToQuantity = (value?: string | null): Quantity => 
     : parseK8sQuantityOrZero(annotationValue);
 };
 
-export const cpuRequestQuantity = (limit: Quantity): Quantity =>
+export const cpuRequestQuantity = (limit: unknown): Quantity =>
   cpuMillicoresToQuantity(Math.floor(quantityToCpuMillicores(limit) * 0.1));
 
-export const memoryRequestQuantity = (limit: Quantity): Quantity =>
+export const memoryRequestQuantity = (limit: unknown): Quantity =>
   memoryMiToQuantity(Math.floor(quantityToMemoryMi(limit) * 0.1));


### PR DESCRIPTION
Fixes the Applaunchpad client crash caused by serialized or form-cloned `Quantity` values losing methods like `milliValue()`.

Adds runtime quantity hydration at conversion/form boundaries plus a regression test for serialized CPU, memory, and storage values.