### PR TITLE
fix(applaunchpad): redirect root to app list

### DIFF
--- a/frontend/providers/applaunchpad/next.config.js
+++ b/frontend/providers/applaunchpad/next.config.js
@@ -27,6 +27,15 @@ const nextConfig = {
     outputFileTracingRoot: path.join(__dirname, '../../'),
     instrumentationHook: true
   },
+  async redirects () {
+    return [
+      {
+        source: '/',
+        destination: '/apps',
+        permanent: false
+      }
+    ]
+  },
   async rewrites () {
     return [
       {


### PR DESCRIPTION
## Summary
- add a server-side redirect from `/` to `/apps` for App Launchpad
- keep the existing `/apps` page and `/api/platform/getInitData` probe path unchanged

## Testing
- `node -e "const cfg=require('./frontend/providers/applaunchpad/next.config.js'); Promise.resolve(cfg.redirects()).then(r=>{console.log(JSON.stringify(r)); if(!r.some(x=>x.source==='/'&&x.destination==='/apps'&&x.permanent===false)) process.exit(1);})"`
- `helm lint frontend/providers/applaunchpad/deploy/charts/applaunchpad-frontend`
- `helm template applaunchpad-frontend frontend/providers/applaunchpad/deploy/charts/applaunchpad-frontend >/tmp/applaunchpad-helm-template-default.yaml`
- `helm lint frontend/providers/applaunchpad/deploy/charts/applaunchpad-frontend -f frontend/providers/applaunchpad/deploy/charts/applaunchpad-frontend/applaunchpad-frontend-values.yaml`
- `helm template applaunchpad-frontend frontend/providers/applaunchpad/deploy/charts/applaunchpad-frontend -f frontend/providers/applaunchpad/deploy/charts/applaunchpad-frontend/applaunchpad-frontend-values.yaml >/tmp/applaunchpad-helm-template-values.yaml`
- Built and pushed a linux/amd64 test image: `crpi-7jr40k6elhldekqp.cn-hangzhou.personal.cr.aliyuncs.com/mlhiter/sealos-applaunchpad-frontend:applaunchpad-root-redirect-v51-20260727171605`
- Rolled the test image to cluster 161 and verified `https://applaunchpad.192.168.12.161.nip.io/` returns `307 Location: /apps`
- Verified `https://applaunchpad.192.168.12.161.nip.io/apps` returns `200`
- Verified `https://applaunchpad.192.168.12.161.nip.io/api/platform/getInitData` returns `200`
- `helm --kubeconfig /Users/mlhiter/.kube/161 test applaunchpad-frontend -n applaunchpad-frontend --logs`
