### PR TITLE
fix(applaunchpad): list namespace services for path routes

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/utils/adapt.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/adapt.test.ts
@@ -47,31 +47,23 @@ const createDeployment = (): DeployKindsType =>
     }
   } as DeployKindsType);
 
-const createService = (): DeployKindsType =>
+const createService = (name = 'demo', ports = [80, 81]): DeployKindsType =>
   ({
     apiVersion: 'v1',
     kind: 'Service',
     metadata: {
-      name: 'demo',
+      name,
       labels: {}
     },
     spec: {
-      ports: [
-        {
-          name: 'web',
-          port: 80,
-          targetPort: 80,
-          protocol: 'TCP'
-        },
-        {
-          name: 'api',
-          port: 81,
-          targetPort: 81,
-          protocol: 'TCP'
-        }
-      ],
+      ports: ports.map((port) => ({
+        name: port === 80 ? 'web' : `p-${port}`,
+        port,
+        targetPort: port,
+        protocol: 'TCP'
+      })),
       selector: {
-        app: 'demo'
+        app: name
       }
     }
   } as DeployKindsType);
@@ -80,12 +72,12 @@ const createIngress = (): DeployKindsType =>
   ({
     apiVersion: 'networking.k8s.io/v1',
     kind: 'Ingress',
-      metadata: {
-        name: 'network-demo',
-        labels: {
-          'cloud.sealos.io/app-deploy-manager-domain': 'demo',
-          'cloud.sealos.io/app-deploy-manager-port': '80'
-        },
+    metadata: {
+      name: 'network-demo',
+      labels: {
+        'cloud.sealos.io/app-deploy-manager-domain': 'demo',
+        'cloud.sealos.io/app-deploy-manager-port': '80'
+      },
       annotations: {
         'nginx.ingress.kubernetes.io/backend-protocol': 'HTTP'
       }
@@ -186,5 +178,47 @@ describe('adaptAppDetail', () => {
     expect(publicNetworks[0].port).toBe(80);
     expect(publicNetworks[0].routes?.map((route) => route.servicePort)).toEqual([81, 80]);
     expect(app.networks.find((network) => network.port === 81)?.openPublicDomain).toBe(false);
+  });
+
+  it('can expose backend service candidates without treating them as current app ports', async () => {
+    const app = await adaptAppDetail([createDeployment(), createService(), createIngress()], {
+      SEALOS_DOMAIN: '192.168.13.209.nip.io',
+      SEALOS_USER_DOMAINS: [
+        {
+          name: '192.168.13.209.nip.io',
+          secretName: 'wildcard-cert'
+        }
+      ],
+      backendServices: [createService() as any, createService('api-demo', [8080]) as any]
+    });
+
+    expect(app.serviceList).toEqual([
+      {
+        name: 'demo',
+        ports: [
+          {
+            name: 'web',
+            port: 80,
+            protocol: 'TCP'
+          },
+          {
+            name: 'p-81',
+            port: 81,
+            protocol: 'TCP'
+          }
+        ]
+      },
+      {
+        name: 'api-demo',
+        ports: [
+          {
+            name: 'p-8080',
+            port: 8080,
+            protocol: 'TCP'
+          }
+        ]
+      }
+    ]);
+    expect(app.networks.map((network) => network.port)).toEqual([80, 81]);
   });
 });

--- a/frontend/providers/applaunchpad/public/locales/en/common.json
+++ b/frontend/providers/applaunchpad/public/locales/en/common.json
@@ -160,6 +160,8 @@
   "Public Access": "Internet Access",
   "Public Address": "Public Address",
   "Path Route Backend Service": "Backend Service",
+  "Path Route Match Exact": "Exact match",
+  "Path Route Match Prefix": "Prefix match",
   "Path Route Match Type": "Match Type",
   "Path Route Path Duplicated": "Route path already exists",
   "Path Route Path Must Start With Slash": "Path must start with /",

--- a/frontend/providers/applaunchpad/public/locales/zh/common.json
+++ b/frontend/providers/applaunchpad/public/locales/zh/common.json
@@ -160,6 +160,8 @@
   "Public Access": "外网访问",
   "Public Address": "公网地址",
   "Path Route Backend Service": "目标后端服务（Backend Service）",
+  "Path Route Match Exact": "Exact（精确匹配）",
+  "Path Route Match Prefix": "Prefix（前缀匹配）",
   "Path Route Match Type": "匹配类型",
   "Path Route Path Duplicated": "路由路径已存在",
   "Path Route Path Must Start With Slash": "Path 路径必须以 / 开头",

--- a/frontend/providers/applaunchpad/src/api/app.ts
+++ b/frontend/providers/applaunchpad/src/api/app.ts
@@ -6,6 +6,7 @@ import { MonitorDataResult, MonitorQueryKey } from '@/types/monitor';
 import { LogQueryPayload } from '@/pages/api/log/queryLogs';
 import { PodListQueryPayload } from '@/pages/api/log/queryPodList';
 import { track } from '@sealos/gtm';
+import type { BackendServiceItem } from '@/pages/api/listBackendServices';
 
 export const postDeployApp = (yamlList: string[], mode: 'create' | 'replace' = 'create') =>
   POST('/api/applyApp', { yamlList, mode });
@@ -35,6 +36,8 @@ export const delAppByName = (name: string) => {
 
 export const getAppByName = (name: string, mock = false) =>
   GET<AppDetailType>(`/api/getAppByAppName?appName=${name}&mock=${mock}`);
+
+export const getBackendServices = () => GET<BackendServiceItem[]>('/api/listBackendServices');
 
 export const getAppPodsByAppName = (name: string) =>
   GET<PodDetailType[]>('/api/getAppPodsByAppName', { name });

--- a/frontend/providers/applaunchpad/src/pages/api/getAppByAppName.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/getAppByAppName.ts
@@ -8,6 +8,7 @@ import { adaptAppDetail } from '@/utils/adapt';
 import { getServerEnv } from './platform/getInitData';
 import { DeployKindsType } from '@/types/app';
 import { MOCK_APP_DETAIL } from '@/mock/apps';
+import type { V1Service } from '@kubernetes/client-node';
 
 export const config = {
   api: {
@@ -28,7 +29,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       });
     }
 
-    const response = await GetAppByAppName({ appName, req });
+    const { response, backendServices } = await GetAppByAppName({ appName, req });
 
     // Check for errors other than 404
     const responseData = response
@@ -41,10 +42,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       .filter((item) => item)
       .flat();
 
-    const data = await adaptAppDetail(
-      responseData as DeployKindsType[],
-      getServerEnv(global.AppConfig)
-    );
+    const serverEnv = getServerEnv(global.AppConfig);
+    const data = await adaptAppDetail(responseData as DeployKindsType[], {
+      SEALOS_DOMAIN: serverEnv.SEALOS_DOMAIN,
+      SEALOS_USER_DOMAINS: serverEnv.SEALOS_USER_DOMAINS,
+      backendServices
+    });
 
     jsonRes(res, {
       data: data
@@ -109,5 +112,19 @@ export async function GetAppByAppName({
     k8sAutoscaling.readNamespacedHorizontalPodAutoscaler(appName, namespace)
   ]);
 
-  return response;
+  const backendServices = await k8sCore
+    .listNamespacedService(namespace, undefined, undefined, undefined, undefined, appDeployKey)
+    .then((res) =>
+      res.body.items.map((item) => ({
+        ...item,
+        apiVersion: res.body.apiVersion,
+        kind: 'Service'
+      }))
+    )
+    .catch(() => [] as V1Service[]);
+
+  return {
+    response,
+    backendServices
+  };
 }

--- a/frontend/providers/applaunchpad/src/pages/api/listBackendServices.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/listBackendServices.ts
@@ -1,0 +1,45 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { appDeployKey } from '@/constants/app';
+import { authSession } from '@/services/backend/auth';
+import { getK8s } from '@/services/backend/kubernetes';
+import { jsonRes } from '@/services/backend/response';
+import type { ApiResp } from '@/services/kubernet';
+import type { AppEditType } from '@/types/app';
+
+export type BackendServiceItem = NonNullable<AppEditType['serviceList']>[number];
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
+  try {
+    const { k8sCore, namespace } = await getK8s({
+      kubeconfig: await authSession(req.headers)
+    });
+
+    const {
+      body: { items: services }
+    } = await k8sCore.listNamespacedService(
+      namespace,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      appDeployKey
+    );
+
+    const data: BackendServiceItem[] = services.map((service) => ({
+      name: service.metadata?.name || '',
+      ports:
+        service.spec?.ports?.map((port) => ({
+          name: port.name,
+          port: port.port,
+          protocol: port.protocol as BackendServiceItem['ports'][number]['protocol']
+        })) || []
+    }));
+
+    jsonRes(res, { data });
+  } catch (err: any) {
+    jsonRes(res, {
+      code: 500,
+      error: err
+    });
+  }
+}

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/NetworkSection.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/NetworkSection.tsx
@@ -773,30 +773,27 @@ export function NetworkSection({
 
   const getServiceOptions = useCallback(() => {
     const currentForm = getValues();
-    const serviceOptions =
-      currentForm.serviceList
-        ?.flatMap((service) =>
-          service.ports.map((port) => ({
-            label: `${service.name}:${port.port}`,
-            value: getBackendServiceValue(service.name, port.port),
-            serviceName: service.name,
-            servicePort: port.port
-          }))
-        )
-        .filter(
-          (option, index, list) => list.findIndex((item) => item.value === option.value) === index
-        ) || [];
-
-    if (serviceOptions.length) {
-      return serviceOptions;
-    }
-
-    return currentForm.networks.map((network) => ({
-      label: `${t('Main Service')}:${network.port}`,
-      value: getBackendServiceValue('', network.port),
-      serviceName: '',
+    const currentServiceOptions = currentForm.networks.map((network) => ({
+      label: network.serviceName
+        ? `${network.serviceName}:${network.port}`
+        : `${t('Main Service')}:${network.port}`,
+      value: getBackendServiceValue(network.serviceName || '', network.port),
+      serviceName: network.serviceName || '',
       servicePort: network.port
     }));
+    const backendServiceOptions =
+      currentForm.serviceList?.flatMap((service) =>
+        service.ports.map((port) => ({
+          label: `${service.name}:${port.port}`,
+          value: getBackendServiceValue(service.name, port.port),
+          serviceName: service.name,
+          servicePort: port.port
+        }))
+      ) || [];
+
+    return [...currentServiceOptions, ...backendServiceOptions].filter(
+      (option, index, list) => list.findIndex((item) => item.value === option.value) === index
+    );
   }, [getValues, t]);
 
   const getDomainDisplay = useCallback(
@@ -982,8 +979,8 @@ export function NetworkSection({
                                 network.openPublicDomain
                                   ? network.appProtocol
                                   : network.openNodePort
-                                    ? network.protocol
-                                    : 'HTTP'
+                                  ? network.protocol
+                                  : 'HTTP'
                               }
                               list={ProtocolList}
                               onchange={(val: any) => {

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/RouteRulesModal.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/RouteRulesModal.tsx
@@ -20,16 +20,12 @@ import { useTranslation } from 'next-i18next';
 import { useMemo } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
 
-const pathTypeList: Array<{ label: NetworkRoutePathType; value: NetworkRoutePathType }> = [
-  { label: 'Prefix', value: 'Prefix' },
-  { label: 'Exact', value: 'Exact' },
-  { label: 'ImplementationSpecific', value: 'ImplementationSpecific' }
-];
 const routeRuleFieldWidthPx = 219.5;
 const routeRuleFieldGapPx = 19;
 const routeRuleFieldWidth = `${routeRuleFieldWidthPx}px`;
 const routeRuleFieldGap = `${routeRuleFieldGapPx}px`;
 const routeRuleContentWidth = `${routeRuleFieldWidthPx * 2 + routeRuleFieldGapPx}px`;
+const routeRuleSelectDropdownGap = '8px';
 const routeRulesScrollbarWidth = '6px';
 
 type RouteRulesForm = {
@@ -93,6 +89,13 @@ export default function RouteRulesModal({
 }) {
   const { t } = useTranslation();
   const theme = useTheme();
+  const pathTypeList: Array<{ label: string; value: NetworkRoutePathType }> = useMemo(
+    () => [
+      { label: t('Path Route Match Prefix'), value: 'Prefix' },
+      { label: t('Path Route Match Exact'), value: 'Exact' }
+    ],
+    [t]
+  );
 
   const backendServiceOptions = useMemo(() => {
     const options = serviceOptions.length ? serviceOptions : [];
@@ -343,6 +346,16 @@ export default function RouteRulesModal({
                           routes?.[index]?.servicePort || defaultServicePort
                         )}
                         list={backendServiceOptions}
+                        boxStyle={{
+                          sx: {
+                            '& [aria-haspopup="menu"][aria-expanded="true"] + .chakra-menu__menu-list':
+                              {
+                                position: 'static',
+                                transform: 'none !important',
+                                mt: routeRuleSelectDropdownGap
+                              }
+                          }
+                        }}
                         onchange={(val: string) => {
                           const backendService = parseBackendServiceValue(val);
                           setValue(`routes.${index}.serviceName`, backendService.serviceName, {

--- a/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
@@ -1,4 +1,4 @@
-import { postDeployApp, putApp } from '@/api/app';
+import { getBackendServices, postDeployApp, putApp } from '@/api/app';
 import {
   checkPermission,
   checkPublicDomain,
@@ -489,6 +489,12 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
     ['initLaunchpadApp'],
     () => {
       if (!appName) {
+        getBackendServices()
+          .then((serviceList) => {
+            formHook.setValue('serviceList', serviceList);
+          })
+          .catch(() => {});
+
         const defaultApp = {
           ...defaultEditVal,
           cpu: formSliderListConfig[defaultSliderKey].cpu[0],
@@ -818,8 +824,8 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
                             data.hpa.target === 'cpu'
                               ? 'CPU'
                               : data.hpa.target === 'gpu'
-                                ? 'GPU'
-                                : 'RAM',
+                              ? 'GPU'
+                              : 'RAM',
                           value: data.hpa.value
                         }
                       : undefined

--- a/frontend/providers/applaunchpad/src/utils/adapt.ts
+++ b/frontend/providers/applaunchpad/src/utils/adapt.ts
@@ -262,6 +262,7 @@ export const adaptAppDetail = async (
       name: string;
       secretName: string;
     }[];
+    backendServices?: V1Service[];
   }
 ): Promise<AppDetailType> => {
   const { SEALOS_DOMAIN, SEALOS_USER_DOMAINS } = options ?? (await getInitData());
@@ -269,6 +270,7 @@ export const adaptAppDetail = async (
   const allServices = configs
     .filter((item) => item.kind === YamlKindEnum.Service)
     .map((item) => item as V1Service);
+  const backendServices = options?.backendServices || allServices;
 
   const allServicePorts = allServices.flatMap((service) => service.spec?.ports || []);
 
@@ -529,7 +531,7 @@ export const adaptAppDetail = async (
           valueFrom: env.valueFrom
         };
       }) || [],
-    serviceList: allServices.map((service) => ({
+    serviceList: backendServices.map((service) => ({
       name: service.metadata?.name || '',
       ports:
         service.spec?.ports?.map((port) => ({
@@ -578,8 +580,8 @@ export const adaptAppDetail = async (
           domain: isCustomDomain
             ? SEALOS_DOMAIN
             : item?.nodePort
-              ? domain
-              : domain.split('.').slice(1).join('.') || SEALOS_DOMAIN,
+            ? domain
+            : domain.split('.').slice(1).join('.') || SEALOS_DOMAIN,
           routes: ingressPaths.length
             ? ingressPaths.map((path) => ({
                 path: path.path || '/',
@@ -714,8 +716,8 @@ export const sliderNumber2MarkList = ({
           ? `${item / 1024} G`
           : `${item} M`
         : type === 'ephemeralStorage'
-          ? `${item}`
-          : `${item / 1000}`,
+        ? `${item}`
+        : `${item / 1000}`,
     value: item
   }));
 };


### PR DESCRIPTION
## Summary
- list Launchpad services in the current namespace as path route backend candidates
- keep current app networks derived only from the app's own services
- load backend service candidates for new app creation and keep current service options available in the route modal

## Related Issue
Fixes labring-sigs/sealos-issues#341

## Tests
- `/Users/wangzhihao/Desktop/sealos-applaunchpad/frontend/node_modules/.bin/prettier --check frontend/providers/applaunchpad/__tests__/unit/utils/adapt.test.ts frontend/providers/applaunchpad/src/api/app.ts frontend/providers/applaunchpad/src/pages/api/getAppByAppName.ts frontend/providers/applaunchpad/src/pages/api/listBackendServices.ts frontend/providers/applaunchpad/src/pages/app/edit/components/NetworkSection.tsx frontend/providers/applaunchpad/src/pages/app/edit/index.tsx frontend/providers/applaunchpad/src/utils/adapt.ts`
- `git diff --cached --check`
