### PR TITLE
fix(applaunchpad): bind frontend server to all interfaces

### DIFF
--- a/frontend/providers/applaunchpad/deploy/charts/applaunchpad-frontend/templates/deployment.yaml
+++ b/frontend/providers/applaunchpad/deploy/charts/applaunchpad-frontend/templates/deployment.yaml
@@ -40,6 +40,9 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           image: {{ .Values.image | quote }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          env:
+            - name: HOSTNAME
+              value: "0.0.0.0"
           volumeMounts:
             - mountPath: /app/providers/applaunchpad/.env
               name: applaunchpad-frontend-volume


### PR DESCRIPTION
## Summary
- set `HOSTNAME=0.0.0.0` for the AppLaunchpad frontend chart
- prevent Next standalone server from binding to the Kubernetes pod hostname/IP only

## Root Cause
Next standalone `server.js` reads `process.env.HOSTNAME` as its bind host. In Kubernetes, `HOSTNAME` defaults to the pod name, so the server bound to the pod hostname/IP instead of all interfaces. On cluster 209 this made the pod appear Running/Ready while HTTP requests to the service hung or failed.

## Verification
- `git diff --check origin/release-v5.1...HEAD`
- hot-fixed cluster 209 deployment with `HOSTNAME=0.0.0.0`
- verified `https://applaunchpad.192.168.13.209.nip.io/apps` returns HTTP 200 repeatedly

Note: `helm template` was not run locally because `helm` is not installed in this environment.
