### PR TITLE
fix(applaunchpad): prevent public domain truncation

### DIFF
--- a/frontend/providers/applaunchpad/README.md
+++ b/frontend/providers/applaunchpad/README.md
@@ -2,6 +2,31 @@
 
 ## Preparation, refer to the README.md in the frontend directory
 
+## Image port detection
+
+AppLaunchpad can read image manifests to infer exposed ports when
+`launchpad.imagePorts.enabled` is enabled in `data/config.yaml`.
+
+By default, registry hosts that resolve to private, loopback, link-local, or
+reserved IP ranges are blocked. Internal registries can be allowed with exact
+host entries in `launchpad.imagePorts.trustedRegistries`; the Helm chart exposes
+the same setting as `applaunchpadConfig.imagePortsTrustedRegistries`.
+
+Example:
+
+```yaml
+launchpad:
+  imagePorts:
+    enabled: true
+    trustedRegistries:
+      - registry.192.168.10.70.nip.io
+      - hub.192.168.10.70.nip.io
+```
+
+Trusted entries are hostnames only. IP literals and localhost are still denied,
+and redirects or auth realms must stay on the image registry host or another
+trusted host.
+
 ## project tree
 
 ```bash

--- a/frontend/providers/applaunchpad/__tests__/unit/utils/image-exposed-ports.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/image-exposed-ports.test.ts
@@ -35,6 +35,8 @@ type MockRequestCall = {
 };
 
 const requestCalls: MockRequestCall[] = [];
+const lookupCallbackAddresses: unknown[] = [];
+let connectionLookupOptions: Record<string, unknown> = {};
 
 function createResponse(response: MockRegistryResponse) {
   const body =
@@ -72,7 +74,8 @@ function createRequestMock(responses: MockRegistryResponse[]) {
         return;
       }
 
-      lookupFn(parsedUrl.hostname, {}, (error) => {
+      lookupFn(parsedUrl.hostname, connectionLookupOptions as any, (error, address) => {
+        lookupCallbackAddresses.push(address);
         if (error) {
           request.emit('error', error);
           return;
@@ -95,6 +98,9 @@ afterEach(() => {
   vi.clearAllMocks();
   lookupMock.mockReset();
   requestCalls.length = 0;
+  lookupCallbackAddresses.length = 0;
+  connectionLookupOptions = {};
+  delete (globalThis as any).AppConfig;
 });
 
 describe('parseExposedPorts', () => {
@@ -189,6 +195,99 @@ describe('getImageExposedPorts registry safety', () => {
     expect(requestMock).toHaveBeenCalledTimes(1);
   });
 
+  it('returns lookup address arrays when Node requests all connection addresses', async () => {
+    connectionLookupOptions = { all: true };
+    lookupMock.mockResolvedValue([{ address: '8.8.8.8', family: 4 }]);
+    mockRegistryRequests(
+      { body: { config: { digest: 'sha256:config' } } },
+      {
+        body: {
+          config: {
+            ExposedPorts: {
+              '80/tcp': {}
+            }
+          }
+        }
+      }
+    );
+
+    await expect(getImageExposedPorts('registry.example.com/team/api:latest')).resolves.toEqual([
+      { port: 80, protocol: 'TCP' }
+    ]);
+    expect(lookupCallbackAddresses).toHaveLength(2);
+    expect(lookupCallbackAddresses.every(Array.isArray)).toBe(true);
+  });
+
+  it('allows configured trusted registry hosts to resolve to private addresses', async () => {
+    (globalThis as any).AppConfig = {
+      launchpad: {
+        imagePorts: {
+          trustedRegistries: ['https://registry.192.168.10.70.nip.io']
+        }
+      }
+    };
+    lookupMock.mockResolvedValue([{ address: '192.168.10.70', family: 4 }]);
+    mockRegistryRequests(
+      { body: { config: { digest: 'sha256:config' } } },
+      {
+        body: {
+          config: {
+            ExposedPorts: {
+              '80/tcp': {}
+            }
+          }
+        }
+      }
+    );
+
+    await expect(
+      getImageExposedPorts('registry.192.168.10.70.nip.io/team/api:latest')
+    ).resolves.toEqual([{ port: 80, protocol: 'TCP' }]);
+  });
+
+  it('allows auth realms on configured trusted registry hosts', async () => {
+    (globalThis as any).AppConfig = {
+      launchpad: {
+        imagePorts: {
+          trustedRegistries: [
+            'registry.192.168.10.70.nip.io',
+            'hub.192.168.10.70.nip.io'
+          ]
+        }
+      }
+    };
+    lookupMock.mockResolvedValue([{ address: '192.168.10.70', family: 4 }]);
+    mockRegistryRequests(
+      {
+        status: 401,
+        body: '',
+        headers: {
+          'www-authenticate':
+            'Bearer realm="https://hub.192.168.10.70.nip.io/token",service="registry.192.168.10.70.nip.io"'
+        }
+      },
+      { body: { token: 'trusted-token' } },
+      { body: { config: { digest: 'sha256:config' } } },
+      {
+        body: {
+          config: {
+            ExposedPorts: {
+              '5000/tcp': {}
+            }
+          }
+        }
+      }
+    );
+
+    await expect(
+      getImageExposedPorts('registry.192.168.10.70.nip.io/team/api:latest', {
+        username: 'user',
+        password: 'password'
+      })
+    ).resolves.toEqual([{ port: 5000, protocol: 'TCP' }]);
+    expect(requestCalls[1].url.hostname).toBe('hub.192.168.10.70.nip.io');
+  });
+
   it('does not forward registry credentials to an untrusted challenge realm', async () => {
     lookupMock.mockResolvedValue([{ address: '8.8.8.8', family: 4 }]);
     const requestMock = mockRegistryRequests({
@@ -197,6 +296,33 @@ describe('getImageExposedPorts registry safety', () => {
       headers: {
         'www-authenticate':
           'Bearer realm="https://attacker.example/token",service="registry.example.com"'
+      }
+    });
+
+    await expect(
+      getImageExposedPorts('registry.example.com/team/api:latest', {
+        username: 'user',
+        password: 'password'
+      })
+    ).rejects.toThrow('Registry auth realm is not trusted');
+    expect(requestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not trust configured internal auth realms for unrelated public registries', async () => {
+    (globalThis as any).AppConfig = {
+      launchpad: {
+        imagePorts: {
+          trustedRegistries: ['hub.192.168.10.70.nip.io']
+        }
+      }
+    };
+    lookupMock.mockResolvedValue([{ address: '8.8.8.8', family: 4 }]);
+    const requestMock = mockRegistryRequests({
+      status: 401,
+      body: '',
+      headers: {
+        'www-authenticate':
+          'Bearer realm="https://hub.192.168.10.70.nip.io/token",service="registry.example.com"'
       }
     });
 

--- a/frontend/providers/applaunchpad/data/config.yaml
+++ b/frontend/providers/applaunchpad/data/config.yaml
@@ -27,6 +27,7 @@ launchpad:
   pvcStorageMax: 100
   imagePorts:
     enabled: false
+    trustedRegistries: []
   publicDomain:
     customPrefixEnabled: false
     reservedPrefixes: []

--- a/frontend/providers/applaunchpad/deploy/charts/applaunchpad-frontend/applaunchpad-frontend-values.yaml
+++ b/frontend/providers/applaunchpad/deploy/charts/applaunchpad-frontend/applaunchpad-frontend-values.yaml
@@ -13,5 +13,6 @@ resources:
 
 applaunchpadConfig:
   imagePortsEnabled: false
+  imagePortsTrustedRegistries: []
   customPublicDomainPrefixEnabled: false
   publicDomainReservedPrefixes: []

--- a/frontend/providers/applaunchpad/deploy/charts/applaunchpad-frontend/templates/configmap.yaml
+++ b/frontend/providers/applaunchpad/deploy/charts/applaunchpad-frontend/templates/configmap.yaml
@@ -33,6 +33,7 @@ data:
         fastGPTKey: ""
       imagePorts:
         enabled: {{ .Values.applaunchpadConfig.imagePortsEnabled }}
+        trustedRegistries:{{ toYaml .Values.applaunchpadConfig.imagePortsTrustedRegistries | nindent 10 }}
       publicDomain:
         customPrefixEnabled: {{ .Values.applaunchpadConfig.customPublicDomainPrefixEnabled }}
         reservedPrefixes:{{ toYaml .Values.applaunchpadConfig.publicDomainReservedPrefixes | nindent 10 }}

--- a/frontend/providers/applaunchpad/deploy/charts/applaunchpad-frontend/values.yaml
+++ b/frontend/providers/applaunchpad/deploy/charts/applaunchpad-frontend/values.yaml
@@ -50,6 +50,7 @@ applaunchpadConfig:
   logUrl: ""
   tlsRejectUnauthorized: "1"
   imagePortsEnabled: false
+  imagePortsTrustedRegistries: []
   customPublicDomainPrefixEnabled: false
   publicDomainReservedPrefixes: []
 

--- a/frontend/providers/applaunchpad/src/instrumentation.ts
+++ b/frontend/providers/applaunchpad/src/instrumentation.ts
@@ -47,7 +47,8 @@ export async function register() {
           currencySymbol: Coin.shellCoin,
           pvcStorageMax: 20,
           imagePorts: {
-            enabled: false
+            enabled: false,
+            trustedRegistries: []
           },
           publicDomain: {
             customPrefixEnabled: false,

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/NetworkSection.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/NetworkSection.tsx
@@ -880,7 +880,7 @@ export function NetworkSection({
           return (
             <Box
               key={field.id}
-              w={'697px'}
+              w={'100%'}
               maxW={'100%'}
               _notLast={{ pb: 6, mb: 6, borderBottom: theme.borders.base }}
             >
@@ -925,13 +925,12 @@ export function NetworkSection({
                 <Box ml={'32px'} flex={isExternalAccess ? '1 1 auto' : '0 0 93px'} minW={0}>
                   <Box {...fieldLabelStyles}>{t('Public Access')}</Box>
                   <FormControl isInvalid={!!publicDomainErrorMessage}>
-                    <Flex alignItems={'flex-start'} minW={0}>
+                    <Flex alignItems={'center'} h={'32px'} minW={0}>
                       <Switch
                         className="driver-deploy-network-switch"
                         size={'lg'}
                         isChecked={isExternalAccess}
                         mr={isExternalAccess ? '24px' : 0}
-                        mt={'1px'}
                         sx={{
                           lineHeight: 0,
                           '.chakra-switch__track': {
@@ -968,20 +967,8 @@ export function NetworkSection({
                       />
 
                       {isExternalAccess && (
-                        <Flex
-                          alignItems={'center'}
-                          flex={'1 1 0'}
-                          minW={0}
-                          flexWrap={'wrap'}
-                          gap={'8px'}
-                        >
-                          <Flex
-                            alignItems={'center'}
-                            flex={canConfigureRouteRules ? '1 1 100%' : '1 1 0'}
-                            w={canConfigureRouteRules ? '100%' : undefined}
-                            h={'32px'}
-                            minW={0}
-                          >
+                        <>
+                          <Flex alignItems={'center'} flex={'1 1 0'} mr={'8px'} h={'32px'} minW={0}>
                             <MySelect
                               width={'90px'}
                               height={'32px'}
@@ -1072,6 +1059,32 @@ export function NetworkSection({
                                 </Tooltip>
                               )}
 
+                              {network.openPublicDomain && !network.openNodePort && (
+                                <Box
+                                  flex={'0 0 auto'}
+                                  px={'8px'}
+                                  py={'4px'}
+                                  fontSize={'11px'}
+                                  lineHeight={'16px'}
+                                  fontWeight={500}
+                                  letterSpacing={'0.5px'}
+                                  color={'brightBlue.600'}
+                                  cursor={'pointer'}
+                                  onClick={async () => {
+                                    const publicDomain = network.customDomain
+                                      ? network.publicDomain
+                                      : await commitPublicDomainDraft(i, network.publicDomain);
+                                    if (!publicDomain) return;
+                                    setCustomAccessModalData({
+                                      publicDomain,
+                                      currentCustomDomain: network.customDomain,
+                                      domain: network.domain
+                                    });
+                                  }}
+                                >
+                                  {t('bind_custom_domain')}
+                                </Box>
+                              )}
                               {/* keep a hidden field registered so customDomain remains part of form state */}
                               <Input
                                 display={'none'}
@@ -1081,27 +1094,6 @@ export function NetworkSection({
                               />
                             </Flex>
                           </Flex>
-                          {network.openPublicDomain && !network.openNodePort && (
-                            <Button
-                              type={'button'}
-                              variant={'outline'}
-                              {...actionButtonStyles}
-                              color={'brightBlue.600'}
-                              onClick={async () => {
-                                const publicDomain = network.customDomain
-                                  ? network.publicDomain
-                                  : await commitPublicDomainDraft(i, network.publicDomain);
-                                if (!publicDomain) return;
-                                setCustomAccessModalData({
-                                  publicDomain,
-                                  currentCustomDomain: network.customDomain,
-                                  domain: network.domain
-                                });
-                              }}
-                            >
-                              {t('bind_custom_domain')}
-                            </Button>
-                          )}
                           {canConfigureRouteRules && (
                             <Button
                               type={'button'}
@@ -1116,6 +1108,7 @@ export function NetworkSection({
                           )}
                           {networks.length > 1 && (
                             <IconButton
+                              ml={2}
                               height={'32px'}
                               width={'32px'}
                               minW={'32px'}
@@ -1132,7 +1125,7 @@ export function NetworkSection({
                               }
                             />
                           )}
-                        </Flex>
+                        </>
                       )}
                     </Flex>
                     <FormErrorMessage mt={1} fontSize={'12px'}>

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/NetworkSection.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/NetworkSection.tsx
@@ -925,12 +925,13 @@ export function NetworkSection({
                 <Box ml={'32px'} flex={isExternalAccess ? '1 1 auto' : '0 0 93px'} minW={0}>
                   <Box {...fieldLabelStyles}>{t('Public Access')}</Box>
                   <FormControl isInvalid={!!publicDomainErrorMessage}>
-                    <Flex alignItems={'center'} h={'32px'} minW={0}>
+                    <Flex alignItems={'flex-start'} minW={0}>
                       <Switch
                         className="driver-deploy-network-switch"
                         size={'lg'}
                         isChecked={isExternalAccess}
                         mr={isExternalAccess ? '24px' : 0}
+                        mt={'1px'}
                         sx={{
                           lineHeight: 0,
                           '.chakra-switch__track': {
@@ -967,8 +968,20 @@ export function NetworkSection({
                       />
 
                       {isExternalAccess && (
-                        <>
-                          <Flex alignItems={'center'} flex={'1 1 0'} mr={'8px'} h={'32px'} minW={0}>
+                        <Flex
+                          alignItems={'center'}
+                          flex={'1 1 0'}
+                          minW={0}
+                          flexWrap={'wrap'}
+                          gap={'8px'}
+                        >
+                          <Flex
+                            alignItems={'center'}
+                            flex={canConfigureRouteRules ? '1 1 100%' : '1 1 0'}
+                            w={canConfigureRouteRules ? '100%' : undefined}
+                            h={'32px'}
+                            minW={0}
+                          >
                             <MySelect
                               width={'90px'}
                               height={'32px'}
@@ -1059,32 +1072,6 @@ export function NetworkSection({
                                 </Tooltip>
                               )}
 
-                              {network.openPublicDomain && !network.openNodePort && (
-                                <Box
-                                  flex={'0 0 auto'}
-                                  px={'8px'}
-                                  py={'4px'}
-                                  fontSize={'11px'}
-                                  lineHeight={'16px'}
-                                  fontWeight={500}
-                                  letterSpacing={'0.5px'}
-                                  color={'brightBlue.600'}
-                                  cursor={'pointer'}
-                                  onClick={async () => {
-                                    const publicDomain = network.customDomain
-                                      ? network.publicDomain
-                                      : await commitPublicDomainDraft(i, network.publicDomain);
-                                    if (!publicDomain) return;
-                                    setCustomAccessModalData({
-                                      publicDomain,
-                                      currentCustomDomain: network.customDomain,
-                                      domain: network.domain
-                                    });
-                                  }}
-                                >
-                                  {t('bind_custom_domain')}
-                                </Box>
-                              )}
                               {/* keep a hidden field registered so customDomain remains part of form state */}
                               <Input
                                 display={'none'}
@@ -1094,6 +1081,27 @@ export function NetworkSection({
                               />
                             </Flex>
                           </Flex>
+                          {network.openPublicDomain && !network.openNodePort && (
+                            <Button
+                              type={'button'}
+                              variant={'outline'}
+                              {...actionButtonStyles}
+                              color={'brightBlue.600'}
+                              onClick={async () => {
+                                const publicDomain = network.customDomain
+                                  ? network.publicDomain
+                                  : await commitPublicDomainDraft(i, network.publicDomain);
+                                if (!publicDomain) return;
+                                setCustomAccessModalData({
+                                  publicDomain,
+                                  currentCustomDomain: network.customDomain,
+                                  domain: network.domain
+                                });
+                              }}
+                            >
+                              {t('bind_custom_domain')}
+                            </Button>
+                          )}
                           {canConfigureRouteRules && (
                             <Button
                               type={'button'}
@@ -1108,7 +1116,6 @@ export function NetworkSection({
                           )}
                           {networks.length > 1 && (
                             <IconButton
-                              ml={2}
                               height={'32px'}
                               width={'32px'}
                               minW={'32px'}
@@ -1125,7 +1132,7 @@ export function NetworkSection({
                               }
                             />
                           )}
-                        </>
+                        </Flex>
                       )}
                     </Flex>
                     <FormErrorMessage mt={1} fontSize={'12px'}>

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/NetworkSection.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/NetworkSection.tsx
@@ -157,9 +157,7 @@ function PublicDomainPrefixInput({
           bg={'transparent'}
           pl={3}
           pr={'30px'}
-          fontSize={'15px'}
-          fontWeight={500}
-          color={'grayModern.900'}
+          {...fieldInputStyles}
           cursor={'text'}
           userSelect={'text'}
           value={draft}
@@ -840,6 +838,22 @@ export function NetworkSection({
     [t]
   );
 
+  const getDomainHostDisplay = useCallback(
+    (network: AppEditType['networks'][number]) => {
+      if (network.customDomain) {
+        return network.customDomain;
+      }
+
+      if (network.openNodePort) {
+        const port = network?.nodePort || t('pending_to_allocated');
+        return `${network.protocol.toLowerCase()}.${network.domain}:${port}`;
+      }
+
+      return `${network.publicDomain}.${network.domain}`;
+    },
+    [t]
+  );
+
   const routeRulesNetwork =
     routeRulesIndex !== undefined ? getValues('networks')[routeRulesIndex] : undefined;
 
@@ -954,7 +968,7 @@ export function NetworkSection({
 
                       {isExternalAccess && (
                         <>
-                          <Flex alignItems={'center'} w={'389px'} mr={'8px'} h={'32px'} minW={0}>
+                          <Flex alignItems={'center'} flex={'1 1 0'} mr={'8px'} h={'32px'} minW={0}>
                             <MySelect
                               width={'90px'}
                               height={'32px'}
@@ -985,7 +999,8 @@ export function NetworkSection({
                             <Flex
                               alignItems={'center'}
                               h={'32px'}
-                              w={'300px'}
+                              flex={'1 1 0'}
+                              minW={0}
                               bg={'grayModern.50'}
                               border={theme.borders.base}
                               borderLeft={0}
@@ -1039,7 +1054,7 @@ export function NetworkSection({
                                       copyData(getDomainDisplay(network));
                                     }}
                                   >
-                                    {getDomainDisplay(network)}
+                                    {getDomainHostDisplay(network)}
                                   </Box>
                                 </Tooltip>
                               )}

--- a/frontend/providers/applaunchpad/src/types/index.d.ts
+++ b/frontend/providers/applaunchpad/src/types/index.d.ts
@@ -64,6 +64,7 @@ export type AppConfigType = {
     pvcStorageMax: number;
     imagePorts?: {
       enabled?: boolean;
+      trustedRegistries?: string[];
     };
     publicDomain?: {
       customPrefixEnabled?: boolean;

--- a/frontend/providers/applaunchpad/src/utils/image-exposed-ports.ts
+++ b/frontend/providers/applaunchpad/src/utils/image-exposed-ports.ts
@@ -4,6 +4,7 @@ import type { IncomingHttpHeaders, IncomingMessage, RequestOptions } from 'http'
 import { request as httpsRequest } from 'https';
 import { isIP } from 'net';
 import type { LookupFunction } from 'net';
+import type { LookupAddress } from 'dns';
 
 export type ImageRegistryAuth = {
   username?: string;
@@ -51,6 +52,19 @@ type RegistryResponse = {
   };
   json: () => Promise<unknown>;
 };
+
+type RegistryLookupOptions = {
+  all?: boolean;
+  family?: number;
+  hints?: number;
+  verbatim?: boolean;
+};
+
+type RegistryLookupCallback = (
+  error: NodeJS.ErrnoException | null,
+  address: string | LookupAddress[],
+  family?: number
+) => void;
 
 const DEFAULT_REGISTRY = 'registry-1.docker.io';
 const DOCKER_HUB_AUTH_SERVICE = 'registry.docker.io';
@@ -140,17 +154,51 @@ function getUrlHost(value: string) {
   const url = new URL(
     value.startsWith('http://') || value.startsWith('https://') ? value : `https://${value}`
   );
