### PR TITLE
fix(applaunchpad): restart workloads only when needed

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/utils/deployYaml2Json.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/deployYaml2Json.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { compare } from 'fast-json-patch';
 import {
   json2DeployCr,
   json2Ingress,
@@ -417,6 +418,22 @@ describe('json2DeployCr', () => {
 
     expect(portNames).toEqual(['p-t-80-0', 'p-t-80-1', 'p-t-80-2']);
     expect(new Set(portNames).size).toBe(portNames.length);
+  });
+
+  it('does not change the pod template when only StatefulSet replicas change', () => {
+    const app = createApp();
+    app.kind = 'statefulset';
+
+    const oldStatefulSet = yamlString2Objects(json2DeployCr(app, 'statefulset'))[0] as any;
+    const newStatefulSet = yamlString2Objects(
+      json2DeployCr({ ...app, replicas: 2 }, 'statefulset')
+    )[0] as any;
+
+    const paths = compare(oldStatefulSet, newStatefulSet).map((operation) => operation.path);
+
+    expect(paths).toContain('/spec/replicas');
+    expect(paths).not.toContain('/spec/template/metadata/labels/restartTime');
+    expect(paths.some((path) => path.startsWith('/spec/template'))).toBe(false);
   });
 });
 

--- a/frontend/providers/applaunchpad/__tests__/unit/utils/tools.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/tools.test.ts
@@ -1,6 +1,11 @@
 import yaml from 'js-yaml';
 import { describe, expect, it } from 'vitest';
-import type { DeployKindsType } from '@/types/app';
+import {
+  json2ConfigMap,
+  json2DeployCr,
+  yamlString2Objects
+} from '@/utils/deployYaml2Json';
+import type { AppEditType, DeployKindsType } from '@/types/app';
 import { patchYamlList } from '@/utils/tools';
 
 const createWorkload = (kind: 'Deployment' | 'StatefulSet', isPrivate: boolean) => ({
@@ -49,6 +54,67 @@ const secret = {
     '.dockerconfigjson': 'credentials'
   }
 };
+
+const createApp = (): AppEditType =>
+  ({
+    appName: 'demo',
+    imageName: 'nginx:latest',
+    runCMD: '',
+    cmdParam: '',
+    replicas: 1,
+    cpu: 100,
+    memory: 128,
+    networks: [
+      {
+        networkName: 'demo-web',
+        portName: 'web',
+        port: 80,
+        protocol: 'TCP',
+        appProtocol: 'HTTP',
+        openPublicDomain: false,
+        publicDomain: 'demo',
+        customDomain: '',
+        domain: 'cloud.example.com',
+        openNodePort: false
+      }
+    ],
+    envs: [],
+    hpa: {
+      use: false,
+      target: 'cpu',
+      value: 50,
+      minReplicas: 1,
+      maxReplicas: 1
+    },
+    secret: {
+      use: false,
+      username: '',
+      password: '',
+      serverAddress: ''
+    },
+    configMapList: [
+      {
+        mountPath: '/etc/demo/config.yaml',
+        key: 'config-yaml',
+        value: 'old-value',
+        volumeName: 'demo-config'
+      }
+    ],
+    storeList: [],
+    networkStoreList: [],
+    labels: {},
+    volumes: [],
+    volumeMounts: [],
+    kind: 'deployment'
+  } as AppEditType);
+
+const createYamlLists = (app: AppEditType) => [
+  json2DeployCr(app, app.kind),
+  json2ConfigMap(app)
+];
+
+const createOriginalYamlList = (yamlList: string[]) =>
+  yamlList.flatMap((item) => yamlString2Objects(item)) as DeployKindsType[];
 
 describe.each(['Deployment', 'StatefulSet'] as const)(
   'patchYamlList private-to-public %s update',
@@ -119,3 +185,76 @@ describe.each(['Deployment', 'StatefulSet'] as const)(
     });
   }
 );
