### PR TITLE
fix(applaunchpad): restore quota guard on release v5.1

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/quota.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/quota.test.ts
@@ -1,0 +1,155 @@
+import { readFileSync } from 'fs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getUserQuota } from '@/api/platform';
+import { defaultEditVal } from '@/constants/editApp';
+import { getUserQuota as getKubernetesUserQuota } from '@/services/backend/kubernetes';
+import { useUserStore } from '@/store/user';
+import type { AppEditType } from '@/types/app';
+
+vi.mock('@/api/platform', () => ({
+  getResourcePrice: vi.fn(),
+  getUserQuota: vi.fn()
+}));
+
+const getUserQuotaMock = vi.mocked(getUserQuota);
+
+const createAppRequest = (overrides: Partial<AppEditType> = {}): AppEditType => ({
+  ...defaultEditVal,
+  gpu: { ...defaultEditVal.gpu! },
+  hpa: { ...defaultEditVal.hpa },
+  networks: defaultEditVal.networks.map((network) => ({ ...network })),
+  storeList: [],
+  ...overrides
+});
+
+describe('useUserStore quota guard', () => {
+  beforeEach(() => {
+    getUserQuotaMock.mockReset();
+    useUserStore.setState({ userQuota: [] });
+  });
+
+  it('refreshes quota before checking a create request', async () => {
+    useUserStore.setState({
+      userQuota: [{ type: 'cpu', used: 0, limit: 100 }]
+    });
+    getUserQuotaMock.mockResolvedValue({
+      quota: [{ type: 'cpu', used: 1.5, limit: 2 }]
+    });
+
+    const result = await useUserStore.getState().checkQuotaAllow(
+      createAppRequest({
+        cpu: 1000,
+        replicas: 1
+      })
+    );
+
+    expect(getUserQuotaMock).toHaveBeenCalledOnce();
+    expect(result).toBe('app.The applied CPU exceeds the quota');
+  });
+
+  it('allows a request that exactly consumes the available quota', async () => {
+    getUserQuotaMock.mockResolvedValue({
+      quota: [{ type: 'cpu', used: 1.5, limit: 2 }]
+    });
+
+    const result = await useUserStore.getState().checkQuotaAllow(
+      createAppRequest({
+        cpu: 500,
+        replicas: 1
+      })
+    );
+
+    expect(result).toBe('');
+  });
+
+  it('checks ephemeral storage across the maximum replica count', async () => {
+    getUserQuotaMock.mockResolvedValue({
+      quota: [{ type: 'ephemeral-storage', used: 1, limit: 4 }]
+    });
+
+    const result = await useUserStore.getState().checkQuotaAllow(
+      createAppRequest({
+        ephemeralStorage: 2,
+        hpa: {
+          ...defaultEditVal.hpa,
+          use: true,
+          maxReplicas: 2
+        }
+      })
+    );
+
+    expect(result).toBe('app.The applied ephemeral storage exceeds the quota');
+  });
+
+  it('checks only the additional ephemeral storage when updating an app', async () => {
+    getUserQuotaMock.mockResolvedValue({
+      quota: [{ type: 'ephemeral-storage', used: 3, limit: 4 }]
+    });
+    const hpa = {
+      ...defaultEditVal.hpa,
+      use: true,
+      maxReplicas: 2
+    };
+
+    const result = await useUserStore
+      .getState()
+      .checkQuotaAllow(
+        createAppRequest({ ephemeralStorage: 3, hpa }),
+        createAppRequest({ ephemeralStorage: 2.5, hpa })
+      );
+
+    expect(result).toBe('');
+  });
+
+  it('does not fall back to stale quota when refreshing quota fails', async () => {
+    useUserStore.setState({
+      userQuota: [{ type: 'cpu', used: 0, limit: 100 }]
+    });
+    getUserQuotaMock.mockRejectedValue(new Error('quota unavailable'));
+
+    await expect(
+      useUserStore.getState().checkQuotaAllow(createAppRequest({ cpu: 1000, replicas: 1 }))
+    ).rejects.toThrow('quota unavailable');
+  });
+});
+
+describe('getUserQuota', () => {
+  it('omits undeclared resources while retaining explicit zero quotas', async () => {
+    const readNamespacedResourceQuota = vi.fn().mockResolvedValue({
+      body: {
+        status: {
+          hard: {
+            'limits.cpu': '2',
+            'services.nodeports': '0'
+          },
+          used: {
+            'limits.cpu': '500m',
+            'services.nodeports': '0'
+          }
+        }
+      }
+    });
+    const kubeConfig = {
+      makeApiClient: vi.fn(() => ({ readNamespacedResourceQuota }))
+    };
+
+    const result = await getKubernetesUserQuota(kubeConfig as any, 'ns-test');
+
+    expect(result).toEqual([
+      { type: 'cpu', limit: 2, used: 0.5 },
+      { type: 'nodeports', limit: 0, used: 0 }
+    ]);
+  });
+});
+
+describe('quota form state', () => {
+  it('uses the per-PVC cap when workspace storage quota is undeclared', () => {
+    const source = readFileSync(
+      new URL('../../src/pages/app/edit/components/Form.tsx', import.meta.url),
+      'utf8'
+    );
+
+    expect(source).toContain('if (!storageQuota) return PVC_STORAGE_MAX;');
+  });
+});

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
@@ -236,7 +236,7 @@ const Form = ({
 
   const storageQuotaLeft = useMemo(() => {
     const storageQuota = userQuota?.find((item) => item.type === 'storage');
-    if (!storageQuota) return 0;
+    if (!storageQuota) return PVC_STORAGE_MAX;
 
     const newlyUsedStorage =
       storeList.reduce((sum, item) => sum + item.value, 0) -

--- a/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
@@ -275,7 +275,7 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
   const [forceUpdate, setForceUpdate] = useState(false);
   const { setAppDetail } = useAppStore();
   const { screenWidth, formSliderListConfig } = useGlobalStore();
-  const { userSourcePrice, loadUserSourcePrice } = useUserStore();
+  const { userSourcePrice, loadUserSourcePrice, checkQuotaAllow } = useUserStore();
   const { title, applyBtnText, applyMessage, applySuccess, applyError } = editModeMap(!!appName);
   const [yamlList, setYamlList] = useState<YamlItemType[]>([]);
   const [errorMessage, setErrorMessage] = useState('');
@@ -837,16 +837,23 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
                   });
                 }
               }
