### PR TITLE
fix(desktop): disable workspace quota bridge

### DIFF
--- a/frontend/desktop/src/components/desktop_content/index.tsx
+++ b/frontend/desktop/src/components/desktop_content/index.tsx
@@ -17,7 +17,6 @@ import { useRealNameAuthNotification } from '../account/RealNameModal';
 import useSessionStore from '@/stores/session';
 import { useQuery } from '@tanstack/react-query';
 import { getAmount, UserInfo, validateKubeconfig } from '@/api/auth';
-import { getResource } from '@/api/platform';
 import OnlineServiceButton from './serviceButton';
 import SaleBanner from '../banner';
 import { useAppDisplayConfigStore } from '@/stores/appDisplayConfig';
@@ -168,10 +167,7 @@ export default function Desktop() {
   useEffect(() => {
     const cleanup = createMasterAPP({
       allowedOrigins: cloudConfig?.allowedOrigins || ['*'],
-      getWorkspaceQuotaApi: async () => {
-        const response = await getResource();
-        return response.data?.workspaceQuota || [];
-      }
+      getWorkspaceQuotaApi: async () => []
     });
     return cleanup;
   }, [cloudConfig?.allowedOrigins]);


### PR DESCRIPTION
## Summary
- Temporarily disables the desktop workspace quota bridge for iframe apps.
- Keeps the desktop header resource display and `/api/desktop/getResource` behavior unchanged.
- Prevents apps using the shared quota guard from consuming desktop display-unit quota values and blocking valid creates.

## Verification
- `PATH="$HOME/.nvm/versions/node/v20.4.0/bin:$PATH" pnpm --dir frontend/desktop lint`
- `git diff --check -- frontend/desktop/src/components/desktop_content/index.tsx`

## Notes
- `PATH="$HOME/.nvm/versions/node/v20.4.0/bin:$PATH" pnpm --dir frontend/desktop build` still fails on an existing unrelated type error in `src/components/desktop_content/apps.tsx:831`, where `announcement_id: 'invitation_referral_prompt'` is not assignable to the current analytics type.
