### PR TITLE
fix(applaunchpad): resolve pod container names

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/utils/pod.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/pod.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import type { V1Pod } from '@kubernetes/client-node';
+
+import { getPodContainerName } from '@/utils/pod';
+
+describe('getPodContainerName', () => {
+  it('uses the first container from the pod spec', () => {
+    const pod = {
+      spec: {
+        containers: [
+          { name: 'real-container', image: 'nginx' },
+          { name: 'sidecar', image: 'busybox' }
+        ]
+      },
+      status: {
+        containerStatuses: [{ name: 'status-container' }]
+      }
+    } as V1Pod;
+
+    expect(getPodContainerName(pod)).toBe('real-container');
+  });
+});

--- a/frontend/providers/applaunchpad/src/api/app.ts
+++ b/frontend/providers/applaunchpad/src/api/app.ts
@@ -71,6 +71,7 @@ export const getPodsMetrics = (podsName: string[]) =>
 export const getPodLogs = (data: {
   appName: string;
   podName: string;
+  containerName?: string;
   stream: boolean;
   logSize?: number;
   sinceTime?: number;

--- a/frontend/providers/applaunchpad/src/components/app/detail/index/LogsModal.tsx
+++ b/frontend/providers/applaunchpad/src/components/app/detail/index/LogsModal.tsx
@@ -20,6 +20,8 @@ import { ChevronDownIcon } from '@chakra-ui/icons';
 import { streamFetch } from '@/services/streamFetch';
 import { default as AnsiUp } from 'ansi_up';
 import { useTranslation } from 'next-i18next';
+import { getPodContainerName } from '@/utils/pod';
+import type { PodDetailType } from '@/types/app';
 
 interface sinceItem {
   key: 'streaming_logs' | 'within_5_minute' | 'within_1_hour' | 'within_1_day' | 'terminated_logs';
@@ -62,13 +64,15 @@ const LogsModal = ({
   podName,
   pods = [],
   podAlias,
+  pod,
   setLogsPodName,
   closeFn
 }: {
   appName: string;
   podName: string;
-  pods: { alias: string; podName: string }[];
+  pods: { alias: string; podName: string; pod?: PodDetailType }[];
   podAlias: string;
+  pod?: PodDetailType;
   setLogsPodName: (name: string) => void;
   closeFn: () => void;
 }) => {
@@ -82,6 +86,7 @@ const LogsModal = ({
   const [sinceKey, setSinceKey] = useState('streaming_logs');
   const [sinceTime, setSinceTime] = useState(0);
   const [previous, setPrevious] = useState(false);
+  const containerName = getPodContainerName(pod || {});
 
   const switchSince = useCallback(
     (item: sinceItem) => {
@@ -105,6 +110,7 @@ const LogsModal = ({
       data: {
         appName,
         podName,
+        containerName,
         stream: true,
         sinceTime,
         previous
@@ -142,7 +148,7 @@ const LogsModal = ({
       }
     });
     return controller;
-  }, [appName, closeFn, podName, sinceTime, previous]);
+  }, [appName, closeFn, containerName, podName, sinceTime, previous]);
 
   useEffect(() => {
     const controller = watchLogs();
@@ -156,6 +162,7 @@ const LogsModal = ({
       const allLogs = await getPodLogs({
         appName,
         podName,
+        containerName,
         stream: false,
         sinceTime,
         previous
@@ -164,7 +171,7 @@ const LogsModal = ({
     } catch (e) {
       console.log('download log error:', e);
     }
-  }, [appName, podName, sinceTime, previous]);
+  }, [appName, containerName, podName, sinceTime, previous]);
 
   return (
     <Modal isOpen={true} onClose={closeFn} isCentered={true} lockFocusAcrossFrames={false}>

--- a/frontend/providers/applaunchpad/src/components/app/detail/index/PodDetailModal.tsx
+++ b/frontend/providers/applaunchpad/src/components/app/detail/index/PodDetailModal.tsx
@@ -26,6 +26,7 @@ import styles from '@/components/app/detail/index/index.module.scss';
 import { useTranslation } from 'next-i18next';
 import { useClientAppConfig } from '@/hooks/useClientAppConfig';
 import { useRouter } from 'next/navigation';
+import { getPodContainerName } from '@/utils/pod';
 
 interface SinceItem {
   key: 'streaming_logs' | 'within_5_minute' | 'within_1_hour' | 'within_1_day' | 'terminated_logs';
@@ -79,6 +80,7 @@ const PodDetailModal = ({
   const [sinceTime, setSinceTime] = useState(0);
   const [previous, setPrevious] = useState(false);
   const sinceItems = useMemo(() => newSinceItems(Date.now()), []);
+  const containerName = getPodContainerName(pod);
 
   const RenderItem = useCallback(
     ({ label, children }: { label: string; children: React.ReactNode }) => {
@@ -148,6 +150,7 @@ const PodDetailModal = ({
       data: {
         appName,
         podName: pod.podName,
+        containerName,
         stream: true,
         sinceTime,
         previous
@@ -174,13 +177,14 @@ const PodDetailModal = ({
       }
     });
     return abortController;
-  }, [appName, pod.podName, sinceTime, previous]);
+  }, [appName, containerName, pod.podName, sinceTime, previous]);
 
   const exportLogs = useCallback(async () => {
     try {
       const allLogs = await getPodLogs({
         appName,
         podName: pod.podName,
+        containerName,
         stream: false,
         sinceTime,
         previous
@@ -189,7 +193,7 @@ const PodDetailModal = ({
     } catch (e) {
       console.log('download log error:', e);
     }
-  }, [appName, pod.podName, sinceTime, previous]);
+  }, [appName, containerName, pod.podName, sinceTime, previous]);
 
   useEffect(() => {
     controller.current = new AbortController();

--- a/frontend/providers/applaunchpad/src/components/app/detail/index/PodFileModal.tsx
+++ b/frontend/providers/applaunchpad/src/components/app/detail/index/PodFileModal.tsx
@@ -66,6 +66,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@sealos/shadcn-ui/popov
 import { Label } from '@sealos/shadcn-ui/label';
 import { storageGiToQuantity } from '@/utils/resourceQuantity';
 import type { Quantity } from '@sealos/shared';
+import { getPodContainerName } from '@/utils/pod';
 
 const PodFile = ({
   isOpen,
@@ -96,7 +97,7 @@ const PodFile = ({
   );
 
   const [fileProgress, setFileProgress] = useState<number>(0);
-  const [appName, setAppName] = useState(appDetail.appName);
+  const containerName = getPodContainerName(podDetail);
   const [basePath, setBasePath] = useState(storeDetail?.path || '/');
   const basePathArray = useMemo(() => basePath?.split('/')?.filter(Boolean), [basePath]);
   const [newFileName, setNewFileName] = useState('');
@@ -120,10 +121,10 @@ const PodFile = ({
   });
 
   const { data, refetch } = useQuery(
-    ['KubeFileSystem-ls', basePath, showHidden, podDetail.podName, appName],
+    ['KubeFileSystem-ls', basePath, showHidden, podDetail.podName, containerName],
     () =>
       kubeFile_ls({
-        containerName: appName,
+        containerName,
         podName: podDetail.podName,
         path: basePath,
         showHidden: showHidden
@@ -267,7 +268,7 @@ const PodFile = ({
     try {
       await kubeFile_delete({
         podName: podDetail.podName,
-        containerName: appName,
+        containerName,
         path: file.path
       });
       toast.success(t('Delete Success') || 'success');
@@ -285,7 +286,7 @@ const PodFile = ({
       const to = file.path.replace(/\/[^/]+$/, `/${newName}`);
       await kubeFile_rename({
         podName: podDetail.podName,
-        containerName: appName,
+        containerName,
         from,
         to
       });
@@ -327,7 +328,7 @@ const PodFile = ({
         },
         body: JSON.stringify({
           podName: podDetail.podName,
-          containerName: appName,
+          containerName,
           path: file.path
         })
       });
@@ -380,7 +381,7 @@ const PodFile = ({
         return await kubeFile_upload(
           {
             podName: podDetail.podName,
-            containerName: appName,
+            containerName,
             path: `${basePath}/${name}`
           },
           form
@@ -399,7 +400,7 @@ const PodFile = ({
       if (!newFileName) return;
       await kubeFile_mkdir({
         podName: podDetail.podName,
-        containerName: appName,
+        containerName,
         path: `${basePath}/${newFileName}`
       });
       toast.success('success');
@@ -411,7 +412,7 @@ const PodFile = ({
       if (!folderName.trim()) return;
       await kubeFile_mkdir({
         podName: podDetail.podName,
-        containerName: appName,
+        containerName,
         path: `${basePath}/${folderName}`
       });
       toast.success(t('Create Folder Success') || 'success');

--- a/frontend/providers/applaunchpad/src/components/app/detail/index/Pods.tsx
+++ b/frontend/providers/applaunchpad/src/components/app/detail/index/Pods.tsx
@@ -25,6 +25,7 @@ import { useAppStore } from '@/store/app';
 import { track } from '@sealos/gtm';
 import { getUserSession } from '@/utils/user';
 import { useUserStore } from '@/store/user';
+import { getPodContainerName } from '@/utils/pod';
 
 const LogsModal = dynamic(() => import('./LogsModal'));
 const DetailModel = dynamic(() => import('./PodDetailModal'));
@@ -168,80 +169,84 @@ const Pods = ({ pods = [], appName }: { pods: PodDetailType[]; appName: string }
     {
       title: '',
       key: 'control',
-      render: (item: PodDetailType, i: number) => (
-        <div className="flex items-center gap-2 driver-detail-operate justify-end">
-          <Button
-            variant="outline"
-            className="px-3 py-2 h-9 rounded-lg text-sm border-zinc-200 hover:bg-zinc-50"
-            onClick={() => setDetailPodIndex(i)}
-          >
-            {t('Details')}
-          </Button>
+      render: (item: PodDetailType, i: number) => {
+        const containerName = getPodContainerName(item);
 
-          <Button
-            variant="outline"
-            className="px-3 py-2 h-9 rounded-lg text-sm border-zinc-200 hover:bg-zinc-50"
-            onClick={openConfirmRestart(() => handleRestartPod(item.podName))}
-          >
-            {t('Restart')}
-          </Button>
+        return (
+          <div className="flex items-center gap-2 driver-detail-operate justify-end">
+            <Button
+              variant="outline"
+              className="px-3 py-2 h-9 rounded-lg text-sm border-zinc-200 hover:bg-zinc-50"
+              onClick={() => setDetailPodIndex(i)}
+            >
+              {t('Details')}
+            </Button>
 
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="outline"
-                className="w-9 h-9 rounded-lg border-zinc-200 hover:bg-zinc-50 driver-detail-terminal"
-                onClick={() => {
-                  track('deployment_action', {
-                    event_type: 'terminal_open',
-                    module: 'applaunchpad'
-                  });
-                  sealosApp.runEvents('openDesktopApp', {
-                    appKey: 'system-terminal',
-                    pathname: '/exec',
-                    query: {
-                      ns: nsid,
-                      pod: item.podName,
-                      container: appName
-                    },
-                    messageData: {
-                      type: 'InternalAppCall',
-                      ns: nsid,
-                      pod: item.podName,
-                      container: appName
-                    }
-                  });
-                }}
-              >
-                <Terminal className="w-4 h-4 text-zinc-500" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" className="rounded-xl">
-              <p className="text-sm text-zinc-900 font-normal p-2">{t('Terminal')}</p>
-            </TooltipContent>
-          </Tooltip>
+            <Button
+              variant="outline"
+              className="px-3 py-2 h-9 rounded-lg text-sm border-zinc-200 hover:bg-zinc-50"
+              onClick={openConfirmRestart(() => handleRestartPod(item.podName))}
+            >
+              {t('Restart')}
+            </Button>
 
-          {appDetail.storeList?.length > 0 && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
                   variant="outline"
-                  className="w-9 h-9 rounded-lg text-sm border-zinc-200 hover:bg-zinc-50"
+                  className="w-9 h-9 rounded-lg border-zinc-200 hover:bg-zinc-50 driver-detail-terminal"
                   onClick={() => {
-                    setDetailFilePodIndex(i);
-                    setIsOpenPodFile(true);
+                    track('deployment_action', {
+                      event_type: 'terminal_open',
+                      module: 'applaunchpad'
+                    });
+                    sealosApp.runEvents('openDesktopApp', {
+                      appKey: 'system-terminal',
+                      pathname: '/exec',
+                      query: {
+                        ns: nsid,
+                        pod: item.podName,
+                        container: containerName
+                      },
+                      messageData: {
+                        type: 'InternalAppCall',
+                        ns: nsid,
+                        pod: item.podName,
+                        container: containerName
+                      }
+                    });
                   }}
                 >
-                  <FolderOpen className="w-4 h-4 text-zinc-500" />
+                  <Terminal className="w-4 h-4 text-zinc-500" />
                 </Button>
               </TooltipTrigger>
               <TooltipContent side="bottom" className="rounded-xl">
-                <p className="text-sm text-zinc-900 font-normal p-2">{t('File Management')}</p>
+                <p className="text-sm text-zinc-900 font-normal p-2">{t('Terminal')}</p>
               </TooltipContent>
             </Tooltip>
-          )}
-        </div>
-      )
+
+            {appDetail.storeList?.length > 0 && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    className="w-9 h-9 rounded-lg text-sm border-zinc-200 hover:bg-zinc-50"
+                    onClick={() => {
+                      setDetailFilePodIndex(i);
+                      setIsOpenPodFile(true);
+                    }}
+                  >
+                    <FolderOpen className="w-4 h-4 text-zinc-500" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="rounded-xl">
+                  <p className="text-sm text-zinc-900 font-normal p-2">{t('File Management')}</p>
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+        );
+      }
     }
   ];
 
@@ -296,11 +301,13 @@ const Pods = ({ pods = [], appName }: { pods: PodDetailType[]; appName: string }
         <LogsModal
           appName={appName}
           podName={pods[logsPodIndex]?.podName || ''}
+          pod={pods[logsPodIndex]}
           pods={pods
             .filter((pod) => pod.status.value === PodStatusEnum.running)
-            .map((item, i) => ({
+            .map((item) => ({
               alias: item.podName,
-              podName: item.podName
+              podName: item.podName,
+              pod: item
             }))}
           podAlias={pods[logsPodIndex]?.podName || ''}
           setLogsPodName={(name: string) =>

--- a/frontend/providers/applaunchpad/src/pages/api/getPodLogs.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/getPodLogs.ts
@@ -14,6 +14,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   const {
     appName,
     podName,
+    containerName,
     stream = false,
     logSize,
     previous,
@@ -21,6 +22,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   } = req.body as {
     appName: string;
     podName: string;
+    containerName?: string;
     stream: boolean;
     logSize?: number;
     previous?: boolean;
@@ -31,6 +33,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     throw new Error('podName is empty');
   }
 
+  const logContainerName =
+    containerName || (await getFirstPodContainerName(k8sCore, podName, namespace)) || appName;
+
   if (!stream) {
     const sinceSeconds =
       sinceTime && !!!previous ? Math.floor((Date.now() - sinceTime) / 1000) : undefined;
@@ -38,7 +43,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       const { body: data } = await k8sCore.readNamespacedPodLog(
         podName,
         namespace,
-        appName,
+        logContainerName,
         undefined,
         undefined,
         undefined,
@@ -107,7 +112,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     streamResponse = await logs.log(
       namespace,
       podName,
-      appName,
+      logContainerName,
       logStream,
       (err) => {
         if (err) {
@@ -123,4 +128,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
 function timestampToRFC3339(timestamp: number) {
   return new Date(timestamp).toISOString();
+}
+
+async function getFirstPodContainerName(k8sCore: any, podName: string, namespace: string) {
+  try {
+    const { body } = await k8sCore.readNamespacedPod(podName, namespace);
+    return body.spec?.containers?.[0]?.name;
+  } catch {
+    return '';
+  }
 }

--- a/frontend/providers/applaunchpad/src/pages/app/detail/logs.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/detail/logs.tsx
@@ -109,6 +109,7 @@ export default function LogsPage({ appName }: { appName: string }) {
   });
 
   const selectedPods = formHook.watch('pods').filter((pod) => pod.checked);
+  const selectedContainers = formHook.watch('containers').filter((container) => container.checked);
   const jsonFilters = formHook
     .watch('jsonFilters')
     .filter((item) => item.key && item.key.trim() !== '');
@@ -116,6 +117,7 @@ export default function LogsPage({ appName }: { appName: string }) {
   const timeRange = formatTimeRange(startDateTime, endDateTime);
 
   const allPods = formHook.watch('pods');
+  const allContainers = formHook.watch('containers');
 
   // Build the pod -> containers mapping
   const podContainerMap = useMemo(() => {
@@ -183,6 +185,16 @@ export default function LogsPage({ appName }: { appName: string }) {
     return selectedPods.map((pod) => pod.value);
   }, [selectedPods, allPods]);
 
+  const containerParam = useMemo(() => {
+    if (selectedContainers.length === 0 && allContainers.length > 0) {
+      return ['__none__'];
+    }
+    if (selectedContainers.length === allContainers.length) {
+      return [];
+    }
+    return selectedContainers.map((container) => container.value);
+  }, [selectedContainers, allContainers]);
+
   const { isLoading, refetch: refetchLogsData } = useQuery(
     [
       'logs-data',
@@ -192,7 +204,8 @@ export default function LogsPage({ appName }: { appName: string }) {
       formHook.watch('limit'),
       formHook.watch('isJsonMode'),
       formHook.watch('keyword'),
-      podParam
+      podParam,
+      containerParam
     ],
     () =>
       getAppLogs({
@@ -204,7 +217,7 @@ export default function LogsPage({ appName }: { appName: string }) {
         jsonMode: formHook.watch('isJsonMode').toString(),
         keyword: formHook.watch('keyword'),
         pod: podParam,
-        container: [],
+        container: containerParam,
         jsonQuery: jsonFilters
       }),
     {
@@ -230,6 +243,7 @@ export default function LogsPage({ appName }: { appName: string }) {
       startDateTime.getTime(),
       endDateTime.getTime(),
       podParam,
+      containerParam,
       formHook.watch('isJsonMode'),
       formHook.watch('keyword')
     ],
@@ -242,7 +256,7 @@ export default function LogsPage({ appName }: { appName: string }) {
         startTime: startDateTime.toISOString(),
         endTime: endDateTime.toISOString(),
         pod: podParam,
-        container: [],
+        container: containerParam,
         jsonQuery: jsonFilters,
         keyword: formHook.watch('keyword')
       }),

--- a/frontend/providers/applaunchpad/src/utils/pod.ts
+++ b/frontend/providers/applaunchpad/src/utils/pod.ts
@@ -1,0 +1,4 @@
+import type { V1Pod } from '@kubernetes/client-node';
+
+export const getPodContainerName = (pod: Pick<V1Pod, 'spec' | 'status'>): string =>
+  pod.spec?.containers?.[0]?.name || pod.status?.containerStatuses?.[0]?.name || '';


### PR DESCRIPTION
Fix Applaunchpad detail actions that used `appName` as the Kubernetes container name. Terminal, Pod logs, file management, and log API fallback now resolve the real container from
  `pod.spec.containers[0].name`.

  Also fix the standalone logs page so selected container filters are sent to the log query API, and add unit coverage for Pod spec container-name resolution. Verified with `pnpm -C
  providers/applaunchpad test:unit __tests__/unit/utils/pod.test.ts` and `pnpm -C providers/applaunchpad lint`.