### PR TITLE
feat(desktop): open Brain by default from root

### DIFF
--- a/frontend/desktop/src/__tests__/components/desktop-content-behavior.test.tsx
+++ b/frontend/desktop/src/__tests__/components/desktop-content-behavior.test.tsx
@@ -1,0 +1,356 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import Desktop from '@/components/desktop_content';
+
+type RegisteredHandler = (data: { appKey: string }) => void;
+
+const mocks = vi.hoisted(() => {
+  const handlers = new Map<string, RegisteredHandler>();
+  const notification = Object.assign(vi.fn(), { close: vi.fn() });
+
+  return {
+    handlers,
+    appState: {
+      installedApps: [{ key: 'system-template' }],
+      runningInfo: [{ key: 'system-template', pid: 42 }],
+      openApp: vi.fn(),
+      setToHighestLayerById: vi.fn(),
+      closeAppById: vi.fn(),
+      setAutoLaunch: vi.fn(),
+      currentAppKey: 'system-brain'
+    },
+    config: {
+      layoutConfig: {
+        common: {
+          bannerEnabled: false
+        }
+      },
+      cloudConfig: {
+        allowedOrigins: ['*']
+      },
+      commonConfig: {
+        guideEnabled: false,
+        realNameAuthEnabled: false
+      }
+    },
+    guideModal: {
+      openGuideModal: vi.fn()
+    },
+    sessionState: {
+      session: undefined,
+      isGuest: () => false,
+      openGuestLoginModal: vi.fn(),
+      showGuestLoginModal: false,
+      closeGuestLoginModal: vi.fn()
+    },
+    addEventListen: vi.fn(),
+    createMasterAPP: vi.fn(() => vi.fn()),
+    notification
+  };
+});
+
+vi.mock('@/stores/app', () => ({
+  BRAIN_APP_KEY: 'system-brain',
+  SESSION_RESTORE_APP_KEY: 'sealos_desktop_restore_app_key',
+  default: () => mocks.appState
+}));
+
+vi.mock('@/stores/config', () => {
+  const useConfigStore = () => mocks.config;
+  useConfigStore.getState = () => mocks.config;
+  return { useConfigStore };
+});
+
+vi.mock('@/stores/desktopConfig', () => ({
+  useDesktopConfigStore: () => ({
+    isAppBar: false
+  })
+}));
+
+vi.mock('@/stores/appDisplayConfig', () => ({
+  useAppDisplayConfigStore: () => ({
+    backgroundImage: ''
+  })
+}));
+
+vi.mock('@/stores/guideModal', () => ({
+  useGuideModalStore: () => mocks.guideModal
+}));
+
+vi.mock('@/stores/session', () => ({
+  default: () => mocks.sessionState
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({
+    data: undefined,
+    isSuccess: false
+  })
+}));
+
+vi.mock('@/api/platform', () => ({
+  getWorkspaceQuota: vi.fn()
+}));
+
+vi.mock('@/api/auth', () => ({
+  getAmount: vi.fn(),
+  UserInfo: vi.fn()
+}));
+
+vi.mock('sealos-desktop-sdk/master', () => ({
+  createMasterAPP: mocks.createMasterAPP,
+  masterApp: {
+    addEventListen: mocks.addEventListen
+  }
+}));
+
+vi.mock('next-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key
+  })
+}));
+
+vi.mock('next/dynamic', () => {
+  const dynamic = () => () => null;
+  return {
+    __esModule: true,
+    default: Object.assign(dynamic, { default: dynamic })
+  };
+});
+
+vi.mock('@chakra-ui/react', async () => {
+  const { createElement } = await import('react');
+  type MockComponentProps = React.PropsWithChildren<{
+    id?: string;
+    onClick?: React.MouseEventHandler;
+    src?: string;
+    alt?: string;
+    'aria-busy'?: boolean;
+    'data-testid'?: string;
+  }>;
+  const component =
+    (tag: string) =>
+    ({
+      children,
+      id,
+      onClick,
+      src,
+      alt,
+      'aria-busy': ariaBusy,
+      'data-testid': testId
+    }: MockComponentProps) =>
+      createElement(
+        tag,
+        {
+          id,
+          onClick,
+          src,
+          alt,
+          'aria-busy': ariaBusy,
+          'data-testid': testId
+        },
+        children
+      );
+
+  return {
+    Box: component('div'),
+    Flex: component('div'),
+    Image: component('img'),
+    Button: component('button'),
+    Text: component('span')
+  };
+});
+
+vi.mock('@/components/app_window', () => ({
+  default: ({ children }: React.PropsWithChildren) => children
+}));
+
+vi.mock('@/components/desktop_content/iframe_window', () => ({
+  default: () => null
+}));
+
+vi.mock('@/components/desktop_content/ChakraIndicator', () => ({
+  ChakraIndicator: () => null
+}));
+
+vi.mock('@/components/account/AccountCenter/mergeUser/NeedToMergeModal', () => ({
+  default: () => null
+}));
+
+vi.mock('@/components/account/RealNameModal', () => ({
+  useRealNameAuthNotification: () => mocks.notification
+}));
+
+vi.mock('@/components/LoginModal', () => ({
+  default: () => null
+}));
+
+vi.mock('@/components/desktop_content/serviceButton', () => ({
+  default: () => null
+}));
+
+vi.mock('@/components/banner', () => ({
+  default: () => null
+}));
+
+vi.mock('@/components/account/GuideModal', () => ({
+  default: () => null
+}));
+
+vi.mock('@/components/desktop_content/GlobalNotification', () => ({
+  GlobalNotification: () => null
+}));
+
+vi.mock('@/components/AppDock', () => ({
+  default: () => null
+}));
+
+vi.mock('@/components/floating_button', () => ({
+  default: () => null
+}));
+
+vi.mock('@/components/account', () => ({
+  default: () => null
+}));
+
+vi.mock('@/components/desktop_content/apps', () => ({
+  default: () => null
+}));
+
+const mountedRoots: Array<{ root: Root; container: HTMLDivElement }> = [];
+
+const renderDesktop = async (element: React.ReactElement) => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedRoots.push({ root, container });
+
+  const rerender = async (nextElement: React.ReactElement) => {
+    await act(async () => {
+      root.render(nextElement);
+    });
+  };
+
+  await rerender(element);
+  return { rerender };
+};
+
+describe('Desktop startup and guide behavior', () => {
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    sessionStorage.clear();
+    localStorage.clear();
+    mocks.handlers.clear();
+    mocks.appState.currentAppKey = 'system-brain';
+    mocks.config.commonConfig.guideEnabled = false;
+    vi.clearAllMocks();
+    mocks.addEventListen.mockImplementation((eventName: string, handler: RegisteredHandler) => {
+      mocks.handlers.set(eventName, handler);
+      return () => {
+        if (mocks.handlers.get(eventName) === handler) {
+          mocks.handlers.delete(eventName);
+        }
+      };
+    });
+  });
+
+  afterEach(async () => {
+    for (const { root, container } of mountedRoots.splice(0)) {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    }
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: false });
+  });
+
+  it('preserves the tab-local restore key until the initial target is ready', async () => {
+    sessionStorage.setItem('sealos_desktop_restore_app_key', 'system-template');
+
+    const { rerender } = await renderDesktop(
+      <Desktop initialAppLaunch={{ status: 'resolving' }} onInitialAppLoaded={vi.fn()} />
+    );
+
+    expect(mocks.createMasterAPP).toHaveBeenCalled();
+    expect(sessionStorage.getItem('sealos_desktop_restore_app_key')).toBe('system-template');
+
+    await rerender(
+      <Desktop
+        initialAppLaunch={{ status: 'loading', appKey: 'system-template' }}
+        onInitialAppLoaded={vi.fn()}
+      />
+    );
+    expect(sessionStorage.getItem('sealos_desktop_restore_app_key')).toBe('system-template');
+
+    mocks.appState.currentAppKey = 'system-template';
+    await rerender(<Desktop initialAppLaunch={{ status: 'ready' }} onInitialAppLoaded={vi.fn()} />);
+
+    expect(sessionStorage.getItem('sealos_desktop_restore_app_key')).toBe('system-template');
+  });
+
+  it('synchronizes the selected Brain target only after startup is ready', async () => {
+    sessionStorage.setItem('sealos_desktop_restore_app_key', 'system-template');
+
+    const { rerender } = await renderDesktop(
+      <Desktop initialAppLaunch={{ status: 'resolving' }} onInitialAppLoaded={vi.fn()} />
+    );
+
+    expect(mocks.createMasterAPP).toHaveBeenCalled();
+    expect(sessionStorage.getItem('sealos_desktop_restore_app_key')).toBe('system-template');
+
+    await rerender(<Desktop initialAppLaunch={{ status: 'ready' }} onInitialAppLoaded={vi.fn()} />);
+
+    expect(sessionStorage.getItem('sealos_desktop_restore_app_key')).toBeNull();
+  });
+
+  it('clears a stale restore key after startup resolves to Desktop', async () => {
+    sessionStorage.setItem('sealos_desktop_restore_app_key', 'system-template');
+    mocks.appState.currentAppKey = '';
+
+    const { rerender } = await renderDesktop(
+      <Desktop initialAppLaunch={{ status: 'resolving' }} onInitialAppLoaded={vi.fn()} />
+    );
+
+    expect(sessionStorage.getItem('sealos_desktop_restore_app_key')).toBe('system-template');
+
+    await rerender(<Desktop initialAppLaunch={{ status: 'ready' }} onInitialAppLoaded={vi.fn()} />);
+
+    expect(sessionStorage.getItem('sealos_desktop_restore_app_key')).toBeNull();
+  });
+
+  it('closes the source app without opening Desktop guidance when guides are disabled', async () => {
+    await renderDesktop(
+      <Desktop initialAppLaunch={{ status: 'resolving' }} onInitialAppLoaded={vi.fn()} />
+    );
+
+    expect(mocks.handlers.has('quitGuide')).toBe(true);
+
+    act(() => {
+      mocks.handlers.get('quitGuide')?.({ appKey: 'system-template' });
+    });
+
+    expect(mocks.appState.closeAppById).toHaveBeenCalledWith(42);
+    expect(mocks.guideModal.openGuideModal).not.toHaveBeenCalled();
+  });
+
+  it('closes the source app and opens Desktop guidance when guides are enabled', async () => {
+    mocks.config.commonConfig.guideEnabled = true;
+    await renderDesktop(
+      <Desktop initialAppLaunch={{ status: 'resolving' }} onInitialAppLoaded={vi.fn()} />
+    );
+
+    expect(mocks.handlers.has('quitGuide')).toBe(true);
+
+    act(() => {
+      mocks.handlers.get('quitGuide')?.({ appKey: 'system-template' });
+    });
+
+    expect(mocks.appState.closeAppById).toHaveBeenCalledWith(42);
+    expect(mocks.guideModal.openGuideModal).toHaveBeenCalledOnce();
+    expect(mocks.appState.closeAppById.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.guideModal.openGuideModal.mock.invocationCallOrder[0]
+    );
+  });
+});

