### PR TITLE
fix(applaunchpad): constrain route service menu height

### DIFF
--- a/frontend/packages/ui/src/components/Select/index.tsx
+++ b/frontend/packages/ui/src/components/Select/index.tsx
@@ -12,7 +12,7 @@ import {
   MenuButton,
   Flex
 } from '@chakra-ui/react';
-import type { BoxProps, ButtonProps } from '@chakra-ui/react';
+import type { BoxProps, ButtonProps, MenuListProps, MenuProps } from '@chakra-ui/react';
 import { ChevronDownIcon } from '@chakra-ui/icons';
 
 interface Props extends ButtonProps {
@@ -27,6 +27,8 @@ interface Props extends ButtonProps {
   onchange?: (val: string) => void;
   isInvalid?: boolean;
   boxStyle?: BoxProps;
+  menuProps?: Omit<MenuProps, 'children'>;
+  menuListProps?: MenuListProps;
 }
 
 const MySelect = (
@@ -39,6 +41,8 @@ const MySelect = (
     onchange,
     isInvalid,
     boxStyle,
+    menuProps,
+    menuListProps,
     ...props
   }: Props,
   selectRef: any
@@ -66,7 +70,7 @@ const MySelect = (
   }, [list, value]);
 
   return (
-    <Menu autoSelect={false} isOpen={isOpen} onOpen={onOpen} onClose={onClose}>
+    <Menu autoSelect={false} isOpen={isOpen} onOpen={onOpen} onClose={onClose} {...menuProps}>
       <Box
         ref={SelectRef}
         position={'relative'}
@@ -130,6 +134,7 @@ const MySelect = (
           zIndex={99}
           overflow={'overlay'}
           maxH={'300px'}
+          {...menuListProps}
         >
           {list.map((item) => (
             <MenuItem

--- a/frontend/packages/ui/src/components/Select/index.tsx
+++ b/frontend/packages/ui/src/components/Select/index.tsx
@@ -10,7 +10,8 @@ import {
   useDisclosure,
   useOutsideClick,
   MenuButton,
-  Flex
+  Flex,
+  Portal
 } from '@chakra-ui/react';
 import type { BoxProps, ButtonProps, MenuListProps, MenuProps } from '@chakra-ui/react';
 import { ChevronDownIcon } from '@chakra-ui/icons';
@@ -29,6 +30,7 @@ interface Props extends ButtonProps {
   boxStyle?: BoxProps;
   menuProps?: Omit<MenuProps, 'children'>;
   menuListProps?: MenuListProps;
+  menuListPortal?: boolean;
 }
 
 const MySelect = (
@@ -43,6 +45,7 @@ const MySelect = (
     boxStyle,
     menuProps,
     menuListProps,
+    menuListPortal,
     ...props
   }: Props,
   selectRef: any
@@ -54,6 +57,7 @@ const MySelect = (
   useOutsideClick({
     ref: SelectRef,
     handler: () => {
+      if (menuListPortal) return;
       onClose();
     }
   });
@@ -68,6 +72,54 @@ const MySelect = (
     }
     return foundItem;
   }, [list, value]);
+
+  const menuList = (
+    <MenuList
+      minW={(() => {
+        const w = ref.current?.clientWidth;
+        if (w) {
+          return `${w}px !important`;
+        }
+        return Array.isArray(width)
+          ? width.map((item) => `${item} !important`)
+          : `${width} !important`;
+      })()}
+      p={'6px'}
+      borderRadius={'base'}
+      border={'1px solid #E8EBF0'}
+      boxShadow={
+        '0px 4px 10px 0px rgba(19, 51, 107, 0.10), 0px 0px 1px 0px rgba(19, 51, 107, 0.10)'
+      }
+      zIndex={99}
+      overflow={'overlay'}
+      maxH={'300px'}
+      {...menuListProps}
+    >
+      {list.map((item) => (
+        <MenuItem
+          key={item.value}
+          {...(value === item.value
+            ? {
+                color: 'brightBlue.600'
+              }
+            : {})}
+          borderRadius={'4px'}
+          _hover={{
+            bg: 'rgba(17, 24, 36, 0.05)',
+            color: 'brightBlue.600'
+          }}
+          p={'6px'}
+          onClick={() => {
+            if (onchange && value !== item.value) {
+              onchange(item.value);
+            }
+          }}
+        >
+          <Box>{item.label}</Box>
+        </MenuItem>
+      ))}
+    </MenuList>
+  );
 
   return (
     <Menu autoSelect={false} isOpen={isOpen} onOpen={onOpen} onClose={onClose} {...menuProps}>
@@ -115,51 +167,7 @@ const MySelect = (
           <Flex justifyContent={'flex-start'}>{activeMenu ? activeMenu.label : placeholder}</Flex>
         </MenuButton>
 
-        <MenuList
-          minW={(() => {
-            const w = ref.current?.clientWidth;
-            if (w) {
-              return `${w}px !important`;
-            }
-            return Array.isArray(width)
-              ? width.map((item) => `${item} !important`)
-              : `${width} !important`;
-          })()}
-          p={'6px'}
-          borderRadius={'base'}
-          border={'1px solid #E8EBF0'}
-          boxShadow={
-            '0px 4px 10px 0px rgba(19, 51, 107, 0.10), 0px 0px 1px 0px rgba(19, 51, 107, 0.10)'
-          }
-          zIndex={99}
-          overflow={'overlay'}
-          maxH={'300px'}
-          {...menuListProps}
-        >
-          {list.map((item) => (
-            <MenuItem
-              key={item.value}
-              {...(value === item.value
-                ? {
-                    color: 'brightBlue.600'
-                  }
-                : {})}
-              borderRadius={'4px'}
-              _hover={{
-                bg: 'rgba(17, 24, 36, 0.05)',
-                color: 'brightBlue.600'
-              }}
-              p={'6px'}
-              onClick={() => {
-                if (onchange && value !== item.value) {
-                  onchange(item.value);
-                }
-              }}
-            >
-              <Box>{item.label}</Box>
-            </MenuItem>
-          ))}
-        </MenuList>
+        {menuListPortal ? <Portal>{menuList}</Portal> : menuList}
       </Box>
     </Menu>
   );

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/RouteRulesModal.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/RouteRulesModal.tsx
@@ -25,7 +25,6 @@ const routeRuleFieldGapPx = 19;
 const routeRuleFieldWidth = `${routeRuleFieldWidthPx}px`;
 const routeRuleFieldGap = `${routeRuleFieldGapPx}px`;
 const routeRuleContentWidth = `${routeRuleFieldWidthPx * 2 + routeRuleFieldGapPx}px`;
-const routeRuleSelectDropdownGap = '8px';
 const routeRuleBackendSelectMenuMaxH = '220px';
 const routeRulesScrollbarWidth = '6px';
 
@@ -347,19 +346,18 @@ export default function RouteRulesModal({
                           routes?.[index]?.servicePort || defaultServicePort
                         )}
                         list={backendServiceOptions}
-                        boxStyle={{
-                          sx: {
-                            '& [aria-haspopup="menu"][aria-expanded="true"] + .chakra-menu__menu-list':
-                              {
-                                position: 'static',
-                                transform: 'none !important',
-                                mt: routeRuleSelectDropdownGap,
-                                maxH: routeRuleBackendSelectMenuMaxH,
-                                overflowY: 'auto',
-                                overflowX: 'hidden',
-                                overscrollBehavior: 'contain'
-                              }
-                          }
+                        menuProps={{
+                          strategy: 'fixed',
+                          gutter: 8,
+                          flip: true,
+                          preventOverflow: true,
+                          boundary: 'clippingParents'
+                        }}
+                        menuListProps={{
+                          maxH: routeRuleBackendSelectMenuMaxH,
+                          overflowY: 'auto',
+                          overflowX: 'hidden',
+                          overscrollBehavior: 'contain'
                         }}
                         onchange={(val: string) => {
                           const backendService = parseBackendServiceValue(val);

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/RouteRulesModal.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/RouteRulesModal.tsx
@@ -353,7 +353,9 @@ export default function RouteRulesModal({
                           preventOverflow: true,
                           boundary: 'clippingParents'
                         }}
+                        menuListPortal
                         menuListProps={{
+                          zIndex: 1500,
                           maxH: routeRuleBackendSelectMenuMaxH,
                           overflowY: 'auto',
                           overflowX: 'hidden',

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/RouteRulesModal.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/RouteRulesModal.tsx
@@ -26,6 +26,7 @@ const routeRuleFieldWidth = `${routeRuleFieldWidthPx}px`;
 const routeRuleFieldGap = `${routeRuleFieldGapPx}px`;
 const routeRuleContentWidth = `${routeRuleFieldWidthPx * 2 + routeRuleFieldGapPx}px`;
 const routeRuleSelectDropdownGap = '8px';
+const routeRuleBackendSelectMenuMaxH = '220px';
 const routeRulesScrollbarWidth = '6px';
 
 type RouteRulesForm = {
@@ -352,7 +353,11 @@ export default function RouteRulesModal({
                               {
                                 position: 'static',
                                 transform: 'none !important',
-                                mt: routeRuleSelectDropdownGap
+                                mt: routeRuleSelectDropdownGap,
+                                maxH: routeRuleBackendSelectMenuMaxH,
+                                overflowY: 'auto',
+                                overflowX: 'hidden',
+                                overscrollBehavior: 'contain'
                               }
                           }
                         }}


### PR DESCRIPTION
## Summary
- constrain the backend service select menu height inside the route rules modal
- keep the menu in the document flow below the select while making long service lists scroll internally

## Root Cause
The route backend service menu was moved into the modal flow, but it still inherited the global select menu `maxH` of 300px. On the route rules modal there is less than 300px of visible space below the select, so the menu was clipped by `ModalContent` overflow.

## Verification
- `git diff --check`

Notes:
- `pnpm --filter=applaunchpad lint -- --file src/pages/app/edit/components/RouteRulesModal.tsx` could not run because this temporary worktree does not have `node_modules` installed (`next: command not found`).
