### PR TITLE
feat(desktop): delegate template URL deployment to Brain

### DIFF
--- a/frontend/desktop/src/pages/oauth.tsx
+++ b/frontend/desktop/src/pages/oauth.tsx
@@ -74,6 +74,30 @@ export default function OAuth() {
       workspaceName
     } = router.query;
 
+    const openBrainTemplateDeploy = async () => {
+      if (
+        openapp !== 'system-brain' ||
+        typeof templateName !== 'string' ||
+        typeof templateForm !== 'string'
+      ) {
+        return false;
+      }
+
+      const brainDeployQuery = new URLSearchParams({
+        templateName,
+        templateForm
+      });
+
+      setAutoLaunch('system-brain', {
+        pathname: '/deploy',
+        raw: brainDeployQuery.toString()
+      });
+      cancelAutoDeployTemplate();
+      await router.replace('/');
+
+      return true;
+    };
+
     const handleTokenLogin = async () => {
       hasProcessedRef.current = true;
 
@@ -124,6 +148,10 @@ export default function OAuth() {
               await switchWorkspaceMutation.mutateAsync(existNamespace.uid);
             }
           }
+        }
+
+        if (await openBrainTemplateDeploy()) {
+          return;
         }
 
         const { instanceName, error: deploymentError } = await handleTemplateDeployment();
@@ -361,6 +389,10 @@ export default function OAuth() {
       hasProcessedRef.current = true;
 
       (async () => {
+        if (await openBrainTemplateDeploy()) {
+          return;
+        }
+
         let instanceName: string | null = null;
         let deploymentError: string | null = null;
         try {


### PR DESCRIPTION
## Summary

- detect complete Brain template deployment intents on the Desktop OAuth route
- open system-brain at /deploy with templateName and templateForm
- bypass Desktop template deployment only for this exact intent while retaining the existing deployment code as a fallback

## Why

Brain now owns project-oriented template deployment. Desktop should continue to handle authentication, region initialization, and workspace switching, then hand the deployment intent to Brain instead of creating template resources itself.

Depends on labring/brain#193.

## Impact

Links shaped like /oauth?...&openapp=system-brain&templateName=xxx&templateForm=... now open Brain and trigger its URL deployment flow. Other OAuth and template deployment paths retain their existing behavior.

## Validation

- pnpm --filter desktop build
- Prettier check for frontend/desktop/src/pages/oauth.tsx
- git diff --check