### PR TITLE
fix(applaunchpad): clear stale image pull secrets

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/utils/tools.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/tools.test.ts
@@ -1,0 +1,121 @@
+import yaml from 'js-yaml';
+import { describe, expect, it } from 'vitest';
+import type { DeployKindsType } from '@/types/app';
+import { patchYamlList } from '@/utils/tools';
+
+const createWorkload = (kind: 'Deployment' | 'StatefulSet', isPrivate: boolean) => ({
+  apiVersion: 'apps/v1',
+  kind,
+  metadata: {
+    name: 'demo'
+  },
+  spec: {
+    ...(kind === 'StatefulSet' ? { serviceName: 'demo' } : {}),
+    selector: {
+      matchLabels: {
+        app: 'demo'
+      }
+    },
+    template: {
+      metadata: {
+        labels: {
+          app: 'demo'
+        }
+      },
+      spec: {
+        ...(isPrivate ? { imagePullSecrets: [{ name: 'demo' }] } : {}),
+        containers: [
+          {
+            name: 'demo',
+            image: isPrivate ? 'registry.example.com/demo:latest' : 'nginx:latest',
+            volumeMounts: []
+          }
+        ],
+        volumes: []
+      }
+    },
+    ...(kind === 'StatefulSet' ? { volumeClaimTemplates: [] } : {})
+  }
+});
+
+const secret = {
+  apiVersion: 'v1',
+  kind: 'Secret',
+  metadata: {
+    name: 'demo'
+  },
+  type: 'kubernetes.io/dockerconfigjson',
+  data: {
+    '.dockerconfigjson': 'credentials'
+  }
+};
+
+describe.each(['Deployment', 'StatefulSet'] as const)(
+  'patchYamlList private-to-public %s update',
+  (kind) => {
+    it('preserves imagePullSecrets deletion for JSON Merge Patch', () => {
+      const privateWorkload = createWorkload(kind, true);
+      const publicWorkload = createWorkload(kind, false);
+
+      const actions = patchYamlList({
+        parsedOldYamlList: [yaml.dump(privateWorkload), yaml.dump(secret)],
+        parsedNewYamlList: [yaml.dump(publicWorkload)],
+        originalYamlList: [privateWorkload, secret] as DeployKindsType[]
+      });
+
+      const workloadPatch = actions.find((item) => item.type === 'patch' && item.kind === kind);
+
+      expect(workloadPatch).toMatchObject({
+        type: 'patch',
+        kind,
+        value: {
+          spec: {
+            template: {
+              spec: {
+                imagePullSecrets: null
+              }
+            }
+          }
+        }
+      });
+      expect(actions).toContainEqual({
+        type: 'delete',
+        kind: 'Secret',
+        name: 'demo'
+      });
+    });
+
+    it('keeps imagePullSecrets for private image updates', () => {
+      const currentWorkload = createWorkload(kind, true);
+      const updatedWorkload = createWorkload(kind, true);
+      updatedWorkload.spec.template.spec.containers[0].image = 'registry.example.com/demo:v2';
+
+      const actions = patchYamlList({
+        parsedOldYamlList: [yaml.dump(currentWorkload), yaml.dump(secret)],
+        parsedNewYamlList: [yaml.dump(updatedWorkload), yaml.dump(secret)],
+        originalYamlList: [currentWorkload, secret] as DeployKindsType[]
+      });
+
+      const workloadPatch = actions.find((item) => item.type === 'patch' && item.kind === kind);
+
+      expect(workloadPatch).toMatchObject({
+        type: 'patch',
+        kind,
+        value: {
+          spec: {
+            template: {
+              spec: {
+                imagePullSecrets: [{ name: 'demo' }]
+              }
+            }
+          }
+        }
+      });
+      expect(actions).not.toContainEqual({
+        type: 'delete',
+        kind: 'Secret',
+        name: 'demo'
+      });
+    });
+  }
+);

--- a/frontend/providers/applaunchpad/src/utils/tools.ts
+++ b/frontend/providers/applaunchpad/src/utils/tools.ts
@@ -464,6 +464,17 @@ export const patchYamlList = ({
 
           const patchResYamlJson = jsonpatch.applyPatch(crOldYamlJson, _patchRes, true).newDocument;
 
+          if (
+            (oldFormJson.kind === YamlKindEnum.Deployment ||
+              oldFormJson.kind === YamlKindEnum.StatefulSet) &&
+            patchRes.some(
+              (item) => item.op === 'remove' && item.path === '/spec/template/spec/imagePullSecrets'
+            )
+          ) {
+            // JSON Merge Patch requires null to delete a field; omission preserves the old value.
+            (patchResYamlJson as any).spec.template.spec.imagePullSecrets = null;
+          }
+
           // delete invalid field
           // @ts-ignore
           delete patchResYamlJson.status;


### PR DESCRIPTION
## What this PR does

- Preserve `imagePullSecrets` removal as an explicit `null` value when generating JSON Merge Patch payloads for Deployments and StatefulSets.
- Add regression coverage for private-to-public image changes and private image updates.

## Why this is needed

When an application switched from a private image to a public image, the generated workload payload omitted `imagePullSecrets`. JSON Merge Patch treats an omitted field as unchanged, while the registry Secret was deleted separately. The workload therefore kept referencing a Secret that no longer existed and image pulls failed.

## Verification

- `npx --yes vitest@3.2.4 run` (103 tests passed)
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm build`
- Verified with `kubectl patch --local --type=merge` that an explicit `null` removes `imagePullSecrets`
