### PR TITLE
fix(account): advance workspace debt cleanup status

### DIFF
--- a/controllers/account/controllers/workspace_subscription_debt.go
+++ b/controllers/account/controllers/workspace_subscription_debt.go
@@ -356,7 +356,7 @@ func (wdp *WorkspaceSubscriptionDebtProcessor) sendWorkspaceDebtEmail(
 
 	if _, err = wdp.UserNotificationService.HandleWorkspaceSubscriptionEvent(context.Background(), userUID, eventData, types.SubscriptionTransactionTypeDebt, []usernotify.NotificationMethod{usernotify.NotificationMethodEmail}); err != nil {
 		wdp.logWorkspaceDebtErrorf(
-			"failed to send subscription success notification for user %s: %v",
+			"failed to send workspace debt notification for user %s: %v",
 			userUID,
 			err,
 		)

--- a/controllers/account/controllers/workspace_subscription_debt.go
+++ b/controllers/account/controllers/workspace_subscription_debt.go
@@ -205,7 +205,7 @@ func (wdp *WorkspaceSubscriptionDebtProcessor) processExpiredWorkspaces(
 		}
 
 		// 处理状态变更
-		if err := wdp.processExpiredWorkspace(ctx, subscription, now); err != nil {
+		if err := wdp.processExpiredWorkspace(ctx, subscription, currentStatus); err != nil {
 			wdp.Logger.Error(fmt.Errorf("failed to process workspace: %w", err),
 				"", "workspace", subscription.Workspace)
 			continue
@@ -220,9 +220,9 @@ func (wdp *WorkspaceSubscriptionDebtProcessor) processExpiredWorkspaces(
 func (wdp *WorkspaceSubscriptionDebtProcessor) processExpiredWorkspace(
 	ctx context.Context,
 	subscription *types.WorkspaceSubscription,
-	now time.Time,
+	currentStatus types.SubscriptionStatus,
 ) error {
-	currentStatus, lastStatus := wdp.determineCurrentStatus(now), subscription.Status
+	lastStatus := subscription.Status
 	if lastStatus == currentStatus {
 		return nil
 	}
@@ -265,15 +265,23 @@ func (wdp *WorkspaceSubscriptionDebtProcessor) flushWorkspaceDebtStatus(
 		return wdp.updateSubscriptionStatus(ctx, subscription, types.SubscriptionStatusDeleted)
 	}
 
-	userUID := subscription.UserUID
-	nr, err := wdp.AccountV2.GetNotificationRecipient(subscription.UserUID)
-	if err != nil {
-		// logrus.Errorf("failed to get notification recipient for user %s: %v", userUID, err)
-		wdp.VLogger.Errorf("failed to get notification recipient for user %s: %v", userUID, err)
+	if err := wdp.syncWorkspaceDebtStatus(ctx, subscription, lastDebtStatus, currentDebtStatus, namespaces); err != nil {
+		return err
 	}
-	wdp.UserContactProvider.SetUserContact(userUID, nr)
-	defer wdp.UserContactProvider.RemoveUserContact(userUID)
+	if err := wdp.updateSubscriptionStatus(ctx, subscription, currentDebtStatus); err != nil {
+		return fmt.Errorf("update subscription status error: %w", err)
+	}
 
+	return nil
+}
+
+func (wdp *WorkspaceSubscriptionDebtProcessor) syncWorkspaceDebtStatus(
+	ctx context.Context,
+	subscription *types.WorkspaceSubscription,
+	lastDebtStatus,
+	currentDebtStatus types.SubscriptionStatus,
+	namespaces []string,
+) error {
 	eventData := &usernotify.WorkspaceSubscriptionDebtEventData{
 		Type:          usernotify.EventTypeWorkspaceSubscriptionDebt,
 		PlanName:      subscription.PlanName,
@@ -301,14 +309,7 @@ func (wdp *WorkspaceSubscriptionDebtProcessor) flushWorkspaceDebtStatus(
 		if err := wdp.updateWorkspaceDebtStatus(ctx, types.SuspendDebtNamespaceAnnoStatus, namespaces); err != nil {
 			return fmt.Errorf("update workspace debt status error: %w", err)
 		}
-		if _, err = wdp.UserNotificationService.HandleWorkspaceSubscriptionEvent(context.Background(), userUID, eventData, types.SubscriptionTransactionTypeDebt, []usernotify.NotificationMethod{usernotify.NotificationMethodEmail}); err != nil {
-			wdp.VLogger.Errorf(
-				"failed to send subscription success notification for user %s: %v",
-				userUID,
-				err,
-			)
-			// return fmt.Errorf("failed to send subscription success notification to user %s: %w", userUID, err)
-		}
+		wdp.sendWorkspaceDebtEmail(subscription, eventData)
 
 	case types.SubscriptionStatusDebtPreDeletion:
 		if err := wdp.sendWorkspaceDesktopNotice(ctx, currentDebtStatus, namespaces); err != nil {
@@ -332,11 +333,40 @@ func (wdp *WorkspaceSubscriptionDebtProcessor) flushWorkspaceDebtStatus(
 	if err := wdp.readWorkspaceNotices(ctx, namespaces, wdp.getWorkspaceStatusesGreaterThan(currentDebtStatus)...); err != nil {
 		return fmt.Errorf("read workspace notices error: %w", err)
 	}
-	if err := wdp.updateSubscriptionStatus(ctx, subscription, currentDebtStatus); err != nil {
-		return fmt.Errorf("update subscription status error: %w", err)
-	}
 
 	return nil
+}
+
+func (wdp *WorkspaceSubscriptionDebtProcessor) sendWorkspaceDebtEmail(
+	subscription *types.WorkspaceSubscription,
+	eventData usernotify.EventData,
+) {
+	if wdp.AccountV2 == nil || wdp.UserContactProvider == nil || wdp.UserNotificationService == nil {
+		return
+	}
+
+	userUID := subscription.UserUID
+	nr, err := wdp.AccountV2.GetNotificationRecipient(userUID)
+	if err != nil {
+		wdp.logWorkspaceDebtErrorf("failed to get notification recipient for user %s: %v", userUID, err)
+		return
+	}
+	wdp.UserContactProvider.SetUserContact(userUID, nr)
+	defer wdp.UserContactProvider.RemoveUserContact(userUID)
+
+	if _, err = wdp.UserNotificationService.HandleWorkspaceSubscriptionEvent(context.Background(), userUID, eventData, types.SubscriptionTransactionTypeDebt, []usernotify.NotificationMethod{usernotify.NotificationMethodEmail}); err != nil {
+		wdp.logWorkspaceDebtErrorf(
+			"failed to send subscription success notification for user %s: %v",
+			userUID,
+			err,
+		)
+	}
+}
+
+func (wdp *WorkspaceSubscriptionDebtProcessor) logWorkspaceDebtErrorf(format string, args ...any) {
+	if wdp.VLogger != nil {
+		wdp.VLogger.Errorf(format, args...)
+	}
 }
 
 // updateSubscriptionStatus 更新订阅状态

--- a/controllers/account/controllers/workspace_subscription_debt_test.go
+++ b/controllers/account/controllers/workspace_subscription_debt_test.go
@@ -1,0 +1,115 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	notificationv1 "github.com/labring/sealos/controllers/pkg/notification/api/v1"
+	"github.com/labring/sealos/controllers/pkg/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestWorkspaceSubscriptionDebtStatusSyncsNamespaceAnnotations(t *testing.T) {
+	tests := []struct {
+		name               string
+		expiredFor         time.Duration
+		expectedStatus     types.SubscriptionStatus
+		expectedDebtStatus string
+	}{
+		{
+			name:               "recent expiration suspends workspace",
+			expiredFor:         time.Hour,
+			expectedStatus:     types.SubscriptionStatusDebt,
+			expectedDebtStatus: types.SuspendDebtNamespaceAnnoStatus,
+		},
+		{
+			name:               "debt over grace period stays suspended before deletion",
+			expiredFor:         time.Duration(ExpiredGracePeriodHours+1) * time.Hour,
+			expectedStatus:     types.SubscriptionStatusDebtPreDeletion,
+			expectedDebtStatus: types.SuspendDebtNamespaceAnnoStatus,
+		},
+		{
+			name:               "debt over final deletion period marks workspace for deletion",
+			expiredFor:         time.Duration(FinalDeletionPeriodHours+1) * time.Hour,
+			expectedStatus:     types.SubscriptionStatusDebtFinalDeletion,
+			expectedDebtStatus: types.FinalDeletionDebtNamespaceAnnoStatus,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			namespace := "test-workspace"
+			processor := newWorkspaceSubscriptionDebtTestProcessor(t, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespace,
+				},
+			})
+
+			now := time.Now().UTC()
+			expireTime := now.Add(-tt.expiredFor)
+			subscription := &types.WorkspaceSubscription{
+				PlanName:             "Free",
+				Workspace:            namespace,
+				RegionDomain:         "test.example.com",
+				Status:               types.SubscriptionStatusDebt,
+				CurrentPeriodStartAt: expireTime.Add(-30 * 24 * time.Hour),
+				CurrentPeriodEndAt:   expireTime,
+				CancelAtPeriodEnd:    false,
+				CreateAt:             now.Add(-60 * 24 * time.Hour),
+				UpdateAt:             now,
+			}
+
+			currentStatus := processor.determineCurrentStatus(subscription.CurrentPeriodEndAt)
+			if currentStatus != tt.expectedStatus {
+				t.Fatalf("expected current status %s, got %s", tt.expectedStatus, currentStatus)
+			}
+
+			if err := processor.syncWorkspaceDebtStatus(ctx, subscription, subscription.Status, currentStatus, []string{namespace}); err != nil {
+				t.Fatalf("sync workspace debt status failed: %v", err)
+			}
+
+			var updatedNS corev1.Namespace
+			if err := processor.Get(ctx, client.ObjectKey{Name: namespace}, &updatedNS); err != nil {
+				t.Fatalf("failed to get updated namespace: %v", err)
+			}
+
+			if got := updatedNS.Annotations[types.DebtNamespaceAnnoStatusKey]; got != tt.expectedDebtStatus {
+				t.Fatalf("expected debt annotation %s, got %s", tt.expectedDebtStatus, got)
+			}
+			if got := updatedNS.Annotations[types.WorkspaceSubscriptionStatusAnnoKey]; got != tt.expectedDebtStatus {
+				t.Fatalf("expected workspace subscription annotation %s, got %s", tt.expectedDebtStatus, got)
+			}
+		})
+	}
+}
+
+func newWorkspaceSubscriptionDebtTestProcessor(t *testing.T, objects ...client.Object) *WorkspaceSubscriptionDebtProcessor {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add core scheme: %v", err)
+	}
+	if err := notificationv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add notification scheme: %v", err)
+	}
+
+	fakeClient := clientfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		Build()
+
+	return &WorkspaceSubscriptionDebtProcessor{
+		AccountReconciler: &AccountReconciler{
+			Client: fakeClient,
+			Logger: logr.Discard(),
+		},
+	}
+}


### PR DESCRIPTION
## Summary

  - Fix workspace subscription debt cleanup so overdue workspaces advance from `DEBT` to `DEBT_PRE_DELETION` and `DEBT_FINAL_DELETION` based on
  `CurrentPeriodEndAt`.
  - Ensure `DEBT_FINAL_DELETION` writes the namespace `FinalDeletion` status, allowing the existing resource cleanup path to delete PVCs.
  - Keep debt notification delivery optional when notification dependencies are not configured.
  - Add tests covering recent expiration, pre-deletion, and final-deletion namespace annotation updates.

  ## Root Cause

  `processExpiredWorkspaces` calculated the desired status from `subscription.CurrentPeriodEndAt`, but then called `processExpiredWorkspace` with `now`.

  Inside `processExpiredWorkspace`, the status was recalculated from `now`, which always resolved back to `DEBT`. As a result, overdue workspaces never reached
  `DEBT_PRE_DELETION` or `DEBT_FINAL_DELETION`, so namespaces stayed at `SuspendCompleted` and never entered the `FinalDeletion` cleanup path.
