### PR TITLE
fix(template): prevent debug button wrapping

### DIFF
--- a/frontend/providers/template/src/pages/app/index.tsx
+++ b/frontend/providers/template/src/pages/app/index.tsx
@@ -44,7 +44,8 @@ export default function MyApp() {
         </Tabs>
         <Center
           cursor={'pointer'}
-          w="124px"
+          minW="124px"
+          whiteSpace={'nowrap'}
           bg="rgba(150, 153, 180, 0.15)"
           p="4px 12px"
           borderRadius={'40px'}


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->

### What this PR does

- Prevents the Template app debug entry button from wrapping its Chinese label in Chrome versions with slightly different font metrics.
- Changes the fixed width to a minimum width and forces the pill content to stay on one line.

### Verification

- `git diff --check -- frontend/providers/template/src/pages/app/index.tsx`
- `docker buildx build --platform linux/amd64 -f frontend/Dockerfile --build-arg name=template --build-arg path=providers/template -t sealos-template:verify-debug-nowrap-5.1 --load frontend`
- Deployed and smoke-checked on the 70 test cluster with computed style confirming `min-width: 124px` and `white-space: nowrap`.
