### PR TITLE
fix(applaunchpad): preserve legacy fields on update

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/utils/tools.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/tools.test.ts
@@ -1,10 +1,6 @@
 import yaml from 'js-yaml';
 import { describe, expect, it } from 'vitest';
-import {
-  json2ConfigMap,
-  json2DeployCr,
-  yamlString2Objects
-} from '@/utils/deployYaml2Json';
+import { json2ConfigMap, json2DeployCr, yamlString2Objects } from '@/utils/deployYaml2Json';
 import type { AppEditType, DeployKindsType } from '@/types/app';
 import { patchYamlList } from '@/utils/tools';
 
@@ -108,13 +104,19 @@ const createApp = (): AppEditType =>
     kind: 'deployment'
   } as AppEditType);
 
-const createYamlLists = (app: AppEditType) => [
-  json2DeployCr(app, app.kind),
-  json2ConfigMap(app)
-];
+const createYamlLists = (app: AppEditType) => [json2DeployCr(app, app.kind), json2ConfigMap(app)];
 
 const createOriginalYamlList = (yamlList: string[]) =>
   yamlList.flatMap((item) => yamlString2Objects(item)) as DeployKindsType[];
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+
+const getPatchValue = (actions: ReturnType<typeof patchYamlList>, kind: string) => {
+  const action = actions.find((item) => item.type === 'patch' && item.kind === kind);
+
+  expect(action?.type).toBe('patch');
+  return action?.type === 'patch' ? (action.value as any) : undefined;
+};
 
 describe.each(['Deployment', 'StatefulSet'] as const)(
   'patchYamlList private-to-public %s update',
@@ -256,5 +258,283 @@ describe('patchYamlList restart behavior', () => {
       statefulSetPatch?.type === 'patch' &&
         statefulSetPatch.value.spec?.template?.metadata?.labels?.restartTime
     ).toBeFalsy();
+  });
+});
+
+describe('patchYamlList intent-driven normalization', () => {
+  it('preserves live StatefulSet storage fields when only replicas change', () => {
+    const oldFormWorkload = createWorkload('StatefulSet', false) as any;
+    oldFormWorkload.spec.replicas = 1;
+    oldFormWorkload.spec.volumeClaimTemplates = [
+      {
+        metadata: {
+          name: 'data',
+          annotations: {
+            path: '/data',
+            value: '1',
+            storageType: 'local'
+          }
+        },
+        spec: {
+          accessModes: ['ReadWriteOnce'],
+          resources: {
+            requests: {
+              storage: '1Gi'
+            }
+          }
+        }
+      }
+    ];
+
+    const newFormWorkload = clone(oldFormWorkload);
+    newFormWorkload.spec.replicas = 2;
+
+    const liveWorkload = clone(oldFormWorkload);
+    delete liveWorkload.spec.volumeClaimTemplates[0].metadata.annotations.storageType;
+    liveWorkload.spec.volumeClaimTemplates[0].metadata.annotations['example.com/keep'] = 'true';
+    liveWorkload.spec.volumeClaimTemplates[0].metadata.labels = {
+      'example.com/keep': 'true'
+    };
+    liveWorkload.spec.template.spec.volumes = [
+      {
+        name: 'injected-volume',
+        emptyDir: {}
+      }
+    ];
+    liveWorkload.spec.template.spec.containers[0].volumeMounts = [
+      {
+        name: 'injected-volume',
+        mountPath: '/injected'
+      }
+    ];
+
+    const actions = patchYamlList({
+      parsedOldYamlList: [yaml.dump(oldFormWorkload)],
+      parsedNewYamlList: [yaml.dump(newFormWorkload)],
+      originalYamlList: [liveWorkload] as DeployKindsType[]
+    });
+    const patchValue = getPatchValue(actions, 'StatefulSet');
+
+    expect(patchValue.spec.volumeClaimTemplates).toEqual(liveWorkload.spec.volumeClaimTemplates);
+    expect(
+      patchValue.spec.volumeClaimTemplates[0].metadata.annotations.storageType
+    ).toBeUndefined();
+    expect(patchValue.spec.template.spec.volumes).toEqual(liveWorkload.spec.template.spec.volumes);
+    expect(patchValue.spec.template.spec.containers[0].volumeMounts).toEqual(
+      liveWorkload.spec.template.spec.containers[0].volumeMounts
+    );
+  });
+
+  it('preserves a legacy unnamed workload port on unrelated updates', () => {
+    const oldFormWorkload = createWorkload('Deployment', false) as any;
+    oldFormWorkload.spec.replicas = 1;
+    oldFormWorkload.spec.template.spec.containers[0].ports = [
+      {
+        name: 'web',
+        containerPort: 80,
+        protocol: 'TCP'
+      }
+    ];
+
+    const newFormWorkload = clone(oldFormWorkload);
+    newFormWorkload.spec.replicas = 2;
+
+    const liveWorkload = clone(oldFormWorkload);
+    delete liveWorkload.spec.template.spec.containers[0].ports[0].name;
+
+    const actions = patchYamlList({
+      parsedOldYamlList: [yaml.dump(oldFormWorkload)],
+      parsedNewYamlList: [yaml.dump(newFormWorkload)],
+      originalYamlList: [liveWorkload] as DeployKindsType[]
+    });
+    const patchValue = getPatchValue(actions, 'Deployment');
+
+    expect(patchValue.spec.template.spec.containers[0].ports).toEqual(
+      liveWorkload.spec.template.spec.containers[0].ports
+    );
+  });
+
+  it('preserves a legacy unnamed Service port on unrelated updates', () => {
+    const oldFormService = {
+      apiVersion: 'v1',
+      kind: 'Service',
+      metadata: {
+        name: 'demo'
+      },
+      spec: {
+        selector: {
+          app: 'demo'
+        },
+        ports: [
+          {
+            name: 'web',
+            port: 80,
+            targetPort: 80,
+            protocol: 'TCP'
+          }
+        ]
+      }
+    };
+    const newFormService = clone(oldFormService) as any;
+    newFormService.metadata.annotations = {
+      'example.com/change': 'true'
+    };
+
+    const liveService = clone(oldFormService) as any;
+    delete liveService.spec.ports[0].name;
+
+    const actions = patchYamlList({
+      parsedOldYamlList: [yaml.dump(oldFormService)],
+      parsedNewYamlList: [yaml.dump(newFormService)],
+      originalYamlList: [liveService] as DeployKindsType[]
+    });
+    const patchValue = getPatchValue(actions, 'Service');
+
+    expect(patchValue.spec.ports).toEqual(liveService.spec.ports);
+  });
+
+  it('updates an explicitly modified volumeClaimTemplate', () => {
+    const oldFormWorkload = createWorkload('StatefulSet', false) as any;
+    oldFormWorkload.spec.volumeClaimTemplates = [
+      {
+        metadata: {
+          name: 'data',
+          annotations: {
+            path: '/data',
+            value: '1',
+            storageType: 'local'
+          }
+        },
+        spec: {
+          accessModes: ['ReadWriteOnce'],
+          resources: {
+            requests: {
+              storage: '1Gi'
+            }
+          }
+        }
+      }
+    ];
+
+    const newFormWorkload = clone(oldFormWorkload);
+    newFormWorkload.spec.volumeClaimTemplates[0].metadata.annotations.value = '2';
+    newFormWorkload.spec.volumeClaimTemplates[0].spec.resources.requests.storage = '2Gi';
+
+    const liveWorkload = clone(oldFormWorkload);
+    delete liveWorkload.spec.volumeClaimTemplates[0].metadata.annotations.storageType;
+
+    const actions = patchYamlList({
+      parsedOldYamlList: [yaml.dump(oldFormWorkload)],
+      parsedNewYamlList: [yaml.dump(newFormWorkload)],
+      originalYamlList: [liveWorkload] as DeployKindsType[]
+    });
+    const patchValue = getPatchValue(actions, 'StatefulSet');
+
+    expect(patchValue.spec.volumeClaimTemplates[0]).toMatchObject({
+      metadata: {
+        annotations: {
+          value: '2',
+          storageType: 'local'
+        }
+      },
+      spec: {
+        resources: {
+          requests: {
+            storage: '2Gi'
+          }
+        }
+      }
+    });
+  });
+
+  it('updates explicitly modified workload volumes and volume mounts', () => {
+    const oldFormWorkload = createWorkload('Deployment', false) as any;
+    oldFormWorkload.spec.template.spec.volumes = [
+      {
+        name: 'data',
+        emptyDir: {}
+      }
+    ];
+    oldFormWorkload.spec.template.spec.containers[0].volumeMounts = [
+      {
+        name: 'data',
+        mountPath: '/data'
+      }
+    ];
+
+    const newFormWorkload = clone(oldFormWorkload);
+    newFormWorkload.spec.template.spec.volumes[0].emptyDir.medium = 'Memory';
+    newFormWorkload.spec.template.spec.containers[0].volumeMounts[0].mountPath = '/cache';
+
+    const actions = patchYamlList({
+      parsedOldYamlList: [yaml.dump(oldFormWorkload)],
+      parsedNewYamlList: [yaml.dump(newFormWorkload)],
+      originalYamlList: [clone(oldFormWorkload)] as DeployKindsType[]
+    });
+    const patchValue = getPatchValue(actions, 'Deployment');
+
+    expect(patchValue.spec.template.spec.volumes[0].emptyDir.medium).toBe('Memory');
+    expect(patchValue.spec.template.spec.containers[0].volumeMounts[0].mountPath).toBe('/cache');
+  });
+
+  it.each([
+    {
+      kind: 'Deployment',
+      path: (resource: any) => resource.spec.template.spec.containers[0].ports,
+      oldResource: (() => {
+        const workload = createWorkload('Deployment', false) as any;
+        workload.spec.template.spec.containers[0].ports = [
+          {
+            name: 'web',
+            containerPort: 80,
+            protocol: 'TCP'
+          }
+        ];
+        return workload;
+      })()
+    },
+    {
+      kind: 'Service',
+      path: (resource: any) => resource.spec.ports,
+      oldResource: {
+        apiVersion: 'v1',
+        kind: 'Service',
+        metadata: {
+          name: 'demo'
+        },
+        spec: {
+          selector: {
+            app: 'demo'
+          },
+          ports: [
+            {
+              name: 'web',
+              port: 80,
+              targetPort: 80,
+              protocol: 'TCP'
+            }
+          ]
+        }
+      }
+    }
+  ])('normalizes ports after an explicit $kind port edit', ({ kind, path, oldResource }) => {
+    const newResource = clone(oldResource) as any;
+    const newPorts = path(newResource);
+    delete newPorts[0].name;
+    if (kind === 'Service') {
+      newPorts[0].port = 8080;
+      newPorts[0].targetPort = 8080;
+    } else {
+      newPorts[0].containerPort = 8080;
+    }
+
+    const actions = patchYamlList({
+      parsedOldYamlList: [yaml.dump(oldResource)],
+      parsedNewYamlList: [yaml.dump(newResource)],
+      originalYamlList: [clone(oldResource)] as DeployKindsType[]
+    });
+    const patchValue = getPatchValue(actions, kind);
+
+    expect(path(patchValue)[0].name).toBe('p-t-8080-0');
   });
 });

