### PR TITLE
fix(template): render v2alpha instance yaml before parsing

### DIFF
--- a/frontend/providers/template/__tests__/v2alpha-template-instance-rendering.test.ts
+++ b/frontend/providers/template/__tests__/v2alpha-template-instance-rendering.test.ts
@@ -1,0 +1,71 @@
+import JsYaml from 'js-yaml';
+import { describe, expect, it } from 'vitest';
+
+import { renderTemplateInstanceYamls } from '@/utils/templateInstanceRendering';
+
+describe('v2alpha template instance rendering', () => {
+  it('renders conditional template YAML before parsing and renames the Instance', () => {
+    const appYaml = `apiVersion: app.sealos.io/v1
+kind: Instance
+metadata:
+  name: fastgpt-default
+spec: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: \${{ defaults.app_name }}
+spec:
+  ports:
+    - port: 80
+    \${{ if(inputs.agent_sandbox_baseurl) }}
+    - port: 3000
+      name: sandbox
+    \${{ endif() }}
+`;
+
+    expect(() => JsYaml.loadAll(appYaml)).toThrow(/bad indentation|end of the stream/i);
+
+    const [yaml] = renderTemplateInstanceYamls({
+      appYaml,
+      defaults: {
+        app_name: 'fastgpt-brain'
+      },
+      extraLabels: {
+        'brain.io/managed-by': 'deployment-task'
+      },
+      inputs: {
+        agent_sandbox_baseurl: 'https://sandbox.example.com'
+      },
+      instanceName: 'fastgpt-brain',
+      templateEnvs: {}
+    });
+    const docs = JsYaml.loadAll(yaml).filter(Boolean) as any[];
+
+    expect(docs[0]).toMatchObject({
+      apiVersion: 'app.sealos.io/v1',
+      kind: 'Instance',
+      metadata: {
+        name: 'fastgpt-brain',
+        labels: {
+          'brain.io/managed-by': 'deployment-task'
+        }
+      }
+    });
+    expect(docs[1]).toMatchObject({
+      kind: 'Service',
+      metadata: {
+        name: 'fastgpt-brain'
+      },
+      spec: {
+        ports: [
+          { port: 80 },
+          {
+            name: 'sandbox',
+            port: 3000
+          }
+        ]
+      }
+    });
+  });
+});

--- a/frontend/providers/template/__tests__/v2alpha-template-instance-rendering.test.ts
+++ b/frontend/providers/template/__tests__/v2alpha-template-instance-rendering.test.ts
@@ -68,4 +68,62 @@ spec:
       }
     });
   });
+
+  it.each([
+    { expectedBucket: true, useSealosObjectStorage: 'true' },
+    { expectedBucket: false, useSealosObjectStorage: 'false' }
+  ])(
+    'renders APITable-style top-level conditional documents when object storage is $useSealosObjectStorage',
+    ({ expectedBucket, useSealosObjectStorage }) => {
+      const appYaml = `apiVersion: app.sealos.io/v1
+kind: Instance
+metadata:
+  name: apitable-default
+spec: {}
+---
+\${{ if(inputs.use_sealos_objectstorage === 'true') }}
+apiVersion: objectstorage.sealos.io/v1
+kind: ObjectStorageBucket
+metadata:
+  name: \${{ defaults.app_name }}
+spec:
+  policy: private
+---
+\${{ endif() }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: \${{ defaults.app_name }}
+spec:
+  ports:
+    - port: 80
+`;
+
+      expect(() => JsYaml.loadAll(appYaml)).toThrow(/end of the stream/i);
+
+      const [yaml] = renderTemplateInstanceYamls({
+        appYaml,
+        defaults: {
+          app_name: 'apitable-brain'
+        },
+        inputs: {
+          use_sealos_objectstorage: useSealosObjectStorage
+        },
+        instanceName: 'apitable-brain',
+        templateEnvs: {}
+      });
+      const docs = JsYaml.loadAll(yaml).filter(Boolean) as any[];
+      const instance = docs.find((doc) => doc.kind === 'Instance');
+      const bucket = docs.find((doc) => doc.kind === 'ObjectStorageBucket');
+      const service = docs.find((doc) => doc.kind === 'Service');
+
+      expect(instance?.metadata?.name).toBe('apitable-brain');
+      expect(Boolean(bucket)).toBe(expectedBucket);
+      if (expectedBucket) {
+        expect(bucket?.metadata?.name).toBe('apitable-brain');
+      }
+      expect(service?.metadata?.name).toBe('apitable-brain');
+    }
+  );
 });

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/instances.ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/instances.ts
@@ -1,13 +1,12 @@
 import { authSession } from '@/services/backend/auth';
 import { getK8s } from '@/services/backend/kubernetes';