+
+describe('patchYamlList restart behavior', () => {
+  it('restarts the workload when only ConfigMap data changes', () => {
+    const oldApp = createApp();
+    const newApp = {
+      ...oldApp,
+      configMapList: [{ ...oldApp.configMapList[0], value: 'new-value' }]
+    };
+    const oldYamlList = createYamlLists(oldApp);
+    const newYamlList = createYamlLists(newApp);
+
+    const actions = patchYamlList({
+      parsedOldYamlList: oldYamlList,
+      parsedNewYamlList: newYamlList,
+      originalYamlList: createOriginalYamlList(oldYamlList)
+    });
+
+    const configMapPatch = actions.find(
+      (item) => item.type === 'patch' && item.kind === 'ConfigMap'
+    );
+    const deploymentPatch = actions.find(
+      (item) => item.type === 'patch' && item.kind === 'Deployment'
+    );
+
+    expect(configMapPatch).toBeDefined();
+    expect(deploymentPatch?.type === 'patch' && deploymentPatch.value).toMatchObject({
+      metadata: {
+        name: 'demo'
+      },
+      spec: {
+        template: {
+          metadata: {
+            labels: {
+              restartTime: expect.any(String)
+            }
+          }
+        }
+      }
+    });
+  });
+
+  it('does not restart the workload when only StatefulSet replicas change', () => {
+    const oldApp = createApp();
+    oldApp.kind = 'statefulset';
+    oldApp.storeList = [
+      {
+        name: 'data',
+        path: '/data',
+        value: 1,
+        storageType: 'local'
+      }
+    ];
+    const newApp = { ...oldApp, replicas: 2 };
+    const oldYamlList = createYamlLists(oldApp);
+    const newYamlList = createYamlLists(newApp);
+
+    const actions = patchYamlList({
+      parsedOldYamlList: oldYamlList,
+      parsedNewYamlList: newYamlList,
+      originalYamlList: createOriginalYamlList(oldYamlList)
+    });
+
+    const statefulSetPatch = actions.find(
+      (item) => item.type === 'patch' && item.kind === 'StatefulSet'
+    );
+
+    expect(statefulSetPatch?.type === 'patch' && statefulSetPatch.value).toBeTruthy();
+    expect(
+      statefulSetPatch?.type === 'patch' &&
+        statefulSetPatch.value.spec?.template?.metadata?.labels?.restartTime
+    ).toBeFalsy();
+  });
+});

--- a/frontend/providers/applaunchpad/src/pages/api/updateApp.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/updateApp.ts
@@ -62,11 +62,6 @@ const normalizeNetworkResource = <T extends Record<string, any>>(resource: T): T
 const isWorkloadKind = (kind?: string) =>
   kind === YamlKindEnum.Deployment || kind === YamlKindEnum.StatefulSet;
 
-const isRestartTimeWorkloadPatch = (item: AppPatchPropsType[number]) =>
-  item.type === 'patch' &&
-  isWorkloadKind(item.kind) &&
-  !!item.value?.spec?.template?.metadata?.labels?.restartTime;
-
 async function updateAppCRUrl(
   k8sCustomObjects: CustomObjectsApi,
   namespace: string,
@@ -408,8 +403,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
         return !!cr && item.type === 'patch' && !!item.value?.metadata;
       }
     );
-    const restartTimeWorkloadPatches = patchItems.filter(isRestartTimeWorkloadPatch);
-    const regularPatches = patchItems.filter((item) => !isRestartTimeWorkloadPatch(item));
+    const workloadPatches = patchItems.filter((item) => isWorkloadKind(item.kind));
+    const regularPatches = patchItems.filter((item) => !isWorkloadKind(item.kind));
     const applyPatchItem = (
       item: Extract<AppPatchPropsType[number], { type: 'patch' }>
     ): Promise<any> | undefined => {
@@ -420,10 +415,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       return cr.patch(item.value);
     };
 
-    // Patch ConfigMap/Service/etc. first. ConfigMap subPath updates need the file content
-    // replaced before the restartTime workload patch creates fresh Pods.
+    // Patch ConfigMap/Service/etc. first. Workload patches can create fresh Pods, so run them
+    // after referenced resources are patched or created.
     await Promise.all(regularPatches.map(applyPatchItem));
-    await Promise.all(restartTimeWorkloadPatches.map(applyPatchItem));
 
     // create
     const createYamlList = patch
@@ -488,6 +482,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
         );
       }
     }
