### PR TITLE
fix(license): parse Kubernetes resource quantities

### DIFF
--- a/frontend/providers/license/package.json
+++ b/frontend/providers/license/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test:quantity": "node src/utils/kubernetesQuantity.test.js",
     "link-sdk": "rm -rf node_modules/sealos-desktop-sdk && yalc link sealos-desktop-sdk",
     "unlink-sdk": "yalc remove --all && pnpm install sealos-desktop-sdk"
   },

--- a/frontend/providers/license/src/pages/api/platform/getClusterId.ts
+++ b/frontend/providers/license/src/pages/api/platform/getClusterId.ts
@@ -2,6 +2,7 @@ import { authSession } from '@/services/backend/auth';
 import { K8sApiDefault, getK8s } from '@/services/backend/kubernetes';
 import { jsonRes } from '@/services/backend/response';
 import { ApiResp } from '@/services/kubernet';
+import { parseKubernetesQuantity } from '@/utils/kubernetesQuantity';
 import * as k8s from '@kubernetes/client-node';
 import { Decimal } from 'decimal.js';
 import type { NextApiRequest, NextApiResponse } from 'next';
@@ -53,16 +54,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     const totalWorkspaces = usersResult?.body?.items?.length || 0;
 
     let totalCpu = new Decimal(0);
-    let totalMemoryKi = new Decimal(0);
+    let totalMemoryBytes = new Decimal(0);
 
     nodesResult.body.items.forEach((node) => {
       if (!node?.status?.capacity) return;
-      const cpu = new Decimal(node.status.capacity.cpu);
-      const memoryKi = new Decimal(node.status.capacity.memory.replace('Ki', ''));
-      totalCpu = totalCpu.plus(cpu);
-      totalMemoryKi = totalMemoryKi.plus(memoryKi);
+      const { cpu, memory } = node.status.capacity;
+      if (cpu) {
+        totalCpu = totalCpu.plus(parseKubernetesQuantity(cpu));
+      }
+      if (memory) {
+        totalMemoryBytes = totalMemoryBytes.plus(parseKubernetesQuantity(memory));
+      }
     });
-    const totalMemoryGB = totalMemoryKi.dividedBy(Decimal.pow(2, 20)).ceil(); // 1 GB = 2^20 Ki
+    const totalMemoryGB = totalMemoryBytes.dividedBy(Decimal.pow(2, 30)).ceil();
 
     jsonRes<TSystemInfo>(res, {
       data: {

--- a/frontend/providers/license/src/utils/kubernetesQuantity.js
+++ b/frontend/providers/license/src/utils/kubernetesQuantity.js
@@ -1,0 +1,52 @@
+const { Decimal } = require('decimal.js');
+
+const DECIMAL_SI_EXPONENTS = {
+  n: -9,
+  u: -6,
+  m: -3,
+  '': 0,
+  k: 3,
+  K: 3,
+  M: 6,
+  G: 9,
+  T: 12,
+  P: 15,
+  E: 18
+};
+
+const BINARY_SI_EXPONENTS = {
+  Ki: 10,
+  Mi: 20,
+  Gi: 30,
+  Ti: 40,
+  Pi: 50,
+  Ei: 60
+};
+
+const QUANTITY_RE = /^([+-]?(?:\d+(?:\.\d*)?|\.\d+))([numkKMGTPE]i?)?$/;
+
+function parseKubernetesQuantity(value) {
+  const input = String(value ?? '').trim();
+  const match = input.match(QUANTITY_RE);
+
+  if (!match) {
+    throw new Error(`Invalid Kubernetes quantity: ${input}`);
+  }
+
+  const amount = new Decimal(match[1]);
+  const suffix = match[2] || '';
+
+  if (suffix in BINARY_SI_EXPONENTS) {
+    return amount.times(Decimal.pow(2, BINARY_SI_EXPONENTS[suffix]));
+  }
+
+  if (suffix in DECIMAL_SI_EXPONENTS) {
+    return amount.times(Decimal.pow(10, DECIMAL_SI_EXPONENTS[suffix]));
+  }
+
+  throw new Error(`Unsupported Kubernetes quantity suffix: ${suffix}`);
+}
+
+module.exports = {
+  parseKubernetesQuantity
+};

--- a/frontend/providers/license/src/utils/kubernetesQuantity.test.js
+++ b/frontend/providers/license/src/utils/kubernetesQuantity.test.js
@@ -1,0 +1,24 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { Decimal } = require('decimal.js');
+const { parseKubernetesQuantity } = require('./kubernetesQuantity');
+
+test('parses Kubernetes binary memory quantities', () => {
+  assert.equal(
+    parseKubernetesQuantity('30265652Ki').dividedBy(Decimal.pow(2, 30)).ceil().toString(),
+    '29'
+  );
+  assert.equal(
+    parseKubernetesQuantity('260236Mi').dividedBy(Decimal.pow(2, 30)).ceil().toString(),
+    '255'
+  );
+  assert.equal(
+    parseKubernetesQuantity('256Gi').dividedBy(Decimal.pow(2, 30)).ceil().toString(),
+    '256'
+  );
+});
+
+test('parses Kubernetes decimal CPU quantities as cores', () => {
+  assert.equal(parseKubernetesQuantity('8').toString(), '8');
+  assert.equal(parseKubernetesQuantity('2500m').toString(), '2.5');
+});


### PR DESCRIPTION
## Summary

- Parse Kubernetes resource quantities in the license cluster info API instead of assuming node memory is always reported in `Ki`.
- Convert memory quantities to bytes before reporting GiB, while keeping CPU quantities in cores.
- Add regression coverage for `Ki`, `Mi`, `Gi`, and millicore CPU quantities.

## Testing

- `pnpm --filter ./providers/license run test:quantity`
- `pnpm --filter ./providers/license run build`

Notes: the build passes with existing local warnings for Node v23.11.0 vs the package requirement of 20.20.2, existing `_app.tsx` hook dependency warnings, outdated Browserslist data, and static-generation i18next initialization messages.