--- a/frontend/desktop/src/__tests__/unit/components/guide-feature-flag.test.tsx
+++ b/frontend/desktop/src/__tests__/unit/components/guide-feature-flag.test.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import SecondaryLinks from '@/components/SecondaryLinks';
+import { GlobalAnnouncement } from '@/components/desktop_content/GlobalAnnouncement';
+
+const mocks = vi.hoisted(() => ({
+  config: {
+    layoutConfig: {
+      version: 'cn',
+      currencySymbol: 'shellCoin',
+      common: {
+        announcementEnabled: true,
+        subscriptionEnabled: false
+      }
+    },
+    commonConfig: {
+      guideEnabled: false
+    }
+  },
+  queryData: undefined as unknown,
+  openGuideModal: vi.fn(),
+  setInitGuide: vi.fn()
+}));
+
+vi.mock('@/stores/config', () => ({
+  useConfigStore: (selector?: (state: typeof mocks.config) => unknown) =>
+    selector ? selector(mocks.config) : mocks.config
+}));
+
+vi.mock('@/stores/app', () => ({
+  default: () => ({
+    openDesktopApp: vi.fn()
+  })
+}));
+
+vi.mock('@/stores/guideModal', () => ({
+  useGuideModalStore: () => ({
+    openGuideModal: mocks.openGuideModal,
+    setInitGuide: mocks.setInitGuide
+  })
+}));
+
+vi.mock('@/stores/session', () => ({
+  default: () => ({
+    session: undefined,
+    isGuest: () => false
+  })
+}));
+
+vi.mock('@/stores/subscription', () => ({
+  useSubscriptionStore: () => ({
+    subscriptionInfo: undefined,
+    fetchSubscriptionInfo: vi.fn()
+  })
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({
+    data: mocks.queryData
+  })
+}));
+
+vi.mock('@/components/account/BalancePopover', () => ({
+  BalancePopover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  getPlanBackground: () => 'transparent'
+}));
+
+vi.mock('@/components/account/JoinDiscordPrompt', () => ({
+  JoinDiscordPrompt: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}));
+
+vi.mock('@sealos/ui', () => ({
+  CurrencySymbol: () => <span>currency</span>
+}));
+
+vi.mock('@sealos/shadcn-ui', () => ({
+  cn: (...values: string[]) => values.filter(Boolean).join(' ')
+}));
+
+vi.mock('next-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key
+  })
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'zh-Hans' }
+  })
+}));
+
+vi.mock('dompurify', () => ({
+  default: {
+    sanitize: (value: string) => value
+  }
+}));
+
+vi.mock('@sealos/gtm', () => ({
+  track: vi.fn()
+}));
+
+vi.mock('@chakra-ui/react', async () => {
+  const actual = await vi.importActual<typeof import('@chakra-ui/react')>('@chakra-ui/react');
+  return {
+    ...actual,
+    useBreakpointValue: () => false
+  };
+});
+
+describe('guide feature flag', () => {
+  beforeEach(() => {
+    mocks.config.commonConfig.guideEnabled = false;
+    mocks.queryData = undefined;
+    vi.clearAllMocks();
+  });
+
+  it('hides the manual guide entry when guideEnabled is false', () => {
+    const html = renderToStaticMarkup(<SecondaryLinks />);
+
+    expect(html).not.toContain('common:guide');
+  });
+
+  it('shows the manual guide entry when guideEnabled is true', () => {
+    mocks.config.commonConfig.guideEnabled = true;
+
+    const html = renderToStaticMarkup(<SecondaryLinks />);
+
+    expect(html).toContain('common:guide');
+  });
+
+  it('hides only the guide fallback when guideEnabled is false', () => {
+    const html = renderToStaticMarkup(<GlobalAnnouncement />);
+
+    expect(html).not.toContain('v2:onboard_guide');
+  });
+
+  it('keeps a real regional announcement visible when guideEnabled is false', () => {
+    mocks.queryData = [
+      {
+        uid: 'announcement-1',
+        from: 'Desktop-Announcement',
+        i18n: {
+          'zh-Hans': {
+            title: '中国区推荐公告'
+          }
+        }
+      }
+    ];
+
+    const html = renderToStaticMarkup(<GlobalAnnouncement />);
+
+    expect(html).toContain('中国区推荐公告');
+  });
+});