+
+    await Promise.all(workloadPatches.map(applyPatchItem));
 
     // delete
     await Promise.all(

--- a/frontend/providers/applaunchpad/src/pages/api/updateApp.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/updateApp.ts
@@ -59,6 +59,14 @@ const normalizeCertificateResource = <T extends Record<string, any>>(resource: T
 const normalizeNetworkResource = <T extends Record<string, any>>(resource: T): T =>
   normalizeCertificateResource(normalizeIngressResource(resource));
 
+const isWorkloadKind = (kind?: string) =>
+  kind === YamlKindEnum.Deployment || kind === YamlKindEnum.StatefulSet;
+
+const isRestartTimeWorkloadPatch = (item: AppPatchPropsType[number]) =>
+  item.type === 'patch' &&
+  isWorkloadKind(item.kind) &&
+  !!item.value?.spec?.template?.metadata?.labels?.restartTime;
+
 async function updateAppCRUrl(
   k8sCustomObjects: CustomObjectsApi,
   namespace: string,
@@ -394,18 +402,28 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       })
     );
 
-    // patch
-    await Promise.all(
-      patch.map((item) => {
+    const patchItems = patch.filter(
+      (item): item is Extract<AppPatchPropsType[number], { type: 'patch' }> => {
         const cr = crMap[item.kind];
-        if (!cr || item.type !== 'patch' || !item.value?.metadata) {
-          return;
-        }
-        normalizeNetworkResource(item.value);
-        infoLog('patch cr', { kind: item.kind, name: item.value?.metadata?.name });
-        return cr.patch(item.value);
-      })
+        return !!cr && item.type === 'patch' && !!item.value?.metadata;
+      }
     );
+    const restartTimeWorkloadPatches = patchItems.filter(isRestartTimeWorkloadPatch);
+    const regularPatches = patchItems.filter((item) => !isRestartTimeWorkloadPatch(item));
+    const applyPatchItem = (
+      item: Extract<AppPatchPropsType[number], { type: 'patch' }>
+    ): Promise<any> | undefined => {
+      const cr = crMap[item.kind];
+      if (!cr) return;
+      normalizeNetworkResource(item.value);
+      infoLog('patch cr', { kind: item.kind, name: item.value?.metadata?.name });
+      return cr.patch(item.value);
+    };
+
+    // Patch ConfigMap/Service/etc. first. ConfigMap subPath updates need the file content
+    // replaced before the restartTime workload patch creates fresh Pods.
+    await Promise.all(regularPatches.map(applyPatchItem));
+    await Promise.all(restartTimeWorkloadPatches.map(applyPatchItem));
 
     // create
     const createYamlList = patch

--- a/frontend/providers/applaunchpad/src/utils/deployYaml2Json.ts
+++ b/frontend/providers/applaunchpad/src/utils/deployYaml2Json.ts
@@ -19,7 +19,6 @@ import type { AppEditType } from '@/types/app';
 import { syncDefaultRouteServicePort } from '@/utils/network-routes';
 import { ensureUniquePortNames, getFallbackPortName, str2Num, strToBase64 } from '@/utils/tools';
 import type { V1OwnerReference } from '@kubernetes/client-node';
-import dayjs from 'dayjs';
 import yaml from 'js-yaml';
 import { customRandom } from 'nanoid';
 import crypto from 'crypto';
@@ -168,8 +167,7 @@ export const json2DeployCr = (data: AppEditType, type: 'deployment' | 'statefuls
   };
   const templateMetadata = {
     labels: {
-      app: data.appName,
-      restartTime: `${dayjs().format('YYYYMMDDHHmmss')}`
+      app: data.appName
     },
     annotations: gpuAnnotations
   };

--- a/frontend/providers/applaunchpad/src/utils/tools.ts
+++ b/frontend/providers/applaunchpad/src/utils/tools.ts
@@ -303,6 +303,66 @@ export const storageFormatToGi = (storage: string) => {
   return Number(value.toFixed(2));
 };
 
+const isWorkloadKind = (
+  kind?: string
+): kind is YamlKindEnum.Deployment | YamlKindEnum.StatefulSet =>
+  kind === YamlKindEnum.Deployment || kind === YamlKindEnum.StatefulSet;
+
+const createRestartTimePatch = (workload: DeployKindsType, restartTime: string) => ({
+  apiVersion: workload.apiVersion,
+  kind: workload.kind,
+  metadata: {
+    name: workload.metadata?.name,
+    namespace: workload.metadata?.namespace
+  },
+  spec: {
+    template: {
+      metadata: {
+        labels: {
+          restartTime
+        }
+      }
+    }
+  }
+});
+
+const ensureRestartTimePatch = ({
+  actions,
+  originalYamlList,
+  oldFormJsonList
+}: {
+  actions: AppPatchPropsType;
+  originalYamlList: DeployKindsType[];
+  oldFormJsonList: DeployKindsType[];
+}) => {
+  const workload =
+    originalYamlList.find((item) => isWorkloadKind(item.kind)) ||
+    oldFormJsonList.find((item) => isWorkloadKind(item.kind));
+
+  if (!workload || !isWorkloadKind(workload.kind)) return;
+
+  const restartTime = dayjs().format('YYYYMMDDHHmmss');
+  const workloadPatch = actions.find(
+    (item) => item.type === 'patch' && item.kind === workload.kind
+  ) as Extract<AppPatchPropsType[number], { type: 'patch' }> | undefined;
+
+  if (workloadPatch) {
+    workloadPatch.value.spec = workloadPatch.value.spec || {};
+    workloadPatch.value.spec.template = workloadPatch.value.spec.template || {};
+    workloadPatch.value.spec.template.metadata = workloadPatch.value.spec.template.metadata || {};
+    workloadPatch.value.spec.template.metadata.labels =
+      workloadPatch.value.spec.template.metadata.labels || {};
+    workloadPatch.value.spec.template.metadata.labels.restartTime = restartTime;
+    return;
+  }
+
+  actions.push({
+    type: 'patch',
+    kind: workload.kind,
+    value: createRestartTimePatch(workload, restartTime)
+  });
+};
+
 /**
  * format pod createTime
  */
@@ -378,6 +438,8 @@ export const patchYamlList = ({
     .flat() as DeployKindsType[];
 
   const actions: AppPatchPropsType = [];
+  let configMapDataChanged = false;
+  let workloadTemplateChanged = false;
 
   // find delete
   oldFormJsonList.forEach((oldYamlJson) => {
@@ -410,6 +472,22 @@ export const patchYamlList = ({
       const patchRes = jsonpatch.compare(oldFormJson, newYamlJson);
 
       if (patchRes.length === 0) return;
+
+      if (
+        oldFormJson.kind === YamlKindEnum.ConfigMap &&
+        patchRes.some((item) => item.path === '/data' || item.path.startsWith('/data/'))
+      ) {
+        configMapDataChanged = true;
+      }
+
+      if (
+        isWorkloadKind(oldFormJson.kind) &&
+        patchRes.some(
+          (item) => item.path === '/spec/template' || item.path.startsWith('/spec/template/')
+        )
+      ) {
+        workloadTemplateChanged = true;
+      }
 
       /* Generate a new json using the formPatchResult and the crJson */
       const actionsJson = (() => {
@@ -526,6 +604,10 @@ export const patchYamlList = ({
       });
     }
   });
+
+  if (configMapDataChanged && !workloadTemplateChanged) {
+    ensureRestartTimePatch({ actions, originalYamlList, oldFormJsonList });
+  }
 
   return actions;
 };


### PR DESCRIPTION
### Summary

- Remove the generated `restartTime` pod-template label from rendered workloads so replica-only StatefulSet edits do not restart Pods.
- Add an explicit workload restart patch when ConfigMap data changes without another pod-template change.
- Apply non-workload dependency patches before workload patches so restarted Pods see updated ConfigMaps/Services/etc.
- Keep regression coverage for StatefulSet replica edits, ConfigMap data edits, and existing imagePullSecrets patch behavior.

### Related issue

None linked.

### Tests

- `timeout 120s npx -y vitest@1.6.1 run __tests__/unit/utils/tools.test.ts --config vitest.config.ts --pool=forks`
- `timeout 120s npx -y vitest@1.6.1 run __tests__/unit/utils/deployYaml2Json.test.ts --config vitest.config.ts --pool=forks`
- `timeout 300s npx -y -p node@20.4.0 -p pnpm@8.9.0 -c 'pnpm --filter ./providers/applaunchpad exec tsc --noEmit --pretty false'`
- `timeout 300s npx -y -p node@20.4.0 -p pnpm@8.9.0 -c 'pnpm --filter ./providers/applaunchpad lint'` (passes with existing `react-hooks/exhaustive-deps` warnings in unrelated files)
