### PR TITLE
perf(template): split detail README loading

### DIFF
--- a/frontend/providers/template/src/api/app.ts
+++ b/frontend/providers/template/src/api/app.ts
@@ -1,10 +1,28 @@
 import { GET, POST } from '@/services/request';
 import { TemplateSourceType } from '@/types/app';
 
+type GetTemplateSourceOptions = {
+  locale?: string;
+  includeReadme?: boolean;
+  includeRequirements?: boolean;
+};
+
 export const postDeployApp = (
   yamlList: string[],
   type: 'create' | 'replace' | 'dryrun' = 'create'
 ) => POST('/api/applyApp', { yamlList, type });
 
-export const getTemplateSource = (templateName: string) =>
-  GET<TemplateSourceType>('/api/getTemplateSource', { templateName });
+export const getTemplateSource = (templateName: string, options?: GetTemplateSourceOptions) =>
+  GET<TemplateSourceType>('/api/getTemplateSource', {
+    templateName,
+    locale: options?.locale,
+    includeReadme: options?.includeReadme === undefined ? undefined : String(options.includeReadme),
+    includeRequirements:
+      options?.includeRequirements === undefined ? undefined : String(options.includeRequirements)
+  });
+
+export const getTemplateReadme = (templateName: string, locale?: string) =>
+  GET<Pick<TemplateSourceType, 'readUrl' | 'readmeContent'>>('/api/getTemplateReadme', {
+    templateName,
+    locale
+  });

--- a/frontend/providers/template/src/pages/api/getTemplateReadme.ts
+++ b/frontend/providers/template/src/pages/api/getTemplateReadme.ts
@@ -1,0 +1,46 @@
+import { authSession } from '@/services/backend/auth';
+import { getK8s } from '@/services/backend/kubernetes';
+import { jsonRes } from '@/services/backend/response';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { GetTemplateReadmeByName } from './getTemplateSource';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const { templateName, locale = 'en' } = req.query as {
+      templateName: string;
+      locale: string;
+    };
+
+    let user_namespace = '';
+    try {
+      const { namespace } = await getK8s({
+        kubeconfig: await authSession(req.headers)
+      });
+      user_namespace = namespace;
+    } catch (error) {}
+
+    const { code, message, readmeContent, readUrl } = await GetTemplateReadmeByName({
+      namespace: user_namespace,
+      templateName,
+      locale
+    });
+
+    if (code !== 20000) {
+      return jsonRes(res, { code, message });
+    }
+
+    jsonRes(res, {
+      code: 200,
+      data: {
+        readmeContent,
+        readUrl
+      }
+    });
+  } catch (err: any) {
+    console.log(err);
+    jsonRes(res, {
+      code: 500,
+      error: err
+    });
+  }
+}

