### PR TITLE
fix(applaunchpad): prevent invalid app names on 5.1

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/utils/appNameValidation.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/appNameValidation.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  APP_NAME_BASE_MAX_LENGTH,
+  K8S_RFC1035_NAME_MAX_LENGTH,
+  getInvalidGeneratedAppNameMessage,
+  getInvalidRfc1035ServiceNameMessage,
+  generateAppName,
+  isValidAppNameBase,
+  isValidGeneratedAppName,
+  isValidRfc1035Name
+} from '@/utils/appNameValidation';
+
+describe('app name validation', () => {
+  it('accepts valid user-entered base names up to the reserved suffix budget', () => {
+    const maxLengthBase = `a${'b'.repeat(APP_NAME_BASE_MAX_LENGTH - 1)}`;
+
+    expect(isValidAppNameBase('a')).toBe(true);
+    expect(isValidAppNameBase('app')).toBe(true);
+    expect(isValidAppNameBase('app-1')).toBe(true);
+    expect(isValidAppNameBase('hello-world')).toBe(true);
+    expect(maxLengthBase).toHaveLength(25);
+    expect(isValidAppNameBase(maxLengthBase)).toBe(true);
+  });
+
+  it('rejects base names that would break RFC 1035 or reserved suffix budgets', () => {
+    const tooLongBase = `a${'b'.repeat(APP_NAME_BASE_MAX_LENGTH)}`;
+
+    expect(isValidAppNameBase('')).toBe(false);
+    expect(isValidAppNameBase('1app')).toBe(false);
+    expect(isValidAppNameBase('App')).toBe(false);
+    expect(isValidAppNameBase('app_1')).toBe(false);
+    expect(isValidAppNameBase('-app')).toBe(false);
+    expect(isValidAppNameBase('app-')).toBe(false);
+    expect(isValidAppNameBase('app.name')).toBe(false);
+    expect(isValidAppNameBase('app name')).toBe(false);
+    expect(tooLongBase).toHaveLength(26);
+    expect(isValidAppNameBase(tooLongBase)).toBe(false);
+  });
+
+  it('uses the user-entered app name without appending a random suffix', () => {
+    const generatedName = generateAppName('demo');
+
+    expect(generatedName).toBe('demo');
+    expect(isValidGeneratedAppName(generatedName)).toBe(true);
+  });
+
+  it('keeps app names, generated nodeport service names, and pod names inside RFC 1035', () => {
+    const maxLengthBase = `a${'b'.repeat(APP_NAME_BASE_MAX_LENGTH - 1)}`;
+    const generatedName = generateAppName(maxLengthBase);
+    const serviceName = `${generatedName}-nodeport-${'c'.repeat(12)}`;
+    const podName = `${serviceName}-${'d'.repeat(15)}`;
+
+    expect(generatedName).toHaveLength(APP_NAME_BASE_MAX_LENGTH);
+    expect(isValidGeneratedAppName(generatedName)).toBe(true);
+    expect(serviceName).toHaveLength(47);
+    expect(podName).toHaveLength(K8S_RFC1035_NAME_MAX_LENGTH);
+    expect(isValidGeneratedAppName(podName)).toBe(false);
+    expect(/^[a-z]([-a-z0-9]*[a-z0-9])?$/.test(podName)).toBe(true);
+  });
+
+  it('reports app names that exceed the generated name budget before apply', () => {
+    const tooLongBase = `a${'b'.repeat(APP_NAME_BASE_MAX_LENGTH)}`;
+
+    expect(isValidRfc1035Name(tooLongBase)).toBe(true);
+    expect(getInvalidGeneratedAppNameMessage(tooLongBase)).toContain(
+      `Use ${APP_NAME_BASE_MAX_LENGTH} characters or fewer`
+    );
+  });
+
+  it('reports invalid service names before the Kubernetes apply step', () => {
+    expect(
+      getInvalidRfc1035ServiceNameMessage([
+        {
+          kind: 'Deployment',
+          metadata: { name: '111111hello-world' }
+        },
+        {
+          kind: 'Service',
+          metadata: { name: '111111hello-world-yanexremmrtr' }
+        }
+      ])
+    ).toContain('Service "111111hello-world-yanexremmrtr" has an invalid name');
+  });
+});

