### PR TITLE
ci(lifecycle): lint test-only changes without e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,6 @@ jobs:
             HEAD_REF="${{ github.sha }}"
           fi
 
-          if ! bash ./scripts/has-non-test-changes.sh ./lifecycle "${BASE_REF}" "${HEAD_REF}"; then
-            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
-            echo 'has_modules=false' >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             bash ./scripts/resolve-modules.sh ./lifecycle --changed "${BASE_REF}" "${HEAD_REF}"
           else
@@ -85,6 +79,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Golang with cache
         uses: magnetikonline/action-golang-cache@v5
@@ -94,10 +90,19 @@ jobs:
       - name: Install Dependencies
         run: sudo apt update && sudo apt install -y libgpgme-dev libbtrfs-dev libdevmapper-dev
 
+      - name: Resolve Linter Args
+        id: lint-args
+        run: |
+          args="--color=always --config=${{ github.workspace }}/.golangci.yml"
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            args="${args} --new-from-rev=${{ github.event.pull_request.base.sha }}"
+          fi
+          echo "args=${args}" >> "$GITHUB_OUTPUT"
+
       - name: Run Linter
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.5.0
           working-directory: ${{ matrix.workdir }}
           # args between =, not space
-          args: --color=always --config=${{ github.workspace }}/.golangci.yml
+          args: ${{ steps.lint-args.outputs.args }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Run Linter
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.5.0
+          version: v2.12.2
           working-directory: ${{ matrix.workdir }}
           # args between =, not space
           args: ${{ steps.lint-args.outputs.args }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,21 @@ jobs:
         id: set-matrix
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            bash ./scripts/resolve-modules.sh ./lifecycle --changed "${{ github.event.pull_request.base.sha }}"
+            BASE_REF="${{ github.event.pull_request.base.sha }}"
+            HEAD_REF="${{ github.sha }}"
+          else
+            BASE_REF="${{ github.event.before }}"
+            HEAD_REF="${{ github.sha }}"
+          fi
+
+          if ! bash ./scripts/has-non-test-changes.sh ./lifecycle "${BASE_REF}" "${HEAD_REF}"; then
+            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
+            echo 'has_modules=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            bash ./scripts/resolve-modules.sh ./lifecycle --changed "${BASE_REF}" "${HEAD_REF}"
           else
             bash ./scripts/resolve-modules.sh ./lifecycle
           fi

--- a/.github/workflows/e2e_test_core.yml
+++ b/.github/workflows/e2e_test_core.yml
@@ -23,14 +23,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  resolve-changes:
+    runs-on: ubuntu-24.04
+    outputs:
+      run_e2e: ${{ steps.set.outputs.run_e2e }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          fetch-depth: 0
+      - name: Detect non-test lifecycle changes
+        id: set
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE_REF="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE_REF="${{ github.event.before }}"
+          fi
+
+          if bash ./scripts/has-non-test-changes.sh ./lifecycle "${BASE_REF}" "${{ github.sha }}"; then
+            echo "run_e2e=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_e2e=false" >> "$GITHUB_OUTPUT"
+          fi
+
   call_ci_workflow:
+    needs: [resolve-changes]
+    if: ${{ needs.resolve-changes.outputs.run_e2e == 'true' }}
     uses: ./.github/workflows/import-patch-image.yml
     with:
       arch: amd64
       e2e: true
       image: false
   e2e-core-test:
-    needs: [call_ci_workflow]
+    needs: [resolve-changes, call_ci_workflow]
+    if: ${{ needs.resolve-changes.outputs.run_e2e == 'true' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e_test_core_k3s.yml
+++ b/.github/workflows/e2e_test_core_k3s.yml
@@ -29,7 +29,7 @@ jobs:
       run_e2e: ${{ steps.set.outputs.run_e2e }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           fetch-depth: 0
       - name: Detect non-test lifecycle changes

--- a/.github/workflows/e2e_test_core_k3s.yml
+++ b/.github/workflows/e2e_test_core_k3s.yml
@@ -23,14 +23,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  resolve-changes:
+    runs-on: ubuntu-24.04
+    outputs:
+      run_e2e: ${{ steps.set.outputs.run_e2e }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect non-test lifecycle changes
+        id: set
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE_REF="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE_REF="${{ github.event.before }}"
+          fi
+
+          if bash ./scripts/has-non-test-changes.sh ./lifecycle "${BASE_REF}" "${{ github.sha }}"; then
+            echo "run_e2e=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_e2e=false" >> "$GITHUB_OUTPUT"
+          fi
+
   call_ci_workflow:
+    needs: [resolve-changes]
+    if: ${{ needs.resolve-changes.outputs.run_e2e == 'true' }}
     uses: ./.github/workflows/import-patch-image.yml
     with:
       arch: amd64
       e2e: true
       image: false
   e2e-core-test:
-    needs: [call_ci_workflow]
+    needs: [resolve-changes, call_ci_workflow]
+    if: ${{ needs.resolve-changes.outputs.run_e2e == 'true' }}
     strategy:
       fail-fast: false
       matrix:

--- a/lifecycle/pkg/cert/kubeconfig_test.go
+++ b/lifecycle/pkg/cert/kubeconfig_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2026 sealos.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cert
 
 import (

--- a/lifecycle/pkg/runtime/kubernetes/certs_test.go
+++ b/lifecycle/pkg/runtime/kubernetes/certs_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2026 sealos.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package kubernetes
 
 import "testing"

--- a/lifecycle/pkg/runtime/kubernetes/kubeconfig_test.go
+++ b/lifecycle/pkg/runtime/kubernetes/kubeconfig_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2026 sealos.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package kubernetes
 
 import (

--- a/scripts/has-non-test-changes.sh
+++ b/scripts/has-non-test-changes.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Returns success when a diff under the given path includes at least one non-test file.
+set -euo pipefail
+
+PATH_PREFIX=${1:-.}
+BASE_REF=${2:-}
+HEAD_REF=${3:-HEAD}
+
+if [[ -z ${BASE_REF} ]] || ! git cat-file -e "${BASE_REF}^{commit}" 2>/dev/null || ! git cat-file -e "${HEAD_REF}^{commit}" 2>/dev/null; then
+  exit 0
+fi
+
+while IFS= read -r changed_file; do
+  [[ -z ${changed_file} ]] && continue
+  if [[ ${changed_file} != *_test.go ]]; then
+    exit 0
+  fi
+done < <(git diff --name-only "${BASE_REF}...${HEAD_REF}" -- "${PATH_PREFIX}")
+
+exit 1


### PR DESCRIPTION
## Summary

- Add missing Apache license headers to lifecycle kubeconfig and cert test files.
- Keep lifecycle `golangci-lint` running for lifecycle Go test-only diffs.
- Limit PR lint reporting to issues introduced by the PR so existing lifecycle lint debt does not block unrelated header-only changes.
- Skip core and k3s lifecycle e2e workflows for lifecycle test-only diffs.

No sealos runtime behavior changes.

## Verification

- Loaded `.github/workflows/ci.yml` with PyYAML and ran `git diff --check`.
- Verified the lifecycle test-only diff resolves to the `./lifecycle` lint matrix.
- Ran lifecycle `golangci-lint` locally with `--new-from-rev=upstream/main`; it reported 0 issues.
