### PR TITLE
fix(applaunchpad): align log field labels

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/utils/logFields.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/logFields.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { getLogFieldLabel } from '@/utils/logFields';
+
+describe('getLogFieldLabel', () => {
+  it.each([
+    ['_time', 'time'],
+    ['_msg', 'msg'],
+    ['container', 'container'],
+    ['custom_field', 'custom_field']
+  ])('formats %s as %s', (field, expected) => {
+    expect(getLogFieldLabel(field)).toBe(expected);
+  });
+});

--- a/frontend/providers/applaunchpad/src/components/app/detail/logs/LogTable.tsx
+++ b/frontend/providers/applaunchpad/src/components/app/detail/logs/LogTable.tsx
@@ -21,6 +21,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import MyIcon from '@/components/Icon';
 import { formatTime } from '@/utils/tools';
+import { getLogFieldLabel } from '@/utils/logFields';
 import { LogsFormData } from '@/pages/app/detail/logs';
 import { UseFormReturn } from 'react-hook-form';
 import { useLogStore } from '@/store/logStore';
@@ -72,7 +73,7 @@ export const LogTable = ({
 
     return Array.from(uniqueKeys).map((key) => ({
       value: key,
-      label: key,
+      label: getLogFieldLabel(key),
       checked: key in prevFieldStates ? prevFieldStates[key] : true,
       accessorKey: key
     }));
@@ -102,12 +103,7 @@ export const LogTable = ({
       .filter((field) => field.checked)
       .map((field) => ({
         accessorKey: field.accessorKey,
-        header: () => {
-          if (field.label === '_time' || field.label === '_msg') {
-            return field.label.substring(1);
-          }
-          return field.label;
-        },
+        header: field.label,
         cell: ({ row }) => {
           let value = get(row.original, field.accessorKey, '');
 

--- a/frontend/providers/applaunchpad/src/utils/logFields.ts
+++ b/frontend/providers/applaunchpad/src/utils/logFields.ts
@@ -1,0 +1,3 @@
+export const getLogFieldLabel = (field: string) => {
+  return field === '_time' || field === '_msg' ? field.substring(1) : field;
+};


### PR DESCRIPTION
## What changed

- Use the same display label for log field settings and table headers.
- Keep raw field keys unchanged for data access and filtering.
- Add regression coverage for `_time`, `_msg`, and ordinary fields.

## Why

The field settings showed raw `_time` and `_msg` keys while the table headers showed `time` and `msg`, so the descriptions for the same fields did not match.

## Verification

- `vitest run --config vitest.config.ts`: 19 files, 103 tests passed
- `tsc --noEmit -p tsconfig.json`: passed
- `next lint`: passed with pre-existing hook dependency warnings
- `prettier --check`: passed
- Browser verification: expanded field settings and table headers both show `time` and `msg`

Fixes labring-sigs/sealos-issues#356
