### PR TITLE
fix(account): replay final debt namespace cleanup

### DIFF
--- a/controllers/account/controllers/debt.go
+++ b/controllers/account/controllers/debt.go
@@ -47,7 +47,7 @@ import (
 const (
 	DebtDetectionCycleEnv = "DebtDetectionCycleSeconds"
 
-	finalDeletionDebtNamespaceSyncInterval = 5 * time.Minute
+	finalDeletionDebtNamespaceSyncInterval = time.Hour
 	finalDeletionDebtNamespaceQueryTimeout = 30 * time.Second
 	flushDebtResourceStatusRequestTimeout  = 30 * time.Second
 

--- a/controllers/account/controllers/debt.go
+++ b/controllers/account/controllers/debt.go
@@ -668,7 +668,10 @@ func (r *DebtReconciler) syncFinalDeletionDebtNamespaces(ctx context.Context, db
 	var errs []error
 	for _, userUID := range users {
 		if err := r.syncFinalDeletionDebtNamespacesForUser(userUID); err != nil {
-			errs = append(errs, fmt.Errorf("failed to sync final deletion debt namespaces for user %s: %w", userUID, err))
+			errs = append(
+				errs,
+				fmt.Errorf("failed to sync final deletion debt namespaces for user %s: %w", userUID, err),
+			)
 		}
 	}
 	if len(users) > 0 {

--- a/controllers/account/controllers/debt.go
+++ b/controllers/account/controllers/debt.go
@@ -668,10 +668,9 @@ func (r *DebtReconciler) syncFinalDeletionDebtNamespaces(ctx context.Context, db
 	var errs []error
 	for _, userUID := range users {
 		if err := r.syncFinalDeletionDebtNamespacesForUser(userUID); err != nil {
-			errs = append(
-				errs,
-				fmt.Errorf("failed to sync final deletion debt namespaces for user %s: %w", userUID, err),
-			)
+			errMsg := "failed to sync final deletion debt namespaces " +
+				"for user %s: %w"
+			errs = append(errs, fmt.Errorf(errMsg, userUID, err))
 		}
 	}
 	if len(users) > 0 {

--- a/controllers/account/controllers/debt.go
+++ b/controllers/account/controllers/debt.go
@@ -47,6 +47,8 @@ import (
 const (
 	DebtDetectionCycleEnv = "DebtDetectionCycleSeconds"
 
+	finalDeletionDebtNamespaceSyncInterval = 5 * time.Minute
+
 	SMSAccessKeyIDEnv     = "SMS_AK"
 	SMSAccessKeySecretEnv = "SMS_SK"
 	VmsAccessKeyIDEnv     = "VMS_AK"
@@ -525,6 +527,13 @@ func (r *DebtReconciler) start() {
 		}
 	}()
 
+	// 1.4 replay final deletion status for accounts that are already in the terminal debt state.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		r.syncFinalDeletionDebtNamespacesLoop(db)
+	}()
+
 	// 2.1 recharge record processing
 	// wg.Add(1)
 	// go func() {
@@ -630,6 +639,54 @@ func (r *DebtReconciler) start() {
 	}()
 
 	wg.Wait()
+}
+
+func (r *DebtReconciler) syncFinalDeletionDebtNamespacesLoop(db *gorm.DB) {
+	run := func() {
+		if err := r.syncFinalDeletionDebtNamespaces(context.Background(), db); err != nil {
+			r.Error(err, "failed to sync final deletion debt namespaces")
+		}
+	}
+
+	run()
+	ticker := time.NewTicker(finalDeletionDebtNamespaceSyncInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		run()
+	}
+}
+
+func (r *DebtReconciler) syncFinalDeletionDebtNamespaces(ctx context.Context, db *gorm.DB) error {
+	var users []uuid.UUID
+	if err := db.WithContext(ctx).Model(&types.Debt{}).
+		Where("account_debt_status = ?", types.FinalDeletionPeriod).
+		Distinct("user_uid").
+		Pluck("user_uid", &users).Error; err != nil {
+		return fmt.Errorf("failed to query final deletion debt users: %w", err)
+	}
+
+	var errs []error
+	for _, userUID := range users {
+		if err := r.syncFinalDeletionDebtNamespacesForUser(userUID); err != nil {
+			errs = append(errs, fmt.Errorf("failed to sync final deletion debt namespaces for user %s: %w", userUID, err))
+		}
+	}
+	if len(users) > 0 {
+		r.Info("synced final deletion debt namespaces", "users", len(users))
+	}
+	return errors.Join(errs...)
+}
+
+func (r *DebtReconciler) syncFinalDeletionDebtNamespacesForUser(userUID uuid.UUID) error {
+	return r.sendFlushDebtResourceStatusRequest(finalDeletionDebtNamespaceFlushReq(userUID))
+}
+
+func finalDeletionDebtNamespaceFlushReq(userUID uuid.UUID) AdminFlushResourceStatusReq {
+	return AdminFlushResourceStatusReq{
+		UserUID:           userUID,
+		LastDebtStatus:    types.DebtDeletionPeriod,
+		CurrentDebtStatus: types.FinalDeletionPeriod,
+	}
 }
 
 func (r *DebtReconciler) RefreshDebtStatus(userUID uuid.UUID) error {

--- a/controllers/account/controllers/debt.go
+++ b/controllers/account/controllers/debt.go
@@ -425,12 +425,12 @@ func (r *DebtReconciler) Start(ctx context.Context) error {
 		}
 	}()
 	log.Printf("debt reconciler lock acquired, process ID: %s", r.processID)
-	r.start()
+	r.start(ctx)
 	log.Printf("debt reconciler started")
 	return nil
 }
 
-func (r *DebtReconciler) start() {
+func (r *DebtReconciler) start(ctx context.Context) {
 	db := r.AccountV2.GetGlobalDB()
 	var wg sync.WaitGroup
 
@@ -533,7 +533,7 @@ func (r *DebtReconciler) start() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		r.syncFinalDeletionDebtNamespacesLoop(db)
+		r.syncFinalDeletionDebtNamespacesLoop(ctx, db)
 	}()
 
 	// 2.1 recharge record processing
@@ -643,9 +643,9 @@ func (r *DebtReconciler) start() {
 	wg.Wait()
 }
 
-func (r *DebtReconciler) syncFinalDeletionDebtNamespacesLoop(db *gorm.DB) {
+func (r *DebtReconciler) syncFinalDeletionDebtNamespacesLoop(ctx context.Context, db *gorm.DB) {
 	run := func() {
-		if err := r.syncFinalDeletionDebtNamespaces(context.Background(), db); err != nil {
+		if err := r.syncFinalDeletionDebtNamespaces(ctx, db); err != nil {
 			r.Error(err, "failed to sync final deletion debt namespaces")
 		}
 	}
@@ -653,8 +653,13 @@ func (r *DebtReconciler) syncFinalDeletionDebtNamespacesLoop(db *gorm.DB) {
 	run()
 	ticker := time.NewTicker(finalDeletionDebtNamespaceSyncInterval)
 	defer ticker.Stop()
-	for range ticker.C {
-		run()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			run()
+		}
 	}
 }
 

--- a/controllers/account/controllers/debt.go
+++ b/controllers/account/controllers/debt.go
@@ -48,6 +48,8 @@ const (
 	DebtDetectionCycleEnv = "DebtDetectionCycleSeconds"
 
 	finalDeletionDebtNamespaceSyncInterval = 5 * time.Minute
+	finalDeletionDebtNamespaceQueryTimeout = 30 * time.Second
+	flushDebtResourceStatusRequestTimeout  = 30 * time.Second
 
 	SMSAccessKeyIDEnv     = "SMS_AK"
 	SMSAccessKeySecretEnv = "SMS_SK"
@@ -658,7 +660,10 @@ func (r *DebtReconciler) syncFinalDeletionDebtNamespacesLoop(db *gorm.DB) {
 
 func (r *DebtReconciler) syncFinalDeletionDebtNamespaces(ctx context.Context, db *gorm.DB) error {
 	var users []uuid.UUID
-	if err := db.WithContext(ctx).Model(&types.Debt{}).
+	queryCtx, cancel := context.WithTimeout(ctx, finalDeletionDebtNamespaceQueryTimeout)
+	defer cancel()
+
+	if err := db.WithContext(queryCtx).Model(&types.Debt{}).
 		Where("account_debt_status = ?", types.FinalDeletionPeriod).
 		Distinct("user_uid").
 		Pluck("user_uid", &users).Error; err != nil {
@@ -667,7 +672,7 @@ func (r *DebtReconciler) syncFinalDeletionDebtNamespaces(ctx context.Context, db
 
 	var errs []error
 	for _, userUID := range users {
-		if err := r.syncFinalDeletionDebtNamespacesForUser(userUID); err != nil {
+		if err := r.syncFinalDeletionDebtNamespacesForUser(ctx, userUID); err != nil {
 			errMsg := "failed to sync final deletion debt namespaces " +
 				"for user %s: %w"
 			errs = append(errs, fmt.Errorf(errMsg, userUID, err))
@@ -679,8 +684,11 @@ func (r *DebtReconciler) syncFinalDeletionDebtNamespaces(ctx context.Context, db
 	return errors.Join(errs...)
 }
 
-func (r *DebtReconciler) syncFinalDeletionDebtNamespacesForUser(userUID uuid.UUID) error {
-	return r.sendFlushDebtResourceStatusRequest(finalDeletionDebtNamespaceFlushReq(userUID))
+func (r *DebtReconciler) syncFinalDeletionDebtNamespacesForUser(ctx context.Context, userUID uuid.UUID) error {
+	return r.sendFlushDebtResourceStatusRequestWithContext(
+		ctx,
+		finalDeletionDebtNamespaceFlushReq(userUID),
+	)
 }
 
 func finalDeletionDebtNamespaceFlushReq(userUID uuid.UUID) AdminFlushResourceStatusReq {
@@ -1002,6 +1010,17 @@ type AdminFlushResourceStatusReq struct {
 func (r *DebtReconciler) sendFlushDebtResourceStatusRequest(
 	quotaReq AdminFlushResourceStatusReq,
 ) error {
+	return r.sendFlushDebtResourceStatusRequestWithContext(context.Background(), quotaReq)
+}
+
+func (r *DebtReconciler) sendFlushDebtResourceStatusRequestWithContext(
+	ctx context.Context,
+	quotaReq AdminFlushResourceStatusReq,
+) error {
+	client := http.Client{
+		Timeout: flushDebtResourceStatusRequestTimeout,
+	}
+
 	for _, domain := range r.allRegionDomain {
 		token, err := r.jwtManager.GenerateToken(utils.JwtUser{
 			Requester: AdminUserName,
@@ -1029,14 +1048,18 @@ func (r *DebtReconciler) sendFlushDebtResourceStatusRequest(
 
 		maxRetries := 3
 		for attempt := 1; attempt <= maxRetries; attempt++ {
-			req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(quotaReqBody))
+			req, err := http.NewRequestWithContext(
+				ctx,
+				http.MethodPost,
+				url,
+				bytes.NewBuffer(quotaReqBody),
+			)
 			if err != nil {
 				return fmt.Errorf("failed to create request: %w", err)
 			}
 
 			req.Header.Set("Authorization", "Bearer "+token)
 			req.Header.Set("Content-Type", "application/json")
-			client := http.Client{}
 
 			resp, err := client.Do(req)
 			if err != nil {

--- a/controllers/account/controllers/debt_final_deletion_sync_test.go
+++ b/controllers/account/controllers/debt_final_deletion_sync_test.go
@@ -16,9 +16,17 @@ func TestFinalDeletionDebtNamespaceFlushReq(t *testing.T) {
 		t.Fatalf("expected user uid %s, got %s", userUID, req.UserUID)
 	}
 	if req.LastDebtStatus != types.DebtDeletionPeriod {
-		t.Fatalf("expected last debt status %s, got %s", types.DebtDeletionPeriod, req.LastDebtStatus)
+		t.Fatalf(
+			"expected last debt status %s, got %s",
+			types.DebtDeletionPeriod,
+			req.LastDebtStatus,
+		)
 	}
 	if req.CurrentDebtStatus != types.FinalDeletionPeriod {
-		t.Fatalf("expected current debt status %s, got %s", types.FinalDeletionPeriod, req.CurrentDebtStatus)
+		t.Fatalf(
+			"expected current debt status %s, got %s",
+			types.FinalDeletionPeriod,
+			req.CurrentDebtStatus,
+		)
 	}
 }

--- a/controllers/account/controllers/debt_final_deletion_sync_test.go
+++ b/controllers/account/controllers/debt_final_deletion_sync_test.go
@@ -1,0 +1,24 @@
+package controllers
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/labring/sealos/controllers/pkg/types"
+)
+
+func TestFinalDeletionDebtNamespaceFlushReq(t *testing.T) {
+	userUID := uuid.New()
+
+	req := finalDeletionDebtNamespaceFlushReq(userUID)
+
+	if req.UserUID != userUID {
+		t.Fatalf("expected user uid %s, got %s", userUID, req.UserUID)
+	}
+	if req.LastDebtStatus != types.DebtDeletionPeriod {
+		t.Fatalf("expected last debt status %s, got %s", types.DebtDeletionPeriod, req.LastDebtStatus)
+	}
+	if req.CurrentDebtStatus != types.FinalDeletionPeriod {
+		t.Fatalf("expected current debt status %s, got %s", types.FinalDeletionPeriod, req.CurrentDebtStatus)
+	}
+}


### PR DESCRIPTION
## Summary

- Replay final debt namespace cleanup for accounts that are already in `FinalDeletionPeriod`.
- Reuse the existing all-region debt resource status flush path so non-subscription namespaces advance to `FinalDeletion`.
- Add a focused unit test for the replay request status transition.

This covers accounts that reached the terminal debt state before the controller fix, where no later debt transition would otherwise patch their namespaces for PVC cleanup.
