### PR TITLE
fix(applaunchpad): delete pvcs for owner-referenced apps

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/pages/api/delApp.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/pages/api/delApp.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DeleteAppByName } from '@/pages/api/delApp';
+
+const authSessionMock = vi.hoisted(() => vi.fn());
+const getK8sMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/services/backend/auth', () => ({
+  authSession: authSessionMock
+}));
+
+vi.mock('@/services/backend/kubernetes', () => ({
+  getK8s: getK8sMock
+}));
+
+function notFound() {
+  return Promise.reject({
+    body: {
+      code: 404
+    }
+  });
+}
+
+function createK8sContext() {
+  return {
+    namespace: 'ns-demo',
+    k8sApp: {
+      deleteNamespacedDeployment: vi.fn(() => notFound()),
+      deleteNamespacedStatefulSet: vi.fn(() => Promise.resolve({})),
+      readNamespacedDeployment: vi.fn(() => notFound()),
+      readNamespacedStatefulSet: vi.fn(() =>
+        Promise.resolve({
+          body: {
+            metadata: {
+              annotations: {
+                'cloud.sealos.io/owner-references': 'ready'
+              }
+            }
+          }
+        })
+      )
+    },
+    k8sCore: {
+      deleteCollectionNamespacedService: vi.fn(() => Promise.resolve({})),
+      deleteNamespacedConfigMap: vi.fn(() => notFound()),
+      deleteNamespacedSecret: vi.fn(() => notFound()),
+      deleteCollectionNamespacedPersistentVolumeClaim: vi.fn(() => Promise.resolve({}))
+    },
+    k8sNetworkingApp: {
+      deleteCollectionNamespacedIngress: vi.fn(() => Promise.resolve({}))
+    },
+    k8sAutoscaling: {
+      deleteNamespacedHorizontalPodAutoscaler: vi.fn(() => notFound())
+    },
+    k8sCustomObjects: {
+      listNamespacedCustomObject: vi.fn(() =>
+        Promise.resolve({
+          body: {
+            items: []
+          }
+        })
+      )
+    }
+  };
+}
+
+describe('DeleteAppByName', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authSessionMock.mockResolvedValue('kubeconfig');
+  });
+
+  it('deletes app PVCs before returning from ownerReferences cascade path', async () => {
+    const k8s = createK8sContext();
+    getK8sMock.mockResolvedValue(k8s);
+
+    await DeleteAppByName({
+      name: 'demo',
+      req: {
+        headers: {}
+      } as any
+    });
+
+    expect(k8s.k8sCore.deleteCollectionNamespacedPersistentVolumeClaim).toHaveBeenCalledWith(
+      'ns-demo',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'app=demo'
+    );
+    expect(k8s.k8sApp.deleteNamespacedStatefulSet).toHaveBeenCalledWith('demo', 'ns-demo');
+    expect(k8s.k8sCore.deleteCollectionNamespacedService).not.toHaveBeenCalled();
+    expect(k8s.k8sNetworkingApp.deleteCollectionNamespacedIngress).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/providers/applaunchpad/src/pages/api/delApp.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/delApp.ts
@@ -60,13 +60,36 @@ export async function DeleteAppByName({ name, req }: DeleteAppParams & { req: Ne
     }
   }
 
-  // If app has ownerReferences, only delete main workload (cascade delete handles rest)
+  // If app has ownerReferences, cascade delete handles owner-referenced resources.
+  // StatefulSet volumeClaimTemplates PVCs are retained by default, so clean PVCs explicitly.
   if (hasOwnerReferences && workloadKind) {
     if (workloadKind === 'Deployment') {
       await k8sApp.deleteNamespacedDeployment(name, namespace);
     } else {
       await k8sApp.deleteNamespacedStatefulSet(name, namespace);
     }
+
+    const delPvc = await Promise.allSettled([
+      k8sCore.deleteCollectionNamespacedPersistentVolumeClaim(
+        namespace,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        `app=${name}`
+      )
+    ]);
+
+    delPvc.forEach((item) => {
+      console.log(item, 'delApp PVC err');
+      if (item.status === 'rejected' && +item?.reason?.body?.code !== 404) {
+        throw new Error(
+          item?.reason?.body?.reason || item?.reason?.body?.message || '删除 App 异常'
+        );
+      }
+    });
+
     return;
   }
 


### PR DESCRIPTION
## Summary
- remove the `/api/delApp` ownerReferences fast path so app deletion always runs explicit dependent cleanup
- keep the existing `app=<name>` PVC collection delete for owner-referenced StatefulSet apps
- add a regression test covering a StatefulSet app with `cloud.sealos.io/owner-references=ready`

## Root Cause
`/api/delApp` assumed ownerReferences cascade deletion would clean every dependent resource and returned immediately after deleting the workload. StatefulSet `volumeClaimTemplates` PVCs are retained by default, so the PVC cleanup block was skipped and app PVCs remained after deletion.

## Validation
- `pnpm --dir frontend/providers/applaunchpad exec vitest run`

## Additional Information

Use `persistentVolumeClaimRetentionPolicy` after Kubernetes v1.32: https://github.com/labring/sealos/pull/7034#issuecomment-4807811441