### PR TITLE
fix(applaunchpad): hydrate legacy app quantities

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/pages/api/v1alpha/createApp.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/pages/api/v1alpha/createApp.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import type { AppEditType } from '@/types/app';
+import { hydrateLegacyAppForm } from '@/utils/hydrateLegacyAppForm';
+import {
+  cpuMillicoresToQuantity,
+  memoryMiToQuantity,
+  storageGiToQuantity
+} from '@/utils/resourceQuantity';
+
+const createApp = (): AppEditType =>
+  ({
+    appName: 'demo',
+    imageName: 'nginx:latest',
+    runCMD: '',
+    cmdParam: '',
+    replicas: 1,
+    cpu: cpuMillicoresToQuantity(100),
+    memory: memoryMiToQuantity(128),
+    networks: [],
+    envs: [],
+    hpa: {
+      use: false,
+      target: 'cpu',
+      value: 50,
+      minReplicas: 1,
+      maxReplicas: 1
+    },
+    secret: {
+      use: false,
+      username: '',
+      password: '',
+      serverAddress: ''
+    },
+    configMapList: [],
+    storeList: [],
+    labels: {},
+    volumes: [],
+    volumeMounts: [],
+    kind: 'deployment'
+  } as AppEditType);
+
+describe('hydrateLegacyAppForm', () => {
+  it('converts legacy numeric resources to Quantity values', () => {
+    const app = hydrateLegacyAppForm({
+      ...createApp(),
+      cpu: '500',
+      memory: 1024,
+      storeList: [
+        {
+          name: 'data',
+          path: '/data',
+          value: 2
+        }
+      ]
+    } as unknown as AppEditType);
+
+    expect(app.cpu.toString()).toBe('500m');
+    expect(app.memory.toString()).toBe('1Gi');
+    expect(app.storeList[0].value.toString()).toBe('2Gi');
+  });
+
+  it('keeps Quantity resources unchanged', () => {
+    const cpu = cpuMillicoresToQuantity(300);
+    const memory = memoryMiToQuantity(512);
+    const storage = storageGiToQuantity(1);
+    const app = hydrateLegacyAppForm({
+      ...createApp(),
+      cpu,
+      memory,
+      storeList: [
+        {
+          name: 'data',
+          path: '/data',
+          value: storage
+        }
+      ]
+    });
+
+    expect(app.cpu).toBe(cpu);
+    expect(app.memory).toBe(memory);
+    expect(app.storeList[0].value).toBe(storage);
+  });
+});

--- a/frontend/providers/applaunchpad/__tests__/unit/utils/deployYaml2Json.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/deployYaml2Json.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { json2DeployCr, json2Ingress, json2Service, yamlString2Objects } from '@/utils/deployYaml2Json';
+import {
+  json2DeployCr,
+  json2Ingress,
+  json2Service,
+  yamlString2Objects
+} from '@/utils/deployYaml2Json';
 import type { AppEditType } from '@/types/app';
 import { deployPVCResizeKey } from '@/constants/app';
 import {

--- a/frontend/providers/applaunchpad/src/pages/api/v1alpha/createApp.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/v1alpha/createApp.ts
@@ -6,6 +6,7 @@ import { ApiResp } from '@/services/kubernet';
 import { AppEditType } from '@/types/app';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { Config } from '@/config';
+import { hydrateLegacyAppForm } from '@/utils/hydrateLegacyAppForm';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
   try {
@@ -15,12 +16,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       kubeconfig: await authSession(req.headers)
     });
 
-    appForm.networks = appForm.networks.map((network) => ({
+    const hydratedAppForm = hydrateLegacyAppForm(appForm);
+
+    hydratedAppForm.networks = hydratedAppForm.networks.map((network) => ({
       ...network,
       domain: Config().cloud.domain
     }));
 
-    const parseYamls = formData2Yamls(appForm, Config().cloud.userDomains);
+    const parseYamls = formData2Yamls(hydratedAppForm, Config().cloud.userDomains);
 
     const yamls = parseYamls.map((item) => item.value);
 

--- a/frontend/providers/applaunchpad/src/utils/hydrateLegacyAppForm.ts
+++ b/frontend/providers/applaunchpad/src/utils/hydrateLegacyAppForm.ts
@@ -1,0 +1,41 @@
+import type { AppEditType } from '@/types/app';
+import {
+  cpuMillicoresToQuantity,
+  memoryMiToQuantity,
+  quantityFromJSONOrZero,
+  storageAnnotationToQuantity,
+  storageGiToQuantity
+} from '@/utils/resourceQuantity';
+import { Quantity } from '@sealos/shared';
+
+const isNumericString = (value: unknown): value is string =>
+  typeof value === 'string' && /^\d+(?:\.\d+)?$/.test(value.trim());
+
+export const hydrateLegacyAppForm = (appForm: AppEditType): AppEditType => ({
+  ...appForm,
+  cpu:
+    appForm.cpu instanceof Quantity
+      ? appForm.cpu
+      : typeof appForm.cpu === 'number'
+      ? cpuMillicoresToQuantity(appForm.cpu)
+      : isNumericString(appForm.cpu)
+      ? cpuMillicoresToQuantity(Number(appForm.cpu))
+      : quantityFromJSONOrZero(appForm.cpu),
+  memory:
+    appForm.memory instanceof Quantity
+      ? appForm.memory
+      : typeof appForm.memory === 'number'
+      ? memoryMiToQuantity(appForm.memory)
+      : isNumericString(appForm.memory)
+      ? memoryMiToQuantity(Number(appForm.memory))
+      : quantityFromJSONOrZero(appForm.memory),
+  storeList: appForm.storeList.map((store) => ({
+    ...store,
+    value:
+      store.value instanceof Quantity
+        ? store.value
+        : typeof store.value === 'number'
+        ? storageGiToQuantity(store.value)
+        : storageAnnotationToQuantity(store.value)
+  }))
+});


### PR DESCRIPTION
Fix objectstorage static hosting creation through Launchpad’s legacy `/createApp` path by normalizing numeric CPU, memory, and storage values into `Quantity` before YAML generation,
  preventing `withFormat is not a function`.

  Add unit coverage for legacy numeric resource payloads to verify `500` CPU becomes `500m`, `1024` memory becomes `1Gi`, and the existing 10% request calculation stays intact.