-import { generateYamlList, parseTemplateString } from '@/utils/json-yaml';
 import { validateExtraLabels } from '@/utils/common';
 import { mapValues, reduce } from 'lodash';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { GetTemplateByName } from '../../getTemplateSource';
-import JsYaml from 'js-yaml';
 import { sendError, ErrorType, ErrorCode } from '@/types/v2alpha/error';
 import { applyWithInstanceOwnerReferences } from '@/services/backend/instanceOwnerReferencesApply';
+import { renderTemplateInstanceYamls } from '@/utils/templateInstanceRendering';
 
 interface CreateInstanceRequest {
   name: string;
@@ -281,94 +280,26 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const _defaults = mapValues(dataSource.defaults || {}, (value) => value?.value ?? '');
     _defaults['app_name'] = trimmedName;
 
-    // Replace Instance metadata.name with user-provided name
-    // The appYaml contains Instance YAML with default random name, we need to update it
-    let updatedAppYaml: string;
+    // Render template conditionals before YAML parsing. Some templates contain conditional
+    // blocks that are not valid YAML until parseTemplateString removes or expands them.
+    let yamls: string[] = [];
     try {
-      const yamlDocs = JsYaml.loadAll(appYaml).filter((doc) => doc);
-      if (yamlDocs.length === 0) {
-        return sendError(res, {
-          status: 500,
-          type: ErrorType.INTERNAL_ERROR,
-          code: ErrorCode.INTERNAL_ERROR,
-          message: 'Failed to parse template YAML: no valid documents found.'
-        });
-      }
-
-      let instanceFound = false;
-      const updatedDocs = yamlDocs.map((doc: any) => {
-        if (doc?.kind === 'Instance' && doc?.apiVersion === 'app.sealos.io/v1') {
-          instanceFound = true;
-          // Update Instance name to use user-provided name
-          return {
-            ...doc,
-            metadata: {
-              ...doc.metadata,
-              name: trimmedName
-            }
-          };
-        }
-        return doc;
+      yamls = renderTemplateInstanceYamls({
+        appYaml,
+        defaults: _defaults,
+        inputs: _inputs,
+        instanceName: trimmedName,
+        extraLabels,
+        templateEnvs: TemplateEnvs
       });
-
-      if (!instanceFound) {
-        return sendError(res, {
-          status: 500,
-          type: ErrorType.INTERNAL_ERROR,
-          code: ErrorCode.INTERNAL_ERROR,
-          message: 'Failed to process template: Instance resource not found in template YAML.'
-        });
-      }
-
-      updatedAppYaml = updatedDocs.map((doc) => JsYaml.dump(doc)).join('---\n');
     } catch (yamlErr: any) {
-      console.error('Failed to update Instance name in YAML:', yamlErr);
+      console.error('Failed to process template YAML:', yamlErr);
       return sendError(res, {
         status: 500,
         type: ErrorType.INTERNAL_ERROR,
         code: ErrorCode.INTERNAL_ERROR,
         message: 'Failed to process template YAML.',
         details: yamlErr?.message || String(yamlErr)
-      });
-    }
-
-    // Generate YAML from template
-    const generateStr = parseTemplateString(updatedAppYaml, {
-      ...TemplateEnvs,
-      defaults: _defaults,
-      inputs: _inputs
-    });
-
-    if (!generateStr || generateStr.trim() === '') {
-      return sendError(res, {
-        status: 500,
-        type: ErrorType.INTERNAL_ERROR,
-        code: ErrorCode.INTERNAL_ERROR,
-        message: 'Failed to generate YAML from template: empty result.'
-      });
-    }
-
-    const correctYaml = generateYamlList(generateStr, trimmedName, extraLabels);
-
-    if (!correctYaml || correctYaml.length === 0) {
-      return sendError(res, {
-        status: 500,
-        type: ErrorType.INTERNAL_ERROR,
-        code: ErrorCode.INTERNAL_ERROR,
-        message: 'Failed to generate YAML list from template: no resources generated.'
-      });
-    }
-
-    const yamls = correctYaml
-      .map((item) => item.value)
-      .filter((yaml) => yaml && yaml.trim() !== '');
-
-    if (yamls.length === 0) {
-      return sendError(res, {
-        status: 500,
-        type: ErrorType.INTERNAL_ERROR,
-        code: ErrorCode.INTERNAL_ERROR,
-        message: 'Failed to generate valid YAML: all resources are empty.'
       });
     }
 

--- a/frontend/providers/template/src/utils/templateInstanceRendering.ts
+++ b/frontend/providers/template/src/utils/templateInstanceRendering.ts
@@ -1,0 +1,84 @@
+import JsYaml from 'js-yaml';
+
+import { generateYamlList, parseTemplateString } from '@/utils/json-yaml';
+
+type TemplateRenderContext = {
+  [key: string]: string | Record<string, string>;
+};
+
+type K8sResource = {
+  apiVersion?: string;
+  kind?: string;
+  metadata?: {
+    name?: string;
+    [key: string]: any;
+  };
+  [key: string]: any;
+};
+
+function isTemplateInstanceResource(resource: K8sResource): boolean {
+  return resource?.kind === 'Instance' && resource?.apiVersion === 'app.sealos.io/v1';
+}
+
+function applyInstanceNameToYamlList(yamlList: string[], instanceName: string): string[] {
+  let instanceFound = false;
+
+  const renamedYamlList = yamlList.map((yaml) => {
+    const docs = JsYaml.loadAll(yaml)
+      .filter((doc): doc is K8sResource => Boolean(doc))
+      .map((doc) => {
+        if (isTemplateInstanceResource(doc)) {
+          instanceFound = true;
+          return {
+            ...doc,
+            metadata: {
+              ...doc.metadata,
+              name: instanceName
+            }
+          };
+        }
+        return doc;
+      });
+
+    return docs.map((doc) => JsYaml.dump(doc)).join('---\n');
+  });
+
+  if (!instanceFound) {
+    throw new Error('Failed to process template: Instance resource not found in template YAML.');
+  }
+
+  return renamedYamlList;
+}
+
+export function renderTemplateInstanceYamls(input: {
+  appYaml: string;
+  defaults: Record<string, string>;
+  extraLabels?: Record<string, string>;
+  inputs: Record<string, string>;
+  instanceName: string;
+  templateEnvs: TemplateRenderContext;
+}): string[] {
+  const generateStr = parseTemplateString(input.appYaml, {
+    ...input.templateEnvs,
+    defaults: input.defaults,
+    inputs: input.inputs
+  });
+
+  if (!generateStr || generateStr.trim() === '') {
+    throw new Error('Failed to generate YAML from template: empty result.');
+  }
+
+  const correctYaml = generateYamlList(generateStr, input.instanceName, input.extraLabels);
+
+  if (!correctYaml || correctYaml.length === 0) {
+    throw new Error('Failed to generate YAML list from template: no resources generated.');
+  }
+
+  const yamls = correctYaml.map((item) => item.value).filter((yaml) => yaml && yaml.trim() !== '');
+
+  if (yamls.length === 0) {
+    throw new Error('Failed to generate valid YAML: all resources are empty.');
+  }
+
+  return applyInstanceNameToYamlList(yamls, input.instanceName);
+}


### PR DESCRIPTION
## Summary
- render template conditionals before parsing YAML in the v2alpha instance creation API
- keep the requested instance name while preserving extra labels and the existing owner-reference apply flow
- add regression coverage for APITable-style top-level conditional resources with object storage enabled and disabled

## Why
The App Store path renders template directives before calling `/api/applyApp`, but `POST /api/v2alpha/templates/instances` parsed raw `appYaml` first to rename the `Instance`. Templates containing top-level `${{ if(...) }}` documents therefore failed in `JsYaml.loadAll` before `parseTemplateString` could run.

## Testing
- `pnpm test:ci -- v2alpha-template-instance-rendering.test.ts` — 7 files, 33 tests passed
- `pnpm build` — passed

## Notes
- no public API schema changes
- no changes to `/api/applyApp` or Brain deployment ownership
- failed requests hit this error before Kubernetes apply, so no data migration or cleanup is required