### PR TITLE
fix(applaunchpad): make edit page responsive in iframes

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/pages/app/edit/index.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/pages/app/edit/index.test.ts
@@ -2,6 +2,29 @@ import { readFileSync } from 'fs';
 import { describe, expect, it } from 'vitest';
 
 describe('EditApp yaml display state', () => {
+  it('keeps the edit layout inside a narrow iframe viewport', () => {
+    const editPageSource = readFileSync(
+      new URL('../../../../../src/pages/app/edit/index.tsx', import.meta.url),
+      'utf8'
+    );
+    const formSource = readFileSync(
+      new URL('../../../../../src/pages/app/edit/components/Form.tsx', import.meta.url),
+      'utf8'
+    );
+    const yamlSource = readFileSync(
+      new URL('../../../../../src/pages/app/edit/components/Yaml.tsx', import.meta.url),
+      'utf8'
+    );
+
+    expect(editPageSource).toContain("'html, body':");
+    expect(editPageSource).toContain('minWidth: 0');
+    expect(editPageSource).toContain('minWidth={0}');
+    expect(editPageSource).not.toContain("minWidth={'1024px'}");
+    expect(formSource).toContain("md: '180px minmax(0, 1fr)'");
+    expect(formSource).toContain("lg: '220px minmax(0, 1fr)'");
+    expect(yamlSource).toContain("md: '180px minmax(0, 1fr)'");
+  });
+
   it('keeps custom-domain verification yaml display masked while caching raw yaml', () => {
     const source = readFileSync(
       new URL('../../../../../src/pages/app/edit/index.tsx', import.meta.url),

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
@@ -461,7 +461,7 @@ const Form = ({
 
   const headerStyles = {
     py: 4,
-    pl: '42px',
+    pl: { base: '16px', md: '24px', lg: '42px' },
     borderTopRadius: 'lg',
     fontSize: 'xl',
     color: 'grayModern.900',
@@ -621,10 +621,14 @@ const Form = ({
     <>
       <Grid
         height={'100%'}
-        templateColumns={'220px 1fr'}
-        gridGap={5}
+        templateColumns={{
+          base: 'minmax(0, 1fr)',
+          md: '180px minmax(0, 1fr)',
+          lg: '220px minmax(0, 1fr)'
+        }}
+        gridGap={{ base: 3, lg: 5 }}
         alignItems={'start'}
-        pl={`${pxVal}px`}
+        px={`${pxVal}px`}
       >
         <Box>
           <Tabs
@@ -716,9 +720,10 @@ const Form = ({
 
         <Box
           id={'form-container'}
-          pr={`${pxVal}px`}
           height={'100%'}
           position={'relative'}
+          minW={0}
+          overflowX={{ base: 'auto', md: 'visible' }}
           // overflowY={'scroll'}
         >
           {/* base info */}
@@ -727,13 +732,15 @@ const Form = ({
               <MyIcon name={'formInfo'} mr={'12px'} w={'24px'} color={'grayModern.900'} />
               {t('Basic Config')}
             </Box>
-            <Box px={'42px'} py={'24px'}>
+            <Box px={{ base: '16px', md: '24px', lg: '42px' }} py={'24px'}>
               {/* app name */}
-              <FormControl mb={7} isInvalid={!!errors.appName} w={'500px'}>
+              <FormControl mb={7} isInvalid={!!errors.appName} w={'100%'} maxW={'500px'}>
                 <Flex alignItems={'center'}>
                   <Label>{t('App Name')}</Label>
                   <Input
-                    width={'350px'}
+                    flex={1}
+                    minW={0}
+                    maxW={'350px'}
                     disabled={isEdit}
                     title={isEdit ? t('Not allowed to change app name') || '' : ''}
                     autoFocus={true}
@@ -810,10 +817,11 @@ const Form = ({
                     <Box mb={1} fontSize={'sm'}>
                       {t('Image Name')}
                     </Box>
-                    <Flex alignItems={'center'} gap={3}>
+                    <Flex alignItems={'center'} gap={3} flexWrap={{ base: 'wrap', lg: 'nowrap' }}>
                       <Input
-                        width={'350px'}
-                        flexShrink={0}
+                        width={'100%'}
+                        maxW={'350px'}
+                        minW={0}
                         value={getValues('imageName')}
                         backgroundColor={getValues('imageName') ? 'myWhite.500' : 'grayModern.100'}
                         placeholder={`${t('Image Name')}`}
@@ -827,8 +835,9 @@ const Form = ({
                       <Flex
                         alignItems={'center'}
                         gap={2}
-                        minW={'160px'}
+                        minW={0}
                         maxW={'220px'}
+                        flex={{ base: '1 1 100%', lg: '0 1 220px' }}
                         h={'22px'}
                         fontSize={'12px'}
                         color={imagePortDetectionView?.color}
@@ -845,7 +854,12 @@ const Form = ({
                   </FormControl>
                   {getValues('secret.use') ? (
                     <>
-                      <FormControl mt={4} isInvalid={!!errors.secret?.username} w={'420px'}>
+                      <FormControl
+                        mt={4}
+                        isInvalid={!!errors.secret?.username}
+                        w={'100%'}
+                        maxW={'420px'}
+                      >
                         <Box mb={1} fontSize={'sm'}>
                           {t('Username')}
                         </Box>
@@ -859,7 +873,12 @@ const Form = ({
                           })}
                         />
                       </FormControl>
-                      <FormControl mt={4} isInvalid={!!errors.secret?.password} w={'420px'}>
+                      <FormControl
+                        mt={4}
+                        isInvalid={!!errors.secret?.password}
+                        w={'100%'}
+                        maxW={'420px'}
+                      >
                         <Box mb={1} fontSize={'sm'}>
                           {t('Password')}
                         </Box>
@@ -874,7 +893,12 @@ const Form = ({
                           })}
                         />
                       </FormControl>
-                      <FormControl mt={4} isInvalid={!!errors.secret?.serverAddress} w={'420px'}>
+                      <FormControl
+                        mt={4}
+                        isInvalid={!!errors.secret?.serverAddress}
+                        w={'100%'}
+                        maxW={'420px'}
+                      >
                         <Box mb={1} fontSize={'sm'}>
                           {t('Image Address')}
                         </Box>
@@ -968,7 +992,7 @@ const Form = ({
                         <Label mb={1} fontSize={'sm'}>
                           {t('Replicas')}
                         </Label>
-                        <Box w={'410px'} ml={'7px'}>
+                        <Box w={'100%'} maxW={'410px'} ml={'7px'}>
                           <MyRangeSlider
                             min={1}
                             max={20}
@@ -1190,7 +1214,7 @@ const Form = ({
                   <AccordionIcon w={'20px'} h={'20px'} color={'#485264'} />
                 </AccordionButton>
 
-                <AccordionPanel px={'42px'} py={'24px'}>
+                <AccordionPanel px={{ base: '16px', md: '24px', lg: '42px' }} py={'24px'}>
                   {/* Shared Memory */}
                   <Flex alignItems={'center'} gap={'32px'} mb={'24px'}>
                     <Flex alignItems={'center'} gap={'16px'}>

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/Header.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/Header.tsx
@@ -83,13 +83,17 @@ const Header = ({
       )}
       <Flex
         w={'100%'}
-        px={10}
-        h={'86px'}
+        px={{ base: 4, md: 10 }}
+        minH={'86px'}
+        py={{ base: 4, md: 0 }}
         alignItems={'center'}
+        flexWrap={{ base: 'wrap', md: 'nowrap' }}
+        rowGap={3}
         borderBottom={'1px solid'}
         borderColor={'grayModern.200'}
       >
         <Flex
+          w={{ base: '100%', md: 'auto' }}
           alignItems={'center'}
           cursor={'pointer'}
           gap={'6px'}
@@ -102,106 +106,109 @@ const Header = ({
             {t(title)}
           </Box>
         </Flex>
-        <Box flex={1}></Box>
-        <Button
-          h={'40px'}
-          mr={'14px'}
-          minW={'140px'}
-          variant={'outline'}
-          onClick={handleExportYaml}
-        >
-          {t('Export')} Yaml
-        </Button>
-        <Box position={'relative'}>
+        <Flex w={{ base: '100%', md: 'auto' }} ml={{ base: 0, md: 'auto' }}>
           <Button
-            className="driver-deploy-button"
-            minW={'140px'}
             h={'40px'}
-            onClick={applyCb}
-            _focusVisible={{ boxShadow: '' }}
-            outline={isClientSide && !createCompleted ? '2px solid #1C4EF5' : 'none'}
-            outlineOffset={isClientSide && !createCompleted ? '2px' : '0'}
+            mr={'14px'}
+            minW={{ base: 0, md: '140px' }}
+            flex={{ base: 1, md: 'initial' }}
+            variant={'outline'}
+            onClick={handleExportYaml}
           >
-            {t(applyBtnText)}
+            {t('Export')} Yaml
           </Button>
-          {isClientSide && !createCompleted && (
-            <Box
-              zIndex={1000}
-              position={'absolute'}
-              left={'-180px'}
-              bottom={'-170px'}
-              width={'250px'}
-              bg={'#2563EB'}
-              p={'16px'}
-              borderRadius={'12px'}
-              color={'#fff'}
+          <Box position={'relative'} flex={{ base: 1, md: 'initial' }}>
+            <Button
+              className="driver-deploy-button"
+              minW={{ base: 0, md: '140px' }}
+              w={{ base: '100%', md: 'auto' }}
+              h={'40px'}
+              onClick={applyCb}
+              _focusVisible={{ boxShadow: '' }}
+              outline={isClientSide && !createCompleted ? '2px solid #1C4EF5' : 'none'}
+              outlineOffset={isClientSide && !createCompleted ? '2px' : '0'}
             >
-              <Flex alignItems={'center'} justifyContent={'space-between'}>
-                <Text fontSize={'14px'} fontWeight={600}>
-                  {t('driver.configure_launchpad')}
-                </Text>
-                <Box
-                  cursor={'pointer'}
-                  ml={'auto'}
-                  onClick={() => {
-                    track('guide_exit', {
-                      module: 'guide',
-                      guide_name: 'applaunchpad',
-                      duration_seconds: (Date.now() - (startTimeMs ?? Date.now())) / 1000,
-                      progress_step: 3
-                    });
-
-                    startDriver(quitGuideDriverObj(t));
-                  }}
-                >
-                  <X width={'16px'} height={'16px'} />
-                </Box>
-              </Flex>
-              <Text
-                textAlign={'start'}
-                whiteSpace={'wrap'}
-                mt={'8px'}
-                color={'#FFFFFFCC'}
-                fontSize={'14px'}
-                fontWeight={400}
-              >
-                {t('driver.define_image_settings')}
-              </Text>
-              <Flex mt={'16px'} justifyContent={'space-between'} alignItems={'center'}>
-                <Text fontSize={'13px'} fontWeight={500}>
-                  3/4
-                </Text>
-                <Center
-                  w={'86px'}
-                  color={'#fff'}
-                  fontSize={'14px'}
-                  fontWeight={500}
-                  cursor={'pointer'}
-                  borderRadius={'8px'}
-                  background={'rgba(255, 255, 255, 0.20)'}
-                  h={'32px'}
-                  p={'px'}
-                  onClick={() => {
-                    applyCb();
-                  }}
-                >
-                  {t('driver.next')}
-                </Center>
-              </Flex>
+              {t(applyBtnText)}
+            </Button>
+            {isClientSide && !createCompleted && (
               <Box
+                zIndex={1000}
                 position={'absolute'}
-                top={'-10px'}
-                right={'16px'}
-                width={0}
-                height={0}
-                borderLeft={'8px solid transparent'}
-                borderRight={'8px solid transparent'}
-                borderTop={'10px solid #2563EB'}
-                transform={'rotate(180deg)'}
-              />
-            </Box>
-          )}
-        </Box>
+                left={'-180px'}
+                bottom={'-170px'}
+                width={'250px'}
+                bg={'#2563EB'}
+                p={'16px'}
+                borderRadius={'12px'}
+                color={'#fff'}
+              >
+                <Flex alignItems={'center'} justifyContent={'space-between'}>
+                  <Text fontSize={'14px'} fontWeight={600}>
+                    {t('driver.configure_launchpad')}
+                  </Text>
+                  <Box
+                    cursor={'pointer'}
+                    ml={'auto'}
+                    onClick={() => {
+                      track('guide_exit', {
+                        module: 'guide',
+                        guide_name: 'applaunchpad',
+                        duration_seconds: (Date.now() - (startTimeMs ?? Date.now())) / 1000,
+                        progress_step: 3
+                      });
+
+                      startDriver(quitGuideDriverObj(t));
+                    }}
+                  >
+                    <X width={'16px'} height={'16px'} />
+                  </Box>
+                </Flex>
+                <Text
+                  textAlign={'start'}
+                  whiteSpace={'wrap'}
+                  mt={'8px'}
+                  color={'#FFFFFFCC'}
+                  fontSize={'14px'}
+                  fontWeight={400}
+                >
+                  {t('driver.define_image_settings')}
+                </Text>
+                <Flex mt={'16px'} justifyContent={'space-between'} alignItems={'center'}>
+                  <Text fontSize={'13px'} fontWeight={500}>
+                    3/4
+                  </Text>
+                  <Center
+                    w={'86px'}
+                    color={'#fff'}
+                    fontSize={'14px'}
+                    fontWeight={500}
+                    cursor={'pointer'}
+                    borderRadius={'8px'}
+                    background={'rgba(255, 255, 255, 0.20)'}
+                    h={'32px'}
+                    p={'px'}
+                    onClick={() => {
+                      applyCb();
+                    }}
+                  >
+                    {t('driver.next')}
+                  </Center>
+                </Flex>
+                <Box
+                  position={'absolute'}
+                  top={'-10px'}
+                  right={'16px'}
+                  width={0}
+                  height={0}
+                  borderLeft={'8px solid transparent'}
+                  borderRight={'8px solid transparent'}
+                  borderTop={'10px solid #2563EB'}
+                  transform={'rotate(180deg)'}
+                />
+              </Box>
+            )}
+          </Box>
+        </Flex>
       </Flex>
     </Flex>
   );

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/Yaml.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/Yaml.tsx
@@ -21,8 +21,12 @@ const Yaml = ({ yamlList = [], pxVal }: { yamlList: YamlItemType[]; pxVal: numbe
   return (
     <Grid
       h={'100%'}
-      templateColumns={'220px 1fr'}
-      gridGap={5}
+      templateColumns={{
+        base: 'minmax(0, 1fr)',
+        md: '180px minmax(0, 1fr)',
+        lg: '220px minmax(0, 1fr)'
+      }}
+      gridGap={{ base: 3, lg: 5 }}
       alignItems={'start'}
       px={`${pxVal}px`}
     >

--- a/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
@@ -57,16 +57,14 @@ import {
   validatePublicDomainPrefix
 } from '@/utils/public-domain';
 import { getCustomDomainBindings } from '@/utils/custom-domain';
-import {
-  APP_NAME_BASE_MAX_LENGTH,
-  getInvalidNameMessageI18nKey
-} from '@/utils/appNameValidation';
+import { APP_NAME_BASE_MAX_LENGTH, getInvalidNameMessageI18nKey } from '@/utils/appNameValidation';
+import { Global } from '@emotion/react';
 
 const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz', 12);
 
 const ErrorModal = dynamic(() => import('./components/ErrorModal'));
 
-const EDIT_PAGE_MIN_PADDING = 20;
+const EDIT_PAGE_MIN_PADDING = 12;
 const EDIT_PAGE_NAV_WIDTH = 220;
 const EDIT_PAGE_COLUMN_GAP = 20;
 const EDIT_PAGE_CONTENT_TARGET_WIDTH = 1100;
@@ -317,8 +315,8 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
               result.status === 'pendingSync'
                 ? ('certificate_domain_pending_sync' as const)
                 : result.status === 'unsupported'
-                  ? ('certificate_domain_unsupported' as const)
-                  : ('certificate_domain_not_configured' as const)
+                ? ('certificate_domain_unsupported' as const)
+                : ('certificate_domain_not_configured' as const)
           };
         } catch (error) {
           return {
@@ -756,13 +754,23 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
 
   return (
     <>
+      <Global
+        styles={{
+          'html, body': {
+            minWidth: 0,
+            overflowX: 'hidden'
+          }
+        }}
+      />
       <Flex
         flexDirection={'column'}
         alignItems={'center'}
         h={'100%'}
-        minWidth={'1024px'}
+        minWidth={0}
+        w={'100%'}
         backgroundColor={'grayModern.100'}
         overflowY={'auto'}
+        overflowX={'hidden'}
       >
         <Header
           appName={formHook.getValues('appName')}
@@ -864,10 +872,10 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
                         customDomain: invalidCustomDomain.customDomain
                       })
                     : invalidCustomDomain.reason === 'certificate_domain_unsupported'
-                      ? t('custom_domain_certificate_unavailable')
-                      : t('custom_domain_certificate_not_configured', {
-                          customDomain: invalidCustomDomain.customDomain
-                        });
+                    ? t('custom_domain_certificate_unavailable')
+                    : t('custom_domain_certificate_not_configured', {
+                        customDomain: invalidCustomDomain.customDomain
+                      });
 
                 return toast({
                   status: 'warning',
@@ -928,8 +936,8 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
                             data.hpa.target === 'cpu'
                               ? 'CPU'
                               : data.hpa.target === 'gpu'
-                                ? 'GPU'
-                                : 'RAM',
+                              ? 'GPU'
+                              : 'RAM',
                           value: data.hpa.value
                         }
                       : undefined


### PR DESCRIPTION
## Summary

- Remove the edit page's fixed 1024px viewport constraint so a resized desktop iframe cannot drift horizontally.
- Make the form and YAML layouts responsive, using a compact sidebar at medium widths and a single-column layout on narrow viewports.
- Let the header actions and fixed-width form controls wrap or shrink without changing the existing wide-screen layout.
- Add a regression test for the iframe layout constraints.

## Related Issue

Fixes https://github.com/labring-sigs/sealos-issues/issues/347

## Root Cause

The edit page combined a 1024px minimum width with nested horizontal overflow while the iframe viewport could be narrower. Vertical trackpad scrolling could then change the horizontal scroll offset, alternating between a clipped sidebar and a clipped form.

## Verification

- `npx --yes --package=vitest@1.6.1 vitest run __tests__/unit/pages/app/edit/index.test.ts` (3 tests passed)
- `next lint` on the five changed files (passed, with pre-existing Hook dependency warnings)
- `NEXT_PUBLIC_MOCK_USER=true next build` (passed)
- Browser checks at 375px, 800px, and 1024px for the form and YAML views
- At 800px, verified `document.scrollWidth === body.scrollWidth === window.innerWidth === 800`, including external access enabled and advanced settings expanded