-  return url.hostname.replace(/^\[|\]$/g, '');
+  return normalizeHost(url.hostname);
+}
+
+function normalizeHost(host: string) {
+  return host
+    .replace(/^\[|\]$/g, '')
+    .replace(/\.$/, '')
+    .toLowerCase();
+}
+
+function getTrustedRegistryHosts() {
+  const registries = (globalThis as any).AppConfig?.launchpad?.imagePorts?.trustedRegistries;
+  if (!Array.isArray(registries)) return new Set<string>();
+
+  return new Set(
+    registries
+      .map((registry) => {
+        if (typeof registry !== 'string' || !registry.trim()) return null;
+        try {
+          return getUrlHost(registry.trim());
+        } catch {
+          return null;
+        }
+      })
+      .filter((host): host is string => !!host && isIP(host) === 0 && host !== 'localhost')
+  );
+}
+
+function isTrustedRegistryHost(host: string) {
+  return getTrustedRegistryHosts().has(normalizeHost(host));
 }
 
 async function assertPublicRegistryHost(registry: string) {
   const host = getUrlHost(registry);
-  await assertPublicHost(host, 'Registry host');
+  await assertRegistryHost(host, 'Registry host');
 }
 
-async function assertPublicHost(host: string, context: string) {
-  const hostIsIp = isIP(host) !== 0;
-  if (host === 'localhost' || host.endsWith('.localhost') || (hostIsIp && isBlockedAddress(host))) {
+async function assertRegistryHost(host: string, context: string) {
+  const normalizedHost = normalizeHost(host);
+  const hostIsIp = isIP(normalizedHost) !== 0;
+  if (
+    normalizedHost === 'localhost' ||
+    normalizedHost.endsWith('.localhost') ||
+    (hostIsIp && isBlockedAddress(normalizedHost))
+  ) {
     throw new Error(`${context} is not allowed`);
   }
 
@@ -158,8 +206,12 @@ async function assertPublicHost(host: string, context: string) {
     return;
   }
 
-  const addresses = await lookup(host, { all: true });
-  if (!addresses.length || addresses.some((item) => isBlockedAddress(item.address))) {
+  const addresses = await lookup(normalizedHost, { all: true });
+  if (
+    !addresses.length ||
+    (!isTrustedRegistryHost(normalizedHost) &&
+      addresses.some((item) => isBlockedAddress(item.address)))
+  ) {
     throw new Error(`${context} resolves to a private address`);
   }
 }
@@ -170,64 +222,91 @@ function assertRegistryUrl(url: URL) {
   }
 }
 
-const publicLookup: LookupFunction = (hostname, options, callback) => {
+function callbackLookupError(callback: RegistryLookupCallback, error: NodeJS.ErrnoException) {
+  callback(error, '', 0);
+}
+
+function callbackLookupSuccess(
+  callback: RegistryLookupCallback,
+  options: RegistryLookupOptions,
+  addresses: LookupAddress[]
+) {
+  if (options.all) {
+    callback(null, addresses);
+    return;
+  }
+
+  const preferredFamily = options.family === 4 || options.family === 6 ? options.family : undefined;
+  const selected = preferredFamily
+    ? addresses.find((item) => item.family === preferredFamily)
+    : addresses[0];
+
+  if (!selected) {
+    callbackLookupError(
+      callback,
+      Object.assign(new Error('Registry host address family is unavailable'), {
+        code: 'ENOTFOUND'
+      })
+    );
+    return;
+  }
+
+  callback(null, selected.address, selected.family);
+}
+
+const publicLookup = ((
+  hostname: string,
+  options: RegistryLookupOptions,
+  callback: RegistryLookupCallback
+) => {
   const lookupOptions = {
     family: options.family,
     hints: options.hints,
     verbatim: options.verbatim
   };
+  const normalizedHostname = normalizeHost(hostname);
+  const trusted = isTrustedRegistryHost(normalizedHostname);
 
-  const hostIsIp = isIP(hostname) !== 0;
+  const hostIsIp = isIP(normalizedHostname) !== 0;
   if (hostIsIp) {
-    if (isBlockedAddress(hostname)) {
-      callback(
-        Object.assign(new Error('Registry host is not allowed'), { code: 'EHOSTDENIED' }),
-        '',
-        0
+    if (isBlockedAddress(normalizedHostname)) {
+      callbackLookupError(
+        callback,
+        Object.assign(new Error('Registry host is not allowed'), { code: 'EHOSTDENIED' })
       );
       return;
     }
 
-    callback(null, hostname, isIP(hostname));
+    callbackLookupSuccess(callback, options, [
+      {
+        address: normalizedHostname,
+        family: isIP(normalizedHostname)
+      }
+    ]);
     return;
   }
 
-  lookup(hostname, { ...lookupOptions, all: true })
+  lookup(normalizedHostname, { ...lookupOptions, all: true })
     .then((addresses) => {
-      if (!addresses.length || addresses.some((item) => isBlockedAddress(item.address))) {
-        callback(
+      if (
+        !addresses.length ||
+        (!trusted && addresses.some((item) => isBlockedAddress(item.address)))
+      ) {
+        callbackLookupError(
+          callback,
           Object.assign(new Error('Registry host resolves to a private address'), {
             code: 'EHOSTDENIED'
-          }),
-          '',
-          0
+          })
         );
         return;
       }
 
-      const preferredFamily =
-        lookupOptions.family === 4 || lookupOptions.family === 6 ? lookupOptions.family : undefined;
-      const selected = preferredFamily
-        ? addresses.find((item) => item.family === preferredFamily)
-        : addresses[0];
-
-      if (!selected) {
-        callback(
-          Object.assign(new Error('Registry host address family is unavailable'), {
-            code: 'ENOTFOUND'
-          }),
-          '',
-          0
-        );
-        return;
-      }
-
-      callback(null, selected.address, selected.family);
+      callbackLookupSuccess(callback, options, addresses);
     })
     .catch((error) => {
-      callback(error, '', 0);
+      callbackLookupError(callback, error);
     });
-};
+}) as unknown as LookupFunction;
 
 function getHeader(headers: IncomingHttpHeaders, name: string) {
   const value = headers[name.toLowerCase()];
@@ -283,7 +362,7 @@ async function requestRegistryUrl(
   options: { headers?: Record<string, string>; signal?: AbortSignal; context: string }
 ) {
   assertRegistryUrl(url);
-  await assertPublicHost(url.hostname, 'Registry host');
+  await assertRegistryHost(url.hostname, 'Registry host');
 
   const request = url.protocol === 'https:' ? httpsRequest : httpRequest;
   const requestOptions: RequestOptions = {
@@ -345,7 +424,7 @@ async function registryHttpRequest(
     throw new Error('Registry request redirect is not trusted');
   }
 
-  await assertPublicHost(redirectUrl.hostname, 'Registry host');
+  await assertRegistryHost(redirectUrl.hostname, 'Registry host');
 
   return await registryHttpRequest(
     redirectUrl.toString(),
@@ -373,9 +452,14 @@ function assertTrustedRealm(challenge: ChallengeParams, image: ImageRef) {
 
   const registryHost = getUrlHost(image.registry);
   const allowedHosts =
-    image.registry === DEFAULT_REGISTRY ? new Set([DOCKER_HUB_AUTH_HOST]) : new Set([registryHost]);
+    image.registry === DEFAULT_REGISTRY
+      ? new Set([DOCKER_HUB_AUTH_HOST])
+      : new Set([
+          registryHost,
+          ...(isTrustedRegistryHost(registryHost) ? getTrustedRegistryHosts() : [])
+        ]);
 
-  if (!allowedHosts.has(realmUrl.hostname)) {
+  if (!allowedHosts.has(normalizeHost(realmUrl.hostname))) {
     throw new Error('Registry auth realm is not trusted');
   }
 }


### PR DESCRIPTION
## Summary

- Improve the App Launchpad public access row so generated public domains and custom domain actions do not truncate each other.
- Display only the host portion in the domain field while keeping the full copy target behavior.
- Move custom-domain binding into a compact action button so it can wrap with route-rules and delete actions.

## Tests

- pnpm --dir frontend/providers/applaunchpad lint
- pnpm --dir frontend/providers/applaunchpad build
