### PR TITLE
fix(account): use dns-safe workspace debt notice names

### DIFF
--- a/controllers/account/controllers/workspace_subscription_debt.go
+++ b/controllers/account/controllers/workspace_subscription_debt.go
@@ -420,6 +420,10 @@ func (wdp *WorkspaceSubscriptionDebtProcessor) updateWorkspaceDebtStatus(
 	return nil
 }
 
+func workspaceDebtNoticeName(status types.SubscriptionStatus) string {
+	return workspaceDebtNoticePrefix + strings.ReplaceAll(strings.ToLower(string(status)), "_", "-")
+}
+
 // sendWorkspaceDesktopNotice 发送工作空间桌面通知
 func (wdp *WorkspaceSubscriptionDebtProcessor) sendWorkspaceDesktopNotice(
 	ctx context.Context,
@@ -429,7 +433,7 @@ func (wdp *WorkspaceSubscriptionDebtProcessor) sendWorkspaceDesktopNotice(
 	now := time.Now().UTC().Unix()
 	ntfTmp := &notificationv1.Notification{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: workspaceDebtNoticePrefix + strings.ToLower(string(debtStatus)),
+			Name: workspaceDebtNoticeName(debtStatus),
 		},
 	}
 
@@ -477,7 +481,7 @@ func (wdp *WorkspaceSubscriptionDebtProcessor) readWorkspaceNotices(
 	for _, nsName := range namespaces {
 		for _, noticeStatus := range noticeTypes {
 			ntf := &notificationv1.Notification{}
-			notificationName := workspaceDebtNoticePrefix + strings.ToLower(string(noticeStatus))
+			notificationName := workspaceDebtNoticeName(noticeStatus)
 
 			if err := wdp.Get(ctx, types2.NamespacedName{
 				Name:      notificationName,

--- a/controllers/account/controllers/workspace_subscription_debt_test.go
+++ b/controllers/account/controllers/workspace_subscription_debt_test.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -85,6 +86,46 @@ func TestWorkspaceSubscriptionDebtStatusSyncsNamespaceAnnotations(t *testing.T) 
 			}
 			if got := updatedNS.Annotations[types.WorkspaceSubscriptionStatusAnnoKey]; got != tt.expectedDebtStatus {
 				t.Fatalf("expected workspace subscription annotation %s, got %s", tt.expectedDebtStatus, got)
+			}
+
+			var notice notificationv1.Notification
+			if err := processor.Get(ctx, client.ObjectKey{
+				Name:      workspaceDebtNoticeName(tt.expectedStatus),
+				Namespace: namespace,
+			}, &notice); err != nil {
+				t.Fatalf("failed to get workspace debt notice: %v", err)
+			}
+		})
+	}
+}
+
+func TestWorkspaceDebtNoticeNameIsDNS1123Compatible(t *testing.T) {
+	tests := []struct {
+		status types.SubscriptionStatus
+		want   string
+	}{
+		{
+			status: types.SubscriptionStatusDebt,
+			want:   "workspace-debt-debt",
+		},
+		{
+			status: types.SubscriptionStatusDebtPreDeletion,
+			want:   "workspace-debt-debt-pre-deletion",
+		},
+		{
+			status: types.SubscriptionStatusDebtFinalDeletion,
+			want:   "workspace-debt-debt-final-deletion",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			got := workspaceDebtNoticeName(tt.status)
+			if got != tt.want {
+				t.Fatalf("expected notice name %s, got %s", tt.want, got)
+			}
+			if errs := validation.IsDNS1123Subdomain(got); len(errs) > 0 {
+				t.Fatalf("expected DNS1123-compatible notice name, got errors: %v", errs)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Generate workspace debt notification names with DNS-safe status values.
- Reuse the same notification-name helper when creating and marking debt notices as read.
- Add coverage for `DEBT_PRE_DELETION` and `DEBT_FINAL_DELETION` notification names.