-              // quote check
-              // const quoteCheckRes = checkQuotaAllow(data, oldAppEditData.current);
-              // if (quoteCheckRes) {
-              //   return toast({
-              //     status: 'warning',
-              //     title: t(quoteCheckRes),
-              //     duration: 5000,
-              //     isClosable: true
-              //   });
-              // }
+              // quota check
+              try {
+                const quotaCheckResult = await checkQuotaAllow(data, oldAppEditData.current);
+                if (quotaCheckResult) {
+                  return toast({
+                    status: 'warning',
+                    title: t(quotaCheckResult),
+                    duration: 5000,
+                    isClosable: true
+                  });
+                }
+              } catch (error) {
+                return toast({
+                  status: 'error',
+                  title: getErrText(error) || t('Submit Error')
+                });
+              }
 
               // check network port
               if (!checkNetworkPorts(data.networks)) {

--- a/frontend/providers/applaunchpad/src/services/backend/kubernetes.ts
+++ b/frontend/providers/applaunchpad/src/services/backend/kubernetes.ts
@@ -147,38 +147,55 @@ export async function getUserQuota(
     body: { status }
   } = await k8sApi.readNamespacedResourceQuota(`quota-${namespace}`, namespace);
 
-  return [
+  const quotaItems: Array<{
+    type: UserQuotaItemType['type'];
+    resourceName: string;
+    parse: (quantity: string) => number;
+  }> = [
     {
       type: 'cpu',
-      limit: cpuFormatToM(status?.hard?.['limits.cpu'] || '') / 1000,
-      used: cpuFormatToM(status?.used?.['limits.cpu'] || '') / 1000
+      resourceName: 'limits.cpu',
+      parse: (quantity) => cpuFormatToM(quantity) / 1000
     },
     {
       type: 'memory',
-      limit: memoryFormatToMi(status?.hard?.['limits.memory'] || '') / 1024,
-      used: memoryFormatToMi(status?.used?.['limits.memory'] || '') / 1024
+      resourceName: 'limits.memory',
+      parse: (quantity) => memoryFormatToMi(quantity) / 1024
     },
     {
       type: 'storage',
-      limit: storageQuantityToMi(status?.hard?.['requests.storage'] || '') / 1024,
-      used: storageQuantityToMi(status?.used?.['requests.storage'] || '') / 1024
+      resourceName: 'requests.storage',
+      parse: (quantity) => storageQuantityToMi(quantity) / 1024
     },
     {
       type: 'ephemeral-storage',
-      limit: storageQuantityToMi(status?.hard?.['limits.ephemeral-storage'] || '') / 1024,
-      used: storageQuantityToMi(status?.used?.['limits.ephemeral-storage'] || '') / 1024
+      resourceName: 'limits.ephemeral-storage',
+      parse: (quantity) => storageQuantityToMi(quantity) / 1024
     },
     {
       type: 'nodeports',
-      limit: Number(status?.hard?.['services.nodeports']) || 0,
-      used: Number(status?.used?.['services.nodeports']) || 0
+      resourceName: 'services.nodeports',
+      parse: (quantity) => Number(quantity) || 0
     },
     {
       type: 'gpu',
-      limit: Number(status?.hard?.['requests.nvidia.com/gpu'] || 0),
-      used: Number(status?.used?.['requests.nvidia.com/gpu'] || 0)
+      resourceName: 'requests.nvidia.com/gpu',
+      parse: (quantity) => Number(quantity) || 0
     }
   ];
+
+  return quotaItems.flatMap(({ type, resourceName, parse }) => {
+    const hardLimit = status?.hard?.[resourceName];
+    if (hardLimit === undefined) return [];
+
+    return [
+      {
+        type,
+        limit: parse(hardLimit),
+        used: parse(status?.used?.[resourceName] || '')
+      }
+    ];
+  });
 }
 
 export async function getUserBalance(kc: k8s.KubeConfig) {

--- a/frontend/providers/applaunchpad/src/store/user.ts
+++ b/frontend/providers/applaunchpad/src/store/user.ts
@@ -11,7 +11,7 @@ type State = {
   loadUserQuota: () => Promise<null>;
   userSourcePrice: userPriceType | undefined;
   loadUserSourcePrice: () => Promise<null>;
-  checkQuotaAllow: (request: AppEditType, usedData?: AppEditType) => string;
+  checkQuotaAllow: (request: AppEditType, usedData?: AppEditType) => Promise<string>;
 };
 
 let retryGetPrice = 3;
@@ -47,11 +47,15 @@ export const useUserStore = create<State>()(
         });
         return null;
       },
