### PR TITLE
fix(costcenter): surface account summary request failures

### DIFF
--- a/frontend/providers/costcenter/__tests__/unit/account.test.ts
+++ b/frontend/providers/costcenter/__tests__/unit/account.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { getAccountSummary } from '@/api/account';
+
+describe('getAccountSummary', () => {
+  it('uses null values when account data is unavailable', () => {
+    expect(getAccountSummary(undefined)).toEqual({
+      balance: null,
+      expenditure: null,
+      recharge: null
+    });
+  });
+
+  it('preserves valid zero amounts', () => {
+    expect(getAccountSummary({ balance: 0, deductionBalance: 0 })).toEqual({
+      balance: 0,
+      expenditure: 0,
+      recharge: 0
+    });
+  });
+});

--- a/frontend/providers/costcenter/__tests__/unit/region.test.ts
+++ b/frontend/providers/costcenter/__tests__/unit/region.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { resolveRequestRegionUid } from '@/service/backend/region';
+
+describe('resolveRequestRegionUid', () => {
+  it('prefers an explicitly requested region', () => {
+    expect(resolveRequestRegionUid('region-request', 'region-session', 'region-current')).toBe(
+      'region-request'
+    );
+  });
+
+  it('uses the authenticated session region when the request omits one', () => {
+    expect(resolveRequestRegionUid(undefined, 'region-session', 'region-current')).toBe(
+      'region-session'
+    );
+  });
+
+  it('falls back to the current cluster region for legacy sessions', () => {
+    expect(resolveRequestRegionUid('  ', undefined, 'region-current')).toBe('region-current');
+  });
+});

--- a/frontend/providers/costcenter/src/api/account.ts
+++ b/frontend/providers/costcenter/src/api/account.ts
@@ -6,6 +6,24 @@ export interface AccountBalanceResponse {
   balance: number;
 }
 
+export interface AccountSummary {
+  balance: number | null;
+  expenditure: number | null;
+  recharge: number | null;
+}
+
+export function getAccountSummary(account?: AccountBalanceResponse | null): AccountSummary {
+  if (!account || !Number.isFinite(account.balance) || !Number.isFinite(account.deductionBalance)) {
+    return { balance: null, expenditure: null, recharge: null };
+  }
+
+  return {
+    balance: account.balance - account.deductionBalance,
+    expenditure: account.deductionBalance,
+    recharge: account.balance
+  };
+}
+
 // Get account balance data
 export const getAccountBalance = () =>
   request.post<any, ApiResp<AccountBalanceResponse>>('/api/account/getAmount');

--- a/frontend/providers/costcenter/src/components/plan/BalanceSection.tsx
+++ b/frontend/providers/costcenter/src/components/plan/BalanceSection.tsx
@@ -1,24 +1,31 @@
-import { Button, Tooltip, TooltipTrigger, TooltipContent } from '@sealos/shadcn-ui';
+import { Button, Skeleton, Tooltip, TooltipTrigger, TooltipContent } from '@sealos/shadcn-ui';
 import { displayMoney, formatMoney } from '@/utils/format';
 import GiftCode from '@/components/cost_overview/components/GiftCode';
 import { useTranslation } from 'next-i18next';
 import CurrencySymbol from '../CurrencySymbol';