--- a/frontend/providers/applaunchpad/src/utils/tools.ts
+++ b/frontend/providers/applaunchpad/src/utils/tools.ts
@@ -161,6 +161,12 @@ export const ensureUniquePortNames = <T extends { name?: string; port?: any; con
   });
 };
 
+const patchTouchesPath = (patches: jsonpatch.Operation[], targetPath: string) =>
+  patches.some(
+    ({ path }) =>
+      path === targetPath || path.startsWith(`${targetPath}/`) || targetPath.startsWith(`${path}/`)
+  );
+
 /**
  * read a file text content
  */
@@ -509,14 +515,20 @@ export const patchYamlList = ({
             oldFormJson.kind === YamlKindEnum.Deployment ||
             oldFormJson.kind === YamlKindEnum.StatefulSet
           ) {
-            // @ts-ignore
-            crOldYamlJson.spec.template.spec.volumes = oldFormJson.spec.template.spec.volumes;
-            // @ts-ignore
-            crOldYamlJson.spec.template.spec.containers[0].volumeMounts =
+            if (patchTouchesPath(patchRes, '/spec/template/spec/volumes')) {
               // @ts-ignore
-              oldFormJson.spec.template.spec.containers[0].volumeMounts;
-            // @ts-ignore
-            crOldYamlJson.spec.volumeClaimTemplates = oldFormJson.spec.volumeClaimTemplates;
+              crOldYamlJson.spec.template.spec.volumes = oldFormJson.spec.template.spec.volumes;
+            }
+            if (patchTouchesPath(patchRes, '/spec/template/spec/containers/0/volumeMounts')) {
+              // @ts-ignore
+              crOldYamlJson.spec.template.spec.containers[0].volumeMounts =
+                // @ts-ignore
+                oldFormJson.spec.template.spec.containers[0].volumeMounts;
+            }
+            if (patchTouchesPath(patchRes, '/spec/volumeClaimTemplates')) {
+              // @ts-ignore
+              crOldYamlJson.spec.volumeClaimTemplates = oldFormJson.spec.volumeClaimTemplates;
+            }
           }
 
           /* generate new json */
@@ -579,14 +591,17 @@ export const patchYamlList = ({
       ) {
         const workloadJson = actionsJson as any;
         const ports = workloadJson?.spec.template.spec.containers[0].ports || [];
-        if (ports.length > 0) {
+        if (
+          ports.length > 0 &&
+          patchTouchesPath(patchRes, '/spec/template/spec/containers/0/ports')
+        ) {
           workloadJson.spec.template.spec.containers[0].ports = ensureUniquePortNames(ports);
         }
       }
       if (actionsJson.kind === YamlKindEnum.Service) {
         const serviceJson = actionsJson as any;
         const ports = serviceJson?.spec.ports || [];
-        if (ports.length > 0) {
+        if (ports.length > 0 && patchTouchesPath(patchRes, '/spec/ports')) {
           serviceJson.spec.ports = ensureUniquePortNames(ports);
         }
       }


### PR DESCRIPTION
## What this PR does

- Preserves live StatefulSet volume claim templates, workload volumes, and volume mounts during unrelated app updates.
- Normalizes workload and Service port names only when the corresponding port subtree is explicitly edited.
- Keeps the existing normalization behavior for explicit storage and port changes.

## Why

`patchYamlList` previously copied form-rendered storage fields and normalized port names for every update. For legacy resources, a replica-only update could therefore add fields such as `storageType: local`, discard live-only metadata, or generate port names. StatefulSet volume claim template drift could then trigger the existing recreation fallback.

The update path now uses JSON Patch path intersection to apply derived normalization only to resource subtrees that the user actually changed.

## Testing

- `npx -y vitest@1.6.1 run __tests__/unit/utils/tools.test.ts __tests__/unit/utils/deployYaml2Json.test.ts --config vitest.config.ts --pool=forks` (33 tests passed)
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm lint`
- `pnpm build`
