### PR TITLE
fix(desktop): honor guide feature flag

### DIFF
--- a/frontend/desktop/src/__tests__/unit/guideFeatureFlag.test.ts
+++ b/frontend/desktop/src/__tests__/unit/guideFeatureFlag.test.ts
@@ -1,0 +1,100 @@
+/** @jest-environment jsdom */
+
+import React from 'react';
+import { ChakraProvider, useBreakpointValue } from '@chakra-ui/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import SecondaryLinks from '@/components/SecondaryLinks';
+import { useConfigStore } from '@/stores/config';
+
+const openGuideModal = jest.fn();
+const setInitGuide = jest.fn();
+
+jest.mock('@/stores/config', () => ({
+  useConfigStore: jest.fn()
+}));
+
+jest.mock('@/stores/app', () => ({
+  __esModule: true,
+  default: () => ({ openDesktopApp: jest.fn() })
+}));
+
+jest.mock('@/stores/guideModal', () => ({
+  useGuideModalStore: () => ({ openGuideModal, setInitGuide })
+}));
+
+jest.mock('@/stores/session', () => ({
+  __esModule: true,
+  default: () => ({ session: undefined })
+}));
+
+jest.mock('@/api/platform', () => ({ getResource: jest.fn() }));
+jest.mock('@/api/auth', () => ({ getAmount: jest.fn() }));
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}));
+
+jest.mock('@chakra-ui/react', () => {
+  const actual = jest.requireActual('@chakra-ui/react');
+  return {
+    ...actual,
+    useBreakpointValue: jest.fn()
+  };
+});
+
+const mockedUseConfigStore = useConfigStore as jest.MockedFunction<typeof useConfigStore>;
+const mockedUseBreakpointValue = useBreakpointValue as jest.MockedFunction<
+  typeof useBreakpointValue
+>;
+
+function renderSecondaryLinks(guideEnabled: boolean) {
+  mockedUseConfigStore.mockReturnValue({
+    layoutConfig: {
+      common: {}
+    },
+    commonConfig: {
+      guideEnabled
+    }
+  } as ReturnType<typeof useConfigStore>);
+
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false }
+    }
+  });
+
+  return render(
+    React.createElement(
+      ChakraProvider,
+      null,
+      React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        React.createElement(SecondaryLinks)
+      )
+    )
+  );
+}
+
+describe('guide feature flag', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseBreakpointValue.mockReturnValue(false);
+  });
+
+  it('hides the guide entry when the feature is disabled', () => {
+    renderSecondaryLinks(false);
+
+    expect(screen.queryByText('common:guide')).toBeNull();
+  });
+
+  it('shows the guide entry and opens the guide when enabled', () => {
+    renderSecondaryLinks(true);
+
+    fireEvent.click(screen.getByText('common:guide'));
+
+    expect(openGuideModal).toHaveBeenCalledTimes(1);
+    expect(setInitGuide).toHaveBeenCalledWith(false);
+  });
+});

