### PR TITLE
fix(applaunchpad): show current form validation errors

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/utils/formErrorMessage.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/formErrorMessage.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { getSubmitErrorMessage } from '@/utils/formErrorMessage';
+
+describe('getSubmitErrorMessage', () => {
+  it('maps form invalid placeholders to the localized validation message', () => {
+    expect(
+      getSubmitErrorMessage(
+        {
+          appName: {
+            type: 'pattern',
+            message: 'invalid'
+          }
+        },
+        'Submit Error',
+        'Invalid name'
+      )
+    ).toBe('Invalid name');
+  });
+
+  it('keeps specific nested form error messages', () => {
+    expect(
+      getSubmitErrorMessage(
+        {
+          imageName: {
+            message: 'Image name cannot be empty'
+          }
+        },
+        'Submit Error',
+        'Invalid name'
+      )
+    ).toBe('Image name cannot be empty');
+  });
+
+  it('falls back when no field error message exists', () => {
+    expect(getSubmitErrorMessage({}, 'Submit Error', 'Invalid name')).toBe('Submit Error');
+  });
+});

--- a/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
@@ -20,13 +20,14 @@ import {
 } from '@/utils/deployYaml2Json';
 import { serviceSideProps } from '@/utils/i18n';
 import { getErrText, patchYamlList } from '@/utils/tools';
+import { getSubmitErrorMessage } from '@/utils/formErrorMessage';
 
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'next-i18next';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, type SubmitErrorHandler } from 'react-hook-form';
 import Form from './components/Form';
 import Header from './components/Header';
 import Yaml from './components/Yaml';
@@ -45,7 +46,6 @@ import {
   quantityToMemoryMi,
   quantityToStorageGi
 } from '@/utils/resourceQuantity';
-import { hydrateLegacyAppFormData } from '@/utils/hydrateLegacyAppForm';
 
 const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz', 12);
 
@@ -249,16 +249,12 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
     ]
   );
 
-  const submitError = useCallback(() => {
-    const deepSearch = (obj: any): string => {
-      if (!obj || typeof obj !== 'object') return t('Submit Error');
-      if (!!obj.message) {
-        return obj.message;
-      }
-      return deepSearch(Object.values(obj)[0]);
-    };
-    toast.error(deepSearch(formHook.formState.errors));
-  }, [formHook.formState.errors, t]);
+  const submitError = useCallback<SubmitErrorHandler<AppEditType>>(
+    (errors) => {
+      toast.error(getSubmitErrorMessage(errors, t('Submit Error'), t('Invalid name')));
+    },
+    [t]
+  );
 
   const handleDomainVerified = useCallback(
     ({ index, customDomain }: { index: number; customDomain: string }) => {
@@ -363,8 +359,8 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
       const query = router.query as { formData?: string; name?: string };
       if (!query.formData) return;
 
-      const parsedData: Partial<AppEditSyncedFields> = hydrateLegacyAppFormData(
-        JSON.parse(decodeURIComponent(query.formData))
+      const parsedData: Partial<AppEditSyncedFields> = JSON.parse(
+        decodeURIComponent(query.formData)
       );
 
       const basicFields: (keyof AppEditSyncedFields)[] = router.query?.name

--- a/frontend/providers/applaunchpad/src/utils/formErrorMessage.ts
+++ b/frontend/providers/applaunchpad/src/utils/formErrorMessage.ts
@@ -1,0 +1,14 @@
+export const getSubmitErrorMessage = (
+  error: unknown,
+  fallbackMessage: string,
+  invalidMessage: string
+): string => {
+  if (!error || typeof error !== 'object') return fallbackMessage;
+
+  const message = (error as { message?: unknown }).message;
+  if (typeof message === 'string' && message) {
+    return message === 'invalid' ? invalidMessage : message;
+  }
+
+  return getSubmitErrorMessage(Object.values(error)[0], fallbackMessage, invalidMessage);
+};


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->

## Summary
- Use the React Hook Form invalid-submit errors directly instead of stale `formState.errors`.
- Map the internal `invalid` placeholder to the localized app-name validation message.
- Add a regression test for the submit error message resolver.

## Tests
- `pnpm --filter ./providers/applaunchpad exec vitest run __tests__/unit/utils/formErrorMessage.test.ts __tests__/unit/utils/appNameValidation.test.ts`
- `./node_modules/.bin/prettier --check providers/applaunchpad/src/pages/app/edit/index.tsx providers/applaunchpad/src/utils/formErrorMessage.ts providers/applaunchpad/__tests__/unit/utils/formErrorMessage.test.ts`
- `pnpm --filter ./providers/applaunchpad lint`

Fixes labring-sigs/sealos-issues#207
Follow-up to #7007.