--- a/frontend/providers/applaunchpad/__tests__/unit/utils/deployYaml2Json.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/deployYaml2Json.test.ts
@@ -328,6 +328,17 @@ describe('json2Service', () => {
     expect(portNames).toEqual(['p-t-80-0', 'p-t-80-1', 'p-t-80-2']);
     expect(new Set(portNames).size).toBe(portNames.length);
   });
+
+  it('keeps the numeric-prefix app name invalidity visible before apply', () => {
+    const app = createApp();
+    app.appName = '111111hello-world';
+    app.networks[0].openNodePort = true;
+    app.networks[0].nodePort = 30080;
+
+    const objects = yamlString2Objects(json2Service(app)) as any[];
+
+    expect(objects[0].metadata.name).toMatch(/^111111hello-world-nodeport-[a-z]{12}$/);
+  });
 });
 
 describe('json2DeployCr', () => {
@@ -379,4 +390,5 @@ describe('json2Secret', () => {
     expect(secretYaml).toContain('.dockerconfigjson: ********');
     expect(secretYaml).not.toContain(".dockerconfigjson: '********'");
   });
+
 });

--- a/frontend/providers/applaunchpad/__tests__/unit/utils/deployYaml2Json.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/deployYaml2Json.test.ts
@@ -390,5 +390,4 @@ describe('json2Secret', () => {
     expect(secretYaml).toContain('.dockerconfigjson: ********');
     expect(secretYaml).not.toContain(".dockerconfigjson: '********'");
   });
-
 });

--- a/frontend/providers/applaunchpad/__tests__/unit/utils/formErrorMessage.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/formErrorMessage.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { getSubmitErrorMessage } from '@/utils/formErrorMessage';
+
+describe('getSubmitErrorMessage', () => {
+  it('maps form invalid placeholders to the localized validation message', () => {
+    expect(
+      getSubmitErrorMessage(
+        {
+          appName: {
+            type: 'pattern',
+            message: 'invalid'
+          }
+        },
+        'Submit Error',
+        'Invalid name'
+      )
+    ).toBe('Invalid name');
+  });
+
+  it('keeps specific nested form error messages', () => {
+    expect(
+      getSubmitErrorMessage(
+        {
+          imageName: {
+            message: 'Image name cannot be empty'
+          }
+        },
+        'Submit Error',
+        'Invalid name'
+      )
+    ).toBe('Image name cannot be empty');
+  });
+
+  it('falls back when no field error message exists', () => {
+    expect(getSubmitErrorMessage({}, 'Submit Error', 'Invalid name')).toBe('Submit Error');
+  });
+});

--- a/frontend/providers/applaunchpad/public/locales/en/common.json
+++ b/frontend/providers/applaunchpad/public/locales/en/common.json
@@ -12,6 +12,8 @@
   "Amount": "Amount",
   "AnticipatedPrice": "The Estimated Cost",
   "App Name": "Name",
+  "App Name is required": "App name is required",
+  "App name base length limit": "Use {{length}} characters or fewer. We reserve space for the NodePort Service suffix and Pod suffix.",
   "App Store": "App Store",
   "Application Deployment": "Application Deployment",
   "Application Source": "Application Source",

--- a/frontend/providers/applaunchpad/public/locales/zh/common.json
+++ b/frontend/providers/applaunchpad/public/locales/zh/common.json
@@ -12,6 +12,8 @@
   "Amount": "数量",
   "AnticipatedPrice": "预估价格",
   "App Name": "应用名称",
+  "App Name is required": "应用名称不能为空",
+  "App name base length limit": "最多使用 {{length}} 个字符。系统需要为 NodePort Service 后缀和 Pod 后缀预留长度。",
   "App Store": "应用商店",
   "Application Deployment": "应用部署",
   "Application Source": "应用来源",

--- a/frontend/providers/applaunchpad/src/pages/api/applyApp.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/applyApp.ts
@@ -7,10 +7,15 @@ import yaml from 'js-yaml';
 import { generateOwnerReference, shouldHaveOwnerReference } from '@/utils/deployYaml2Json';
 import { appDeployKey } from '@/constants/app';
 import {
+  getInvalidGeneratedAppNameMessage,
+  getInvalidRfc1035ServiceNameMessage
+} from '@/utils/appNameValidation';
+import {
   ensurePublicDomainTargetsAvailable,
   PublicDomainError,
   PublicDomainTarget
 } from '@/services/backend/publicDomain';