-import { HelpCircle } from 'lucide-react';
+import { HelpCircle, RefreshCw } from 'lucide-react';
 
 interface BalanceSectionProps {
-  balance: number;
+  balance: number | null;
+  isError?: boolean;
+  isLoading?: boolean;
   rechargeEnabled: boolean;
   subscriptionEnabled?: boolean;
   onTopUpClick: () => void;
+  onRetry?: () => void;
 }
 
 export function BalanceSection({
   balance,
+  isError = false,
+  isLoading = false,
   rechargeEnabled,
   subscriptionEnabled = false,
-  onTopUpClick
+  onTopUpClick,
+  onRetry
 }: BalanceSectionProps) {
   const { t } = useTranslation();
+  const errorLabel = `${t('common:error')}: ${t('common:balance')}`;
 
   return (
     <div className="p-2 border rounded-2xl">
@@ -39,10 +46,30 @@ export function BalanceSection({
               </Tooltip>
             )}
           </div>
-          <span className="text-foreground text-2xl font-semibold leading-none">
-            <CurrencySymbol className="size-5" />
-            <span>{displayMoney(formatMoney(balance))}</span>
-          </span>
+          {isLoading ? (
+            <Skeleton aria-label={t('common:balance')} className="h-7 w-32" />
+          ) : isError || balance === null ? (
+            <div className="flex h-7 items-center gap-2" role="status" aria-label={errorLabel}>
+              <span className="text-foreground text-2xl font-semibold leading-none">--</span>
+              {onRetry && (
+                <Button
+                  aria-label={errorLabel}
+                  className="size-7"
+                  size="icon"
+                  title={errorLabel}
+                  variant="ghost"
+                  onClick={onRetry}
+                >
+                  <RefreshCw className="size-4" />
+                </Button>
+              )}
+            </div>
+          ) : (
+            <span className="text-foreground text-2xl font-semibold leading-none">
+              <CurrencySymbol className="size-5" />
+              <span>{displayMoney(formatMoney(balance))}</span>
+            </span>
+          )}
         </div>
 
         <div className="flex gap-4 items-center">

--- a/frontend/providers/costcenter/src/components/plan/RechargeExpenditureSection.tsx
+++ b/frontend/providers/costcenter/src/components/plan/RechargeExpenditureSection.tsx
@@ -1,15 +1,18 @@
+import { Skeleton } from '@sealos/shadcn-ui';
 import { displayMoney, formatMoney } from '@/utils/format';
 import { useTranslation } from 'next-i18next';
 import CurrencySymbol from '../CurrencySymbol';
 
 interface RechargeExpenditureSectionProps {
-  recharge: number;
-  expenditure: number;
+  expenditure: number | null;
+  isLoading?: boolean;
+  recharge: number | null;
 }
 
 export function RechargeExpenditureSection({
   recharge,
-  expenditure
+  expenditure,
+  isLoading = false
 }: RechargeExpenditureSectionProps) {
   const { t } = useTranslation();
 
@@ -18,20 +21,31 @@ export function RechargeExpenditureSection({
       <div className="bg-plan-payg flex items-center rounded-xl px-6 py-5 gap-8">
         <div className="flex flex-col gap-1">
           <span className="text-sm text-slate-500">{t('common:total_recharge')}</span>
-          <span className="text-foreground text-2xl font-semibold leading-none">
-            <CurrencySymbol className="size-5" />
-            <span>{displayMoney(formatMoney(recharge))}</span>
-          </span>
+          <AccountAmount isLoading={isLoading} value={recharge} />
         </div>
 
         <div className="flex flex-col gap-1">
           <span className="text-sm text-slate-500">{t('common:total_expenditure')}</span>
-          <span className="text-foreground text-2xl font-semibold leading-none">
-            <CurrencySymbol className="size-5" />
-            <span>{displayMoney(formatMoney(expenditure))}</span>
-          </span>
+          <AccountAmount isLoading={isLoading} value={expenditure} />
         </div>
       </div>
     </div>
+  );
+}
+
+function AccountAmount({ isLoading, value }: { isLoading: boolean; value: number | null }) {
+  if (isLoading) {
+    return <Skeleton className="h-7 w-28" />;
+  }
+
+  if (value === null) {
+    return <span className="text-foreground text-2xl font-semibold leading-none">--</span>;
+  }
+
+  return (
+    <span className="text-foreground text-2xl font-semibold leading-none">
+      <CurrencySymbol className="size-5" />
+      <span>{displayMoney(formatMoney(value))}</span>
+    </span>
   );
 }

--- a/frontend/providers/costcenter/src/pages/api/account/getAmount.ts
+++ b/frontend/providers/costcenter/src/pages/api/account/getAmount.ts
@@ -27,7 +27,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       }
     });
   } catch (error) {
-    console.log(error);
+    const message = error instanceof Error ? error.message : 'unknown error';
+    console.error('get account amount error:', message);
     jsonRes(res, { code: 500, message: 'get amount error' });
   }
 }

