### PR TITLE
fix(account): force stop KubeBlocks clusters on suspension

### DIFF
--- a/controllers/account/controllers/namespace_controller.go
+++ b/controllers/account/controllers/namespace_controller.go
@@ -682,6 +682,7 @@ func (r *NamespaceReconciler) suspendKBCluster(ctx context.Context, namespace st
 		opsSpec := map[string]any{
 			"clusterRef":             clusterName,
 			"type":                   "Stop",
+			"force":                  true,
 			"ttlSecondsAfterSucceed": int64(1),
 			"ttlSecondsBeforeAbort":  int64(60 * 60),
 		}

--- a/controllers/account/controllers/namespace_controller_test.go
+++ b/controllers/account/controllers/namespace_controller_test.go
@@ -424,7 +424,20 @@ func TestSuspendResumeKBCluster(t *testing.T) {
 				_ = unstructured.SetNestedField(cluster.Object, true, "spec", "backup", "enabled")
 			}
 
-			dynamicClient := fake.NewSimpleDynamicClient(scheme, cluster)
+			clusterGVR := schema.GroupVersionResource{
+				Group:    "apps.kubeblocks.io",
+				Version:  "v1alpha1",
+				Resource: "clusters",
+			}
+			opsGVR := schema.GroupVersionResource{
+				Group:    "apps.kubeblocks.io",
+				Version:  "v1alpha1",
+				Resource: "opsrequests",
+			}
+			dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{
+				clusterGVR: "ClusterList",
+				opsGVR:     "OpsRequestList",
+			}, cluster)
 
 			reconciler := &NamespaceReconciler{
 				dynamicClient: dynamicClient,
@@ -440,12 +453,6 @@ func TestSuspendResumeKBCluster(t *testing.T) {
 			}
 
 			// Verify suspension
-			clusterGVR := schema.GroupVersionResource{
-				Group:    "apps.kubeblocks.io",
-				Version:  "v1alpha1",
-				Resource: "clusters",
-			}
-
 			suspendedCluster, err := dynamicClient.Resource(clusterGVR).
 				Namespace("test-ns").
 				Get(ctx, "test-cluster", v1.GetOptions{})
@@ -488,6 +495,22 @@ func TestSuspendResumeKBCluster(t *testing.T) {
 				} else if enabled {
 					t.Error("expected backup to be disabled")
 				}
+			}
+
+			opsList, err := dynamicClient.Resource(opsGVR).Namespace("test-ns").List(ctx, v1.ListOptions{})
+			if err != nil {
+				t.Fatalf("failed to list OpsRequests: %v", err)
+			}
+			if tt.shouldCreateOps {
+				if len(opsList.Items) != 1 {
+					t.Fatalf("expected one Stop OpsRequest, got %d", len(opsList.Items))
+				}
+				force, found, err := unstructured.NestedBool(opsList.Items[0].Object, "spec", "force")
+				if err != nil || !found || !force {
+					t.Fatalf("expected force Stop OpsRequest, force=%v found=%v err=%v", force, found, err)
+				}
+			} else if len(opsList.Items) != 0 {
+				t.Fatalf("expected no Stop OpsRequest, got %d", len(opsList.Items))
 			}
 
 			// Simulate cluster being stopped


### PR DESCRIPTION
## Summary

Create KubeBlocks Stop OpsRequests with `spec.force: true` when suspending a namespace because of debt.

## Problem

The debt suspension flow creates `debt-limit0` and then sends a Stop OpsRequest for each active KubeBlocks Cluster.

If a Start OpsRequest is already running, a normal Stop waits behind it. The running Start may then fail to create Pods or PVCs because of `debt-limit0`, preventing Stop from progressing.

## Changes

- Add `force: true` to debt-triggered KubeBlocks Stop OpsRequests.
- Extend the existing suspension test to verify that:
  - active Clusters receive exactly one forced Stop OpsRequest;
  - already Stopped or Stopping Clusters do not receive another Stop.

No polling, additional suspension states, quota repair, deduplication, or waiting-for-Stopped logic is introduced.

## Expected Behavior

With the corresponding KubeBlocks change deployed:

- An earlier Start can be aborted by the forced Stop.
- HScale, VScale, Restart, and other non-Start operations are not interrupted.
- A Cluster in Creating can still be stopped.
- Existing resume behavior remains unchanged.

## Validation
- The focused KubeBlocks suspension test covers forced Stop creation.
- gofmt and git diff --check passed.