### PR TITLE
fix(applaunchpad): preserve init container volumes during yaml patch

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/utils/tools.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/tools.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import yaml from 'js-yaml';
+
+import { patchYamlList } from '@/utils/tools';
+
+const createFormDeployment = (image: string) => ({
+  apiVersion: 'apps/v1',
+  kind: 'Deployment',
+  metadata: {
+    name: 'litellm-demo'
+  },
+  spec: {
+    replicas: 1,
+    selector: {
+      matchLabels: {
+        app: 'litellm-demo'
+      }
+    },
+    template: {
+      metadata: {
+        labels: {
+          app: 'litellm-demo'
+        }
+      },
+      spec: {
+        containers: [
+          {
+            name: 'litellm-demo',
+            image,
+            volumeMounts: []
+          }
+        ],
+        volumes: []
+      }
+    }
+  }
+});
+
+describe('patchYamlList', () => {
+  it('preserves volumes referenced only by init containers from the source deployment', () => {
+    const originalDeployment = {
+      ...createFormDeployment('litellm/litellm-database:v1.88.1'),
+      metadata: {
+        name: 'litellm-demo',
+        namespace: 'ns-demo'
+      },
+      spec: {
+        ...createFormDeployment('litellm/litellm-database:v1.88.1').spec,
+        template: {
+          ...createFormDeployment('litellm/litellm-database:v1.88.1').spec.template,
+          spec: {
+            ...createFormDeployment('litellm/litellm-database:v1.88.1').spec.template.spec,
+            initContainers: [
+              {
+                name: 'init-s3-config',
+                image: 'minio/mc:latest',
+                volumeMounts: [
+                  {
+                    name: 'litellm-demo-cm',
+                    mountPath: '/tmp/init-s3-config.sh',
+                    subPath: 'init-s3-config.sh'
+                  }
+                ]
+              }
+            ],
+            volumes: [
+              {
+                name: 'litellm-demo-cm',
+                configMap: {
+                  name: 'litellm-demo'
+                }
+              }
+            ]
+          }
+        }
+      }
+    };
+
+    const actions = patchYamlList({
+      parsedOldYamlList: [yaml.dump(createFormDeployment('litellm/litellm-database:v1.88.1'))],
+      parsedNewYamlList: [yaml.dump(createFormDeployment('litellm/litellm-database:v1.88.2'))],
+      originalYamlList: [originalDeployment as any]
+    });
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({
+      type: 'patch',
+      kind: 'Deployment'
+    });
+
+    const patchedDeployment = actions[0].type === 'patch' ? actions[0].value : undefined;
+
+    expect(patchedDeployment?.spec.template.spec.initContainers[0].volumeMounts[0].name).toBe(
+      'litellm-demo-cm'
+    );
+    expect(patchedDeployment?.spec.template.spec.volumes).toContainEqual({
+      name: 'litellm-demo-cm',
+      configMap: {
+        name: 'litellm-demo'
+      }
+    });
+  });
+});

--- a/frontend/providers/applaunchpad/src/utils/tools.ts
+++ b/frontend/providers/applaunchpad/src/utils/tools.ts
@@ -10,6 +10,37 @@ import { useTranslation } from 'next-i18next';
 import * as jsonpatch from 'fast-json-patch';
 import { Base64 } from 'js-base64';
 
+const preserveInitContainerVolumes = (source: any, target: any) => {
+  const initVolumeMountNames = new Set<string>();
+
+  source?.spec?.template?.spec?.initContainers?.forEach((container: any) => {
+    container?.volumeMounts?.forEach((mount: any) => {
+      if (mount?.name) {
+        initVolumeMountNames.add(mount.name);
+      }
+    });
+  });
+
+  if (initVolumeMountNames.size === 0) return;
+
+  const sourceVolumes = source?.spec?.template?.spec?.volumes || [];
+  const targetSpec = target?.spec?.template?.spec;
+  if (!targetSpec) return;
+
+  const targetVolumes = targetSpec.volumes || [];
+  const targetVolumeNames = new Set(
+    targetVolumes.map((volume: any) => volume?.name).filter(Boolean)
+  );
+  const missingVolumes = sourceVolumes.filter(
+    (volume: any) =>
+      volume?.name && initVolumeMountNames.has(volume.name) && !targetVolumeNames.has(volume.name)
+  );
+
+  if (missingVolumes.length === 0) return;
+
+  targetSpec.volumes = [...targetVolumes, ...missingVolumes];
+};
+
 export function formatSize(size: number, fixedNumber = 2) {
   const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
   let i = 0;
@@ -358,6 +389,20 @@ export const patchYamlList = ({
           }
 
           const patchResYamlJson = jsonpatch.applyPatch(crOldYamlJson, _patchRes, true).newDocument;
+
+          if (
+            oldFormJson.kind === YamlKindEnum.Deployment ||
+            oldFormJson.kind === YamlKindEnum.StatefulSet
+          ) {
+            preserveInitContainerVolumes(
+              originalYamlList.find(
+                (item) =>
+                  item.kind === oldFormJson?.kind &&
+                  item?.metadata?.name === oldFormJson?.metadata?.name
+              ),
+              patchResYamlJson
+            );
+          }
 
           // delete invalid field
           // @ts-ignore


### PR DESCRIPTION
## Summary
- Preserve volumes referenced only by initContainers when patching Deployment and StatefulSet YAML.
- Add a unit regression test for Deployment patching so configMap volumes used only by initContainers are retained.

## Testing
- pnpm --filter ./providers/applaunchpad test:unit