+import { ResponseCode } from '@/types/response';
 
 type K8sResource = {
   kind?: string;
@@ -88,12 +93,32 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       allResources.push(...resources);
     });
 
+    const mainWorkloadIndex = allResources.findIndex(isWorkloadResource);
+    const invalidAppNameMessage =
+      mainWorkloadIndex === -1
+        ? undefined
+        : getInvalidGeneratedAppNameMessage(allResources[mainWorkloadIndex].metadata?.name);
+    if (mode === 'create' && invalidAppNameMessage) {
+      jsonRes(res, {
+        code: ResponseCode.BAD_REQUEST,
+        message: invalidAppNameMessage
+      });
+      return;
+    }
+
+    const invalidServiceNameMessage = getInvalidRfc1035ServiceNameMessage(allResources);
+    if (invalidServiceNameMessage) {
+      jsonRes(res, {
+        code: ResponseCode.BAD_REQUEST,
+        message: invalidServiceNameMessage
+      });
+      return;
+    }
+
     await ensurePublicDomainTargetsAvailable(getPublicDomainTargets(allResources), {
       k8sNetworkingApp,
       namespace
     });
-
-    const mainWorkloadIndex = allResources.findIndex(isWorkloadResource);
 
     if (mainWorkloadIndex === -1) {
       const applyRes = await applyYamlList(yamlList, mode);

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
@@ -54,6 +54,11 @@ import styles from './index.module.scss';
 import { NetworkSection } from './NetworkSection';
 import { mountPathToConfigMapKey } from '@/utils/tools';
 import { useQuery } from '@tanstack/react-query';
+import {
+  APP_NAME_BASE_MAX_LENGTH,
+  APP_NAME_BASE_PATTERN,
+  isValidAppNameBase
+} from '@/utils/appNameValidation';
 
 const ConfigmapModal = dynamic(() => import('./ConfigmapModal'));
 const StoreModal = dynamic(() => import('./StoreModal'));
@@ -717,22 +722,39 @@ const Form = ({
                     disabled={isEdit}
                     title={isEdit ? t('Not allowed to change app name') || '' : ''}
                     autoFocus={true}
-                    maxLength={60}
+                    maxLength={isEdit ? undefined : APP_NAME_BASE_MAX_LENGTH}
                     placeholder={
                       t(
                         'Starts with a letter and can contain only lowercase letters, digits, and hyphens (-)'
                       ) || ''
                     }
-                    {...register('appName', {
-                      required: t('Not allowed to change app name') || '',
-                      maxLength: 60,
-                      pattern: {
-                        value: /[a-z]([-a-z0-9]*[a-z0-9])?/g,
-                        message: t(
-                          'The application name can contain only lowercase letters, digits, and hyphens (-) and must start with a letter'
-                        )
-                      }
-                    })}
+                    {...register(
+                      'appName',
+                      isEdit
+                        ? {}
+                        : {
+                            required: t('App Name is required') || '',
+                            maxLength: {
+                              value: APP_NAME_BASE_MAX_LENGTH,
+                              message: t('App name base length limit', {
+                                length: APP_NAME_BASE_MAX_LENGTH
+                              })
+                            },
+                            pattern: {
+                              value: APP_NAME_BASE_PATTERN,
+                              message:
+                                t(
+                                  'The application name can contain only lowercase letters, digits, and hyphens (-) and must start with a letter'
+                                ) || ''
+                            },
+                            validate: (value) =>
+                              isValidAppNameBase(value) ||
+                              t('App name base length limit', {
+                                length: APP_NAME_BASE_MAX_LENGTH
+                              }) ||
+                              ''
+                          }
+                    )}
                   />
                 </Flex>
               </FormControl>

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
@@ -543,14 +543,14 @@ const Form = ({
     const sortedCpuList = !!gpuType
       ? cpuList
       : cpu !== undefined
-        ? [...new Set([...cpuList, cpu])].sort((a, b) => a - b)
-        : cpuList;
+      ? [...new Set([...cpuList, cpu])].sort((a, b) => a - b)
+      : cpuList;
 
     const sortedMemoryList = !!gpuType
       ? memoryList
       : memory !== undefined
-        ? [...new Set([...memoryList, memory])].sort((a, b) => a - b)
-        : memoryList;
+      ? [...new Set([...memoryList, memory])].sort((a, b) => a - b)
+      : memoryList;
 
     const sortedEphemeralStorageList =
       ephemeralStorage !== undefined
@@ -1288,8 +1288,8 @@ const Form = ({
                             const valText = env.value
                               ? env.value
                               : env.valueFrom
-                                ? 'value from | ***'
-                                : '';
+                              ? 'value from | ***'
+                              : '';
                             return (
                               <tr key={env.id}>
                                 <th>{env.key}</th>

--- a/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
@@ -28,13 +28,14 @@ import {
 } from '@/utils/deployYaml2Json';
 import { serviceSideProps } from '@/utils/i18n';
 import { getErrText, patchYamlList } from '@/utils/tools';
+import { getSubmitErrorMessage } from '@/utils/formErrorMessage';
 import { Box, Flex } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'next-i18next';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, type SubmitErrorHandler } from 'react-hook-form';
 import Form from './components/Form';
 import Header from './components/Header';
 import Yaml from './components/Yaml';
@@ -427,23 +428,24 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
     ]
   );
 
-  const submitError = useCallback(() => {
-    // deep search message
-    const deepSearch = (obj: any): string => {
-      if (!obj || typeof obj !== 'object') return t('Submit Error');
-      if (!!obj.message) {
-        return obj.message;
-      }
-      return deepSearch(Object.values(obj)[0]);
-    };
-    toast({
-      title: deepSearch(formHook.formState.errors),
-      status: 'error',
-      position: 'top',
-      duration: 3000,
-      isClosable: true
-    });
-  }, [formHook.formState.errors, t, toast]);
+  const submitError = useCallback<SubmitErrorHandler<AppEditType>>(
+    (errors) => {
+      toast({
+        title: getSubmitErrorMessage(
+          errors,
+          t('Submit Error'),
+          t(
+            'The application name can contain only lowercase letters, digits, and hyphens (-) and must start with a letter'
+          )
+        ),
+        status: 'error',
+        position: 'top',
+        duration: 3000,
+        isClosable: true
+      });
+    },
+    [t, toast]
+  );
 
   const handleDomainVerified = useCallback(
     ({ index, customDomain }: { index: number; customDomain: string }) => {
@@ -818,8 +820,8 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
                             data.hpa.target === 'cpu'
                               ? 'CPU'
                               : data.hpa.target === 'gpu'
-                                ? 'GPU'
-                                : 'RAM',
+                              ? 'GPU'
+                              : 'RAM',
                           value: data.hpa.value
                         }
                       : undefined

--- a/frontend/providers/applaunchpad/src/utils/appNameValidation.ts
+++ b/frontend/providers/applaunchpad/src/utils/appNameValidation.ts
@@ -1,0 +1,54 @@
+export const K8S_RFC1035_NAME_MAX_LENGTH = 63;
+export const SERVICE_RANDOM_SUFFIX_LENGTH = 22;
+export const POD_GENERATED_SUFFIX_LENGTH = 16;
+
+// 25 = 63 RFC1035 max - 22 nodeport service suffix - 16 pod suffix.
+export const APP_NAME_BASE_MAX_LENGTH =
+  K8S_RFC1035_NAME_MAX_LENGTH - SERVICE_RANDOM_SUFFIX_LENGTH - POD_GENERATED_SUFFIX_LENGTH;
+export const APP_GENERATED_NAME_MAX_LENGTH = APP_NAME_BASE_MAX_LENGTH;
+
+export const APP_NAME_BASE_PATTERN = /^[a-z]([-a-z0-9]*[a-z0-9])?$/;
+export const APP_GENERATED_NAME_PATTERN = /^[a-z]([-a-z0-9]*[a-z0-9])?$/;
+
+export const isValidAppNameBase = (baseName: string) =>
+  baseName.length > 0 &&
+  baseName.length <= APP_NAME_BASE_MAX_LENGTH &&
+  APP_NAME_BASE_PATTERN.test(baseName);
+
+export const isValidGeneratedAppName = (appName: string) =>
+  appName.length > 0 &&
+  appName.length <= APP_GENERATED_NAME_MAX_LENGTH &&
+  APP_GENERATED_NAME_PATTERN.test(appName);
+
+export const generateAppName = (baseName: string) => baseName;
+
+export const isValidRfc1035Name = (name: string) =>
+  name.length > 0 &&
+  name.length <= K8S_RFC1035_NAME_MAX_LENGTH &&
+  APP_GENERATED_NAME_PATTERN.test(name);
+
+type NamedKubernetesResource = {
+  kind?: string;
+  metadata?: {
+    name?: unknown;
+  };
+};
+
+export const getInvalidGeneratedAppNameMessage = (name: unknown) => {
+  if (typeof name !== 'string' || isValidGeneratedAppName(name)) return;
+
+  return `Application name "${name}" is invalid. Use ${APP_GENERATED_NAME_MAX_LENGTH} characters or fewer, start with a lowercase letter, use only lowercase letters, numbers, or hyphens, and end with a lowercase letter or number.`;
+};
+
+export const getInvalidRfc1035ServiceNameMessage = (resources: NamedKubernetesResource[]) => {
+  const invalidResource = resources.find((resource) => {
+    const name = resource?.metadata?.name;
+    return resource.kind === 'Service' && typeof name === 'string' && !isValidRfc1035Name(name);
+  });
+
+  if (!invalidResource) return;
+
+  return `${invalidResource.kind || 'Resource'} "${
+    invalidResource.metadata?.name
+  }" has an invalid name. Names must start with a lowercase letter, contain only lowercase letters, numbers, or hyphens, and end with a lowercase letter or number.`;
+};

--- a/frontend/providers/applaunchpad/src/utils/formErrorMessage.ts
+++ b/frontend/providers/applaunchpad/src/utils/formErrorMessage.ts
@@ -1,0 +1,14 @@
+export const getSubmitErrorMessage = (
+  error: unknown,
+  fallbackMessage: string,
+  invalidMessage: string
+): string => {
+  if (!error || typeof error !== 'object') return fallbackMessage;
+
+  const message = (error as { message?: unknown }).message;
+  if (typeof message === 'string' && message) {
+    return message === 'invalid' ? invalidMessage : message;
+  }
+
+  return getSubmitErrorMessage(Object.values(error)[0], fallbackMessage, invalidMessage);
+};


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->

## Summary
- Fix issue 207 on `release-v5.1` as one complete PR.
- Add app-name validation for the 5.1 editor so invalid names are rejected before submit.
- Add API preflight validation so invalid generated app or Service names return a `BAD_REQUEST` before any Kubernetes apply can partially create resources.
- Use the current React Hook Form invalid-submit errors so the first invalid submit shows the app-name validation error instead of the generic submit error.

## Tests
- `pnpm dlx vitest@4.0.15 run --config providers/applaunchpad/vitest.config.ts providers/applaunchpad/__tests__/unit/utils/formErrorMessage.test.ts providers/applaunchpad/__tests__/unit/utils/appNameValidation.test.ts providers/applaunchpad/__tests__/unit/utils/deployYaml2Json.test.ts`
- `./node_modules/.bin/prettier --check providers/applaunchpad/src/pages/api/applyApp.ts providers/applaunchpad/src/pages/app/edit/components/Form.tsx providers/applaunchpad/src/pages/app/edit/index.tsx providers/applaunchpad/src/utils/appNameValidation.ts providers/applaunchpad/src/utils/formErrorMessage.ts providers/applaunchpad/__tests__/unit/utils/appNameValidation.test.ts providers/applaunchpad/__tests__/unit/utils/deployYaml2Json.test.ts providers/applaunchpad/__tests__/unit/utils/formErrorMessage.test.ts providers/applaunchpad/public/locales/en/common.json providers/applaunchpad/public/locales/zh/common.json`
- `pnpm --filter ./providers/applaunchpad lint`

Fixes labring-sigs/sealos-issues#207
