### PR TITLE
fix(dbprovider): cleanup backup repo PVC after backup delete

### DIFF
--- a/frontend/providers/dbprovider/src/pages/api/backup/delBackup.ts
+++ b/frontend/providers/dbprovider/src/pages/api/backup/delBackup.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { ApiResp } from '@/services/kubernet';
 import { authSession } from '@/services/backend/auth';
+import { deleteBackupAndCleanupRepoPVC } from '@/services/backend/backupCleanup';
 import { getK8s } from '@/services/backend/kubernetes';
 import { jsonRes } from '@/services/backend/response';
 
@@ -34,19 +35,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 }
 
 export async function delBackupByName({ backupName, req }: Props & { req: NextApiRequest }) {
-  const group = 'dataprotection.kubeblocks.io';
-  const version = 'v1alpha1';
-  const plural = 'backups';
-
-  const { k8sCustomObjects, namespace } = await getK8s({
+  const { k8sCore, k8sCustomObjects, namespace } = await getK8s({
     kubeconfig: await authSession(req)
   });
 
-  return await k8sCustomObjects.deleteNamespacedCustomObject(
-    group,
-    version,
-    namespace,
-    plural,
-    backupName
-  );
+  return await deleteBackupAndCleanupRepoPVC({
+    backupName,
+    k8sCore,
+    k8sCustomObjects,
+    namespace
+  });
 }

--- a/frontend/providers/dbprovider/src/pages/api/v1/database/[databaseName]/backup/[backupName].ts
+++ b/frontend/providers/dbprovider/src/pages/api/v1/database/[databaseName]/backup/[backupName].ts
@@ -1,5 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { authSession } from '@/services/backend/auth';
+import { deleteBackupAndCleanupRepoPVC } from '@/services/backend/backupCleanup';
 import { getK8s } from '@/services/backend/kubernetes';
 import { handleK8sError, jsonRes } from '@/services/backend/response';
 import { ResponseCode, ResponseMessages } from '@/types/response';
@@ -238,17 +239,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   // Handle DELETE request
   if (req.method === 'DELETE') {
     try {
-      const group = 'dataprotection.kubeblocks.io';
-      const version = 'v1alpha1';
-      const plural = 'backups';
-
-      await k8s.k8sCustomObjects.deleteNamespacedCustomObject(
-        group,
-        version,
-        k8s.namespace,
-        plural,
-        backupName
-      );
+      await deleteBackupAndCleanupRepoPVC({
+        backupName,
+        k8sCore: k8s.k8sCore,
+        k8sCustomObjects: k8s.k8sCustomObjects,
+        namespace: k8s.namespace
+      });
 
       return jsonRes(res, {
         code: 200,

--- a/frontend/providers/dbprovider/src/pages/api/v2alpha/databases/[databaseName]/backups/[backupName].ts
+++ b/frontend/providers/dbprovider/src/pages/api/v2alpha/databases/[databaseName]/backups/[backupName].ts
@@ -1,5 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { authSession } from '@/services/backend/auth';
+import { deleteBackupAndCleanupRepoPVC } from '@/services/backend/backupCleanup';
 import { getK8s } from '@/services/backend/kubernetes';
 import { sendError, sendK8sError, ErrorType, ErrorCode } from '@/types/v2alpha/error';
 
@@ -40,17 +41,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   if (req.method === 'DELETE') {
     try {
-      const group = 'dataprotection.kubeblocks.io';
-      const version = 'v1alpha1';
-      const plural = 'backups';
-
-      await k8s.k8sCustomObjects.deleteNamespacedCustomObject(
-        group,
-        version,
-        k8s.namespace,
-        plural,
-        backupName
-      );
+      await deleteBackupAndCleanupRepoPVC({
+        backupName,
+        k8sCore: k8s.k8sCore,
+        k8sCustomObjects: k8s.k8sCustomObjects,
+        namespace: k8s.namespace
+      });
 
       return res.status(204).end();
     } catch (err: any) {

--- a/frontend/providers/dbprovider/src/services/backend/backupCleanup.ts
+++ b/frontend/providers/dbprovider/src/services/backend/backupCleanup.ts
@@ -1,0 +1,227 @@
+import * as k8s from '@kubernetes/client-node';
+
+const dataProtectionGroup = 'dataprotection.kubeblocks.io';
+const dataProtectionVersion = 'v1alpha1';
+const backupRepoNameLabel = 'dataprotection.kubeblocks.io/backup-repo-name';
+
+type K8sObjectList = {
+  items?: unknown[];
+};
+
+type BackupObject = {
+  metadata?: {
+    labels?: Record<string, string>;
+  };
+  status?: {
+    persistentVolumeClaimName?: string;
+  };
+};
+
+type BackupCleanupInfo = {
+  pvcName?: string;
+  repoName?: string;
+};
+
+type DeleteBackupParams = {
+  backupName: string;
+  k8sCore: k8s.CoreV1Api;
+  k8sCustomObjects: k8s.CustomObjectsApi;
+  namespace: string;
+};
+
+type WaitBackupDeletedOptions = {
+  maxAttempts?: number;
+  intervalMs?: number;
+};
+
+const isNotFoundError = (err: any) =>
+  err?.response?.statusCode === 404 ||
+  err?.statusCode === 404 ||
+  err?.body?.code === 404 ||
+  err?.body?.reason === 'NotFound';
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function getBackupCleanupInfo({
+  backupName,
+  k8sCustomObjects,
+  namespace
+}: Omit<DeleteBackupParams, 'k8sCore'>): Promise<BackupCleanupInfo> {
+  try {
+    const { body } = (await k8sCustomObjects.getNamespacedCustomObject(
+      dataProtectionGroup,
+      dataProtectionVersion,
+      namespace,
+      'backups',
+      backupName
+    )) as { body: BackupObject };
+
+    return {
+      pvcName: body.status?.persistentVolumeClaimName,
+      repoName: body.metadata?.labels?.[backupRepoNameLabel]
+    };
+  } catch (err) {
+    if (isNotFoundError(err)) return {};
+    throw err;
+  }
+}
+
+async function waitBackupDeleted({
+  backupName,
+  k8sCustomObjects,
+  namespace,
+  maxAttempts = 180,
+  intervalMs = 1000
+}: Omit<DeleteBackupParams, 'k8sCore'> & WaitBackupDeletedOptions) {
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      await k8sCustomObjects.getNamespacedCustomObject(
+        dataProtectionGroup,
+        dataProtectionVersion,
+        namespace,
+        'backups',
+        backupName
+      );
+    } catch (err) {
+      if (isNotFoundError(err)) return true;
+      throw err;
+    }
+    await wait(intervalMs);
+  }
+
+  return false;
+}
+
+async function hasDataProtectionObjects({
+  k8sCustomObjects,
+  namespace,
+  plural,
+  repoName
+}: Pick<DeleteBackupParams, 'k8sCustomObjects' | 'namespace'> & {
+  plural: 'backups' | 'restores';
+  repoName: string;
+}) {
+  const { body } = (await k8sCustomObjects.listNamespacedCustomObject(
+    dataProtectionGroup,
+    dataProtectionVersion,
+    namespace,
+    plural,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    `${backupRepoNameLabel}=${repoName}`
+  )) as { body: K8sObjectList };
+
+  return Boolean(body.items?.length);
+}
+
+async function cleanupBackupRepoPVC({
+  k8sCore,
+  k8sCustomObjects,
+  namespace,
+  pvcName,
+  repoName
+}: Pick<DeleteBackupParams, 'k8sCore' | 'k8sCustomObjects' | 'namespace'> & {
+  pvcName?: string;
+  repoName: string;
+}) {
+  const [hasBackups, hasRestores] = await Promise.all([
+    hasDataProtectionObjects({ k8sCustomObjects, namespace, plural: 'backups', repoName }),
+    hasDataProtectionObjects({ k8sCustomObjects, namespace, plural: 'restores', repoName })
+  ]);
+
+  if (hasBackups || hasRestores) return;
+
+  if (pvcName) {
+    try {
+      const { body: pvc } = await k8sCore.readNamespacedPersistentVolumeClaim(pvcName, namespace);
+      const ownedByBackupRepo = pvc.metadata?.ownerReferences?.some(
+        (owner) => owner.kind === 'BackupRepo' && owner.name === repoName
+      );
+
+      if (ownedByBackupRepo && pvc.metadata?.labels?.[backupRepoNameLabel] === repoName) {
+        await k8sCore.deleteNamespacedPersistentVolumeClaim(pvcName, namespace);
+      }
+    } catch (err) {
+      if (!isNotFoundError(err)) throw err;
+    }
+    return;
+  }
+
+  const { body } = await k8sCore.listNamespacedPersistentVolumeClaim(
+    namespace,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    `${backupRepoNameLabel}=${repoName}`
+  );
+
+  await Promise.all(
+    (body.items || []).map(async (pvc) => {
+      const name = pvc.metadata?.name;
+      const ownedByBackupRepo = pvc.metadata?.ownerReferences?.some(
+        (owner) => owner.kind === 'BackupRepo' && owner.name === repoName
+      );
+
+      if (!name || !ownedByBackupRepo) return;
+
+      try {
+        await k8sCore.deleteNamespacedPersistentVolumeClaim(name, namespace);
+      } catch (err) {
+        if (!isNotFoundError(err)) throw err;
+      }
+    })
+  );
+}
+
+async function cleanupBackupRepoPVCAfterBackupDeleted({
+  backupName,
+  k8sCore,
+  k8sCustomObjects,
+  namespace,
+  pvcName,
+  repoName
+}: DeleteBackupParams & BackupCleanupInfo & { repoName: string }) {
+  const backupDeleted = await waitBackupDeleted({ backupName, k8sCustomObjects, namespace });
+  if (!backupDeleted) return;
+
+  await cleanupBackupRepoPVC({ k8sCore, k8sCustomObjects, namespace, pvcName, repoName });
+}
+
+export async function deleteBackupAndCleanupRepoPVC({
+  backupName,
+  k8sCore,
+  k8sCustomObjects,
+  namespace
+}: DeleteBackupParams) {
+  const { pvcName, repoName } = await getBackupCleanupInfo({
+    backupName,
+    k8sCustomObjects,
+    namespace
+  });
+
+  const result = await k8sCustomObjects.deleteNamespacedCustomObject(
+    dataProtectionGroup,
+    dataProtectionVersion,
+    namespace,
+    'backups',
+    backupName
+  );
+
+  if (!repoName) return result;
+
+  cleanupBackupRepoPVCAfterBackupDeleted({
+    backupName,
+    k8sCore,
+    k8sCustomObjects,
+    namespace,
+    pvcName,
+    repoName
+  }).catch((err) => {
+    console.error('Failed to cleanup backup repo PVC', err?.body || err);
+  });
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- add shared dbprovider backup deletion cleanup that records the backup repo/PVC before deleting the Backup CR
- after delete, continue waiting for the Backup CR to disappear before checking same-namespace Backup/Restore usage
- delete only PVCs labelled for the same backup repo and owned by the matching BackupRepo

## Root cause
Manual database backup deletion only removed the KubeBlocks Backup CR. For mounted BackupRepo storage, the per-namespace `pvc-backuprepo-*` can outlive the Backup CR, so deleting the last backup for a repo left the repo PVC behind.

## Verification
- Built dbprovider frontend image with `docker buildx build --platform linux/amd64 -f frontend/Dockerfile --build-arg name=dbprovider --build-arg path=providers/dbprovider ... --load frontend`.
- Deployed test image to `192.168.13.209.nip.io` as `hub.192.168.13.209.nip.io/labring/sealos-dbprovider-frontend:v5.1.2-rc5-pvc-cleanup-async-202606251207`.
- Verified via database UI: create manual backup for `test-db-wangzhihao`, delete it from the database app, then confirmed `backuprepo-minio` had no Backup, no Restore, and no matching PVC in `ns-admin`.

Related issue: N/A, reproduced from manual test report.
