### PR TITLE
fix(dbprovider): apply create patch yamls

### DIFF
--- a/frontend/providers/dbprovider/__tests__/json2Yaml.test.ts
+++ b/frontend/providers/dbprovider/__tests__/json2Yaml.test.ts
@@ -1,0 +1,46 @@
+import yaml from 'js-yaml';
+import { DBCreatePatchYamlMap, DBTypeEnum, getDBCreatePatchYamls } from '@/constants/db';
+
+describe('DBCreatePatchYamlMap', () => {
+  it('builds PostgreSQL create patches that remove bg_mon', () => {
+    const parsed = yaml.load(getDBCreatePatchYamls(DBTypeEnum.postgresql, 'pg-prod')[0]) as any;
+
+    expect(parsed).toMatchObject({
+      apiVersion: 'apps.kubeblocks.io/v1alpha1',
+      kind: 'OpsRequest',
+      metadata: {
+        generateName: 'pg-prod-disable-bg-mon-'
+      },
+      spec: {
+        type: 'Reconfiguring',
+        clusterName: 'pg-prod',
+        force: false,
+        reconfigure: {
+          componentName: 'postgresql',
+          configurations: [
+            {
+              name: 'postgresql-configuration',
+              keys: [
+                {
+                  key: 'postgresql.conf',
+                  parameters: [
+                    {
+                      key: 'shared_preload_libraries',
+                      value:
+                        "'pg_stat_statements,auto_explain,pgextwlist,pg_auth_mon,set_user,pg_cron,pg_stat_kcache,timescaledb,pgaudit'"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        preConditionDeadlineSeconds: 0
+      }
+    });
+  });
+
+  it('infers patch keys as database types', () => {
+    expect(Object.keys(DBCreatePatchYamlMap)).toEqual([DBTypeEnum.postgresql]);
+  });
+});

--- a/frontend/providers/dbprovider/src/constants/db.ts
+++ b/frontend/providers/dbprovider/src/constants/db.ts
@@ -12,6 +12,7 @@ import {
 import { I18nCommonKey } from '@/types/i18next';
 import { CpuSlideMarkList, MemorySlideMarkList } from './editApp';
 import type { SecretResponse } from '@/pages/api/getSecretByName';
+import yaml from 'js-yaml';
 
 export const crLabelKey = 'sealos-db-provider-cr';
 export const CloudMigraionLabel = 'sealos-db-provider-cr-migrate';
@@ -44,6 +45,54 @@ export enum DBTypeEnum {
   pulsar = 'pulsar',
   clickhouse = 'clickhouse'
 }
+
+type DBCreatePatchYamlBuilder = (dbName: string) => string;
+type DBTypeValue = `${DBTypeEnum}`;
+
+export const DBCreatePatchYamlMap = {
+  [DBTypeEnum.postgresql]: [
+    (dbName: string) =>
+      yaml.dump({
+        apiVersion: 'apps.kubeblocks.io/v1alpha1',
+        kind: 'OpsRequest',
+        metadata: {
+          generateName: `${dbName}-disable-bg-mon-`
+        },
+        spec: {
+          type: 'Reconfiguring',
+          clusterName: dbName,
+          force: false,
+          reconfigure: {
+            componentName: 'postgresql',
+            configurations: [
+              {
+                name: 'postgresql-configuration',
+                keys: [
+                  {
+                    key: 'postgresql.conf',
+                    parameters: [
+                      {
+                        key: 'shared_preload_libraries',
+                        value:
+                          "'pg_stat_statements,auto_explain,pgextwlist,pg_auth_mon,set_user,pg_cron,pg_stat_kcache,timescaledb,pgaudit'"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          preConditionDeadlineSeconds: 0
+        }
+      })
+  ]
+} as const satisfies Partial<Record<DBTypeValue, readonly DBCreatePatchYamlBuilder[]>>;
+
+const dbCreatePatchYamlMap: Partial<Record<DBTypeValue, readonly DBCreatePatchYamlBuilder[]>> =
+  DBCreatePatchYamlMap;
+
+export const getDBCreatePatchYamls = (dbType: DBType, dbName: string) =>
+  dbCreatePatchYamlMap[dbType]?.map((buildYaml) => buildYaml(dbName)) ?? [];
 
 export const DB_REMARK_KEY = 'cloud.sealos.io/remark';
 

--- a/frontend/providers/dbprovider/src/pages/api/createDB.ts
+++ b/frontend/providers/dbprovider/src/pages/api/createDB.ts
@@ -1,4 +1,5 @@
 import { Config } from '@/config';
+import { getDBCreatePatchYamls } from '@/constants/db';
 import { authSession } from '@/services/backend/auth';
 import {
   getDBConfigurationByName,
@@ -215,6 +216,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     }
 
     await applyYamlList(yamlList, 'create');
+
+    const createPatchYamls = getDBCreatePatchYamls(dbForm.dbType, dbForm.dbName);
+    if (createPatchYamls.length > 0) {
+      await applyYamlList(createPatchYamls, 'create');
+    }
+
     const { body } = (await k8sCustomObjects.getNamespacedCustomObject(
       'apps.kubeblocks.io',
       'v1alpha1',

--- a/frontend/providers/dbprovider/src/services/backend/apis/create-database.ts
+++ b/frontend/providers/dbprovider/src/services/backend/apis/create-database.ts
@@ -1,4 +1,5 @@
 import { Config } from '@/config';
+import { getDBCreatePatchYamls } from '@/constants/db';
 import { createDatabaseSchemas } from '@/types/apis';
 import {
   getEffectiveParameterConfig,
@@ -174,6 +175,11 @@ export async function createDatabase(
   console.log('Applying YAML resources to K8s...');
 
   await k8s.applyYamlList(yamlList, 'create');
+
+  const createPatchYamls = getDBCreatePatchYamls(rawDbForm.dbType, rawDbForm.dbName);
+  if (createPatchYamls.length > 0) {
+    await k8s.applyYamlList(createPatchYamls, 'create');
+  }
 
   await new Promise((resolve) => setTimeout(resolve, 2000));
 

--- a/frontend/providers/dbprovider/src/services/backend/v2alpha/create-database.ts
+++ b/frontend/providers/dbprovider/src/services/backend/v2alpha/create-database.ts
@@ -1,4 +1,5 @@
 import { Config } from '@/config';
+import { getDBCreatePatchYamls } from '@/constants/db';
 import { createDatabaseSchemas } from '@/types/apis/v2alpha';
 import {
   getEffectiveParameterConfig,
@@ -184,6 +185,11 @@ export async function createDatabase(
   }
 
   await k8s.applyYamlList(yamlList, 'create');
+
+  const createPatchYamls = getDBCreatePatchYamls(rawDbForm.dbType, rawDbForm.dbName);
+  if (createPatchYamls.length > 0) {
+    await k8s.applyYamlList(createPatchYamls, 'create');
+  }
 
   const { body } = (await k8s.k8sCustomObjects.getNamespacedCustomObject(
     'apps.kubeblocks.io',


### PR DESCRIPTION
Apply DB create-time patch YAMLs from `constants/db.ts`, starting with PostgreSQL reconfiguration to remove `bg_mon` from `shared_preload_libraries`.

Wire the shared patch flow into all dbprovider create paths and add unit coverage for the PostgreSQL OpsRequest payload.