--- a/frontend/providers/template/src/pages/api/getTemplateSource.ts
+++ b/frontend/providers/template/src/pages/api/getTemplateSource.ts
@@ -23,9 +23,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   try {
     const envEnableReadme = process.env.ENABLE_README_FETCH;
     const queryIncludeReadme = req.query.includeReadme !== 'false';
+    const includeRequirements = req.query.includeRequirements !== 'false';
 
     const includeReadme =
-      envEnableReadme === 'false' ? 'false' : queryIncludeReadme ? 'true' : 'true';
+      envEnableReadme === 'false' ? 'false' : queryIncludeReadme ? 'true' : 'false';
 
     const { templateName, locale = 'en' } = req.query as {
       templateName: string;
@@ -79,16 +80,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     };
 
     let requirements: ResourceUsage | null = null;
-    try {
-      const platformEnvs = getTemplateEnvs(user_namespace);
-      const renderedYaml = generateYamlData(
-        templateSource,
-        getTemplateDefaultValues(templateSource),
-        platformEnvs
-      );
-      requirements = getResourceUsage(renderedYaml.map((item) => item.value));
-    } catch (error) {
-      console.error(`Error getting default resource requirements for template '${templateName}'`);
+    if (includeRequirements) {
+      try {
+        const platformEnvs = getTemplateEnvs(user_namespace);
+        const renderedYaml = generateYamlData(
+          templateSource,
+          getTemplateDefaultValues(templateSource),
+          platformEnvs
+        );
+        requirements = getResourceUsage(renderedYaml.map((item) => item.value));
+      } catch (error) {
+        console.error(`Error getting default resource requirements for template '${templateName}'`);
+      }
     }
 
     jsonRes(res, {
@@ -118,53 +121,14 @@ export async function GetTemplateByName({
   locale?: string;
   includeReadme?: string;
 }) {
-  const cdnUrl = process.env.CDN_URL;
-  const targetFolder = process.env.TEMPLATE_REPO_FOLDER || 'template';
-
   const TemplateEnvs = getTemplateEnvs(namespace);
-
-  const originalPath = process.cwd();
-  const repoRootPath = path.resolve(originalPath, 'templates');
-  const targetPath = path.resolve(repoRootPath, targetFolder);
-
-  const jsonPath = path.resolve(originalPath, 'templates.json');
-  const jsonData: TemplateType[] = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
-  const _tempalte = jsonData.find((item) => item.metadata.name === templateName);
-  const _tempalteName = _tempalte ? _tempalte.spec.fileName : `${templateName}.yaml`;
-  const templateFilePath = _tempalte?.spec?.filePath || `${targetPath}/${_tempalteName}`;
-  const yamlString = fs.readFileSync(templateFilePath, 'utf-8');
-
-  let { appYaml, templateYaml } = getYamlTemplate(yamlString);
+  let { appYaml, templateYaml } = getTemplateYamlByName(templateName, TemplateEnvs);
 
   if (!templateYaml) {
     return {
       code: 40000,
       message: 'Lack of kind template'
     };
-  }
-  templateYaml.spec.deployCount = _tempalte?.spec?.deployCount;
-  templateYaml = resolveTemplateAssetUrls(templateYaml, {
-    repo: {
-      url: TemplateEnvs.TEMPLATE_REPO_URL,
-      branch: TemplateEnvs.TEMPLATE_REPO_BRANCH
-    },
-    templateFilePath,
-    repoRootPath
-  });
-
-  if (cdnUrl) {
-    templateYaml.spec.readme = replaceRawWithCDN(templateYaml.spec.readme, cdnUrl);
-    templateYaml.spec.icon = replaceRawWithCDN(templateYaml.spec.icon, cdnUrl);
-    if (templateYaml?.spec?.i18n) {
-      Object.keys(templateYaml?.spec?.i18n || {}).forEach((lang) => {
-        const i18nLang = templateYaml?.spec?.i18n?.[lang];
-        ['readme', 'icon'].forEach((field) => {
-          if (i18nLang?.[field]) {
-            i18nLang[field] = replaceRawWithCDN(i18nLang[field], cdnUrl);
-          }
-        });
-      });
-    }
   }
 
   templateYaml = parseTemplateVariable(templateYaml, TemplateEnvs);
@@ -204,6 +168,93 @@ export async function GetTemplateByName({
     readmeContent,
     readUrl
   };
+}
+
+export async function GetTemplateReadmeByName({
+  namespace,
+  templateName,
+  locale = 'en'
+}: {
+  namespace: string;
+  templateName: string;
+  locale?: string;
+}) {
+  if (process.env.ENABLE_README_FETCH === 'false') {
+    return {
+      code: 20000,
+      message: 'success',
+      readmeContent: '',
+      readUrl: ''
+    };
+  }
+
+  const TemplateEnvs = getTemplateEnvs(namespace);
+  const { templateYaml } = getTemplateYamlByName(templateName, TemplateEnvs);
+  const readUrl = templateYaml?.spec?.i18n?.[locale]?.readme || templateYaml?.spec?.readme || '';
+  let readmeContent = '';
+
+  if (readUrl) {
+    try {
+      readmeContent = await fetchReadmeContentWithRetry(readUrl);
+    } catch (error) {
+      readmeContent = '';
+    }
+  }
+
+  return {
+    code: 20000,
+    message: 'success',
+    readmeContent,
+    readUrl
+  };
+}
+
+function getTemplateYamlByName(
+  templateName: string,
+  TemplateEnvs: ReturnType<typeof getTemplateEnvs>
+) {
+  const cdnUrl = process.env.CDN_URL;
+  const targetFolder = process.env.TEMPLATE_REPO_FOLDER || 'template';
+
+  const originalPath = process.cwd();
+  const repoRootPath = path.resolve(originalPath, 'templates');
+  const targetPath = path.resolve(repoRootPath, targetFolder);
+
+  const jsonPath = path.resolve(originalPath, 'templates.json');
+  const jsonData: TemplateType[] = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+  const template = jsonData.find((item) => item.metadata.name === templateName);
+  const templateFileName = template ? template.spec.fileName : `${templateName}.yaml`;
+  const templateFilePath = template?.spec?.filePath || `${targetPath}/${templateFileName}`;
+  const yamlString = fs.readFileSync(templateFilePath, 'utf-8');
+
+  const { appYaml, templateYaml: rawTemplateYaml } = getYamlTemplate(yamlString);
+  let templateYaml = rawTemplateYaml;
+  templateYaml.spec.deployCount = template?.spec?.deployCount;
+  templateYaml = resolveTemplateAssetUrls(templateYaml, {
+    repo: {
+      url: TemplateEnvs.TEMPLATE_REPO_URL,
+      branch: TemplateEnvs.TEMPLATE_REPO_BRANCH
+    },
+    templateFilePath,
+    repoRootPath
+  });
+
+  if (cdnUrl) {
+    templateYaml.spec.readme = replaceRawWithCDN(templateYaml.spec.readme, cdnUrl);
+    templateYaml.spec.icon = replaceRawWithCDN(templateYaml.spec.icon, cdnUrl);
+    if (templateYaml?.spec?.i18n) {
+      Object.keys(templateYaml?.spec?.i18n || {}).forEach((lang) => {
+        const i18nLang = templateYaml?.spec?.i18n?.[lang];
+        ['readme', 'icon'].forEach((field) => {
+          if (i18nLang?.[field]) {
+            i18nLang[field] = replaceRawWithCDN(i18nLang[field], cdnUrl);
+          }
+        });
+      });
+    }
+  }
+
+  return { appYaml, templateYaml };
 }
 
 async function fetchReadmeContentWithRetry(url: string): Promise<string> {

--- a/frontend/providers/template/src/pages/deploy/components/ReadMe.tsx
+++ b/frontend/providers/template/src/pages/deploy/components/ReadMe.tsx
@@ -1,5 +1,5 @@
 import MyIcon from '@/components/Icon';
-import { Box } from '@chakra-ui/react';
+import { Box, Center, Spinner, Text } from '@chakra-ui/react';
 import 'github-markdown-css/github-markdown-light.css';
 import ReactMarkdown from 'react-markdown';
 import rehypeRaw from 'rehype-raw';
@@ -8,7 +8,15 @@ import remarkGfm from 'remark-gfm';
 import remarkUnwrapImages from 'remark-unwrap-images';
 import styles from './index.module.scss';
 
-const ReadMe = ({ readUrl, readmeContent }: { readUrl: string; readmeContent: string }) => {
+const ReadMe = ({
+  readUrl,
+  readmeContent,
+  isLoading
+}: {
+  readUrl: string;
+  readmeContent: string;
+  isLoading?: boolean;
+}) => {
   // @ts-ignore
   const myRewrite = (node, index, parent) => {
     if (node.tagName === 'img' && !node.properties.src.startsWith('http')) {
@@ -32,13 +40,22 @@ const ReadMe = ({ readUrl, readmeContent }: { readUrl: string; readmeContent: st
         README.md
       </Box>
       <Box borderRadius={'8px'} p={'24px'} className={`markdown-body ${styles.customMarkDownBody}`}>
-        <ReactMarkdown
-          linkTarget={'_blank'}
-          rehypePlugins={[rehypeRaw, [rehypeRewrite, { rewrite: myRewrite }]]}
-          remarkPlugins={[remarkGfm, remarkUnwrapImages]}
-        >
-          {readmeContent}
-        </ReactMarkdown>
+        {isLoading ? (
+          <Center minH={'160px'} flexDirection={'column'} color={'#7B838B'}>
+            <Spinner size={'sm'} />
+            <Text mt={'12px'} fontSize={'14px'}>
+              README loading...
+            </Text>
+          </Center>
+        ) : (
+          <ReactMarkdown
+            linkTarget={'_blank'}
+            rehypePlugins={[rehypeRaw, [rehypeRewrite, { rewrite: myRewrite }]]}
+            remarkPlugins={[remarkGfm, remarkUnwrapImages]}
+          >
+            {readmeContent}
+          </ReactMarkdown>
+        )}
       </Box>
     </Box>
   );

--- a/frontend/providers/template/src/pages/deploy/index.tsx
+++ b/frontend/providers/template/src/pages/deploy/index.tsx
@@ -1,4 +1,4 @@
-import { getTemplateSource, postDeployApp } from '@/api/app';
+import { getTemplateReadme, getTemplateSource, postDeployApp } from '@/api/app';
 import { getPlatformEnv } from '@/api/platform';
 import { editModeMap } from '@/constants/editApp';
 import { useConfirm } from '@/hooks/useConfirm';
@@ -53,6 +53,10 @@ export default function EditApp({
   const { Loading, setIsLoading } = useLoading();
   const { title, applyBtnText, applyMessage, applySuccess, applyError } = editModeMap(false);
   const [templateSource, setTemplateSource] = useState<TemplateSourceType>();
+  const [readmeSource, setReadmeSource] = useState<Pick<
+    TemplateSourceType,
+    'readUrl' | 'readmeContent'
+  > | null>(initTemplateData);
   const [yamlList, setYamlList] = useState<YamlItemType[]>([]);
   const [errorMessage, setErrorMessage] = useState('');
   const [errorCode, setErrorCode] = useState<ResponseCode>();
@@ -252,7 +256,12 @@ export default function EditApp({
 
   const { data, isLoading: isTemplateLoading } = useQuery(
     ['getTemplateSource', templateName],
-    () => getTemplateSource(templateName),
+    () =>
+      getTemplateSource(templateName, {
+        locale: i18n.language,
+        includeReadme: false,
+        includeRequirements: false
+      }),
     {
       initialData: initTemplateData,
       enabled: !!initTemplateData,
@@ -267,6 +276,21 @@ export default function EditApp({
           duration: 3000,
           isClosable: true
         });
+      }
+    }
+  );
+
+  const { isLoading: isReadmeLoading } = useQuery(
+    ['getTemplateReadme', templateName, i18n.language],
+    () => getTemplateReadme(templateName, i18n.language),
+    {
+      enabled: !!templateName,
+      onSuccess(data) {
+        setReadmeSource(data);
+      },
+      onError(err) {
+        console.log(err);
+        setReadmeSource({ readUrl: '', readmeContent: '' });
       }
     }
   );
@@ -295,7 +319,7 @@ export default function EditApp({
     return (
       !isTemplateLoading && !isPlatformEnvsLoading && !!templateSource && !!data && !!platformEnvs
     );
-  }, [isTemplateLoading, isPlatformEnvsLoading, templateSource, data, platformEnvs, yamlList]);
+  }, [isTemplateLoading, isPlatformEnvsLoading, templateSource, data, platformEnvs]);
 
   return (
     <Box
@@ -393,9 +417,10 @@ export default function EditApp({
             {/* <QuotaBox /> */}
             <Form formHook={formHook} formSource={templateSource!} platformEnvs={platformEnvs!} />
             <ReadMe
-              key={templateSource?.readUrl || 'readme_url'}
-              readUrl={templateSource?.readUrl || ''}
-              readmeContent={templateSource?.readmeContent || ''}
+              key={readmeSource?.readUrl || 'readme_url'}
+              readUrl={readmeSource?.readUrl || ''}
+              readmeContent={readmeSource?.readmeContent || ''}
+              isLoading={isReadmeLoading}
             />
           </Flex>
         </Flex>
@@ -430,7 +455,7 @@ export async function getServerSideProps(content: any) {
 
   try {
     const response = await fetch(
-      `${baseurl}/api/getTemplateSource?templateName=${appName}&locale=${locale}&includeReadme=true`
+      `${baseurl}/api/getTemplateSource?templateName=${appName}&locale=${locale}&includeReadme=false&includeRequirements=false`
     );
     if (!response.ok) {
       throw new Error(`API request failed with status`);

--- a/frontend/providers/template/src/utils/json-yaml.ts
+++ b/frontend/providers/template/src/utils/json-yaml.ts
@@ -17,6 +17,70 @@ function base64(str: string) {
   return Buffer.from(str).toString('base64');
 }
 
+type ExpressionData = {
+  [key: string]: any;
+};
+
+type ExpressionContext = {
+  cache: Map<string, any>;
+};
+
+const createExpressionContext = (): ExpressionContext => ({
+  cache: new Map()
+});
+
+const randomCallReg = /(^|[^\w$])random\s*\(/;
+const simplePathReservedWords = new Set(['true', 'false', 'null', 'undefined', 'NaN', 'Infinity']);
+
+function isCacheableExpression(expression: string) {
+  return !randomCallReg.test(expression);
+}
+
+function evaluateSimplePath(
+  expression: string,
+  data?: ExpressionData
+): { matched: boolean; value?: any } {
+  if (simplePathReservedWords.has(expression)) {
+    return { matched: false };
+  }
+
+  const rootMatch = /^[A-Za-z_$][\w$]*/.exec(expression);
+  if (!rootMatch) {
+    return { matched: false };
+  }
+
+  const parts = [rootMatch[0]];
+  let rest = expression.slice(rootMatch[0].length);
+
+  while (rest) {
+    const dotMatch = /^\.([A-Za-z_$][\w$-]*)/.exec(rest);
+    if (dotMatch) {
+      parts.push(dotMatch[1]);
+      rest = rest.slice(dotMatch[0].length);
+      continue;
+    }
+
+    const bracketMatch = /^\[(?:"([^"\\]*)"|'([^'\\]*)'|(\d+))\]/.exec(rest);
+    if (bracketMatch) {
+      parts.push(bracketMatch[1] ?? bracketMatch[2] ?? bracketMatch[3]);
+      rest = rest.slice(bracketMatch[0].length);
+      continue;
+    }
+
+    return { matched: false };
+  }
+
+  let value: any = data;
+  for (const part of parts) {
+    if (value == null) {
+      return { matched: true, value: undefined };
+    }
+    value = value[part];
+  }
+
+  return { matched: true, value };
+}
+
 export const generateYamlList = (value: string, labelName: string): YamlItemType[] => {
   try {
     let _value = JsYaml.loadAll(value)
@@ -57,12 +121,13 @@ export const parseTemplateString = (
     [key: string]: string | Record<string, string>;
   }
 ): string => {
-  sourceString = parseYamlIfEndif(sourceString, dataSource);
+  const expressionContext = createExpressionContext();
+  sourceString = parseYamlIfEndif(sourceString, dataSource, expressionContext);
   const regex = /\$\{\{\s*(.*?)\s*\}\}/g;
 
   try {
     const replacedString = sourceString.replace(regex, (match: string, key: string) => {
-      const value = evaluateExpression(key, dataSource);
+      const value = evaluateExpression(key, dataSource, expressionContext);
       return value !== undefined ? value : '';
     });
     return replacedString;
@@ -182,14 +247,27 @@ export const handleTemplateToInstanceYaml = (
 // https://github.com/NeilFraser/JS-Interpreter
 export function evaluateExpression(
   expression: string,
-  data?: {
-    [key: string]: any;
-  }
+  data?: ExpressionData,
+  context?: ExpressionContext
 ): any | undefined {
+  const normalizedExpression = expression.trim();
+  const cacheable = isCacheableExpression(normalizedExpression);
+  if (context && cacheable && context.cache.has(normalizedExpression)) {
+    return context.cache.get(normalizedExpression);
+  }
+
   try {
+    const simplePathResult = evaluateSimplePath(normalizedExpression, data);
+    if (simplePathResult.matched) {
+      if (context && cacheable) {
+        context.cache.set(normalizedExpression, simplePathResult.value);
+      }
+      return simplePathResult.value;
+    }
+
     // console.log("expression: ", expression, " data: ", data)
     // const result = new Function('data', `with(data) { return ${expression}; }`)(data);
-    const processedExpression = expression.replace(
+    const processedExpression = normalizedExpression.replace(
       /(\w+)\.([a-zA-Z_$][\w\-]*)/g,
       (match, obj, prop) => {
         if (prop.includes('-')) {
@@ -209,6 +287,9 @@ export function evaluateExpression(
     );
     interpreter.run();
     // console.log('resoult: ', interpreter.value)
+    if (context && cacheable) {
+      context.cache.set(normalizedExpression, interpreter.value);
+    }
     return interpreter.value;
   } catch (error) {
     console.error('Failed to evaluate expression: ', expression, ' data: ', data, error);
@@ -220,10 +301,11 @@ export function parseYamlIfEndif(
   yamlStr: string,
   data: {
     [key: string]: string | Record<string, string>;
-  }
+  },
+  context = createExpressionContext()
 ): string {
   return __parseYamlIfEndif(yamlStr, (exp) => {
-    return !!evaluateExpression(exp, data);
+    return !!evaluateExpression(exp, data, context);
   });
 }
 
@@ -383,6 +465,8 @@ export function parseTemplateVariable(
   platformEnvs?: EnvResponse
 ): TemplateType {
   const regex = /\$\{\{\s*(.*?)\s*\}\}/g;
+  const defaultsExpressionContext = createExpressionContext();
+  const inputsExpressionContext = createExpressionContext();
 
   templateYaml = clone(templateYaml);
 
@@ -391,7 +475,7 @@ export function parseTemplateVariable(
       if (item.value) {
         item.value =
           item.value.replace(regex, (match: string, key: string) => {
-            return evaluateExpression(key, platformEnvs);
+            return evaluateExpression(key, platformEnvs, defaultsExpressionContext);
           }) || item.value;
       }
     }
@@ -405,19 +489,27 @@ export function parseTemplateVariable(
       if (item.description) {
         item.description =
           item.description.replace(regex, (match: string, key: string) => {
-            return evaluateExpression(key, {
-              ...platformEnvs,
-              defaults
-            });
+            return evaluateExpression(
+              key,
+              {
+                ...platformEnvs,
+                defaults
+              },
+              inputsExpressionContext
+            );
           }) || item.description;
       }
       if (item.default) {
         item.default =
           item.default.replace(regex, (match: string, key: string) => {
-            return evaluateExpression(key, {
-              ...platformEnvs,
-              defaults
-            });
+            return evaluateExpression(
+              key,
+              {
+                ...platformEnvs,
+                defaults
+              },
+              inputsExpressionContext
+            );
           }) || item.default;
       }
     }


### PR DESCRIPTION
## Summary

- Split template detail README loading from the initial template source request.
- Fix `includeReadme=false` so `/api/getTemplateSource` can skip README fetching.
- Add `includeRequirements=false` for the detail page initial load to avoid blocking SSR/client fetch on server-side resource calculation.
- Add a lightweight `/api/getTemplateReadme` endpoint that reuses the existing README cache and retry path.

## Tests

- `corepack pnpm@8.9.0 --filter template exec next lint --file src/api/app.ts --file src/pages/api/getTemplateSource.ts --file src/pages/api/getTemplateReadme.ts --file src/pages/deploy/index.tsx --file src/pages/deploy/components/ReadMe.tsx`
- `corepack pnpm@8.9.0 --filter template exec prettier --check src/api/app.ts src/pages/api/getTemplateSource.ts src/pages/api/getTemplateReadme.ts src/pages/deploy/index.tsx src/pages/deploy/components/ReadMe.tsx`
- `git diff --check`

## Notes

Full `tsc --noEmit` is currently blocked in this local workspace by existing unresolved monorepo package typings such as `@sealos/*` and `sealos-desktop-sdk`, plus a local Node version mismatch warning. The targeted changed-file lint and format checks pass.

Refs labring-sigs/sealos-issues#322
