### PR TITLE
fix(frontend): redirect provider root routes

### DIFF
--- a/frontend/providers/applaunchpad/next.config.js
+++ b/frontend/providers/applaunchpad/next.config.js
@@ -27,6 +27,15 @@ const nextConfig = {
     outputFileTracingRoot: path.join(__dirname, '../../'),
     instrumentationHook: true
   },
+  async redirects () {
+    return [
+      {
+        source: '/',
+        destination: '/apps',
+        permanent: false
+      }
+    ]
+  },
   async rewrites () {
     return [
       {

--- a/frontend/providers/dbprovider/next.config.js
+++ b/frontend/providers/dbprovider/next.config.js
@@ -22,6 +22,15 @@ const nextConfig = {
     // this includes files from the monorepo base two directories up
     outputFileTracingRoot: path.join(__dirname, '../../')
   },
+  async redirects () {
+    return [
+      {
+        source: '/',
+        destination: '/dbs',
+        permanent: false
+      }
+    ]
+  },
   async rewrites () {
     return [
       {


### PR DESCRIPTION
## Summary
- add a server-side redirect from `/` to `/dbs` for the database provider frontend
- add a server-side redirect from `/` to `/apps` for App Launchpad
- keep the existing app pages and probe paths unchanged

## Testing
- Verified `dbprovider` redirects config resolves `/` to `/dbs` with `permanent: false`
- Verified `applaunchpad` redirects config resolves `/` to `/apps` with `permanent: false`
- `helm lint frontend/providers/dbprovider/deploy/charts/dbprovider-frontend`
- `helm template dbprovider-frontend frontend/providers/dbprovider/deploy/charts/dbprovider-frontend >/tmp/dbprovider-helm-template-default.yaml`
- `helm lint frontend/providers/dbprovider/deploy/charts/dbprovider-frontend -f frontend/providers/dbprovider/deploy/charts/dbprovider-frontend/dbprovider-frontend-values.yaml`
- `helm template dbprovider-frontend frontend/providers/dbprovider/deploy/charts/dbprovider-frontend -f frontend/providers/dbprovider/deploy/charts/dbprovider-frontend/dbprovider-frontend-values.yaml >/tmp/dbprovider-helm-template-values.yaml`
- `helm lint frontend/providers/applaunchpad/deploy/charts/applaunchpad-frontend`
- `helm template applaunchpad-frontend frontend/providers/applaunchpad/deploy/charts/applaunchpad-frontend >/tmp/applaunchpad-helm-template-default.yaml`
- `helm lint frontend/providers/applaunchpad/deploy/charts/applaunchpad-frontend -f frontend/providers/applaunchpad/deploy/charts/applaunchpad-frontend/applaunchpad-frontend-values.yaml`
- `helm template applaunchpad-frontend frontend/providers/applaunchpad/deploy/charts/applaunchpad-frontend -f frontend/providers/applaunchpad/deploy/charts/applaunchpad-frontend/applaunchpad-frontend-values.yaml >/tmp/applaunchpad-helm-template-values.yaml`
- Built and rolled test images on cluster 161
- Verified `https://dbprovider.192.168.12.161.nip.io/` returns `307 Location: /dbs`
- Verified `https://dbprovider.192.168.12.161.nip.io/dbs` returns `200`
- Verified `https://applaunchpad.192.168.12.161.nip.io/` returns `307 Location: /apps`
- Verified `https://applaunchpad.192.168.12.161.nip.io/apps` returns `200`
- Verified `https://applaunchpad.192.168.12.161.nip.io/api/platform/getInitData` returns `200`
- `helm test dbprovider-frontend -n dbprovider-frontend --logs`
- `helm test applaunchpad-frontend -n applaunchpad-frontend --logs`