--- a/frontend/desktop/src/__tests__/unit/utils/initialAppTarget.test.ts
+++ b/frontend/desktop/src/__tests__/unit/utils/initialAppTarget.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveInitialAppTarget } from '@/utils/initialAppTarget';
+
+const installedAppKeys = ['system-brain', 'system-template', 'system-devbox'];
+
+const resolve = (overrides: Partial<Parameters<typeof resolveInitialAppTarget>[0]> = {}) =>
+  resolveInitialAppTarget({
+    installedAppKeys,
+    hasOpenAppQuery: false,
+    restoreAppKeys: [],
+    defaultAppKey: 'system-brain',
+    ...overrides
+  });
+
+describe('resolveInitialAppTarget', () => {
+  it('keeps an autolaunch target ahead of the normal root-path selection', () => {
+    expect(
+      resolve({
+        autolaunchAppKey: 'system-devbox',
+        hasOpenAppQuery: true,
+        queryAppKey: 'system-template',
+        restoreAppKeys: ['system-brain']
+      })
+    ).toEqual({
+      kind: 'app',
+      appKey: 'system-devbox',
+      source: 'autolaunch'
+    });
+  });
+
+  it('treats an empty openapp query as an explicit Desktop target', () => {
+    expect(
+      resolve({
+        hasOpenAppQuery: true,
+        queryAppKey: '',
+        restoreAppKeys: ['system-template']
+      })
+    ).toEqual({
+      kind: 'desktop',
+      source: 'explicit-desktop'
+    });
+  });
+
+  it('opens an explicitly requested app before a restorable or default app', () => {
+    expect(
+      resolve({
+        hasOpenAppQuery: true,
+        queryAppKey: 'system-devbox',
+        restoreAppKeys: ['system-template']
+      })
+    ).toEqual({
+      kind: 'app',
+      appKey: 'system-devbox',
+      source: 'query'
+    });
+  });
+
+  it('stays on Desktop when an explicit app is unavailable', () => {
+    expect(
+      resolve({
+        hasOpenAppQuery: true,
+        queryAppKey: 'system-missing',
+        restoreAppKeys: ['system-template']
+      })
+    ).toEqual({
+      kind: 'desktop',
+      source: 'explicit-unavailable'
+    });
+  });
+
+  it('restores a fullscreen app before selecting Brain as the default', () => {
+    expect(resolve({ restoreAppKeys: ['system-template'] })).toEqual({
+      kind: 'app',
+      appKey: 'system-template',
+      source: 'restore'
+    });
+  });
+
+  it('uses the first valid restore candidate', () => {
+    expect(resolve({ restoreAppKeys: ['system-missing', 'system-devbox'] })).toEqual({
+      kind: 'app',
+      appKey: 'system-devbox',
+      source: 'restore'
+    });
+  });
+
+  it('defaults to Brain only when there is no explicit or restorable target', () => {
+    expect(resolve()).toEqual({
+      kind: 'app',
+      appKey: 'system-brain',
+      source: 'default'
+    });
+  });
+
+  it('falls back to Desktop when Brain is not installed', () => {
+    expect(resolve({ installedAppKeys: ['system-template'] })).toEqual({
+      kind: 'desktop',
+      source: 'fallback'
+    });
+  });
+
+  it('does not open a target that is unavailable in guest mode', () => {
+    expect(
+      resolve({
+        hasOpenAppQuery: true,
+        queryAppKey: 'system-template',
+        allowedAppKeys: ['system-brain']
+      })
+    ).toEqual({
+      kind: 'desktop',
+      source: 'explicit-unavailable'
+    });
+  });
+});

--- a/frontend/desktop/src/__tests__/unit/utils/initialAppTarget.test.ts
+++ b/frontend/desktop/src/__tests__/unit/utils/initialAppTarget.test.ts
@@ -85,6 +85,14 @@ describe('resolveInitialAppTarget', () => {
     });
   });
 