--- a/frontend/providers/costcenter/src/pages/cost/index.tsx
+++ b/frontend/providers/costcenter/src/pages/cost/index.tsx
@@ -7,7 +7,7 @@ import useBillingStore from '@/stores/billing';
 import { useClientAppConfig } from '@/hooks/useClientAppConfig';
 import { loadStripe } from '@stripe/stripe-js';
 import { BalanceSection } from '@/components/plan/BalanceSection';
-import { getAccountBalance } from '@/api/account';
+import { getAccountBalance, getAccountSummary } from '@/api/account';
 import request from '@/service/request';
 import RechargeModal from '@/components/RechargeModal';
 import TransferModal from '@/components/TransferModal';
@@ -51,16 +51,19 @@ export default function Cost() {
   const transferRef = useRef<any>();
 
   // Get balance data
-  const { data: balance_raw } = useQuery({
+  const accountQuery = useQuery({
     queryKey: ['getAccount'],
     queryFn: getAccountBalance,
     staleTime: 0
   });
 
   // Calculate balance
-  let rechargeAmount = balance_raw?.data?.balance || 0;
-  let expenditureAmount = balance_raw?.data?.deductionBalance || 0;
-  let balance = rechargeAmount - expenditureAmount;
+  const {
+    recharge: rechargeAmount,
+    expenditure: expenditureAmount,
+    balance
+  } = getAccountSummary(accountQuery.data?.data);
+  const accountUnavailable = accountQuery.isError || (!accountQuery.isLoading && balance === null);
 
   // Get k8s_username for transfer functionality
   const getSession = useSessionStore((state) => state.getSession);
@@ -81,13 +84,20 @@ export default function Cost() {
         <div className="flex-1">
           <BalanceSection
             balance={balance}
+            isError={accountUnavailable}
+            isLoading={accountQuery.isLoading}
             rechargeEnabled={config.recharge.enabled}
             subscriptionEnabled={config.features.subscriptionEnabled}
             onTopUpClick={() => rechargeRef?.current?.onOpen()}
+            onRetry={() => void accountQuery.refetch()}
           />
         </div>
 
-        <RechargeExpenditureSection recharge={rechargeAmount} expenditure={expenditureAmount} />
+        <RechargeExpenditureSection
+          expenditure={expenditureAmount}
+          isLoading={accountQuery.isLoading}
+          recharge={rechargeAmount}
+        />
       </div>
 
       <div className="flex flex-col gap-4 overflow-auto">
@@ -99,7 +109,7 @@ export default function Cost() {
       {config.recharge.enabled && (
         <RechargeModal
           ref={rechargeRef}
-          balance={balance}
+          balance={balance ?? 0}
           stripePromise={stripePromise}
           request={request}
           onPaySuccess={async () => {
@@ -113,7 +123,7 @@ export default function Cost() {
       {config.features.transferEnabled && (
         <TransferModal
           ref={transferRef}
-          balance={balance}
+          balance={balance ?? 0}
           onTransferSuccess={async () => {
             await new Promise((s) => setTimeout(s, 2000));
             await queryClient.invalidateQueries({ queryKey: ['billing'] });

--- a/frontend/providers/costcenter/src/pages/plan/index.tsx
+++ b/frontend/providers/costcenter/src/pages/plan/index.tsx
@@ -21,7 +21,7 @@ import { CardInfoSection } from '@/components/plan/CardInfoSection';
 import { InvoicePaymentBanner } from '@/components/plan/InvoicePaymentBanner';
 import { BeingCancelledBanner } from '@/components/plan/BeingCancelledBanner';
 import { FreePlanExpiryBanner } from '@/components/plan/FreePlanExpiryBanner';
-import { getAccountBalance } from '@/api/account';
+import { getAccountBalance, getAccountSummary } from '@/api/account';
 import request from '@/service/request';
 import RechargeModal from '@/components/RechargeModal';
 import TransferModal from '@/components/TransferModal';
@@ -254,7 +254,7 @@ export default function Plan() {
   const transferRef = useRef<any>();
 
   // Get balance data
-  const { data: balance_raw } = useQuery({
+  const accountQuery = useQuery({
     queryKey: ['getAccount'],
     queryFn: getAccountBalance,
     staleTime: 0
@@ -392,9 +392,8 @@ export default function Plan() {
   });
 
   // Calculate balance
-  let rechargAmount = balance_raw?.data?.balance || 0;
-  let expenditureAmount = balance_raw?.data?.deductionBalance || 0;
-  let balance = rechargAmount - expenditureAmount;
+  const { balance } = getAccountSummary(accountQuery.data?.data);
+  const accountUnavailable = accountQuery.isError || (!accountQuery.isLoading && balance === null);
 
   // Get k8s_username for transfer functionality
   const getSession = useSessionStore((state) => state.getSession);
@@ -739,9 +738,12 @@ export default function Plan() {
           <div className="flex-1/3">
             <BalanceSection
               balance={balance}
+              isError={accountUnavailable}
+              isLoading={accountQuery.isLoading}
               rechargeEnabled={config.recharge.enabled}
               subscriptionEnabled={config.features.subscriptionEnabled}
               onTopUpClick={() => rechargeRef?.current?.onOpen()}
+              onRetry={() => void accountQuery.refetch()}
             />
           </div>
         </div>
@@ -809,9 +811,12 @@ export default function Plan() {
 
           <BalanceSection
             balance={balance}
+            isError={accountUnavailable}
+            isLoading={accountQuery.isLoading}
             rechargeEnabled={config.recharge.enabled}
             subscriptionEnabled={config.features.subscriptionEnabled}
             onTopUpClick={() => rechargeRef?.current!.onOpen()}
+            onRetry={() => void accountQuery.refetch()}
           />
         </>
       )}
@@ -829,7 +834,7 @@ export default function Plan() {
       {config.recharge.enabled && (
         <RechargeModal
           ref={rechargeRef}
-          balance={balance}
+          balance={balance ?? 0}
           stripePromise={stripePromise}
           request={request}
           onPaySuccess={async () => {
@@ -843,7 +848,7 @@ export default function Plan() {
       {config.features.transferEnabled && (
         <TransferModal
           ref={transferRef}
-          balance={balance}
+          balance={balance ?? 0}
           onTransferSuccess={async () => {
             // Note: invalidate will be handled when modal closes
             // Wait a bit for transfer to be processed

--- a/frontend/providers/costcenter/src/service/backend/region.ts
+++ b/frontend/providers/costcenter/src/service/backend/region.ts
@@ -88,14 +88,28 @@ export function makeAPIClient(
     }
   });
 }
+
+export function resolveRequestRegionUid(
+  requestedRegionUid: unknown,
+  sessionRegionUid?: string,
+  currentRegionUid?: string
+) {
+  const requested = typeof requestedRegionUid === 'string' ? requestedRegionUid.trim() : '';
+  return requested || sessionRegionUid || currentRegionUid;
+}
+
 export async function makeAPIClientByHeader(req: NextApiRequest, res: NextApiResponse) {
   const token = req.body.internalToken;
-  const regionUid = req.body.regionUid;
   const payload = await verifyInternalToken(token);
   if (!payload) {
     jsonRes(res, { code: 401, message: 'Authorization failed' });
     return null;
   }
+  const regionUid = resolveRequestRegionUid(
+    req.body.regionUid,
+    payload.regionUid,
+    Config().cloud.regionUid
+  );
   const region = await getRegionByUid(regionUid);
   const client = makeAPIClient(region, payload);
   return client;


### PR DESCRIPTION
## Summary

- resolve account requests with the requested region, authenticated session region, or current cluster region
- distinguish account loading/failure states from valid zero amounts on the cost and plan pages
- show a retry action for unavailable balances and avoid logging full Axios errors from the account endpoint
- add regression coverage for region selection and account amount normalization

## Root cause

The account summary request could omit `regionUid`, so `/account/v1alpha1/account` could fail even while cost detail requests succeeded. The UI then normalized missing account data with `|| 0`, masking that failure as zero total expenditure.

## Verification

- `pnpm --filter costcenter test:ci` (4 files, 9 tests passed)
- `pnpm --filter costcenter lint` (passed; existing hook warnings remain)
- `pnpm --filter costcenter build` (passed)
- Prettier check and `git diff --check` passed

## Notes

- No issue number was provided; this was reported directly as a P0.
- Standalone `tsc --noEmit` still reports the pre-existing callable mock error in `__tests__/unit/refetch-after-payment.test.ts:47`; the production Next.js build passes its type-check stage.