### PR TITLE
fix(applaunchpad): handle invalid app names and remarks

### DIFF
--- a/frontend/providers/applaunchpad/public/locales/en/common.json
+++ b/frontend/providers/applaunchpad/public/locales/en/common.json
@@ -202,6 +202,8 @@
   "Terminal": "Terminal",
   "The Cpu target is empty": "Target CPU is required",
   "The application name can contain only lowercase letters, digits, and hyphens (-) and must start with a letter": "Application name can only contain lowercase letters, digits, and hyphens (-), and must start with a letter",
+  "invalid_app_name": "Application name is invalid. Use {{length}} characters or fewer, start with a lowercase letter, use only lowercase letters, numbers, or hyphens, and end with a lowercase letter or number.",
+  "invalid_service_name": "Generated service name is invalid. Use an application name that starts with a lowercase letter, contains only lowercase letters, numbers, or hyphens, and ends with a lowercase letter or number.",
   "The cpu target value must be positive": "Target CPU must be a positive number",
   "The image cannot be empty": "Private image URL is required",
   "The maximum number of instances is 20": "Maximum instance count is 20",

--- a/frontend/providers/applaunchpad/public/locales/zh/common.json
+++ b/frontend/providers/applaunchpad/public/locales/zh/common.json
@@ -202,6 +202,8 @@
   "Terminal": "终端",
   "The Cpu target is empty": "CPU 目标值为空",
   "The application name can contain only lowercase letters, digits, and hyphens (-) and must start with a letter": "应用名称只能包含小写字母、数字和连字符（-），且必须以字母开头",
+  "invalid_app_name": "应用名称不合法。最多输入 {{length}} 个字符，以小写字母开头，只能包含小写字母、数字和连字符（-），并以小写字母或数字结尾。",
+  "invalid_service_name": "生成的服务名称不合法。应用名称需要以小写字母开头，只能包含小写字母、数字和连字符（-），并以小写字母或数字结尾。",
   "The cpu target value must be positive": "CPU 目标值必须为正数",
   "The image cannot be empty": "私有镜像地址不能为空",
   "The maximum number of instances is 20": "实例数最大为20",

--- a/frontend/providers/applaunchpad/src/pages/api/remark.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/remark.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { ApiResp } from '@/services/kubernet';
 import { authSession } from '@/services/backend/auth';
 import { getK8s } from '@/services/backend/kubernetes';
-import { jsonRes } from '@/services/backend/response';
+import { handleK8sError, jsonRes } from '@/services/backend/response';
 import { lauchpadRemarkKey } from '@/constants/account';
 import { PatchUtils } from '@kubernetes/client-node';
 
@@ -14,7 +14,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       kind: 'deployment' | 'statefulset';
     };
 
-    if (!appName || !kind || !remark) {
+    if (!appName || !kind || typeof remark !== 'string') {
       throw new Error('appName or kind or remark is empty');
     }
 
@@ -66,9 +66,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
     jsonRes(res, { data: 'success' });
   } catch (err: any) {
-    jsonRes(res, {
-      code: 500,
-      error: err
-    });
+    jsonRes(res, handleK8sError(err));
   }
 }

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
@@ -289,9 +289,24 @@ const Form = ({
           setValue('sharedMemory.sizeLimit', Math.max(memoryInGi, 1));
         }
       }
+
+      if (!isEdit && name === 'appName' && value.appName && value.configMapList?.length) {
+        const volumeName = `${value.appName}-cm`;
+        const configMapList = value.configMapList as AppEditType['configMapList'];
+        if (configMapList.some((item) => item.volumeName !== volumeName)) {
+          setValue(
+            'configMapList',
+            configMapList.map((item) => ({
+              ...item,
+              volumeName
+            })),
+            { shouldDirty: true }
+          );
+        }
+      }
     });
     return () => subscription.unsubscribe();