+  it('prefers the tab-local restore candidate when both restore candidates are valid', () => {
+    expect(resolve({ restoreAppKeys: ['system-template', 'system-brain'] })).toEqual({
+      kind: 'app',
+      appKey: 'system-template',
+      source: 'restore'
+    });
+  });
+
   it('defaults to Brain only when there is no explicit or restorable target', () => {
     expect(resolve()).toEqual({
       kind: 'app',

--- a/frontend/desktop/src/components/SecondaryLinks/index.tsx
+++ b/frontend/desktop/src/components/SecondaryLinks/index.tsx
@@ -38,7 +38,7 @@ const baseItemStyle = {
 };
 
 export default function SecondaryLinks() {
-  const { layoutConfig } = useConfigStore();
+  const { layoutConfig, commonConfig } = useConfigStore();
   const { t } = useTranslation();
   const { openGuideModal, setInitGuide } = useGuideModalStore();
   const { openDesktopApp } = useAppStore();
@@ -112,6 +112,7 @@ export default function SecondaryLinks() {
   }, [data]);
 
   const handleGuideClick = () => {
+    if (!commonConfig?.guideEnabled) return;
     openGuideModal();
     setInitGuide(false);
   };
@@ -232,16 +233,18 @@ export default function SecondaryLinks() {
           </Center>
         </BalancePopover>
 
-        <Center
-          className="guide-button"
-          cursor={'pointer'}
-          {...baseItemStyle}
-          px={'8px'}
-          borderRadius={'8px'}
-          onClick={handleGuideClick}
-        >
-          {t('common:guide')}
-        </Center>
+        {commonConfig?.guideEnabled ? (
+          <Center
+            className="guide-button"
+            cursor={'pointer'}
+            {...baseItemStyle}
+            px={'8px'}
+            borderRadius={'8px'}
+            onClick={handleGuideClick}
+          >
+            {t('common:guide')}
+          </Center>
+        ) : null}
 
         {layoutConfig?.common.docsUrl && (
           <Center

--- a/frontend/desktop/src/components/account/index.tsx
+++ b/frontend/desktop/src/components/account/index.tsx
@@ -55,6 +55,7 @@ import { cn } from '@sealos/shadcn-ui';
 import { getPlanBackgroundClass } from '@/utils/styling';
 import { AlertSettings } from './AlertSettings';
 import { rotateKubeconfig } from '@/api/auth';
+import { useDesktopConfigStore } from '@/stores/desktopConfig';
 
 const baseItemStyle = {
   minW: '36px',
@@ -68,7 +69,7 @@ const baseItemStyle = {
 };
 
 export default function Account() {
-  const { layoutConfig, authConfig, isLoaded: configLoaded } = useConfigStore();
+  const { layoutConfig, authConfig, commonConfig, isLoaded: configLoaded } = useConfigStore();
   const router = useRouter();
   const { copyData } = useCopyData();
   const { t } = useTranslation();
@@ -81,6 +82,7 @@ export default function Account() {
   const communityDisclosure = useDisclosure();
   const [, setNotificationAmount] = useState(0);
   const { openDesktopApp, autolaunch } = useAppStore();
+  const { canShowGuide } = useDesktopConfigStore();
   const { openGuideModal, initGuide, autoOpenBlocked, blockAutoOpen } = useGuideModalStore();
   const { toggleLanguage, currentLanguage } = useLanguageSwitcher();
   const onAmount = useCallback((amount: number) => setNotificationAmount(amount), []);
@@ -174,10 +176,26 @@ export default function Account() {
       return;
     }
 
-    if (initGuide && !isNarrowScreen && !autoOpenBlocked) {
+    if (
+      commonConfig?.guideEnabled &&
+      canShowGuide &&
+      initGuide &&
+      !isNarrowScreen &&
+      !autoOpenBlocked
+    ) {
       openGuideModal();
     }
-  }, [initGuide, openGuideModal, isNarrowScreen, autoOpenBlocked]);
+  }, [
+    router.query,
+    autolaunch,
+    blockAutoOpen,
+    canShowGuide,
+    commonConfig?.guideEnabled,
+    initGuide,
+    openGuideModal,
+    isNarrowScreen,
+    autoOpenBlocked
+  ]);
   const { subscriptionInfo } = useSubscriptionStore();
 
   return (

--- a/frontend/desktop/src/components/desktop_content/GlobalAnnouncement.tsx
+++ b/frontend/desktop/src/components/desktop_content/GlobalAnnouncement.tsx
@@ -13,7 +13,7 @@ import { track } from '@sealos/gtm';
 
 function GlobalAnnouncementComponent() {
   const { i18n, t } = useTranslation();
-  const { layoutConfig } = useConfigStore();
+  const { layoutConfig, commonConfig } = useConfigStore();
   const { isGuest } = useSessionStore();
   const { openGuideModal } = useGuideModalStore();
 
@@ -55,7 +55,7 @@ function GlobalAnnouncementComponent() {
     onClick = () => {};
   } else {
     // Show guide message (fallback)
-    if (isGuest()) {
+    if (isGuest() || !commonConfig?.guideEnabled) {
       return null;
     }
     content = t('v2:onboard_guide');

--- a/frontend/desktop/src/components/desktop_content/iframe_window.tsx
+++ b/frontend/desktop/src/components/desktop_content/iframe_window.tsx
@@ -2,7 +2,7 @@ import useAppStore from '@/stores/app';
 import { useMemo } from 'react';
 import styles from './index.module.css';
 
-export default function Iframe_window({ pid }: { pid: number }) {
+export default function Iframe_window({ pid, onLoad }: { pid: number; onLoad?: () => void }) {
   const findAppInfo = useAppStore((state) => state.findAppInfoById);
   const app = findAppInfo(pid);
   const url = useMemo(() => app?.data?.url || '', [app?.data?.url]);
@@ -14,6 +14,7 @@ export default function Iframe_window({ pid }: { pid: number }) {
       src={url}
       allow="camera;microphone;clipboard-write;clipboard-read;"
       id={`app-window-${app?.key}`}
+      onLoad={onLoad}
     />
   );
 }

--- a/frontend/desktop/src/components/desktop_content/index.tsx
+++ b/frontend/desktop/src/components/desktop_content/index.tsx
@@ -7,9 +7,9 @@ import { WindowSize } from '@/types';
 import { Box, Flex, Image, Button, Text } from '@chakra-ui/react';
 import { useTranslation } from 'next-i18next';
 import dynamic from 'next/dynamic';
-import { useRouter } from 'next/router';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { createMasterAPP, masterApp } from 'sealos-desktop-sdk/master';
+import type { InitialAppLaunchState } from '@/utils/initialAppTarget';
 import { ChakraIndicator } from './ChakraIndicator';
 // import Apps from './apps';
 import IframeWindow from './iframe_window';
@@ -39,9 +39,13 @@ export const blurBackgroundStyles = {
   borderRadius: '12px'
 };
 
-export default function Desktop() {
+type DesktopProps = {
+  initialAppLaunch: InitialAppLaunchState;
+  onInitialAppLoaded: (appKey: string) => void;
+};
+
+export default function Desktop({ initialAppLaunch, onInitialAppLoaded }: DesktopProps) {
   const { t } = useTranslation();
-  const router = useRouter();
   const { isAppBar } = useDesktopConfigStore();
   const {
     installedApps: apps,
@@ -50,8 +54,7 @@ export default function Desktop() {
     setToHighestLayerById,
     closeAppById,
     setAutoLaunch,
-    currentAppKey,
-    autolaunch
+    currentAppKey
   } = useAppStore();
   const backgroundImage = useConfigStore().layoutConfig?.backgroundImage;
   const { backgroundImage: desktopBackgroundImage } = useAppDisplayConfigStore();
@@ -64,8 +67,8 @@ export default function Desktop() {
   const realNameAuthNotificationIdRef = useRef<string | number | undefined>();
   const prevRestoreAppKeyRef = useRef<string>('');
   const [isClient, setIsClient] = useState(false);
-  const [isRestoring, setIsRestoring] = useState(true);
   const guideModal = useGuideModalStore();
+  const isInitialAppLoading = initialAppLaunch.status !== 'ready';
 
   useEffect(() => {
     setIsClient(true);
@@ -78,7 +81,7 @@ export default function Desktop() {
     prevRestoreAppKeyRef.current = currentAppKey;
 
     if (!currentAppKey) {
-      if (!isRestoring && prevKey) {
+      if (!isInitialAppLoading && prevKey) {
         sessionStorage.removeItem(SESSION_RESTORE_APP_KEY);
       }
       return;
@@ -90,56 +93,17 @@ export default function Desktop() {
     }
 
     sessionStorage.setItem(SESSION_RESTORE_APP_KEY, currentAppKey);
-  }, [isClient, currentAppKey, isRestoring]);
+  }, [isClient, currentAppKey, isInitialAppLoading]);
 
-  // Restore current app after page refresh
+  // Do not keep the startup mask forever when an iframe fails to report load.
   useEffect(() => {
-    if (!isClient) {
+    if (initialAppLaunch.status !== 'loading') {
       return;
     }
 
-    // openapp/autolaunch has higher priority than restore
-    if (router.isReady) {
-      const hasOpenAppQuery = Object.hasOwn(router.query, 'openapp');
-      const isStripeCallback = router.query?.stripeState === 'success' && !!router.query?.payId;
-      if (hasOpenAppQuery || !!autolaunch || isStripeCallback) {
-        setIsRestoring(false);
-        return;
-      }
-    }
-
-    if (apps.length === 0) {
-      return;
-    }
-
-    const sessionRestoreKey = sessionStorage.getItem(SESSION_RESTORE_APP_KEY) || '';
-    const restoreAppKey = currentAppKey || sessionRestoreKey;
-
-    if (restoreAppKey) {
-      const savedApp = apps.find((app) => app.key === restoreAppKey);
-      const isAppRunning = runningInfo.some((app) => app.key === restoreAppKey);
-
-      if (savedApp && !isAppRunning) {
-        openApp(savedApp).then(() => {
-          // Wait a bit for the app to render before hiding loading
-          setTimeout(() => setIsRestoring(false), 100);
-        });
-        return;
-      }
-    }
-
-    // No app to restore or app already running
-    setIsRestoring(false);
-  }, [
-    router.isReady,
-    router.query,
-    autolaunch,
-    currentAppKey,
-    apps,
-    runningInfo,
-    openApp,
-    isClient
-  ]);
+    const timeout = window.setTimeout(() => onInitialAppLoaded(initialAppLaunch.appKey), 10_000);
+    return () => window.clearTimeout(timeout);
+  }, [initialAppLaunch, onInitialAppLoaded]);
 
   const infoData = useQuery({
     queryFn: UserInfo,
@@ -213,10 +177,11 @@ export default function Desktop() {
 
   const quitGuide = useCallback(
     ({ appKey }: { appKey: string }) => {
+      if (!commonConfig?.guideEnabled) return;
       closeDesktopApp({ appKey });
       guideModal.openGuideModal();
     },
-    [closeDesktopApp, guideModal]
+    [closeDesktopApp, commonConfig?.guideEnabled, guideModal]
   );
 
   const handleRequestLogin = useCallback(
@@ -303,8 +268,8 @@ export default function Desktop() {
     }
   }, []);
 
-  // Show loading during app restoration
-  if (isRestoring) {
+  // Keep Desktop chrome hidden until the initial target is resolved and loaded.
+  if (isInitialAppLoading) {
     return (
       <Box
         id="desktop"
@@ -313,34 +278,28 @@ export default function Desktop() {
         display="flex"
         alignItems="center"
         justifyContent="center"
+        bg="#080A11"
+        aria-busy="true"
       >
-        <Box
-          position="absolute"
-          top="0"
-          left="0"
-          right="0"
-          bottom="0"
-          zIndex={-10}
-          overflow="hidden"
-        >
-          <Image
-            src={backgroundImage || desktopBackgroundImage || '/images/bg-light.svg'}
-            alt=""
-            width="100%"
-            height="100vh"
-            objectFit="cover"
-            objectPosition="bottom"
-          />
-        </Box>
-
-        {/* opened apps - need to render during restore */}
+        {/* Open the target behind the startup mask so its iframe can load immediately. */}
         {runningInfo.map((process) => {
           return (
             <AppWindow key={process.pid} style={{ height: '100vh' }} pid={process.pid}>
-              <IframeWindow pid={process.pid} />
+              <IframeWindow pid={process.pid} onLoad={() => onInitialAppLoaded(process.key)} />
             </AppWindow>
           );
         })}
+
+        {initialAppLaunch.status === 'loading' && initialAppLaunch.appKey === BRAIN_APP_KEY && (
+          <Box
+            data-testid="brain-startup-mask"
+            position="fixed"
+            inset={0}
+            zIndex={1000}
+            bg="#080A11"
+            pointerEvents="none"
+          />
+        )}
       </Box>
     );
   }
@@ -412,13 +371,13 @@ export default function Desktop() {
 
       {!isGuest() && (isAppBar ? <AppDock /> : <FloatButton />)}
 
-      <GuideModal />
+      {commonConfig?.guideEnabled ? <GuideModal /> : null}
 
       {/* opened apps */}
       {runningInfo.map((process) => {
         return (
           <AppWindow key={process.pid} style={{ height: '100vh' }} pid={process.pid}>
-            <IframeWindow pid={process.pid} />
+            <IframeWindow pid={process.pid} onLoad={() => onInitialAppLoaded(process.key)} />
           </AppWindow>
         );
       })}

--- a/frontend/desktop/src/components/desktop_content/index.tsx
+++ b/frontend/desktop/src/components/desktop_content/index.tsx
@@ -65,7 +65,6 @@ export default function Desktop({ initialAppLaunch, onInitialAppLoaded }: Deskto
     useSessionStore();
   const { commonConfig } = useConfigStore();
   const realNameAuthNotificationIdRef = useRef<string | number | undefined>();
-  const prevRestoreAppKeyRef = useRef<string>('');
   const [isClient, setIsClient] = useState(false);
   const guideModal = useGuideModalStore();
   const isInitialAppLoading = initialAppLaunch.status !== 'ready';
@@ -75,15 +74,12 @@ export default function Desktop({ initialAppLaunch, onInitialAppLoaded }: Deskto
   }, []);
 
   useEffect(() => {
-    if (!isClient) return;
-
-    const prevKey = prevRestoreAppKeyRef.current;
-    prevRestoreAppKeyRef.current = currentAppKey;
+    // Do not let rehydrated, cross-tab state overwrite this tab's restore
+    // intent before the initial target has been selected and loaded.
+    if (!isClient || isInitialAppLoading) return;
 
     if (!currentAppKey) {
-      if (!isInitialAppLoading && prevKey) {
-        sessionStorage.removeItem(SESSION_RESTORE_APP_KEY);
-      }
+      sessionStorage.removeItem(SESSION_RESTORE_APP_KEY);
       return;
     }
 
@@ -177,9 +173,10 @@ export default function Desktop({ initialAppLaunch, onInitialAppLoaded }: Deskto
 
   const quitGuide = useCallback(
     ({ appKey }: { appKey: string }) => {
-      if (!commonConfig?.guideEnabled) return;
       closeDesktopApp({ appKey });
-      guideModal.openGuideModal();
+      if (commonConfig?.guideEnabled) {
+        guideModal.openGuideModal();
+      }
     },
     [closeDesktopApp, commonConfig?.guideEnabled, guideModal]
   );

--- a/frontend/desktop/src/pages/index.tsx
+++ b/frontend/desktop/src/pages/index.tsx
@@ -5,7 +5,7 @@ import { PhoneBindingModal } from '@/components/account/AccountCenter/PhoneBindi
 import { trackEventName } from '@/constants/account';
 import { useSemParams } from '@/hooks/useSemParams';
 import { useLicenseCheck } from '@/hooks/useLicenseCheck';
-import useAppStore from '@/stores/app';
+import useAppStore, { BRAIN_APP_KEY, SESSION_RESTORE_APP_KEY } from '@/stores/app';
 import useCallbackStore from '@/stores/callback';
 import { useConfigStore } from '@/stores/config';
 import { useDesktopConfigStore } from '@/stores/desktopConfig';
@@ -15,6 +15,8 @@ import { SemData } from '@/types/sem';
 import { NSType } from '@/types/team';
 import { AccessTokenPayload } from '@/types/token';
 import { parseOpenappQuery } from '@/utils/format';
+import { resolveInitialAppTarget } from '@/utils/initialAppTarget';
+import type { InitialAppLaunchState } from '@/utils/initialAppTarget';
 import { sessionConfig, setAdClickData, setUserSemData } from '@/utils/sessionConfig';
 import { switchKubeconfigNamespace } from '@/utils/switchKubeconfigNamespace';
 import { ensureLocaleCookie } from '@/utils/ssrLocale';
@@ -27,7 +29,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import Script from 'next/script';
-import { createContext, useEffect, useMemo, useState } from 'react';
+import { createContext, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import 'react-contexify/dist/ReactContexify.css';
 
 const destination = '/signin';
@@ -55,6 +57,11 @@ interface IMoreAppsContext {
 }
 export const MoreAppsContext = createContext<IMoreAppsContext | null>(null);
 
+type InitialOpenAppIntent = {
+  hasOpenAppQuery: boolean;
+  value: string;
+};
+
 export default function Home({ sealos_cloud_domain }: { sealos_cloud_domain: string }) {
   const router = useRouter();
   const { firstUse, setFirstUse, isUserLogin, setGuestSession, setSessionProp } = useSessionStore();
@@ -67,6 +74,18 @@ export default function Home({ sealos_cloud_domain }: { sealos_cloud_domain: str
   const { workspaceInviteCode, setWorkspaceInviteCode } = useCallbackStore();
   const { setCanShowGuide } = useDesktopConfigStore();
   const { setCaptchaIsLoad } = useScriptStore();
+  const [initialAppLaunch, setInitialAppLaunch] = useState<InitialAppLaunchState>({
+    status: 'resolving'
+  });
+  const initialOpenAppIntentRef = useRef<InitialOpenAppIntent | null>(null);
+  const initialLaunchResolvedRef = useRef(false);
+  const initialLaunchInFlightRef = useRef(false);
+
+  const handleInitialAppLoaded = useCallback((appKey: string) => {
+    setInitialAppLaunch((current) =>
+      current.status === 'loading' && current.appKey === appKey ? { status: 'ready' } : current
+    );
+  }, []);
 
   // Initialize license check after user login
   useLicenseCheck({
@@ -145,29 +164,160 @@ export default function Home({ sealos_cloud_domain }: { sealos_cloud_domain: str
 
   // openApp by query && switch workspace
   useEffect(() => {
+    if (!router.isReady || initialLaunchResolvedRef.current || initialLaunchInFlightRef.current) {
+      return;
+    }
+
+    if (!initialOpenAppIntentRef.current) {
+      initialOpenAppIntentRef.current = {
+        hasOpenAppQuery: Object.hasOwn(router.query, 'openapp'),
+        value: isString(router.query.openapp) ? router.query.openapp : ''
+      };
+    }
+
     const handleInit = async () => {
+      initialLaunchInFlightRef.current = true;
       const { query } = router;
-      const is_login = isUserLogin();
+      const initialOpenAppIntent = initialOpenAppIntentRef.current;
+      const parsedOpenApp = parseOpenappQuery(initialOpenAppIntent?.value || '');
 
-      if (!is_login) {
-        // check if user has logged in before
-        const hasLoggedInBefore = checkIfEverLoggedIn();
-        console.log('hasLoggedInBefore', hasLoggedInBefore);
-        setFirstUse(null);
+      const completeWithDesktop = () => {
+        initialLaunchResolvedRef.current = true;
+        setCanShowGuide(true);
+        setInitialAppLaunch({ status: 'ready' });
+      };
 
-        const { appkey, appQuery, appPath } = parseOpenappQuery((query?.openapp as string) || '');
-
-        // save autolaunch info (for guest and logged in user)
-        let workspaceUid: string | undefined;
-        if (isString(query?.workspaceUid)) workspaceUid = query.workspaceUid;
-        if (appkey && (appQuery || appPath)) {
-          setAutoLaunch(appkey, { raw: appQuery, pathname: appPath }, workspaceUid);
+      const openInitialApp = async ({
+        state,
+        appKey,
+        raw = '',
+        pathname = '/',
+        cancelAutoLaunch = false
+      }: {
+        state: Awaited<ReturnType<typeof init>>;
+        appKey: string;
+        raw?: string;
+        pathname?: string;
+        cancelAutoLaunch?: boolean;
+      }) => {
+        const app = state.installedApps.find((item) => item.key === appKey);
+        if (!app) {
+          completeWithDesktop();
+          return;
         }
 
-        if (hasLoggedInBefore) {
-          // logged in user (logged out) → redirect to login page
-          router.replace('/signin');
-        } else {
+        let appQuery = raw;
+        let appRoute = pathname;
+        if (appKey === BRAIN_APP_KEY && appRoute === '/trial') {
+          appRoute = '/';
+          if (appQuery) {
+            const params = new URLSearchParams(appQuery);
+            params.delete('sessionId');
+            appQuery = params.toString();
+          }
+        }
+
+        const wasAlreadyRunning = state.runningInfo.some((item) => item.key === appKey);
+        initialLaunchResolvedRef.current = true;
+        setCanShowGuide(false);
+        setInitialAppLaunch({ status: 'loading', appKey });
+
+        try {
+          await state.openApp(app, { raw: appQuery, pathname: appRoute });
+          if (cancelAutoLaunch) {
+            state.cancelAutoLaunch();
+          }
+
+          const isRunning = useAppStore.getState().runningInfo.some((item) => item.key === appKey);
+          if (wasAlreadyRunning || !isRunning) {
+            setInitialAppLaunch({ status: 'ready' });
+          }
+        } catch (error) {
+          console.error(`Failed to open initial app ${appKey}`, error);
+          setInitialAppLaunch({ status: 'ready' });
+        }
+      };
+
+      const resolveAndOpenInitialApp = async (
+        state: Awaited<ReturnType<typeof init>>,
+        guestMode: boolean
+      ) => {
+        const target = resolveInitialAppTarget({
+          installedAppKeys: state.installedApps.map((app) => app.key),
+          autolaunchAppKey: state.autolaunch,
+          hasOpenAppQuery: initialOpenAppIntent?.hasOpenAppQuery || false,
+          queryAppKey: parsedOpenApp.appkey,
+          restoreAppKeys: [
+            state.currentAppKey,
+            sessionStorage.getItem(SESSION_RESTORE_APP_KEY) || undefined
+          ],
+          defaultAppKey: BRAIN_APP_KEY,
+          allowedAppKeys: guestMode ? [BRAIN_APP_KEY] : undefined
+        });
+
+        if (
+          target.source === 'query' ||
+          (target.kind === 'desktop' &&
+            target.source === 'explicit-unavailable' &&
+            initialOpenAppIntent?.value)
+        ) {
+          void router.replace(router.pathname, undefined, { shallow: true });
+        }
+
+        if (target.kind === 'desktop') {
+          if (target.source === 'explicit-desktop') {
+            sessionStorage.removeItem(SESSION_RESTORE_APP_KEY);
+          }
+          completeWithDesktop();
+          return;
+        }
+
+        let raw = '';
+        let pathname = '/';
+        if (target.source === 'autolaunch') {
+          raw = state.launchQuery.raw || '';
+          pathname = state.launchQuery.pathname || '';
+        } else if (target.source === 'query') {
+          raw = parsedOpenApp.appQuery;
+          pathname = parsedOpenApp.appPath || '';
+        }
+
+        await openInitialApp({
+          state,
+          appKey: target.appKey,
+          raw,
+          pathname,
+          cancelAutoLaunch: target.source === 'autolaunch' || target.source === 'query'
+        });
+      };
+
+      try {
+        const is_login = isUserLogin();
+
+        if (!is_login) {
+          // check if user has logged in before
+          const hasLoggedInBefore = checkIfEverLoggedIn();
+          console.log('hasLoggedInBefore', hasLoggedInBefore);
+          setFirstUse(null);
+
+          // save autolaunch info (for guest and logged in user)
+          let workspaceUid: string | undefined;
+          if (isString(query?.workspaceUid)) workspaceUid = query.workspaceUid;
+          if (parsedOpenApp.appkey && (parsedOpenApp.appQuery || parsedOpenApp.appPath)) {
+            setAutoLaunch(
+              parsedOpenApp.appkey,
+              { raw: parsedOpenApp.appQuery, pathname: parsedOpenApp.appPath },
+              workspaceUid
+            );
+          }
+
+          if (hasLoggedInBefore) {
+            // logged in user (logged out) → redirect to login page
+            initialLaunchResolvedRef.current = true;
+            await router.replace('/signin');
+            return;
+          }
+
           // Set guest session by default to prevent requests from being blocked while the config is loading
           const isGuest = useSessionStore.getState().isGuest();
           if (!isGuest) {
@@ -180,151 +330,111 @@ export default function Home({ sealos_cloud_domain }: { sealos_cloud_domain: str
           if (layoutConfig.common.guestModeEnabled !== true) {
             // Clear guest session
             useSessionStore.getState().delSession();
-            return router.replace('/signin');
+            initialLaunchResolvedRef.current = true;
+            await router.replace('/signin');
+            return;
           }
 
           // Guest mode enabled, continue guest session process
           const state = await init();
-          if (appkey) {
-            const guestAllowedApps = ['system-brain'];
-            if (guestAllowedApps.includes(appkey)) {
-              const app = state.installedApps.find((item) => item.key === appkey);
-              if (app) {
-                console.log(`Guest mode: Opening app ${appkey}`);
-                state.openApp(app, { raw: appQuery, pathname: appPath }).then(() => {
-                  state.cancelAutoLaunch();
-                });
-              }
-            }
-          }
+          await resolveAndOpenInitialApp(state, true);
           return;
         }
-      } else {
+
         useSessionStore.getState().setHasEverLoggedIn(true);
-      }
-      // Check for Stripe callback with workspace switch
-      const isStripeCallback = query?.stripeState === 'success' && query?.payId;
-      // logged in user logic
-      let workspaceUid: string | undefined;
 
-      // For Stripe callback, convert namespace (ns-xxx) to workspace UID
-      if (isStripeCallback && isString(query?.workspaceId)) {
-        // query.workspaceId contains the namespace (e.g., "ns-abc123")
-        // Find the corresponding workspace object to get the UID
-        const targetWorkspace = workspaces.find((w) => w.id === query.workspaceId);
-        workspaceUid = targetWorkspace?.uid;
-      } else if (!autolaunchWorkspaceUid) {
-        // Use workspace UID from query if no autolaunch (backwards compatibility)
-        if (isString(query?.workspaceUid)) workspaceUid = query.workspaceUid;
-      } else {
-        // Use autolaunch workspace UID if available
-        workspaceUid = autolaunchWorkspaceUid;
-      }
+        // Check for Stripe callback with workspace switch
+        const isStripeCallback = query?.stripeState === 'success' && !!query?.payId;
+        let workspaceUid: string | undefined;
 
-      Promise.resolve()
-        .then(() => {
-          // Handle Stripe callback - workspace switch required
-          if (isStripeCallback && workspaceUid) {
-            // Create callback action to execute after workspace switch
-            const afterSwitchAction = async () => {
-              const state = await init();
+        // workspaceId is a namespace, so wait until the namespace-to-UID mapping is available.
+        if (isStripeCallback && isString(query?.workspaceId) && workspaceQuery.isLoading) {
+          return;
+        }
 
-              // Build query parameters for costcenter
-              const callbackParams = new URLSearchParams();
-              callbackParams.set('stripeState', 'success');
-              callbackParams.set('payId', query.payId as string);
-              if (query.workspaceId) {
-                callbackParams.set('workspaceId', query.workspaceId as string);
-              }
+        // For Stripe callback, convert namespace (ns-xxx) to workspace UID
+        if (isStripeCallback && isString(query?.workspaceId)) {
+          // query.workspaceId contains the namespace (e.g., "ns-abc123")
+          // Find the corresponding workspace object to get the UID
+          const targetWorkspace = workspaces.find((w) => w.id === query.workspaceId);
+          workspaceUid = targetWorkspace?.uid;
+        } else if (!autolaunchWorkspaceUid) {
+          // Use workspace UID from query if no autolaunch (backwards compatibility)
+          if (isString(query?.workspaceUid)) workspaceUid = query.workspaceUid;
+        } else {
+          // Use autolaunch workspace UID if available
+          workspaceUid = autolaunchWorkspaceUid;
+        }
 
-              // Open costcenter with callback parameters
-              const app = state.installedApps.find((item) => item.key === 'system-costcenter');
-              if (app) {
-                setCanShowGuide(false);
-                await state.openApp(app, { raw: callbackParams.toString() });
-              }
-
-              // Clear the URL parameters to avoid re-triggering
-              router.replace(router.pathname, undefined, { shallow: true });
-            };
-
-            // Switch workspace with callback action
-            return swtichWorksapceMutation
-              .mutateAsync(workspaceUid)
-              .then(() => {
-                // Execute callback action after workspace switch completes
-                return afterSwitchAction();
-              })
-              .catch((err) => {
-                console.error(err);
-                return Promise.resolve();
-              });
+        if (isStripeCallback) {
+          if (!workspaceUid) {
+            completeWithDesktop();
+            return;
           }
 
-          // Handle normal workspace switch (non-Stripe)
-          if (workspaceUid) {
-            return swtichWorksapceMutation
-              .mutateAsync(workspaceUid)
-              .then(() => {
-                return Promise.resolve();
-              })
-              .catch((err) => {
-                // workspace not found or other error
-                console.error(err);
-                return Promise.resolve();
-              });
+          try {
+            await swtichWorksapceMutation.mutateAsync(workspaceUid);
+          } catch (error) {
+            console.error(error);
+            completeWithDesktop();
+            return;
           }
 
-          return Promise.resolve();
-        })
-        .then(() => {
-          // Skip normal app opening logic if this is a Stripe callback
-          if (isStripeCallback) return;
-
-          return init();
-        })
-        .then(async (state) => {
-          // Skip normal app opening logic if this is a Stripe callback
-          if (isStripeCallback || !state) return;
-
-          let appQuery = '';
-          let appkey = '';
-          let appRoute = '';
-
-          if (!state.autolaunch) {
-            setCanShowGuide(true);
-            const result = parseOpenappQuery((query?.openapp as string) || '');
-            appQuery = result.appQuery;
-            appkey = result.appkey;
-            appRoute = result.appPath || '';
-            if (!!query.openapp) router.replace(router.pathname);
-          } else {
-            appkey = state.autolaunch;
-            appQuery = state.launchQuery.raw || '';
-            appRoute = state.launchQuery.pathname || '';
+          const state = await init();
+          const callbackParams = new URLSearchParams();
+          callbackParams.set('stripeState', 'success');
+          callbackParams.set('payId', query.payId as string);
+          if (query.workspaceId) {
+            callbackParams.set('workspaceId', query.workspaceId as string);
           }
 
-          if (!appkey) return;
-          if (appkey === 'system-brain' && appRoute === '/trial') {
-            appRoute = '/';
-            // Remove sessionId from appQuery but keep other parameters
-            if (appQuery) {
-              const params = new URLSearchParams(appQuery);
-              params.delete('sessionId');
-              appQuery = params.toString();
-            }
-          }
-          const app = state.installedApps.find((item) => item.key === appkey);
-
-          if (!app) return;
-          setCanShowGuide(false);
-          state.openApp(app, { raw: appQuery, pathname: appRoute }).then(() => {
-            state.cancelAutoLaunch();
+          await openInitialApp({
+            state,
+            appKey: 'system-costcenter',
+            raw: callbackParams.toString()
           });
-        });
+          void router.replace(router.pathname, undefined, { shallow: true });
+          return;
+        }
+
+        // Handle normal workspace switch
+        if (workspaceUid) {
+          try {
+            await swtichWorksapceMutation.mutateAsync(workspaceUid);
+          } catch (error) {
+            // workspace not found or other error
+            console.error(error);
+          }
+        }
+
+        const state = await init();
+        await resolveAndOpenInitialApp(state, false);
+      } catch (error) {
+        console.error('Failed to initialize Desktop', error);
+        if (!initialLaunchResolvedRef.current) {
+          completeWithDesktop();
+        }
+      } finally {
+        initialLaunchInFlightRef.current = false;
+      }
     };
-    handleInit();
-  }, [router, sealos_cloud_domain, workspaces, layoutConfig?.common]);
+    void handleInit();
+  }, [
+    autolaunchWorkspaceUid,
+    init,
+    isUserLogin,
+    layoutConfig?.common,
+    router,
+    router.isReady,
+    sealos_cloud_domain,
+    setAutoLaunch,
+    setCanShowGuide,
+    setFirstUse,
+    setGuestSession,
+    swtichWorksapceMutation,
+    workspaceQuery.isLoading,
+    workspaces
+  ]);
 
   // check workspace
   useEffect(() => {
@@ -443,7 +553,10 @@ export default function Home({ sealos_cloud_domain }: { sealos_cloud_domain: str
         />
       )}
       <MoreAppsContext.Provider value={{ showMoreApps, setShowMoreApps }}>
-        <DesktopContent />
+        <DesktopContent
+          initialAppLaunch={initialAppLaunch}
+          onInitialAppLoaded={handleInitialAppLoaded}
+        />
       </MoreAppsContext.Provider>
 
       {/* Phone binding modal for domestic version */}

--- a/frontend/desktop/src/pages/index.tsx
+++ b/frontend/desktop/src/pages/index.tsx
@@ -248,8 +248,8 @@ export default function Home({ sealos_cloud_domain }: { sealos_cloud_domain: str
           hasOpenAppQuery: initialOpenAppIntent?.hasOpenAppQuery || false,
           queryAppKey: parsedOpenApp.appkey,
           restoreAppKeys: [
-            state.currentAppKey,
-            sessionStorage.getItem(SESSION_RESTORE_APP_KEY) || undefined
+            sessionStorage.getItem(SESSION_RESTORE_APP_KEY) || undefined,
+            state.currentAppKey
           ],
           defaultAppKey: BRAIN_APP_KEY,
           allowedAppKeys: guestMode ? [BRAIN_APP_KEY] : undefined

--- a/frontend/desktop/src/utils/initialAppTarget.ts
+++ b/frontend/desktop/src/utils/initialAppTarget.ts
@@ -1,0 +1,78 @@
+export type InitialAppTargetSource = 'autolaunch' | 'query' | 'restore' | 'default';
+
+export type InitialAppLaunchState =
+  | { status: 'resolving' }
+  | { status: 'loading'; appKey: string }
+  | { status: 'ready' };
+
+export type InitialAppTarget =
+  | {
+      kind: 'app';
+      appKey: string;
+      source: InitialAppTargetSource;
+    }
+  | {
+      kind: 'desktop';
+      source: 'explicit-desktop' | 'explicit-unavailable' | 'fallback';
+    };
+
+export type ResolveInitialAppTargetOptions = {
+  installedAppKeys: readonly string[];
+  autolaunchAppKey?: string;
+  hasOpenAppQuery: boolean;
+  queryAppKey?: string;
+  restoreAppKeys: readonly (string | undefined)[];
+  defaultAppKey: string;
+  allowedAppKeys?: readonly string[];
+};
+
+/**
+ * Resolve the first surface shown at `/`.
+ *
+ * Explicit navigation always wins, including an empty `openapp` query, which is
+ * the Desktop entry used by Brain. A restorable app wins over the environment
+ * default, and the default app is only used when neither intent exists.
+ */
+export const resolveInitialAppTarget = ({
+  installedAppKeys,
+  autolaunchAppKey,
+  hasOpenAppQuery,
+  queryAppKey,
+  restoreAppKeys,
+  defaultAppKey,
+  allowedAppKeys
+}: ResolveInitialAppTargetOptions): InitialAppTarget => {
+  const installedApps = new Set(installedAppKeys);
+  const allowedApps = allowedAppKeys ? new Set(allowedAppKeys) : undefined;
+  const isAvailable = (appKey: string) =>
+    installedApps.has(appKey) && (!allowedApps || allowedApps.has(appKey));
+
+  if (autolaunchAppKey) {
+    return isAvailable(autolaunchAppKey)
+      ? { kind: 'app', appKey: autolaunchAppKey, source: 'autolaunch' }
+      : { kind: 'desktop', source: 'explicit-unavailable' };
+  }
+
+  if (hasOpenAppQuery) {
+    if (!queryAppKey) {
+      return { kind: 'desktop', source: 'explicit-desktop' };
+    }
+
+    return isAvailable(queryAppKey)
+      ? { kind: 'app', appKey: queryAppKey, source: 'query' }
+      : { kind: 'desktop', source: 'explicit-unavailable' };
+  }
+
+  const restoreAppKey = restoreAppKeys.find(
+    (appKey): appKey is string => !!appKey && isAvailable(appKey)
+  );
+  if (restoreAppKey) {
+    return { kind: 'app', appKey: restoreAppKey, source: 'restore' };
+  }
+
+  if (isAvailable(defaultAppKey)) {
+    return { kind: 'app', appKey: defaultAppKey, source: 'default' };
+  }
+
+  return { kind: 'desktop', source: 'fallback' };
+};


### PR DESCRIPTION
## What changed

- centralize the root-path startup target selection
- preserve explicit app/Desktop navigation and restorable fullscreen apps ahead of the Brain default
- open `system-brain` when it is available and no higher-priority target exists
- fall back to Desktop when Brain is unavailable
- keep Desktop chrome hidden behind a dark startup mask until the initial iframe loads
- make automatic, manual, `quitGuide`, and modal guide paths honor `commonConfig.guideEnabled`
- keep real regional announcements visible when the guide fallback is disabled

## Why

The root page previously had separate app-opening and restore flows. It had no environment-aware default target, and the split initialization could expose Desktop before Brain or compete with restored app state.

This change gives the root path one deterministic resolver while retaining the existing login, guest, workspace-switch, Stripe callback, autolaunch, and refresh-restore behavior.

## Impact

- environments with Brain installed enter Brain directly from `/`
- environments without Brain continue to enter Desktop
- `?openapp=` remains an explicit Desktop entry
- explicit app links and refreshed fullscreen Template apps are not overwritten by the Brain default
- overseas environments can disable Desktop onboarding without hiding actual regional announcements

## Validation

- `pnpm --dir frontend/desktop test:ci` — 104 passed, 2 existing todo
- `pnpm --dir frontend/desktop exec tsc --noEmit`
- `pnpm --dir frontend/desktop lint` — passed with existing Hook dependency warnings
- `pnpm --dir frontend/desktop build`

Closes labring/sealos-private#48