-      checkQuotaAllow: (
+      checkQuotaAllow: async (
         { cpu, memory, gpu, storeList, replicas, hpa, networks, ephemeralStorage },
         usedData
       ) => {
-        const quote = get().userQuota;
+        const response = await getUserQuota();
+        const quote = response.quota;
+        set((state) => {
+          state.userQuota = quote;
+        });
 
         const requestReplicas = Number(hpa.use ? hpa.maxReplicas : replicas);
         const nodeportsAmount = networks.filter((item) => item.openNodePort).length;
@@ -62,11 +66,12 @@ export const useUserStore = create<State>()(
           gpu: (gpu?.type ? gpu.amount : 0) * requestReplicas,
           storage: storeList.reduce((sum, item) => sum + item.value, 0) * requestReplicas,
           nodeports: nodeportsAmount,
-          'ephemeral-storage': ephemeralStorage || 0
+          'ephemeral-storage': (ephemeralStorage || 0) * requestReplicas
         };
 
         if (usedData) {
-          const { cpu, memory, gpu, storeList, replicas, hpa, networks } = usedData;
+          const { cpu, memory, gpu, storeList, replicas, hpa, networks, ephemeralStorage } =
+            usedData;
           const requestReplicas = Number(hpa.use ? hpa.maxReplicas : replicas);
           const nodeportsAmount = networks.filter((item) => item.openNodePort).length;
 
@@ -75,6 +80,7 @@ export const useUserStore = create<State>()(
           request.gpu -= (gpu?.type ? gpu.amount : 0) * requestReplicas;
           request.storage -= storeList.reduce((sum, item) => sum + item.value, 0) * requestReplicas;
           request.nodeports -= nodeportsAmount;
+          request['ephemeral-storage'] -= (ephemeralStorage || 0) * requestReplicas;
         }
 
         const overLimitTip = {


### PR DESCRIPTION
## What changed

- Restore the application quota guard before create and update submissions.
- Refresh quota data at submit time and fail closed when the quota request fails.
- Account for ephemeral storage using the requested or HPA maximum replica count.
- Treat undeclared ResourceQuota resources as unlimited while preserving explicit zero limits.
- Add regression coverage for stale quota data, boundary values, HPA ephemeral storage, update deltas, refresh failures, and ResourceQuota normalization.

## Why

The quota check in `release-v5.1` was commented out, so Application Management could submit workloads that exceeded the workspace quota. Kubernetes accepted the Deployment object and rejected Pods later, leaving users without an actionable guard in the creation flow.

Related issue: https://linear.app/luppywang/issue/LUP-342/345-%E5%BA%94%E7%94%A8%E7%AE%A1%E7%90%86%E5%88%9B%E5%BB%BA%E8%B6%85%E5%87%BAquota%E9%85%8D%E9%A2%9D%E6%97%A0%E6%8B%A6%E6%88%AA

## Verification

- `npx --yes pnpm@8.9.0 exec vitest run __tests__/unit` (19 files, 106 tests)
- `npx --yes pnpm@8.9.0 run build`