-  }, [watch, setValue]);
+  }, [watch, setValue, isEdit]);
 
   useEffect(() => {
     if (!IMAGE_PORTS_ENABLED || isEdit || !already) {
@@ -757,6 +772,11 @@ const Form = ({
                     )}
                   />
                 </Flex>
+                {errors.appName?.message && (
+                  <Box mt={1} pl={`${labelWidth}px`} fontSize={'sm'} color={'red.500'}>
+                    {errors.appName.message}
+                  </Box>
+                )}
               </FormControl>
               {/* image */}
               <Box mb={7} className="driver-deploy-image">

--- a/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
@@ -57,6 +57,10 @@ import {
   validatePublicDomainPrefix
 } from '@/utils/public-domain';
 import { getCustomDomainBindings } from '@/utils/custom-domain';
+import {
+  APP_NAME_BASE_MAX_LENGTH,
+  getInvalidNameMessageI18nKey
+} from '@/utils/appNameValidation';
 
 const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz', 12);
 
@@ -449,6 +453,13 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
             module: 'applaunchpad',
             error_code: 'APP_ALREADY_EXISTS'
           });
+        } else if (error?.code === ResponseCode.BAD_REQUEST) {
+          setErrorMessage(
+            t(getInvalidNameMessageI18nKey(error?.message) || error?.message || 'Submit Error', {
+              length: APP_NAME_BASE_MAX_LENGTH
+            })
+          );
+          setErrorCode(ResponseCode.BAD_REQUEST);
         } else {
           setErrorMessage(JSON.stringify(error));
         }

--- a/frontend/providers/applaunchpad/src/utils/appNameValidation.ts
+++ b/frontend/providers/applaunchpad/src/utils/appNameValidation.ts
@@ -9,6 +9,8 @@ export const APP_GENERATED_NAME_MAX_LENGTH = APP_NAME_BASE_MAX_LENGTH;
 
 export const APP_NAME_BASE_PATTERN = /^[a-z]([-a-z0-9]*[a-z0-9])?$/;
 export const APP_GENERATED_NAME_PATTERN = /^[a-z]([-a-z0-9]*[a-z0-9])?$/;
+export const INVALID_APP_NAME_MESSAGE_KEY = 'invalid_app_name';
+export const INVALID_SERVICE_NAME_MESSAGE_KEY = 'invalid_service_name';
 
 export const isValidAppNameBase = (baseName: string) =>
   baseName.length > 0 &&
@@ -58,6 +60,21 @@ export const getInvalidGeneratedAppNameMessage = (name: unknown) => {
   if (typeof name !== 'string' || isValidGeneratedAppName(name)) return;
 
   return `Application name "${name}" is invalid. Use ${APP_GENERATED_NAME_MAX_LENGTH} characters or fewer, start with a lowercase letter, use only lowercase letters, numbers, or hyphens, and end with a lowercase letter or number.`;
+};
+
+export const getInvalidNameMessageI18nKey = (message: unknown) => {
+  if (typeof message !== 'string') return;
+
+  if (/^Application name ".+" is invalid\./.test(message)) {
+    return INVALID_APP_NAME_MESSAGE_KEY;
+  }
+
+  if (
+    /^Service ".+" has an invalid name\./.test(message) ||
+    /^Ingress ".+" references invalid backend service ".+"\./.test(message)
+  ) {
+    return INVALID_SERVICE_NAME_MESSAGE_KEY;
+  }
 };
 
 export const getInvalidRfc1035ServiceNameMessage = (resources: NamedKubernetesResource[]) => {


### PR DESCRIPTION
## Summary

- allow clearing App Launchpad remarks by accepting empty remark values
- map invalid app and service name errors through i18n
- keep configMap volume names in sync when the app name changes after a validation error
- validate app and service names before applying resources to avoid partial invalid YAML state

## Testing

- `pnpm --dir /private/tmp/sealos-applaunchpad-pr-tooltip/frontend --filter applaunchpad lint --file src/pages/api/applyApp.ts --file src/pages/api/remark.ts --file src/pages/app/edit/components/Form.tsx --file src/pages/app/edit/index.tsx --file src/utils/appNameValidation.ts`
- `pnpm --dir /private/tmp/sealos-applaunchpad-pr-tooltip/frontend exec tsc -p providers/applaunchpad/tsconfig.json --noEmit`
- locale JSON parse for `en/common.json` and `zh/common.json`
- `git diff --check origin/release-v5.1..HEAD`

Related: #7023