--- a/frontend/desktop/src/components/SecondaryLinks/index.tsx
+++ b/frontend/desktop/src/components/SecondaryLinks/index.tsx
@@ -67,7 +67,7 @@ const formatQuotaValue = (value: number, type: WorkspaceQuotaItem['type']) => {
 };
 
 export default function SecondaryLinks() {
-  const { layoutConfig } = useConfigStore();
+  const { layoutConfig, commonConfig } = useConfigStore();
   const { t } = useTranslation();
   const { openGuideModal, setInitGuide } = useGuideModalStore();
   const { openDesktopApp } = useAppStore();
@@ -277,16 +277,18 @@ export default function SecondaryLinks() {
           </Portal>
         </Popover>
 
-        <Center
-          className="guide-button"
-          cursor={'pointer'}
-          {...baseItemStyle}
-          px={'8px'}
-          borderRadius={'8px'}
-          onClick={handleGuideClick}
-        >
-          {t('common:guide')}
-        </Center>
+        {commonConfig?.guideEnabled ? (
+          <Center
+            className="guide-button"
+            cursor={'pointer'}
+            {...baseItemStyle}
+            px={'8px'}
+            borderRadius={'8px'}
+            onClick={handleGuideClick}
+          >
+            {t('common:guide')}
+          </Center>
+        ) : null}
 
         {layoutConfig?.common.docsUrl && (
           <Center

--- a/frontend/desktop/src/components/account/index.tsx
+++ b/frontend/desktop/src/components/account/index.tsx
@@ -62,7 +62,7 @@ const baseItemStyle = {
 };
 
 export default function Account() {
-  const { layoutConfig, authConfig, isLoaded: configLoaded } = useConfigStore();
+  const { layoutConfig, authConfig, commonConfig, isLoaded: configLoaded } = useConfigStore();
   const router = useRouter();
   const { copyData } = useCopyData();
   const { t } = useTranslation();
@@ -164,10 +164,19 @@ export default function Account() {
       return;
     }
 
-    if (initGuide && !isNarrowScreen && !autoOpenBlocked) {
+    if (commonConfig?.guideEnabled && initGuide && !isNarrowScreen && !autoOpenBlocked) {
       openGuideModal();
     }
-  }, [initGuide, openGuideModal, isNarrowScreen, autoOpenBlocked]);
+  }, [
+    router.query,
+    autolaunch,
+    blockAutoOpen,
+    commonConfig?.guideEnabled,
+    initGuide,
+    openGuideModal,
+    isNarrowScreen,
+    autoOpenBlocked
+  ]);
 
   return (
     <Box position={'relative'} flex={1} w={'full'}>

--- a/frontend/desktop/src/components/desktop_content/apps.tsx
+++ b/frontend/desktop/src/components/desktop_content/apps.tsx
@@ -515,7 +515,7 @@ export default function Apps() {
   const { message } = useMessage();
   const { installedApps, openApp, openDesktopApp } = useAppStore();
   const { appDisplayConfigs, updateAppDisplayType } = useAppDisplayConfigStore();
-  const { layoutConfig } = useConfigStore();
+  const { layoutConfig, commonConfig } = useConfigStore();
   const [draggedFromFolder, setDraggedFromFolder] = useState(false);
   const [isFolderOpen, setIsFolderOpen] = useState(false);
 
@@ -789,6 +789,10 @@ export default function Apps() {
     });
   };
 
+  const showAnnouncement =
+    layoutConfig?.common.announcementEnabled &&
+    (layoutConfig.version === 'cn' || commonConfig?.guideEnabled);
+
   return (
     <Flex
       flexDirection={'column'}
@@ -811,7 +815,7 @@ export default function Apps() {
         </defs>
       </svg>
       <Flex width={'full'} height={'full'} overflow={'hidden'} flexDirection={'column'}>
-        {layoutConfig?.common.announcementEnabled && (
+        {showAnnouncement ? (
           <Center mx={'12px'}>
             <Center
               width={'fit-content'}
@@ -861,7 +865,7 @@ export default function Apps() {
               </Box>
             </Center>
           </Center>
-        )}
+        ) : null}
 
         <Box p={'12px'} pt={{ base: '56px', sm: '48px' }} w={'full'} h={'full'}>
           <AppGridPagingContainer

--- a/frontend/desktop/src/components/desktop_content/index.tsx
+++ b/frontend/desktop/src/components/desktop_content/index.tsx
@@ -156,10 +156,11 @@ export default function Desktop() {
 
   const quitGuide = useCallback(
     ({ appKey }: { appKey: string }) => {
+      if (!commonConfig?.guideEnabled) return;
       closeDesktopApp({ appKey });
       guideModal.openGuideModal();
     },
-    [closeDesktopApp, guideModal]
+    [closeDesktopApp, commonConfig?.guideEnabled, guideModal]
   );
 
   const { taskComponentState, setTaskComponentState } = useDesktopConfigStore();
@@ -358,7 +359,7 @@ export default function Desktop() {
 
       {isAppBar ? <AppDock /> : <FloatButton />}
 
-      <GuideModal />
+      {commonConfig?.guideEnabled ? <GuideModal /> : null}
 
       {/* opened apps */}
       {runningInfo.map((process) => {


### PR DESCRIPTION
## Summary

- honor `commonConfig.guideEnabled` across desktop onboarding entry points
- prevent automatic, manual, and sub-app `quitGuide` paths from reopening onboarding when disabled
- preserve the China referral announcement while gating the global onboarding prompt

## Testing

- `pnpm --dir frontend/desktop exec jest --runInBand src/__tests__/unit/guideFeatureFlag.test.ts`
- `pnpm --dir frontend/desktop lint`
- `pnpm --dir frontend/desktop build`
