### PR TITLE
fix(account): make hourly billing reconciliation resumable and idempotent

### DIFF
--- a/controllers/account/controllers/billing_controller.go
+++ b/controllers/account/controllers/billing_controller.go
@@ -48,8 +48,10 @@ type BillingTaskRunner struct {
 func (r *BillingTaskRunner) NeedLeaderElection() bool { return true }
 
 const (
-	billingMonitorDelay = 5 * time.Minute
-	billingRetryDelay   = time.Minute
+	billingMonitorDelay              = 5 * time.Minute
+	billingRetryDelay                = time.Minute
+	defaultBillingMaxCatchupDuration = 24 * time.Hour
+	billingMaxCatchupDurationEnv     = "BILLING_MAX_CATCHUP_DURATION"
 )
 
 var (
@@ -142,7 +144,7 @@ type BillingReconciler struct {
 	DBClient               database.Account
 	AccountV2              database.AccountV2
 	Properties             *resources.PropertyTypeLS
-	reconcileBillingFunc   func(owner string, billings []*resources.Billing) error
+	reconcileBillingFunc   func(owner string, billings []*resources.Billing, endHourTime time.Time) error
 	executeBillingHourFunc func(time.Time) error
 	concurrentLimit        int64
 	DebtUserMap            *maps.ConcurrentMap
@@ -153,16 +155,48 @@ func (r *BillingReconciler) ExecuteBillingTask() error {
 	return r.ExecuteBillingTasksUntil(latestReadyBillingHour(time.Now()))
 }
 
-func (r *BillingReconciler) ExecuteBillingTasksUntil(target time.Time) error {
+func (r *BillingReconciler) ExecuteBillingTasksUntil(target time.Time) (err error) {
 	target = target.UTC().Truncate(time.Hour)
+	setBillingTargetMetrics(target)
+	defer func() {
+		setBillingProcessingMetrics(time.Time{}, false)
+		if err != nil {
+			billingReconcileFailures.Inc()
+		}
+	}()
 	checkpoint, exists, err := r.DBClient.GetBillingCheckpoint()
 	if err != nil {
 		return fmt.Errorf("get billing checkpoint: %w", err)
 	}
+	maxCatchup := env.GetDurationEnvWithDefault(
+		billingMaxCatchupDurationEnv,
+		defaultBillingMaxCatchupDuration,
+	)
+	if err := validateBillingMaxCatchupDuration(maxCatchup); err != nil {
+		return err
+	}
+	persistedCheckpoint := checkpoint.UTC().Truncate(time.Hour)
 	if !exists {
 		checkpoint = target.Add(-time.Hour)
+		persistedCheckpoint = checkpoint
+	} else {
+		checkpoint, err = limitBillingCheckpoint(persistedCheckpoint, target, maxCatchup)
+		if err != nil {
+			return err
+		}
+		if checkpoint.After(persistedCheckpoint) {
+			r.Info(
+				"billing catch-up window truncated",
+				"persistedCheckpoint", persistedCheckpoint.Format(time.RFC3339),
+				"replayFrom", checkpoint.Format(time.RFC3339),
+				"skippedHours", int64(checkpoint.Sub(persistedCheckpoint)/time.Hour),
+			)
+		}
 	}
+	setBillingCheckpointMetrics(persistedCheckpoint, target)
+	setBillingPendingCheckpointMetrics(checkpoint, target)
 	for _, billingTime := range billingHoursAfter(checkpoint, target) {
+		setBillingProcessingMetrics(billingTime, true)
 		execute := r.ExecuteBillingTaskAt
 		if r.executeBillingHourFunc != nil {
 			execute = r.executeBillingHourFunc
@@ -181,8 +215,38 @@ func (r *BillingReconciler) ExecuteBillingTasksUntil(target time.Time) error {
 				err,
 			)
 		}
+		checkpoint = billingTime
+		setBillingCheckpointMetrics(checkpoint, target)
+		billingLastSuccessTimestamp.Set(float64(time.Now().UTC().Unix()))
 	}
 	return nil
+}
+
+func validateBillingMaxCatchupDuration(maxCatchup time.Duration) error {
+	if maxCatchup < time.Hour || maxCatchup%time.Hour != 0 {
+		return fmt.Errorf(
+			"%s must be a positive whole number of hours: %s",
+			billingMaxCatchupDurationEnv,
+			maxCatchup,
+		)
+	}
+	return nil
+}
+
+func limitBillingCheckpoint(
+	checkpoint, target time.Time,
+	maxCatchup time.Duration,
+) (time.Time, error) {
+	if err := validateBillingMaxCatchupDuration(maxCatchup); err != nil {
+		return time.Time{}, err
+	}
+	checkpoint = checkpoint.UTC().Truncate(time.Hour)
+	target = target.UTC().Truncate(time.Hour)
+	earliest := target.Add(-maxCatchup)
+	if checkpoint.Before(earliest) {
+		return earliest, nil
+	}
+	return checkpoint, nil
 }
 
 func (r *BillingReconciler) ExecuteBillingTaskAt(endHourTime time.Time) error {
@@ -248,11 +312,13 @@ func (r *BillingReconciler) loadDebtUsersAt(endHourTime time.Time) error {
 	if err := db.Transaction(
 		func(tx *gorm.DB) error {
 			if err := tx.Model(&types.Debt{}).
+				Select("user_uid, account_debt_status").
 				Where("created_at <= ?", effectiveTime).
 				Find(&debts).Error; err != nil {
 				return fmt.Errorf("query billing-period debts: %w", err)
 			}
 			if err := tx.Model(&types.DebtStatusRecord{}).
+				Select("user_uid, last_status, create_at").
 				Where("create_at > ?", effectiveTime).
 				Order("create_at ASC").
 				Find(&recordsAfter).Error; err != nil {
@@ -501,6 +567,11 @@ func (r *BillingReconciler) reconcileOwnerList(
 	ownerListMap map[string][]string,
 	now time.Time,
 ) error {
+	if r.concurrentLimit <= 0 {
+		return fmt.Errorf(
+			"billing concurrent limit must be greater than zero: %d", r.concurrentLimit,
+		)
+	}
 	endHourTime := now.UTC().Truncate(time.Hour)
 	startHourTime := endHourTime.Add(-1 * time.Hour)
 	ownerList := make([]string, 0, len(ownerListMap))
@@ -575,7 +646,7 @@ func (r *BillingReconciler) reconcileOwnerList(
 			defer func() {
 				<-workers
 			}()
-			reconcileErr := r.reconcileBillingFunc(owner, billings)
+			reconcileErr := r.reconcileBillingFunc(owner, billings, endHourTime)
 			if reconcileErr != nil {
 				r.Error(
 					reconcileErr,
@@ -598,8 +669,10 @@ func (r *BillingReconciler) reconcileOwnerList(
 		}
 	}
 	if len(failedList) > 0 {
+		billingFailedOwners.Set(float64(len(failedList)))
 		return fmt.Errorf("failed to reconcile owners: %s", strings.Join(failedList, ","))
 	}
+	billingFailedOwners.Set(0)
 	return nil
 }
 
@@ -616,6 +689,14 @@ func classifyGeneratedBillings(ownerBillings map[string][]*resources.Billing) {
 			}
 		}
 	}
+}
+
+func (r *BillingReconciler) isSubscriptionBilling(billing *resources.Billing) bool {
+	if SubscriptionWorkspaceMap == nil {
+		return false
+	}
+	_, ok := SubscriptionWorkspaceMap.Get(billing.Namespace)
+	return ok
 }
 
 func pendingOwnerBillings(
@@ -637,11 +718,16 @@ func pendingOwnerBillings(
 	return pending
 }
 
-func (r *BillingReconciler) reconcileBilling(owner string, billings []*resources.Billing) error {
+func (r *BillingReconciler) reconcileBilling(
+	owner string,
+	billings []*resources.Billing,
+	_ time.Time,
+) error {
 	amount := int64(0)
 	orderIDs := make([]string, 0, len(billings))
 	for _, billing := range billings {
-		if billing.Status == resources.Subscription {
+		if billing.Status == resources.Subscription || r.isSubscriptionBilling(billing) {
+			billing.Status = resources.Subscription
 			continue
 		}
 		amount += billing.Amount
@@ -669,11 +755,13 @@ func (r *BillingReconciler) reconcileBilling(owner string, billings []*resources
 func (r *BillingReconciler) reconcileBillingWithCredits(
 	owner string,
 	billings []*resources.Billing,
+	endHourTime time.Time,
 ) error {
 	amount := int64(0)
 	orderIDs := make([]string, 0, len(billings))
 	for _, billing := range billings {
-		if billing.Status == resources.Subscription {
+		if billing.Status == resources.Subscription || r.isSubscriptionBilling(billing) {
+			billing.Status = resources.Subscription
 			continue
 		}
 		amount += billing.Amount
@@ -685,8 +773,8 @@ func (r *BillingReconciler) reconcileBillingWithCredits(
 	if amount == 0 {
 		return nil
 	}
-	if err := r.AccountV2.AddDeductionBalanceWithCredits(
-		&types.UserQueryOpts{Owner: owner}, amount, orderIDs,
+	if err := r.AccountV2.AddDeductionBalanceWithCreditsAt(
+		&types.UserQueryOpts{Owner: owner}, amount, orderIDs, endHourTime,
 	); err != nil {
 		if updateErr := r.DBClient.UpdateBillingStatus(
 			orderIDs, resources.Unsettled,
@@ -806,14 +894,11 @@ func (r *BillingReconciler) removeDebtOwners(
 }
 
 func (r *BillingReconciler) ownerInDebt(owner string) bool {
-	if _, inDebt := DebtUserMap.Get(owner); inDebt {
-		return true
+	if r.debtOwnerMap == nil {
+		return false
 	}
-	if r.debtOwnerMap != nil {
-		_, inDebt := r.debtOwnerMap.Get(owner)
-		return inDebt
-	}
-	return false
+	_, inDebt := r.debtOwnerMap.Get(owner)
+	return inDebt
 }
 
 func (r *BillingReconciler) getUsersForNamespaces(namespaces []string) (map[string]string, error) {

--- a/controllers/account/controllers/billing_controller.go
+++ b/controllers/account/controllers/billing_controller.go
@@ -194,7 +194,6 @@ func (r *BillingReconciler) ExecuteBillingTaskAt(endHourTime time.Time) error {
 	r.debtOwnerMap = maps.NewConcurrentNullValueMap()
 	var ownerListMap map[string][]string
 	var ownerUserUIDs map[string]uuid.UUID
-	var unsettledBillings map[string][]*resources.Billing
 	inputStartedAt := time.Now()
 	if err := runBillingReads(
 		func() error {
@@ -208,20 +207,11 @@ func (r *BillingReconciler) ExecuteBillingTaskAt(endHourTime time.Time) error {
 			}
 			return nil
 		},
-		func() error {
-			var err error
-			unsettledBillings, err = r.DBClient.GetUnsettledBillingsAt(endHourTime)
-			if err != nil {
-				return fmt.Errorf("get unsettled billings: %w", err)
-			}
-			return nil
-		},
 	); err != nil {
 		return fmt.Errorf("load billing inputs: %w", err)
 	}
 	r.Info("load billing inputs", "duration", time.Since(inputStartedAt))
 	r.removeDebtOwners(ownerListMap, ownerUserUIDs)
-	addUnsettledBillingOwners(ownerListMap, unsettledBillings)
 	if err := r.loadSubscriptionWorkspacesAt(endHourTime, ownerListMap); err != nil {
 		return err
 	}
@@ -507,25 +497,6 @@ func workspaceSubscriptionTransactionCovers(
 		transaction.UpdatedAt.Add(period).After(effectiveTime), nil
 }
 
-func addUnsettledBillingOwners(
-	ownerListMap map[string][]string,
-	unsettled map[string][]*resources.Billing,
-) {
-	for owner, billings := range unsettled {
-		namespaces := make(map[string]struct{}, len(ownerListMap[owner]))
-		for _, namespace := range ownerListMap[owner] {
-			namespaces[namespace] = struct{}{}
-		}
-		for _, billing := range billings {
-			if _, exists := namespaces[billing.Namespace]; exists {
-				continue
-			}
-			ownerListMap[owner] = append(ownerListMap[owner], billing.Namespace)
-			namespaces[billing.Namespace] = struct{}{}
-		}
-	}
-}
-
 func (r *BillingReconciler) reconcileOwnerList(
 	ownerListMap map[string][]string,
 	now time.Time,
@@ -639,7 +610,7 @@ func billingBusinessKey(billing *resources.Billing) string {
 func classifyGeneratedBillings(ownerBillings map[string][]*resources.Billing) {
 	for _, billings := range ownerBillings {
 		for _, billing := range billings {
-			billing.Status = resources.Unsettled
+			billing.Status = resources.Settled
 			if _, ok := SubscriptionWorkspaceMap.Get(billing.Namespace); ok {
 				billing.Status = resources.Subscription
 			}
@@ -651,14 +622,6 @@ func pendingOwnerBillings(
 	generated, existing map[string][]*resources.Billing,
 ) map[string][]*resources.Billing {
 	pending := make(map[string][]*resources.Billing)
-	for owner, billings := range existing {
-		for _, billing := range billings {
-			if billing.Status == resources.Unsettled &&
-				strings.HasPrefix(billing.OrderID, "bh_") {
-				pending[owner] = append(pending[owner], billing)
-			}
-		}
-	}
 	for owner, billings := range generated {
 		existingByKey := make(map[string]*resources.Billing, len(existing[owner]))
 		for _, billing := range existing[owner] {
@@ -675,27 +638,30 @@ func pendingOwnerBillings(
 }
 
 func (r *BillingReconciler) reconcileBilling(owner string, billings []*resources.Billing) error {
+	amount := int64(0)
+	orderIDs := make([]string, 0, len(billings))
+	for _, billing := range billings {
+		if billing.Status == resources.Subscription {
+			continue
+		}
+		amount += billing.Amount
+		orderIDs = append(orderIDs, billing.OrderID)
+	}
 	if err := r.DBClient.SaveBillings(billings...); err != nil {
 		return fmt.Errorf("save billings failed: %w", err)
 	}
-	for _, billing := range billings {
-		if billing.Status == resources.Subscription {
-			if err := r.DBClient.UpdateBillingStatus(
-				[]string{billing.OrderID}, resources.Subscription,
-			); err != nil {
-				return fmt.Errorf("mark billing %s subscription: %w", billing.OrderID, err)
-			}
-			continue
+	if amount == 0 {
+		return nil
+	}
+	if err := r.AccountV2.AddDeductionBalance(
+		&types.UserQueryOpts{Owner: owner}, amount,
+	); err != nil {
+		if updateErr := r.DBClient.UpdateBillingStatus(
+			orderIDs, resources.Unsettled,
+		); updateErr != nil {
+			r.Error(updateErr, "update billing unsettled status failed", "orderIDs", orderIDs)
 		}
-		orderIDs := []string{billing.OrderID}
-		if err := r.AccountV2.AddDeductionBalanceForBilling(
-			&types.UserQueryOpts{Owner: owner}, billing.Amount, orderIDs,
-		); err != nil {
-			return fmt.Errorf("deduct billing %s balance: %w", billing.OrderID, err)
-		}
-		if err := r.DBClient.UpdateBillingStatus(orderIDs, resources.Settled); err != nil {
-			return fmt.Errorf("mark billing %s settled: %w", billing.OrderID, err)
-		}
+		return fmt.Errorf("deduct owner %s balance: %w", owner, err)
 	}
 	return nil
 }
@@ -704,27 +670,30 @@ func (r *BillingReconciler) reconcileBillingWithCredits(
 	owner string,
 	billings []*resources.Billing,
 ) error {
+	amount := int64(0)
+	orderIDs := make([]string, 0, len(billings))
+	for _, billing := range billings {
+		if billing.Status == resources.Subscription {
+			continue
+		}
+		amount += billing.Amount
+		orderIDs = append(orderIDs, billing.OrderID)
+	}
 	if err := r.DBClient.SaveBillings(billings...); err != nil {
 		return fmt.Errorf("save billings failed: %w", err)
 	}
-	for _, billing := range billings {
-		if billing.Status == resources.Subscription {
-			if err := r.DBClient.UpdateBillingStatus(
-				[]string{billing.OrderID}, resources.Subscription,
-			); err != nil {
-				return fmt.Errorf("mark billing %s subscription: %w", billing.OrderID, err)
-			}
-			continue
+	if amount == 0 {
+		return nil
+	}
+	if err := r.AccountV2.AddDeductionBalanceWithCredits(
+		&types.UserQueryOpts{Owner: owner}, amount, orderIDs,
+	); err != nil {
+		if updateErr := r.DBClient.UpdateBillingStatus(
+			orderIDs, resources.Unsettled,
+		); updateErr != nil {
+			r.Error(updateErr, "update billing unsettled status failed", "orderIDs", orderIDs)
 		}
-		orderIDs := []string{billing.OrderID}
-		if err := r.AccountV2.AddDeductionBalanceWithCredits(
-			&types.UserQueryOpts{Owner: owner}, billing.Amount, orderIDs,
-		); err != nil {
-			return fmt.Errorf("deduct billing %s with credits: %w", billing.OrderID, err)
-		}
-		if err := r.DBClient.UpdateBillingStatus(orderIDs, resources.Settled); err != nil {
-			return fmt.Errorf("mark billing %s settled: %w", billing.OrderID, err)
-		}
+		return fmt.Errorf("deduct owner %s with credits: %w", owner, err)
 	}
 	return nil
 }

--- a/controllers/account/controllers/billing_controller.go
+++ b/controllers/account/controllers/billing_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"os"
@@ -33,6 +34,7 @@ import (
 	"github.com/labring/sealos/controllers/pkg/utils/env"
 	"github.com/labring/sealos/controllers/pkg/utils/maps"
 	userv1 "github.com/labring/sealos/controllers/user/api/v1"
+	"gorm.io/gorm"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -111,6 +113,20 @@ func waitForBillingRun(ctx context.Context, delay time.Duration) bool {
 	}
 }
 
+func runBillingReads(tasks ...func() error) error {
+	errs := make([]error, len(tasks))
+	var wg sync.WaitGroup
+	for i, task := range tasks {
+		wg.Add(1)
+		go func(index int, read func() error) {
+			defer wg.Done()
+			errs[index] = read()
+		}(i, task)
+	}
+	wg.Wait()
+	return errors.Join(errs...)
+}
+
 const (
 	UserNamespacePrefix = "ns-"
 	ResourceQuotaPrefix = "quota-"
@@ -130,6 +146,7 @@ type BillingReconciler struct {
 	executeBillingHourFunc func(time.Time) error
 	concurrentLimit        int64
 	DebtUserMap            *maps.ConcurrentMap
+	debtOwnerMap           *maps.ConcurrentNullValueMap
 }
 
 func (r *BillingReconciler) ExecuteBillingTask() error {
@@ -174,17 +191,36 @@ func (r *BillingReconciler) ExecuteBillingTaskAt(endHourTime time.Time) error {
 	r.Info("start billing reconcile", "billingTime", endHourTime.Format(time.RFC3339))
 	DebtUserMap = maps.NewConcurrentNullValueMap()
 	SubscriptionWorkspaceMap = maps.NewConcurrentNullValueMap()
-	if err := r.loadDebtUsersAt(endHourTime); err != nil {
-		return err
+	r.debtOwnerMap = maps.NewConcurrentNullValueMap()
+	var ownerListMap map[string][]string
+	var ownerUserUIDs map[string]uuid.UUID
+	var unsettledBillings map[string][]*resources.Billing
+	inputStartedAt := time.Now()
+	if err := runBillingReads(
+		func() error {
+			return r.loadDebtUsersAt(endHourTime)
+		},
+		func() error {
+			var err error
+			ownerListMap, ownerUserUIDs, err = r.getRecentUsedOwnersAt(endHourTime)
+			if err != nil {
+				return fmt.Errorf("get recently used owners: %w", err)
+			}
+			return nil
+		},
+		func() error {
+			var err error
+			unsettledBillings, err = r.DBClient.GetUnsettledBillingsAt(endHourTime)
+			if err != nil {
+				return fmt.Errorf("get unsettled billings: %w", err)
+			}
+			return nil
+		},
+	); err != nil {
+		return fmt.Errorf("load billing inputs: %w", err)
 	}
-	ownerListMap, err := r.getRecentUsedOwnersAt(endHourTime)
-	if err != nil {
-		return fmt.Errorf("failed to get the owner list of the recently used resource: %w", err)
-	}
-	unsettledBillings, err := r.DBClient.GetUnsettledBillingsAt(endHourTime)
-	if err != nil {
-		return fmt.Errorf("failed to get unsettled billings: %w", err)
-	}
+	r.Info("load billing inputs", "duration", time.Since(inputStartedAt))
+	r.removeDebtOwners(ownerListMap, ownerUserUIDs)
 	addUnsettledBillingOwners(ownerListMap, unsettledBillings)
 	if err := r.loadSubscriptionWorkspacesAt(endHourTime, ownerListMap); err != nil {
 		return err
@@ -196,13 +232,12 @@ func (r *BillingReconciler) ExecuteBillingTaskAt(endHourTime time.Time) error {
 			endHourTime.Format(time.RFC3339),
 		)
 	}
-	err = r.reconcileOwnerListBatch(
+	if err := r.reconcileOwnerListBatch(
 		ownerListMap,
 		env.GetIntEnvWithDefault("BILLING_RECONCILE_BATCH_COUNT", 200),
 		endHourTime,
 		r.reconcileOwnerList,
-	)
-	if err != nil {
+	); err != nil {
 		return fmt.Errorf("failed to reconcile owner list batch: %w", err)
 	}
 	r.Info(
@@ -214,21 +249,30 @@ func (r *BillingReconciler) ExecuteBillingTaskAt(endHourTime time.Time) error {
 }
 
 func (r *BillingReconciler) loadDebtUsersAt(endHourTime time.Time) error {
+	startedAt := time.Now()
 	effectiveTime := endHourTime.Add(-time.Nanosecond)
 	db := r.AccountV2.GetGlobalDB()
 	var debts []types.Debt
-	if err := db.Model(&types.Debt{}).
-		Where("created_at <= ?", effectiveTime).
-		Find(&debts).Error; err != nil {
-		return fmt.Errorf("query billing-period debts: %w", err)
-	}
-
 	var recordsAfter []types.DebtStatusRecord
-	if err := db.Model(&types.DebtStatusRecord{}).
-		Where("create_at > ?", effectiveTime).
-		Order("create_at ASC").
-		Find(&recordsAfter).Error; err != nil {
-		return fmt.Errorf("query debt status after billing period: %w", err)
+	// Debt and its status record are committed together, so both reads share one snapshot.
+	if err := db.Transaction(
+		func(tx *gorm.DB) error {
+			if err := tx.Model(&types.Debt{}).
+				Where("created_at <= ?", effectiveTime).
+				Find(&debts).Error; err != nil {
+				return fmt.Errorf("query billing-period debts: %w", err)
+			}
+			if err := tx.Model(&types.DebtStatusRecord{}).
+				Where("create_at > ?", effectiveTime).
+				Order("create_at ASC").
+				Find(&recordsAfter).Error; err != nil {
+				return fmt.Errorf("query debt status after billing period: %w", err)
+			}
+			return nil
+		},
+		&sql.TxOptions{Isolation: sql.LevelSerializable, ReadOnly: true},
+	); err != nil {
+		return fmt.Errorf("query consistent billing-period debt state: %w", err)
 	}
 
 	afterByUser := make(map[uuid.UUID]types.DebtStatusRecord, len(recordsAfter))
@@ -245,6 +289,11 @@ func (r *BillingReconciler) loadDebtUsersAt(endHourTime time.Time) error {
 		}
 	}
 	DebtUserMap.Set(users...)
+	r.Info(
+		"load billing-period debt users",
+		"count", len(users),
+		"duration", time.Since(startedAt),
+	)
 	return nil
 }
 
@@ -259,6 +308,7 @@ func (r *BillingReconciler) loadSubscriptionWorkspacesAt(
 	endHourTime time.Time,
 	ownerListMap map[string][]string,
 ) error {
+	startedAt := time.Now()
 	effectiveTime := endHourTime.Add(-time.Nanosecond)
 	db := r.AccountV2.GetGlobalDB()
 	regionDomain := r.AccountV2.GetLocalRegion().Domain
@@ -277,43 +327,58 @@ func (r *BillingReconciler) loadSubscriptionWorkspacesAt(
 	}
 
 	var subscriptions []types.WorkspaceSubscription
-	if err := db.Model(&types.WorkspaceSubscription{}).
-		Where(
-			"region_domain = ? AND workspace IN ? AND create_at <= ?",
-			regionDomain,
-			workspaces,
-			effectiveTime,
-		).
-		Find(&subscriptions).Error; err != nil {
-		return fmt.Errorf("query billing-period workspace subscriptions: %w", err)
-	}
 	var periodTransactions []types.WorkspaceSubscriptionTransaction
-	if err := db.Model(&types.WorkspaceSubscriptionTransaction{}).
-		Where(
-			"region_domain = ? AND workspace IN ? AND status = ? AND pay_status IN (?, ?) AND updated_at <= ?",
-			regionDomain,
-			workspaces,
-			types.SubscriptionTransactionStatusCompleted,
-			types.SubscriptionPayStatusPaid,
-			types.SubscriptionPayStatusNoNeed,
-			effectiveTime,
-		).
-		Find(&periodTransactions).Error; err != nil {
-		return fmt.Errorf("query billing-period workspace subscription transactions: %w", err)
-	}
 	var terminalTransactions []types.WorkspaceSubscriptionTransaction
-	if err := db.Model(&types.WorkspaceSubscriptionTransaction{}).
-		Where(
-			"region_domain = ? AND workspace IN ? AND status = ? AND operator IN (?, ?) AND updated_at <= ?",
-			regionDomain,
-			workspaces,
-			types.SubscriptionTransactionStatusCompleted,
-			types.SubscriptionTransactionTypeCanceled,
-			types.SubscriptionTransactionTypeDeleted,
-			effectiveTime,
-		).
-		Find(&terminalTransactions).Error; err != nil {
-		return fmt.Errorf("query billing-period terminal subscription transactions: %w", err)
+	// The subscription snapshot and completed transactions describe one entitlement state.
+	if err := db.Transaction(
+		func(tx *gorm.DB) error {
+			if err := tx.Model(&types.WorkspaceSubscription{}).
+				Where(
+					"region_domain = ? AND workspace IN ? AND create_at <= ?",
+					regionDomain,
+					workspaces,
+					effectiveTime,
+				).
+				Find(&subscriptions).Error; err != nil {
+				return fmt.Errorf("query billing-period workspace subscriptions: %w", err)
+			}
+			if err := tx.Model(&types.WorkspaceSubscriptionTransaction{}).
+				Where(
+					"region_domain = ? AND workspace IN ? AND status = ? AND pay_status IN (?, ?) AND updated_at <= ?",
+					regionDomain,
+					workspaces,
+					types.SubscriptionTransactionStatusCompleted,
+					types.SubscriptionPayStatusPaid,
+					types.SubscriptionPayStatusNoNeed,
+					effectiveTime,
+				).
+				Find(&periodTransactions).Error; err != nil {
+				return fmt.Errorf(
+					"query billing-period workspace subscription transactions: %w",
+					err,
+				)
+			}
+			if err := tx.Model(&types.WorkspaceSubscriptionTransaction{}).
+				Where(
+					"region_domain = ? AND workspace IN ? AND status = ? AND operator IN (?, ?) AND updated_at <= ?",
+					regionDomain,
+					workspaces,
+					types.SubscriptionTransactionStatusCompleted,
+					types.SubscriptionTransactionTypeCanceled,
+					types.SubscriptionTransactionTypeDeleted,
+					effectiveTime,
+				).
+				Find(&terminalTransactions).Error; err != nil {
+				return fmt.Errorf(
+					"query billing-period terminal subscription transactions: %w",
+					err,
+				)
+			}
+			return nil
+		},
+		&sql.TxOptions{Isolation: sql.LevelSerializable, ReadOnly: true},
+	); err != nil {
+		return fmt.Errorf("query consistent billing-period subscriptions: %w", err)
 	}
 	transactions := make(
 		[]types.WorkspaceSubscriptionTransaction,
@@ -328,6 +393,11 @@ func (r *BillingReconciler) loadSubscriptionWorkspacesAt(
 		return fmt.Errorf("resolve billing-period workspace subscriptions: %w", err)
 	}
 	SubscriptionWorkspaceMap.Set(workspaces...)
+	r.Info(
+		"load billing-period subscriptions",
+		"count", len(workspaces),
+		"duration", time.Since(startedAt),
+	)
 	return nil
 }
 
@@ -466,36 +536,53 @@ func (r *BillingReconciler) reconcileOwnerList(
 	for owner := range ownerListMap {
 		ownerList = append(ownerList, owner)
 	}
-	existingStartedAt := time.Now()
-	existingBillings, err := r.DBClient.GetOwnerBillingsAt(ownerList, endHourTime)
-	if err != nil {
-		return fmt.Errorf("get existing owner billings failed: %w", err)
-	}
-	r.Info(
-		"get existing owner billings",
-		"owner count", len(existingBillings),
-		"duration", time.Since(existingStartedAt),
-	)
-
-	for _, owner := range DebtUserMap.GetAllKey() {
-		delete(ownerListMap, owner)
+	generationOwners := make(map[string][]string, len(ownerListMap))
+	for owner, namespaces := range ownerListMap {
+		if r.ownerInDebt(owner) {
+			continue
+		}
+		generationOwners[owner] = namespaces
 	}
 
-	generateStartedAt := time.Now()
-	ownerBillings, err := r.DBClient.GenerateBillingData(
-		startHourTime,
-		endHourTime,
-		r.Properties,
-		ownerListMap,
-	)
-	if err != nil {
-		return fmt.Errorf("generate billing data failed: %w", err)
+	var existingBillings map[string][]*resources.Billing
+	var ownerBillings map[string][]*resources.Billing
+	if err := runBillingReads(
+		func() error {
+			startedAt := time.Now()
+			var err error
+			existingBillings, err = r.DBClient.GetOwnerBillingsAt(ownerList, endHourTime)
+			if err != nil {
+				return fmt.Errorf("get existing owner billings: %w", err)
+			}
+			r.Info(
+				"get existing owner billings",
+				"owner count", len(existingBillings),
+				"duration", time.Since(startedAt),
+			)
+			return nil
+		},
+		func() error {
+			startedAt := time.Now()
+			var err error
+			ownerBillings, err = r.DBClient.GenerateBillingData(
+				startHourTime,
+				endHourTime,
+				r.Properties,
+				generationOwners,
+			)
+			if err != nil {
+				return fmt.Errorf("generate billing data: %w", err)
+			}
+			r.Info(
+				"generate billing data",
+				"count", len(ownerBillings),
+				"duration", time.Since(startedAt),
+			)
+			return nil
+		},
+	); err != nil {
+		return err
 	}
-	r.Info(
-		"generate billing data",
-		"count", len(ownerBillings),
-		"duration", time.Since(generateStartedAt),
-	)
 	classifyGeneratedBillings(ownerBillings)
 	ownerBillings = pendingOwnerBillings(ownerBillings, existingBillings)
 
@@ -678,13 +765,13 @@ func (r *BillingReconciler) reconcileOwnerListBatch(
 
 func (r *BillingReconciler) getRecentUsedOwnersAt(
 	endHourTime time.Time,
-) (map[string][]string, error) {
+) (map[string][]string, map[string]uuid.UUID, error) {
 	endHourTime = endHourTime.UTC().Truncate(time.Hour)
 	startHourTime := endHourTime.Add(-1 * time.Hour)
 	monitorStartedAt := time.Now()
 	namespaceList, err := r.DBClient.GetTimeUsedNamespaceList(startHourTime, endHourTime)
 	if err != nil {
-		return nil, fmt.Errorf("get recent owners failed: %w", err)
+		return nil, nil, fmt.Errorf("get recent owners failed: %w", err)
 	}
 	r.Info(
 		"get monitored namespaces",
@@ -701,7 +788,7 @@ func (r *BillingReconciler) getRecentUsedOwnersAt(
 	lookupStartedAt := time.Now()
 	nsToOwnerMap, err := r.getUsersForNamespaces(namespaceList)
 	if err != nil {
-		return nil, fmt.Errorf("get users for monitored namespaces failed: %w", err)
+		return nil, nil, fmt.Errorf("get users for monitored namespaces failed: %w", err)
 	}
 	r.Info(
 		"get owner and namespace",
@@ -713,6 +800,7 @@ func (r *BillingReconciler) getRecentUsedOwnersAt(
 		time.Since(lookupStartedAt),
 	)
 	usedOwnerList := make(map[string][]string)
+	ownerUserUIDs := make(map[string]uuid.UUID)
 	for _, ns := range namespaceList {
 		if owner, ok := nsToOwnerMap[ns]; ok {
 			if _, ok := usedOwnerList[owner]; !ok {
@@ -720,24 +808,43 @@ func (r *BillingReconciler) getRecentUsedOwnersAt(
 					&types.UserQueryOpts{Owner: owner, IgnoreEmpty: true},
 				)
 				if err != nil {
-					return nil, fmt.Errorf("get user uid failed: %w", err)
+					return nil, nil, fmt.Errorf("get user uid failed: %w", err)
 				}
 				if userUID == uuid.Nil {
 					r.Error(errors.New("user uid is nil"), "get user uid failed", "owner", owner)
 					continue
 				}
-				_, inDebt := DebtUserMap.Get(userUID.String())
-				if inDebt {
-					// r.Logger.Info("user is in debt", "user uid", userUID.String())
-					continue
-				}
+				ownerUserUIDs[owner] = userUID
 				usedOwnerList[owner] = []string{}
 			}
 			usedOwnerList[owner] = append(usedOwnerList[owner], ns)
 		}
 	}
 	r.Info("get monitored users", "count", len(usedOwnerList))
-	return usedOwnerList, nil
+	return usedOwnerList, ownerUserUIDs, nil
+}
+
+func (r *BillingReconciler) removeDebtOwners(
+	ownerListMap map[string][]string,
+	ownerUserUIDs map[string]uuid.UUID,
+) {
+	for owner, userUID := range ownerUserUIDs {
+		if _, inDebt := DebtUserMap.Get(userUID.String()); inDebt {
+			delete(ownerListMap, owner)
+			r.debtOwnerMap.Set(owner)
+		}
+	}
+}
+
+func (r *BillingReconciler) ownerInDebt(owner string) bool {
+	if _, inDebt := DebtUserMap.Get(owner); inDebt {
+		return true
+	}
+	if r.debtOwnerMap != nil {
+		_, inDebt := r.debtOwnerMap.Get(owner)
+		return inDebt
+	}
+	return false
 }
 
 func (r *BillingReconciler) getUsersForNamespaces(namespaces []string) (map[string]string, error) {

--- a/controllers/account/controllers/billing_controller.go
+++ b/controllers/account/controllers/billing_controller.go
@@ -33,10 +33,8 @@ import (
 	"github.com/labring/sealos/controllers/pkg/utils/env"
 	"github.com/labring/sealos/controllers/pkg/utils/maps"
 	userv1 "github.com/labring/sealos/controllers/user/api/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -44,6 +42,13 @@ import (
 type BillingTaskRunner struct {
 	*BillingReconciler
 }
+
+func (r *BillingTaskRunner) NeedLeaderElection() bool { return true }
+
+const (
+	billingMonitorDelay = 5 * time.Minute
+	billingRetryDelay   = time.Minute
+)
 
 var (
 	DebtUserMap              *maps.ConcurrentNullValueMap
@@ -56,34 +61,53 @@ func (r *BillingTaskRunner) Start(ctx context.Context) error {
 	}()
 
 	for {
-		select {
-		case <-ctx.Done():
+		if err := ctx.Err(); err != nil {
 			return nil
-		default:
-			now := time.Now()
-			minutesLeft := 60 - now.Minute()
-
-			// Execute if 30 or more minutes remain, else wait for next hour
-			if minutesLeft >= 30 {
-				if err := r.ExecuteBillingTask(); err != nil {
-					r.Error(err, "failed to execute billing task")
-				}
-			}
-
-			// Calculate sleep duration to next hour + 5 minutes
-			nextHour := now.Truncate(time.Hour).Add(time.Hour).Add(5 * time.Minute)
-			sleepDuration := nextHour.Sub(now)
-
-			r.Info("next billing reconcile time", "time", nextHour.Format(time.RFC3339))
-
-			// Sleep until next scheduled time or context cancellation
-			select {
-			case <-time.After(sleepDuration):
-				continue
-			case <-ctx.Done():
+		}
+		target := latestReadyBillingHour(time.Now())
+		if err := r.ExecuteBillingTasksUntil(target); err != nil {
+			r.Error(err, "failed to execute billing tasks", "target", target)
+			if !waitForBillingRun(ctx, billingRetryDelay) {
 				return nil
 			}
+			continue
 		}
+
+		// A long catch-up may make another hour ready while the task is running.
+		if latestReadyBillingHour(time.Now()).After(target) {
+			continue
+		}
+		nextRun := target.Add(time.Hour).Add(billingMonitorDelay)
+		r.Info("next billing reconcile time", "time", nextRun.Format(time.RFC3339))
+		if !waitForBillingRun(ctx, time.Until(nextRun)) {
+			return nil
+		}
+	}
+}
+
+func latestReadyBillingHour(now time.Time) time.Time {
+	return now.Add(-billingMonitorDelay).Truncate(time.Hour).UTC()
+}
+
+func billingHoursAfter(checkpoint, target time.Time) []time.Time {
+	var hours []time.Time
+	for hour := checkpoint.UTC().Truncate(time.Hour).Add(time.Hour); !hour.After(target); hour = hour.Add(time.Hour) {
+		hours = append(hours, hour)
+	}
+	return hours
+}
+
+func waitForBillingRun(ctx context.Context, delay time.Duration) bool {
+	if delay < 0 {
+		delay = 0
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
 	}
 }
 
@@ -99,82 +123,365 @@ type BillingReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 	logr.Logger
-	DBClient             database.Account
-	AccountV2            database.AccountV2
-	Properties           *resources.PropertyTypeLS
-	reconcileBillingFunc func(owner string, billings []*resources.Billing) error
-	concurrentLimit      int64
-	DebtUserMap          *maps.ConcurrentMap
+	DBClient               database.Account
+	AccountV2              database.AccountV2
+	Properties             *resources.PropertyTypeLS
+	reconcileBillingFunc   func(owner string, billings []*resources.Billing) error
+	executeBillingHourFunc func(time.Time) error
+	concurrentLimit        int64
+	DebtUserMap            *maps.ConcurrentMap
 }
 
 func (r *BillingReconciler) ExecuteBillingTask() error {
-	r.Info("start billing reconcile", "time", time.Now().Format(time.RFC3339))
+	return r.ExecuteBillingTasksUntil(latestReadyBillingHour(time.Now()))
+}
+
+func (r *BillingReconciler) ExecuteBillingTasksUntil(target time.Time) error {
+	target = target.UTC().Truncate(time.Hour)
+	checkpoint, exists, err := r.DBClient.GetBillingCheckpoint()
+	if err != nil {
+		return fmt.Errorf("get billing checkpoint: %w", err)
+	}
+	if !exists {
+		checkpoint = target.Add(-time.Hour)
+	}
+	for _, billingTime := range billingHoursAfter(checkpoint, target) {
+		execute := r.ExecuteBillingTaskAt
+		if r.executeBillingHourFunc != nil {
+			execute = r.executeBillingHourFunc
+		}
+		if err := execute(billingTime); err != nil {
+			return fmt.Errorf(
+				"reconcile billing hour %s: %w",
+				billingTime.Format(time.RFC3339),
+				err,
+			)
+		}
+		if err := r.DBClient.SaveBillingCheckpoint(billingTime); err != nil {
+			return fmt.Errorf(
+				"save billing checkpoint for %s: %w",
+				billingTime.Format(time.RFC3339),
+				err,
+			)
+		}
+	}
+	return nil
+}
+
+func (r *BillingReconciler) ExecuteBillingTaskAt(endHourTime time.Time) error {
+	endHourTime = endHourTime.UTC().Truncate(time.Hour)
+	taskStartedAt := time.Now()
+	r.Info("start billing reconcile", "billingTime", endHourTime.Format(time.RFC3339))
 	DebtUserMap = maps.NewConcurrentNullValueMap()
 	SubscriptionWorkspaceMap = maps.NewConcurrentNullValueMap()
-	var users []string
-	if err := r.AccountV2.GetGlobalDB().
-		Model(&types.Debt{}).
-		Where("account_debt_status IN (?, ?, ?) ", types.DebtPeriod, types.DebtDeletionPeriod, types.FinalDeletionPeriod).
-		Distinct("user_uid").
-		Pluck("user_uid", &users).
-		Error; err != nil {
-		return fmt.Errorf("failed to query unique users: %w", err)
+	if err := r.loadDebtUsersAt(endHourTime); err != nil {
+		return err
 	}
-	DebtUserMap.Set(users...)
-	var subscriptionWorkspaces []string
-	if err := r.AccountV2.GetGlobalDB().
-		Model(&types.WorkspaceSubscription{}).
-		Where("region_domain = ?", r.AccountV2.GetLocalRegion().Domain).
-		Pluck("workspace", &subscriptionWorkspaces).
-		Error; err != nil {
-		return fmt.Errorf("failed to query workspace subscriptions: %w", err)
-	}
-	SubscriptionWorkspaceMap.Set(subscriptionWorkspaces...)
-	ownerListMap, err := r.getRecentUsedOwners()
+	ownerListMap, err := r.getRecentUsedOwnersAt(endHourTime)
 	if err != nil {
 		return fmt.Errorf("failed to get the owner list of the recently used resource: %w", err)
+	}
+	unsettledBillings, err := r.DBClient.GetUnsettledBillingsAt(endHourTime)
+	if err != nil {
+		return fmt.Errorf("failed to get unsettled billings: %w", err)
+	}
+	addUnsettledBillingOwners(ownerListMap, unsettledBillings)
+	if err := r.loadSubscriptionWorkspacesAt(endHourTime, ownerListMap); err != nil {
+		return err
+	}
+	if len(ownerListMap) == 0 {
+		r.Info(
+			"billing hour has no monitor-backed owners",
+			"billingTime",
+			endHourTime.Format(time.RFC3339),
+		)
 	}
 	err = r.reconcileOwnerListBatch(
 		ownerListMap,
 		env.GetIntEnvWithDefault("BILLING_RECONCILE_BATCH_COUNT", 200),
-		time.Now(),
+		endHourTime,
 		r.reconcileOwnerList,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to reconcile owner list batch: %w", err)
 	}
-	r.Info("finish billing reconcile", "time", time.Now().Format(time.RFC3339))
+	r.Info(
+		"finish billing reconcile",
+		"billingTime", endHourTime.Format(time.RFC3339),
+		"duration", time.Since(taskStartedAt),
+	)
 	return nil
+}
+
+func (r *BillingReconciler) loadDebtUsersAt(endHourTime time.Time) error {
+	effectiveTime := endHourTime.Add(-time.Nanosecond)
+	db := r.AccountV2.GetGlobalDB()
+	var debts []types.Debt
+	if err := db.Model(&types.Debt{}).
+		Where("created_at <= ?", effectiveTime).
+		Find(&debts).Error; err != nil {
+		return fmt.Errorf("query billing-period debts: %w", err)
+	}
+
+	var recordsAfter []types.DebtStatusRecord
+	if err := db.Model(&types.DebtStatusRecord{}).
+		Where("create_at > ?", effectiveTime).
+		Order("create_at ASC").
+		Find(&recordsAfter).Error; err != nil {
+		return fmt.Errorf("query debt status after billing period: %w", err)
+	}
+
+	afterByUser := make(map[uuid.UUID]types.DebtStatusRecord, len(recordsAfter))
+	for _, record := range recordsAfter {
+		if _, exists := afterByUser[record.UserUID]; !exists {
+			afterByUser[record.UserUID] = record
+		}
+	}
+	var users []string
+	for i := range debts {
+		status := debtStatusAt(debts[i], afterByUser[debts[i].UserUID])
+		if types.ContainDebtStatus(types.DebtStates, status) {
+			users = append(users, debts[i].UserUID.String())
+		}
+	}
+	DebtUserMap.Set(users...)
+	return nil
+}
+
+func debtStatusAt(debt types.Debt, recordAfter types.DebtStatusRecord) types.DebtStatusType {
+	if recordAfter.UserUID != uuid.Nil {
+		return recordAfter.LastStatus
+	}
+	return debt.AccountDebtStatus
+}
+
+func (r *BillingReconciler) loadSubscriptionWorkspacesAt(
+	endHourTime time.Time,
+	ownerListMap map[string][]string,
+) error {
+	effectiveTime := endHourTime.Add(-time.Nanosecond)
+	db := r.AccountV2.GetGlobalDB()
+	regionDomain := r.AccountV2.GetLocalRegion().Domain
+	workspaceSet := make(map[string]struct{})
+	for _, workspaces := range ownerListMap {
+		for _, workspace := range workspaces {
+			workspaceSet[workspace] = struct{}{}
+		}
+	}
+	workspaces := make([]string, 0, len(workspaceSet))
+	for workspace := range workspaceSet {
+		workspaces = append(workspaces, workspace)
+	}
+	if len(workspaces) == 0 {
+		return nil
+	}
+
+	var subscriptions []types.WorkspaceSubscription
+	if err := db.Model(&types.WorkspaceSubscription{}).
+		Where(
+			"region_domain = ? AND workspace IN ? AND create_at <= ?",
+			regionDomain,
+			workspaces,
+			effectiveTime,
+		).
+		Find(&subscriptions).Error; err != nil {
+		return fmt.Errorf("query billing-period workspace subscriptions: %w", err)
+	}
+	var periodTransactions []types.WorkspaceSubscriptionTransaction
+	if err := db.Model(&types.WorkspaceSubscriptionTransaction{}).
+		Where(
+			"region_domain = ? AND workspace IN ? AND status = ? AND pay_status IN (?, ?) AND updated_at <= ?",
+			regionDomain,
+			workspaces,
+			types.SubscriptionTransactionStatusCompleted,
+			types.SubscriptionPayStatusPaid,
+			types.SubscriptionPayStatusNoNeed,
+			effectiveTime,
+		).
+		Find(&periodTransactions).Error; err != nil {
+		return fmt.Errorf("query billing-period workspace subscription transactions: %w", err)
+	}
+	var terminalTransactions []types.WorkspaceSubscriptionTransaction
+	if err := db.Model(&types.WorkspaceSubscriptionTransaction{}).
+		Where(
+			"region_domain = ? AND workspace IN ? AND status = ? AND operator IN (?, ?) AND updated_at <= ?",
+			regionDomain,
+			workspaces,
+			types.SubscriptionTransactionStatusCompleted,
+			types.SubscriptionTransactionTypeCanceled,
+			types.SubscriptionTransactionTypeDeleted,
+			effectiveTime,
+		).
+		Find(&terminalTransactions).Error; err != nil {
+		return fmt.Errorf("query billing-period terminal subscription transactions: %w", err)
+	}
+	transactions := make(
+		[]types.WorkspaceSubscriptionTransaction,
+		0,
+		len(periodTransactions)+len(terminalTransactions),
+	)
+	transactions = append(transactions, periodTransactions...)
+	transactions = append(transactions, terminalTransactions...)
+
+	workspaces, err := activeWorkspaceSubscriptionsAt(effectiveTime, subscriptions, transactions)
+	if err != nil {
+		return fmt.Errorf("resolve billing-period workspace subscriptions: %w", err)
+	}
+	SubscriptionWorkspaceMap.Set(workspaces...)
+	return nil
+}
+
+func activeWorkspaceSubscriptionsAt(
+	effectiveTime time.Time,
+	subscriptions []types.WorkspaceSubscription,
+	transactions []types.WorkspaceSubscriptionTransaction,
+) ([]string, error) {
+	active := make(map[string]struct{})
+	terminalAt := make(map[string]time.Time)
+	for i := range transactions {
+		if !isWorkspaceSubscriptionTerminalTransaction(transactions[i], effectiveTime) {
+			continue
+		}
+		previous, exists := terminalAt[transactions[i].Workspace]
+		if !exists || transactions[i].UpdatedAt.After(previous) {
+			terminalAt[transactions[i].Workspace] = transactions[i].UpdatedAt
+		}
+	}
+	for i := range subscriptions {
+		terminatedAt, terminated := terminalAt[subscriptions[i].Workspace]
+		if workspaceSubscriptionCovers(subscriptions[i], effectiveTime) &&
+			(!terminated || subscriptions[i].UpdateAt.After(terminatedAt)) {
+			active[subscriptions[i].Workspace] = struct{}{}
+		}
+	}
+	for i := range transactions {
+		covers, err := workspaceSubscriptionTransactionCovers(transactions[i], effectiveTime)
+		if err != nil {
+			return nil, err
+		}
+		if !covers {
+			continue
+		}
+		terminatedAt, terminated := terminalAt[transactions[i].Workspace]
+		if !terminated || transactions[i].UpdatedAt.After(terminatedAt) {
+			active[transactions[i].Workspace] = struct{}{}
+		}
+	}
+	workspaces := make([]string, 0, len(active))
+	for workspace := range active {
+		workspaces = append(workspaces, workspace)
+	}
+	return workspaces, nil
+}
+
+func isWorkspaceSubscriptionTerminalTransaction(
+	transaction types.WorkspaceSubscriptionTransaction,
+	effectiveTime time.Time,
+) bool {
+	if transaction.Status != types.SubscriptionTransactionStatusCompleted ||
+		transaction.UpdatedAt.After(effectiveTime) {
+		return false
+	}
+	switch transaction.Operator {
+	case types.SubscriptionTransactionTypeCanceled,
+		types.SubscriptionTransactionTypeDeleted:
+		return true
+	default:
+		return false
+	}
+}
+
+func workspaceSubscriptionCovers(
+	subscription types.WorkspaceSubscription,
+	effectiveTime time.Time,
+) bool {
+	if subscription.CreateAt.After(effectiveTime) || subscription.UpdateAt.After(effectiveTime) {
+		return false
+	}
+	endAt := subscription.CurrentPeriodEndAt
+	if subscription.ExpireAt != nil && subscription.ExpireAt.Before(endAt) {
+		endAt = *subscription.ExpireAt
+	}
+	if !subscription.CancelAtPeriodEnd && !subscription.CancelAt.IsZero() &&
+		subscription.CancelAt.Before(endAt) {
+		endAt = subscription.CancelAt
+	}
+	return !subscription.CurrentPeriodStartAt.After(effectiveTime) && endAt.After(effectiveTime)
+}
+
+func workspaceSubscriptionTransactionCovers(
+	transaction types.WorkspaceSubscriptionTransaction,
+	effectiveTime time.Time,
+) (bool, error) {
+	if transaction.Status != types.SubscriptionTransactionStatusCompleted ||
+		(transaction.PayStatus != types.SubscriptionPayStatusPaid &&
+			transaction.PayStatus != types.SubscriptionPayStatusNoNeed) ||
+		transaction.UpdatedAt.After(effectiveTime) {
+		return false, nil
+	}
+	switch transaction.Operator {
+	case types.SubscriptionTransactionTypeCreated,
+		types.SubscriptionTransactionTypeUpgraded,
+		types.SubscriptionTransactionTypeDowngraded,
+		types.SubscriptionTransactionTypeRenewed:
+	default:
+		return false, nil
+	}
+	period, err := types.ParsePeriod(transaction.Period)
+	if err != nil {
+		return false, fmt.Errorf(
+			"parse subscription transaction %s period: %w", transaction.ID, err,
+		)
+	}
+	return !transaction.UpdatedAt.After(effectiveTime) &&
+		transaction.UpdatedAt.Add(period).After(effectiveTime), nil
+}
+
+func addUnsettledBillingOwners(
+	ownerListMap map[string][]string,
+	unsettled map[string][]*resources.Billing,
+) {
+	for owner, billings := range unsettled {
+		namespaces := make(map[string]struct{}, len(ownerListMap[owner]))
+		for _, namespace := range ownerListMap[owner] {
+			namespaces[namespace] = struct{}{}
+		}
+		for _, billing := range billings {
+			if _, exists := namespaces[billing.Namespace]; exists {
+				continue
+			}
+			ownerListMap[owner] = append(ownerListMap[owner], billing.Namespace)
+			namespaces[billing.Namespace] = struct{}{}
+		}
+	}
 }
 
 func (r *BillingReconciler) reconcileOwnerList(
 	ownerListMap map[string][]string,
 	now time.Time,
 ) error {
-	endHourTime := time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), 0, 0, 0, time.Local).
-		UTC()
+	endHourTime := now.UTC().Truncate(time.Hour)
 	startHourTime := endHourTime.Add(-1 * time.Hour)
 	ownerList := make([]string, 0, len(ownerListMap))
 	for owner := range ownerListMap {
 		ownerList = append(ownerList, owner)
 	}
-	ownersRecentUpdates, err := r.DBClient.GetOwnersRecentUpdates(ownerList, endHourTime)
+	existingStartedAt := time.Now()
+	existingBillings, err := r.DBClient.GetOwnerBillingsAt(ownerList, endHourTime)
 	if err != nil {
-		return fmt.Errorf("get owners without recent updates failed: %w", err)
-	}
-
-	// remove the owner that does not need to be updated; final State The user deletes the service at any time and does not perform billing processing
-	for _, owner := range append(ownersRecentUpdates, DebtUserMap.GetAllKey()...) {
-		delete(ownerListMap, owner)
+		return fmt.Errorf("get existing owner billings failed: %w", err)
 	}
 	r.Info(
-		"get owners recent updates",
-		"already update owner count",
-		len(ownersRecentUpdates),
-		"remaining owner count",
-		len(ownerListMap),
+		"get existing owner billings",
+		"owner count", len(existingBillings),
+		"duration", time.Since(existingStartedAt),
 	)
 
+	for _, owner := range DebtUserMap.GetAllKey() {
+		delete(ownerListMap, owner)
+	}
+
+	generateStartedAt := time.Now()
 	ownerBillings, err := r.DBClient.GenerateBillingData(
 		startHourTime,
 		endHourTime,
@@ -184,7 +491,13 @@ func (r *BillingReconciler) reconcileOwnerList(
 	if err != nil {
 		return fmt.Errorf("generate billing data failed: %w", err)
 	}
-	r.Info("generate billing data", "count", len(ownerBillings))
+	r.Info(
+		"generate billing data",
+		"count", len(ownerBillings),
+		"duration", time.Since(generateStartedAt),
+	)
+	classifyGeneratedBillings(ownerBillings)
+	ownerBillings = pendingOwnerBillings(ownerBillings, existingBillings)
 
 	type result struct {
 		owner string
@@ -227,39 +540,75 @@ func (r *BillingReconciler) reconcileOwnerList(
 		}
 	}
 	if len(failedList) > 0 {
-		r.Error(
-			fmt.Errorf("failed to reconcile owner list: %v", failedList),
-			"failed to reconcile owner list",
-		)
+		return fmt.Errorf("failed to reconcile owners: %s", strings.Join(failedList, ","))
 	}
 	return nil
 }
 
-func (r *BillingReconciler) reconcileBilling(owner string, billings []*resources.Billing) error {
-	amount := int64(0)
-	orderIDs := make([]string, 0, len(billings))
-	for _, billing := range billings {
-		// TODO skip the billing of the subscription workspace: if billing.namespace is the subscription space, billing.Status= subscription, && skip amount ++
-		// Only the traffic charges for the subscription space are processed, and no billing is required. The traffic charges are handled separately within the subscription
-		if _, ok := SubscriptionWorkspaceMap.Get(billing.Namespace); ok {
-			billing.Status = resources.Subscription
-			continue
+func billingBusinessKey(billing *resources.Billing) string {
+	return fmt.Sprintf("%s\x00%d\x00%s", billing.Namespace, billing.AppType, billing.AppName)
+}
+
+func classifyGeneratedBillings(ownerBillings map[string][]*resources.Billing) {
+	for _, billings := range ownerBillings {
+		for _, billing := range billings {
+			billing.Status = resources.Unsettled
+			if _, ok := SubscriptionWorkspaceMap.Get(billing.Namespace); ok {
+				billing.Status = resources.Subscription
+			}
 		}
-		amount += billing.Amount
-		orderIDs = append(orderIDs, billing.OrderID)
 	}
+}
+
+func pendingOwnerBillings(
+	generated, existing map[string][]*resources.Billing,
+) map[string][]*resources.Billing {
+	pending := make(map[string][]*resources.Billing)
+	for owner, billings := range existing {
+		for _, billing := range billings {
+			if billing.Status == resources.Unsettled &&
+				strings.HasPrefix(billing.OrderID, "bh_") {
+				pending[owner] = append(pending[owner], billing)
+			}
+		}
+	}
+	for owner, billings := range generated {
+		existingByKey := make(map[string]*resources.Billing, len(existing[owner]))
+		for _, billing := range existing[owner] {
+			existingByKey[billingBusinessKey(billing)] = billing
+		}
+		for _, billing := range billings {
+			if _, ok := existingByKey[billingBusinessKey(billing)]; ok {
+				continue
+			}
+			pending[owner] = append(pending[owner], billing)
+		}
+	}
+	return pending
+}
+
+func (r *BillingReconciler) reconcileBilling(owner string, billings []*resources.Billing) error {
 	if err := r.DBClient.SaveBillings(billings...); err != nil {
 		return fmt.Errorf("save billings failed: %w", err)
 	}
-	if err := r.rechargeBalance(owner, amount); err != nil {
-		r.Error(err, "recharge balance failed", "owner", owner, "amount", amount)
-		if updateErr := r.DBClient.UpdateBillingStatus(
-			orderIDs,
-			resources.Unsettled,
-		); updateErr != nil {
-			r.Error(updateErr, "update billing unsettled status failed", "orderIDs", orderIDs)
+	for _, billing := range billings {
+		if billing.Status == resources.Subscription {
+			if err := r.DBClient.UpdateBillingStatus(
+				[]string{billing.OrderID}, resources.Subscription,
+			); err != nil {
+				return fmt.Errorf("mark billing %s subscription: %w", billing.OrderID, err)
+			}
+			continue
 		}
-		return fmt.Errorf("recharge balance failed: %w", err)
+		orderIDs := []string{billing.OrderID}
+		if err := r.AccountV2.AddDeductionBalanceForBilling(
+			&types.UserQueryOpts{Owner: owner}, billing.Amount, orderIDs,
+		); err != nil {
+			return fmt.Errorf("deduct billing %s balance: %w", billing.OrderID, err)
+		}
+		if err := r.DBClient.UpdateBillingStatus(orderIDs, resources.Settled); err != nil {
+			return fmt.Errorf("mark billing %s settled: %w", billing.OrderID, err)
+		}
 	}
 	return nil
 }
@@ -268,40 +617,27 @@ func (r *BillingReconciler) reconcileBillingWithCredits(
 	owner string,
 	billings []*resources.Billing,
 ) error {
-	amount := int64(0)
-	orderIDs := make([]string, 0, len(billings))
-	for _, billing := range billings {
-		amount += billing.Amount
-		orderIDs = append(orderIDs, billing.OrderID)
-	}
-	if amount <= 0 {
-		return nil
-	}
 	if err := r.DBClient.SaveBillings(billings...); err != nil {
 		return fmt.Errorf("save billings failed: %w", err)
 	}
-	if err := r.AccountV2.AddDeductionBalanceWithCredits(
-		&types.UserQueryOpts{Owner: owner},
-		amount,
-		orderIDs,
-	); err != nil {
-		r.Error(err, "AddDeductionBalanceWithCredits failed", "owner", owner, "amount", amount)
-		if updateErr := r.DBClient.UpdateBillingStatus(
-			orderIDs,
-			resources.Unsettled,
-		); updateErr != nil {
-			r.Error(
-				updateErr,
-				"update billing unsettled status failed",
-				"owner",
-				owner,
-				"amount",
-				amount,
-				"orderIDs",
-				orderIDs,
-			)
+	for _, billing := range billings {
+		if billing.Status == resources.Subscription {
+			if err := r.DBClient.UpdateBillingStatus(
+				[]string{billing.OrderID}, resources.Subscription,
+			); err != nil {
+				return fmt.Errorf("mark billing %s subscription: %w", billing.OrderID, err)
+			}
+			continue
 		}
-		return fmt.Errorf("recharge balance failed: %w", err)
+		orderIDs := []string{billing.OrderID}
+		if err := r.AccountV2.AddDeductionBalanceWithCredits(
+			&types.UserQueryOpts{Owner: owner}, billing.Amount, orderIDs,
+		); err != nil {
+			return fmt.Errorf("deduct billing %s with credits: %w", billing.OrderID, err)
+		}
+		if err := r.DBClient.UpdateBillingStatus(orderIDs, resources.Settled); err != nil {
+			return fmt.Errorf("mark billing %s settled: %w", billing.OrderID, err)
+		}
 	}
 	return nil
 }
@@ -340,38 +676,41 @@ func (r *BillingReconciler) reconcileOwnerListBatch(
 	return nil
 }
 
-func (r *BillingReconciler) rechargeBalance(owner string, amount int64) (err error) {
-	if amount == 0 {
-		return nil
-	}
-	if err := r.AccountV2.AddDeductionBalance(
-		&types.UserQueryOpts{Owner: owner},
-		amount,
-	); err != nil {
-		return fmt.Errorf("add balance failed: %w", err)
-	}
-	return nil
-}
-
-func (r *BillingReconciler) getRecentUsedOwners() (map[string][]string, error) {
-	now := time.Now()
-	endHourTime := time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), 0, 0, 0, time.Local).
-		UTC()
+func (r *BillingReconciler) getRecentUsedOwnersAt(
+	endHourTime time.Time,
+) (map[string][]string, error) {
+	endHourTime = endHourTime.UTC().Truncate(time.Hour)
 	startHourTime := endHourTime.Add(-1 * time.Hour)
+	monitorStartedAt := time.Now()
 	namespaceList, err := r.DBClient.GetTimeUsedNamespaceList(startHourTime, endHourTime)
 	if err != nil {
 		return nil, fmt.Errorf("get recent owners failed: %w", err)
 	}
-	nsToOwnerMap, err := GetAllUser()
+	r.Info(
+		"get monitored namespaces",
+		"namespace count", len(namespaceList),
+		"duration", time.Since(monitorStartedAt),
+	)
+	if len(namespaceList) == 0 {
+		r.Info(
+			"billing source monitor window is empty",
+			"billingTime",
+			endHourTime.Format(time.RFC3339),
+		)
+	}
+	lookupStartedAt := time.Now()
+	nsToOwnerMap, err := r.getUsersForNamespaces(namespaceList)
 	if err != nil {
-		return nil, fmt.Errorf("get all user failed: %w", err)
+		return nil, fmt.Errorf("get users for monitored namespaces failed: %w", err)
 	}
 	r.Info(
 		"get owner and namespace",
-		"owner count",
+		"matched user count",
 		len(nsToOwnerMap),
 		"namespace count",
 		len(namespaceList),
+		"duration",
+		time.Since(lookupStartedAt),
 	)
 	usedOwnerList := make(map[string][]string)
 	for _, ns := range namespaceList {
@@ -397,8 +736,32 @@ func (r *BillingReconciler) getRecentUsedOwners() (map[string][]string, error) {
 			usedOwnerList[owner] = append(usedOwnerList[owner], ns)
 		}
 	}
-	r.Info("get all user", "count", len(usedOwnerList))
+	r.Info("get monitored users", "count", len(usedOwnerList))
 	return usedOwnerList, nil
+}
+
+func (r *BillingReconciler) getUsersForNamespaces(namespaces []string) (map[string]string, error) {
+	nsToOwnerMap := make(map[string]string, len(namespaces))
+	for _, namespace := range namespaces {
+		if !strings.HasPrefix(namespace, UserNamespacePrefix) {
+			continue
+		}
+		user := &userv1.User{}
+		if err := r.Get(
+			context.Background(),
+			client.ObjectKey{Name: strings.TrimPrefix(namespace, UserNamespacePrefix)},
+			user,
+		); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return nil, fmt.Errorf("get user for namespace %s: %w", namespace, err)
+		}
+		if owner := user.Annotations[userv1.UserLabelOwnerKey]; owner != "" {
+			nsToOwnerMap[namespace] = owner
+		}
+	}
+	return nsToOwnerMap, nil
 }
 
 func getUsername(namespace string) string {
@@ -417,53 +780,4 @@ func (r *BillingReconciler) Init() error {
 		r.reconcileBillingFunc = r.reconcileBillingWithCredits
 	}
 	return nil
-}
-
-// map[namespace]owner
-func GetAllUser() (map[string]string, error) {
-	err := userv1.AddToScheme(scheme.Scheme)
-	if err != nil {
-		return nil, fmt.Errorf("unable to add scheme: %w", err)
-	}
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, fmt.Errorf("unable to build config: %w", err)
-	}
-	// TODO from cluster config
-	// config, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
-	// if err != nil {
-	//	return nil, fmt.Errorf("unable to build config: %v", err)
-	//}
-	k8sClt, err := client.New(config, client.Options{Scheme: scheme.Scheme})
-	if err != nil {
-		return nil, fmt.Errorf("unable to create client: %w", err)
-	}
-	nsToOwnerMap := make(map[string]string)
-
-	listOpts := &client.ListOptions{
-		Limit: 5000,
-	}
-	for {
-		userMetaList := &metav1.PartialObjectMetadataList{}
-		userMetaList.SetGroupVersionKind(userv1.GroupVersion.WithKind("UserList"))
-
-		if err := k8sClt.List(context.Background(), userMetaList, listOpts); err != nil {
-			return nil, fmt.Errorf("failed to list instances: %w", err)
-		}
-
-		for _, user := range userMetaList.Items {
-			owner := user.Annotations[userv1.UserLabelOwnerKey]
-			if owner == "" {
-				continue
-			}
-			nsToOwnerMap["ns-"+user.Name] = owner
-		}
-
-		token := userMetaList.GetContinue()
-		if token == "" {
-			break
-		}
-		listOpts.Continue = token
-	}
-	return nsToOwnerMap, nil
 }

--- a/controllers/account/controllers/billing_controller.go
+++ b/controllers/account/controllers/billing_controller.go
@@ -304,43 +304,30 @@ func (r *BillingReconciler) ExecuteBillingTaskAt(endHourTime time.Time) error {
 
 func (r *BillingReconciler) loadDebtUsersAt(endHourTime time.Time) error {
 	startedAt := time.Now()
-	effectiveTime := endHourTime.Add(-time.Nanosecond)
 	db := r.AccountV2.GetGlobalDB()
 	var debts []types.Debt
-	var recordsAfter []types.DebtStatusRecord
-	// Debt and its status record are committed together, so both reads share one snapshot.
-	if err := db.Transaction(
-		func(tx *gorm.DB) error {
-			if err := tx.Model(&types.Debt{}).
-				Select("user_uid, account_debt_status").
-				Where("created_at <= ?", effectiveTime).
-				Find(&debts).Error; err != nil {
-				return fmt.Errorf("query billing-period debts: %w", err)
-			}
-			if err := tx.Model(&types.DebtStatusRecord{}).
-				Select("user_uid, last_status, create_at").
-				Where("create_at > ?", effectiveTime).
-				Order("create_at ASC").
-				Find(&recordsAfter).Error; err != nil {
-				return fmt.Errorf("query debt status after billing period: %w", err)
-			}
-			return nil
-		},
-		&sql.TxOptions{Isolation: sql.LevelSerializable, ReadOnly: true},
-	); err != nil {
+	// Probe the first transition per debt row so catch-up never materializes
+	// every status record after the billing boundary.
+	if err := db.Raw(`
+		SELECT
+			d.user_uid,
+			COALESCE(first_record.last_status, d.account_debt_status) AS account_debt_status
+		FROM "Debt" AS d
+		LEFT JOIN LATERAL (
+			SELECT r.last_status
+			FROM "DebtStatusRecord" AS r
+			WHERE r.user_uid = d.user_uid AND r.create_at >= ?
+			ORDER BY r.create_at ASC, r.id ASC
+			LIMIT 1
+		) AS first_record ON TRUE
+		WHERE d.created_at < ?`, endHourTime, endHourTime).
+		Scan(&debts).Error; err != nil {
 		return fmt.Errorf("query consistent billing-period debt state: %w", err)
 	}
 
-	afterByUser := make(map[uuid.UUID]types.DebtStatusRecord, len(recordsAfter))
-	for _, record := range recordsAfter {
-		if _, exists := afterByUser[record.UserUID]; !exists {
-			afterByUser[record.UserUID] = record
-		}
-	}
 	var users []string
 	for i := range debts {
-		status := debtStatusAt(debts[i], afterByUser[debts[i].UserUID])
-		if types.ContainDebtStatus(types.DebtStates, status) {
+		if types.ContainDebtStatus(types.DebtStates, debts[i].AccountDebtStatus) {
 			users = append(users, debts[i].UserUID.String())
 		}
 	}
@@ -351,13 +338,6 @@ func (r *BillingReconciler) loadDebtUsersAt(endHourTime time.Time) error {
 		"duration", time.Since(startedAt),
 	)
 	return nil
-}
-
-func debtStatusAt(debt types.Debt, recordAfter types.DebtStatusRecord) types.DebtStatusType {
-	if recordAfter.UserUID != uuid.Nil {
-		return recordAfter.LastStatus
-	}
-	return debt.AccountDebtStatus
 }
 
 func (r *BillingReconciler) loadSubscriptionWorkspacesAt(

--- a/controllers/account/controllers/billing_controller_runtime_test.go
+++ b/controllers/account/controllers/billing_controller_runtime_test.go
@@ -1,0 +1,160 @@
+package controllers
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	"github.com/labring/sealos/controllers/pkg/database"
+	"github.com/labring/sealos/controllers/pkg/types"
+	"github.com/labring/sealos/controllers/pkg/utils/maps"
+	"github.com/testcontainers/testcontainers-go"
+	postgrescontainer "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+type debtSnapshotAccountV2 struct {
+	database.AccountV2
+	db *gorm.DB
+}
+
+func (a *debtSnapshotAccountV2) GetGlobalDB() *gorm.DB {
+	return a.db
+}
+
+func TestLoadDebtUsersAtReadsOneConsistentSnapshot(t *testing.T) {
+	testcontainers.SkipIfProviderIsNotHealthy(t)
+	ctx := context.Background()
+	container, err := postgrescontainer.Run(ctx, "postgres:16-alpine",
+		postgrescontainer.WithDatabase("account"),
+		postgrescontainer.WithUsername("account"),
+		postgrescontainer.WithPassword("account"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
+		),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := container.Terminate(ctx); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	})
+	dsn, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&types.Debt{}, &types.DebtStatusRecord{}); err != nil {
+		t.Fatal(err)
+	}
+
+	userUID := uuid.New()
+	endHourTime := time.Now().UTC().Add(-time.Hour).Truncate(time.Hour)
+	if err := db.Create(&types.Debt{
+		UserUID:           userUID,
+		CreatedAt:         endHourTime.Add(-time.Hour),
+		UpdatedAt:         endHourTime.Add(-time.Hour),
+		AccountDebtStatus: types.NormalPeriod,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	debtRead := make(chan struct{})
+	continueRead := make(chan struct{})
+	var pauseOnce atomic.Bool
+	var transactionMu sync.Mutex
+	var debtTransaction, recordTransaction *sql.Tx
+	if err := db.Callback().Query().After("gorm:query").Register(
+		"test:capture_debt_snapshot",
+		func(tx *gorm.DB) {
+			transaction, ok := tx.Statement.ConnPool.(*sql.Tx)
+			if !ok || tx.Statement.Schema == nil {
+				return
+			}
+			transactionMu.Lock()
+			switch tx.Statement.Schema.Table {
+			case (types.Debt{}).TableName():
+				debtTransaction = transaction
+			case (types.DebtStatusRecord{}).TableName():
+				recordTransaction = transaction
+			}
+			transactionMu.Unlock()
+			if tx.Statement.Schema.Table == (types.Debt{}).TableName() &&
+				pauseOnce.CompareAndSwap(false, true) {
+				close(debtRead)
+				<-continueRead
+			}
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	DebtUserMap = maps.NewConcurrentNullValueMap()
+	reconciler := &BillingReconciler{
+		AccountV2: &debtSnapshotAccountV2{db: db},
+		Logger:    logr.Discard(),
+	}
+	result := make(chan error, 1)
+	go func() {
+		result <- reconciler.loadDebtUsersAt(endHourTime)
+	}()
+	select {
+	case <-debtRead:
+	case <-time.After(5 * time.Second):
+		close(continueRead)
+		t.Fatal("timed out waiting for the debt snapshot read")
+	}
+
+	transitionTime := time.Now().UTC()
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&types.Debt{}).
+			Where("user_uid = ?", userUID).
+			Updates(map[string]any{
+				"account_debt_status": types.DebtPeriod,
+				"updated_at":          transitionTime,
+			}).Error; err != nil {
+			return err
+		}
+		return tx.Create(&types.DebtStatusRecord{
+			ID:            uuid.New(),
+			UserUID:       userUID,
+			LastStatus:    types.NormalPeriod,
+			CurrentStatus: types.DebtPeriod,
+			CreateAt:      transitionTime,
+		}).Error
+	}); err != nil {
+		close(continueRead)
+		t.Fatal(err)
+	}
+	close(continueRead)
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the consistent debt snapshot")
+	}
+
+	transactionMu.Lock()
+	sameTransaction := debtTransaction != nil && debtTransaction == recordTransaction
+	transactionMu.Unlock()
+	if !sameTransaction {
+		t.Fatal("debt and status history were read from different transactions")
+	}
+	if _, inDebt := DebtUserMap.Get(userUID.String()); inDebt {
+		t.Fatal("the historical hour used the concurrently committed debt status")
+	}
+}

--- a/controllers/account/controllers/billing_controller_runtime_test.go
+++ b/controllers/account/controllers/billing_controller_runtime_test.go
@@ -2,9 +2,6 @@ package controllers
 
 import (
 	"context"
-	"database/sql"
-	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -29,7 +26,7 @@ func (a *debtSnapshotAccountV2) GetGlobalDB() *gorm.DB {
 	return a.db
 }
 
-func TestLoadDebtUsersAtReadsOneConsistentSnapshot(t *testing.T) {
+func TestLoadDebtUsersAtUsesFirstLaterTransition(t *testing.T) {
 	testcontainers.SkipIfProviderIsNotHealthy(t)
 	ctx := context.Background()
 	container, err := postgrescontainer.Run(ctx, "postgres:16-alpine",
@@ -60,44 +57,40 @@ func TestLoadDebtUsersAtReadsOneConsistentSnapshot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	userUID := uuid.New()
 	endHourTime := time.Now().UTC().Add(-time.Hour).Truncate(time.Hour)
-	if err := db.Create(&types.Debt{
-		UserUID:           userUID,
-		CreatedAt:         endHourTime.Add(-time.Hour),
-		UpdatedAt:         endHourTime.Add(-time.Hour),
-		AccountDebtStatus: types.NormalPeriod,
-	}).Error; err != nil {
+	historicalUserUID := uuid.New()
+	currentDebtUserUID := uuid.New()
+	createdLaterUserUID := uuid.New()
+	debts := []types.Debt{
+		{
+			UserUID: historicalUserUID, CreatedAt: endHourTime.Add(-time.Hour),
+			UpdatedAt: endHourTime.Add(20 * time.Minute), AccountDebtStatus: types.NormalPeriod,
+		},
+		{
+			UserUID: currentDebtUserUID, CreatedAt: endHourTime.Add(-time.Hour),
+			UpdatedAt: endHourTime.Add(-time.Hour), AccountDebtStatus: types.DebtPeriod,
+		},
+		{
+			UserUID: createdLaterUserUID, CreatedAt: endHourTime.Add(time.Minute),
+			UpdatedAt: endHourTime.Add(time.Minute), AccountDebtStatus: types.DebtPeriod,
+		},
+	}
+	if err := db.Create(&debts).Error; err != nil {
 		t.Fatal(err)
 	}
-
-	debtRead := make(chan struct{})
-	continueRead := make(chan struct{})
-	var pauseOnce atomic.Bool
-	var transactionMu sync.Mutex
-	var debtTransaction, recordTransaction *sql.Tx
-	if err := db.Callback().Query().After("gorm:query").Register(
-		"test:capture_debt_snapshot",
-		func(tx *gorm.DB) {
-			transaction, ok := tx.Statement.ConnPool.(*sql.Tx)
-			if !ok || tx.Statement.Schema == nil {
-				return
-			}
-			transactionMu.Lock()
-			switch tx.Statement.Schema.Table {
-			case (types.Debt{}).TableName():
-				debtTransaction = transaction
-			case (types.DebtStatusRecord{}).TableName():
-				recordTransaction = transaction
-			}
-			transactionMu.Unlock()
-			if tx.Statement.Schema.Table == (types.Debt{}).TableName() &&
-				pauseOnce.CompareAndSwap(false, true) {
-				close(debtRead)
-				<-continueRead
-			}
+	records := []types.DebtStatusRecord{
+		{
+			ID: uuid.New(), UserUID: historicalUserUID,
+			LastStatus: types.NormalPeriod, CurrentStatus: types.DebtPeriod,
+			CreateAt: endHourTime,
 		},
-	); err != nil {
+		{
+			ID: uuid.New(), UserUID: historicalUserUID,
+			LastStatus: types.DebtPeriod, CurrentStatus: types.NormalPeriod,
+			CreateAt: endHourTime.Add(20 * time.Minute),
+		},
+	}
+	if err := db.Create(&records).Error; err != nil {
 		t.Fatal(err)
 	}
 
@@ -106,55 +99,16 @@ func TestLoadDebtUsersAtReadsOneConsistentSnapshot(t *testing.T) {
 		AccountV2: &debtSnapshotAccountV2{db: db},
 		Logger:    logr.Discard(),
 	}
-	result := make(chan error, 1)
-	go func() {
-		result <- reconciler.loadDebtUsersAt(endHourTime)
-	}()
-	select {
-	case <-debtRead:
-	case <-time.After(5 * time.Second):
-		close(continueRead)
-		t.Fatal("timed out waiting for the debt snapshot read")
-	}
-
-	transitionTime := time.Now().UTC()
-	if err := db.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Model(&types.Debt{}).
-			Where("user_uid = ?", userUID).
-			Updates(map[string]any{
-				"account_debt_status": types.DebtPeriod,
-				"updated_at":          transitionTime,
-			}).Error; err != nil {
-			return err
-		}
-		return tx.Create(&types.DebtStatusRecord{
-			ID:            uuid.New(),
-			UserUID:       userUID,
-			LastStatus:    types.NormalPeriod,
-			CurrentStatus: types.DebtPeriod,
-			CreateAt:      transitionTime,
-		}).Error
-	}); err != nil {
-		close(continueRead)
+	if err := reconciler.loadDebtUsersAt(endHourTime); err != nil {
 		t.Fatal(err)
 	}
-	close(continueRead)
-	select {
-	case err := <-result:
-		if err != nil {
-			t.Fatal(err)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for the consistent debt snapshot")
+	if _, inDebt := DebtUserMap.Get(historicalUserUID.String()); inDebt {
+		t.Fatal("historical user did not use the first later transition")
 	}
-
-	transactionMu.Lock()
-	sameTransaction := debtTransaction != nil && debtTransaction == recordTransaction
-	transactionMu.Unlock()
-	if !sameTransaction {
-		t.Fatal("debt and status history were read from different transactions")
+	if _, inDebt := DebtUserMap.Get(currentDebtUserUID.String()); !inDebt {
+		t.Fatal("current debt user without a later transition was omitted")
 	}
-	if _, inDebt := DebtUserMap.Get(userUID.String()); inDebt {
-		t.Fatal("the historical hour used the concurrently committed debt status")
+	if _, inDebt := DebtUserMap.Get(createdLaterUserUID.String()); inDebt {
+		t.Fatal("debt created after the billing hour was included")
 	}
 }

--- a/controllers/account/controllers/billing_controller_test.go
+++ b/controllers/account/controllers/billing_controller_test.go
@@ -27,6 +27,7 @@ type billingTestAccount struct {
 	existing         map[string][]*resources.Billing
 	unsettled        map[string][]*resources.Billing
 	generated        map[string][]*resources.Billing
+	generateInput    map[string][]string
 	saveErr          error
 	saved            []*resources.Billing
 	statuses         map[string]resources.BillingStatus
@@ -64,8 +65,17 @@ func (f *billingTestAccount) GetUnsettledBillingsAt(
 }
 
 func (f *billingTestAccount) GenerateBillingData(
-	time.Time, time.Time, *resources.PropertyTypeLS, map[string][]string,
+	_ time.Time,
+	_ time.Time,
+	_ *resources.PropertyTypeLS,
+	ownerListMap map[string][]string,
 ) (map[string][]*resources.Billing, error) {
+	f.mu.Lock()
+	f.generateInput = make(map[string][]string, len(ownerListMap))
+	for owner, namespaces := range ownerListMap {
+		f.generateInput[owner] = append([]string(nil), namespaces...)
+	}
+	f.mu.Unlock()
 	return f.generated, nil
 }
 
@@ -124,6 +134,37 @@ func (f *billingTestAccountV2) AddDeductionBalanceForBilling(
 func initBillingTestGlobals() {
 	DebtUserMap = maps.NewConcurrentNullValueMap()
 	SubscriptionWorkspaceMap = maps.NewConcurrentNullValueMap()
+}
+
+func TestRunBillingReadsRunsIndependentTasksConcurrently(t *testing.T) {
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	result := make(chan error, 1)
+	wantErr := errors.New("read failed")
+
+	read := func(err error) func() error {
+		return func() error {
+			started <- struct{}{}
+			<-release
+			return err
+		}
+	}
+	go func() {
+		result <- runBillingReads(read(nil), read(wantErr))
+	}()
+
+	for range 2 {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			close(release)
+			t.Fatal("independent read did not start concurrently")
+		}
+	}
+	close(release)
+	if err := <-result; !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want %v", err, wantErr)
+	}
 }
 
 func TestBillingHourScheduling(t *testing.T) {
@@ -224,7 +265,7 @@ func TestExecuteBillingTasksUntilAdvancesCheckpointWhenMonitorDataIsEmpty(t *tes
 	db := &billingTestAccount{checkpoint: start, hasCheckpoint: true}
 	reconciler := &BillingReconciler{DBClient: db, Logger: logr.Discard()}
 	reconciler.executeBillingHourFunc = func(hour time.Time) error {
-		owners, err := reconciler.getRecentUsedOwnersAt(hour)
+		owners, _, err := reconciler.getRecentUsedOwnersAt(hour)
 		if len(owners) != 0 {
 			t.Fatalf("owners=%v", owners)
 		}
@@ -242,7 +283,7 @@ func TestExecuteBillingTasksUntilAdvancesCheckpointWhenMonitorDataIsEmpty(t *tes
 func TestGetRecentUsedOwnersReturnsMonitorError(t *testing.T) {
 	db := &billingTestAccount{monitorErr: errors.New("query failed")}
 	reconciler := &BillingReconciler{DBClient: db}
-	_, err := reconciler.getRecentUsedOwnersAt(time.Now())
+	_, _, err := reconciler.getRecentUsedOwnersAt(time.Now())
 	if err == nil {
 		t.Fatal("expected monitor query error")
 	}
@@ -600,5 +641,54 @@ func TestAddUnsettledBillingOwnersRestoresOwnersWithoutMonitorData(t *testing.T)
 	})
 	if len(owners["owner"]) != 2 || owners["owner"][0] != "ns-a" || owners["owner"][1] != "ns-b" {
 		t.Fatalf("owners = %#v", owners)
+	}
+}
+
+func TestDebtOwnersOnlyGenerateRecoveredUnsettledBillings(t *testing.T) {
+	initBillingTestGlobals()
+	debtUserUID := uuid.New()
+	DebtUserMap.Set(debtUserUID.String())
+	db := &billingTestAccount{existing: map[string][]*resources.Billing{
+		"debt-owner": {{
+			OrderID: "bh_debt-recovery", Owner: "debt-owner", Namespace: "ns-debt",
+			Status: resources.Unsettled,
+		}},
+	}}
+	var reconciled []*resources.Billing
+	reconciler := &BillingReconciler{
+		DBClient:        db,
+		Logger:          logr.Discard(),
+		concurrentLimit: 1,
+		debtOwnerMap:    maps.NewConcurrentNullValueMap(),
+		reconcileBillingFunc: func(_ string, billings []*resources.Billing) error {
+			reconciled = append(reconciled, billings...)
+			return nil
+		},
+	}
+	owners := map[string][]string{
+		"debt-owner":   {"ns-debt"},
+		"normal-owner": {"ns-normal"},
+	}
+	reconciler.removeDebtOwners(owners, map[string]uuid.UUID{
+		"debt-owner": debtUserUID,
+	})
+	if _, exists := owners["debt-owner"]; exists {
+		t.Fatal("monitor-backed debt owner remained in generation input")
+	}
+
+	addUnsettledBillingOwners(owners, map[string][]*resources.Billing{
+		"debt-owner": {{Namespace: "ns-debt"}},
+	})
+	if err := reconciler.reconcileOwnerList(owners, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := db.generateInput["debt-owner"]; exists {
+		t.Fatal("recovered debt owner was included in new billing generation")
+	}
+	if _, exists := db.generateInput["normal-owner"]; !exists {
+		t.Fatal("normal owner was excluded from new billing generation")
+	}
+	if len(reconciled) != 1 || reconciled[0].OrderID != "bh_debt-recovery" {
+		t.Fatalf("reconciled = %#v", reconciled)
 	}
 }

--- a/controllers/account/controllers/billing_controller_test.go
+++ b/controllers/account/controllers/billing_controller_test.go
@@ -397,25 +397,6 @@ func TestGetRecentUsedOwnersReturnsMonitorError(t *testing.T) {
 	}
 }
 
-func TestDebtStatusAtBillingHour(t *testing.T) {
-	userUID := uuid.New()
-	hour := time.Date(2026, time.July, 7, 10, 0, 0, 0, time.UTC)
-	debt := types.Debt{
-		UserUID: userUID, AccountDebtStatus: types.DebtPeriod, UpdatedAt: hour.Add(time.Hour),
-	}
-
-	if got := debtStatusAt(debt, types.DebtStatusRecord{}); got != types.DebtPeriod {
-		t.Fatalf("status without a later transition = %s", got)
-	}
-
-	after := types.DebtStatusRecord{
-		UserUID: userUID, LastStatus: types.NormalPeriod, CurrentStatus: types.DebtPeriod,
-	}
-	if got := debtStatusAt(debt, after); got != types.NormalPeriod {
-		t.Fatalf("status from next record = %s", got)
-	}
-}
-
 func TestActiveWorkspaceSubscriptionsAtBillingHour(t *testing.T) {
 	hour := time.Date(2026, time.July, 7, 10, 0, 0, 0, time.UTC)
 	activeStart := hour.Add(-24 * time.Hour)

--- a/controllers/account/controllers/billing_controller_test.go
+++ b/controllers/account/controllers/billing_controller_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/labring/sealos/controllers/pkg/types"
 	"github.com/labring/sealos/controllers/pkg/utils/maps"
 	userv1 "github.com/labring/sealos/controllers/user/api/v1"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -125,6 +126,19 @@ func (f *billingTestAccountV2) AddDeductionBalance(
 	return nil
 }
 
+func (f *billingTestAccountV2) AddDeductionBalanceWithCreditsAt(
+	_ *types.UserQueryOpts, amount int64, _ []string, _ time.Time,
+) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deductions++
+	f.amounts = append(f.amounts, amount)
+	return nil
+}
+
 func initBillingTestGlobals() {
 	DebtUserMap = maps.NewConcurrentNullValueMap()
 	SubscriptionWorkspaceMap = maps.NewConcurrentNullValueMap()
@@ -158,6 +172,38 @@ func TestRunBillingReadsRunsIndependentTasksConcurrently(t *testing.T) {
 	close(release)
 	if err := <-result; !errors.Is(err, wantErr) {
 		t.Fatalf("error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestBillingMetricsTrackCheckpointLag(t *testing.T) {
+	checkpoint := time.Date(2026, time.July, 7, 9, 0, 0, 0, time.UTC)
+	target := checkpoint.Add(3 * time.Hour)
+	setBillingTargetMetrics(target)
+	setBillingCheckpointMetrics(checkpoint, target)
+
+	wantLag := 3 * float64(time.Hour/time.Second)
+	if got := testutil.ToFloat64(billingCheckpointLagSeconds); got != wantLag {
+		t.Fatalf("checkpoint lag seconds = %v, want %v", got, wantLag)
+	}
+	if got := testutil.ToFloat64(billingPendingCheckpoints); got != 3 {
+		t.Fatalf("pending checkpoints = %v, want 3", got)
+	}
+	if got := testutil.ToFloat64(billingTargetTimestamp); got != float64(target.Unix()) {
+		t.Fatalf("target timestamp = %v, want %v", got, target.Unix())
+	}
+	setBillingProcessingMetrics(target, true)
+	if got := testutil.ToFloat64(billingProcessing); got != 1 {
+		t.Fatalf("processing = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(billingProcessingStartedTimestamp); got <= 0 {
+		t.Fatalf("processing started timestamp = %v, want positive timestamp", got)
+	}
+	setBillingProcessingMetrics(time.Time{}, false)
+	if got := testutil.ToFloat64(billingProcessing); got != 0 {
+		t.Fatalf("processing = %v, want 0", got)
+	}
+	if got := testutil.ToFloat64(billingProcessingStartedTimestamp); got != 0 {
+		t.Fatalf("processing started timestamp = %v, want 0", got)
 	}
 }
 
@@ -196,6 +242,21 @@ func TestBillingHourScheduling(t *testing.T) {
 	})
 }
 
+func TestOwnerInDebtUsesOwnerMapping(t *testing.T) {
+	initBillingTestGlobals()
+	DebtUserMap.Set("owner-uid")
+	reconciler := &BillingReconciler{
+		debtOwnerMap: maps.NewConcurrentNullValueMap(),
+	}
+	if reconciler.ownerInDebt("owner-uid") {
+		t.Fatal("user UID was treated as an owner")
+	}
+	reconciler.debtOwnerMap.Set("owner")
+	if !reconciler.ownerInDebt("owner") {
+		t.Fatal("debt owner was not detected")
+	}
+}
+
 func TestExecuteBillingTasksUntilPersistsEachSuccessfulHour(t *testing.T) {
 	start := time.Date(2026, time.July, 7, 7, 0, 0, 0, time.UTC)
 	db := &billingTestAccount{checkpoint: start, hasCheckpoint: true}
@@ -216,6 +277,7 @@ func TestExecuteBillingTasksUntilPersistsEachSuccessfulHour(t *testing.T) {
 }
 
 func TestExecuteBillingTasksUntilFirstStartProcessesLatestHour(t *testing.T) {
+	t.Setenv(billingMaxCatchupDurationEnv, "72h")
 	target := time.Date(2026, time.July, 7, 10, 0, 0, 0, time.UTC)
 	db := &billingTestAccount{}
 	var executed []time.Time
@@ -231,6 +293,58 @@ func TestExecuteBillingTasksUntilFirstStartProcessesLatestHour(t *testing.T) {
 	}
 	if len(executed) != 1 || !executed[0].Equal(target) {
 		t.Fatalf("executed = %v", executed)
+	}
+}
+
+func TestExecuteBillingTasksUntilLimitsHistoricalCatchup(t *testing.T) {
+	t.Setenv(billingMaxCatchupDurationEnv, "48h")
+	target := time.Date(2026, time.July, 7, 10, 0, 0, 0, time.UTC)
+	db := &billingTestAccount{checkpoint: target.Add(-72 * time.Hour), hasCheckpoint: true}
+	var executed []time.Time
+	var pendingAtStart, checkpointAtStart float64
+	reconciler := &BillingReconciler{
+		DBClient: db,
+		executeBillingHourFunc: func(hour time.Time) error {
+			if len(executed) == 0 {
+				pendingAtStart = testutil.ToFloat64(billingPendingCheckpoints)
+				checkpointAtStart = testutil.ToFloat64(billingCheckpointTimestamp)
+			}
+			executed = append(executed, hour)
+			return nil
+		},
+	}
+	if err := reconciler.ExecuteBillingTasksUntil(target); err != nil {
+		t.Fatal(err)
+	}
+	if len(executed) != 48 {
+		t.Fatalf("executed %d hours, want 48", len(executed))
+	}
+	if pendingAtStart != 48 {
+		t.Fatalf("pending checkpoints at start = %v, want 48", pendingAtStart)
+	}
+	if want := float64(target.Add(-72 * time.Hour).Unix()); checkpointAtStart != want {
+		t.Fatalf("checkpoint metric at start = %v, want %v", checkpointAtStart, want)
+	}
+	if !executed[0].Equal(target.Add(-47 * time.Hour)) {
+		t.Fatalf("first executed hour = %v, want %v", executed[0], target.Add(-47*time.Hour))
+	}
+	if !db.checkpoint.Equal(target) {
+		t.Fatalf("checkpoint = %v, want %v", db.checkpoint, target)
+	}
+}
+
+func TestLimitBillingCheckpointValidatesDuration(t *testing.T) {
+	checkpoint := time.Date(2026, time.July, 4, 10, 0, 0, 0, time.UTC)
+	target := time.Date(2026, time.July, 7, 10, 0, 0, 0, time.UTC)
+	limited, err := limitBillingCheckpoint(checkpoint, target, 48*time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := target.Add(-48 * time.Hour); !limited.Equal(want) {
+		t.Fatalf("limited checkpoint = %v, want %v", limited, want)
+	}
+	if _, err := limitBillingCheckpoint(checkpoint, target, 90*time.Minute); err == nil {
+		t.Fatal("expected non-whole-hour duration error")
 	}
 }
 
@@ -451,7 +565,7 @@ func TestReconcileOwnerListReturnsPartialOwnerFailure(t *testing.T) {
 		DBClient:        db,
 		Logger:          logr.Discard(),
 		concurrentLimit: 2,
-		reconcileBillingFunc: func(owner string, _ []*resources.Billing) error {
+		reconcileBillingFunc: func(owner string, _ []*resources.Billing, _ time.Time) error {
 			db.mu.Lock()
 			if db.statuses == nil {
 				db.statuses = make(map[string]resources.BillingStatus)
@@ -475,11 +589,20 @@ func TestReconcileOwnerListReturnsPartialOwnerFailure(t *testing.T) {
 	}
 }
 
+func TestReconcileOwnerListRejectsNonPositiveConcurrency(t *testing.T) {
+	reconciler := &BillingReconciler{concurrentLimit: 0}
+	if err := reconciler.reconcileOwnerList(nil, time.Now()); err == nil {
+		t.Fatal("expected invalid concurrency error")
+	}
+}
+
 func TestReconcileBillingSaveFailure(t *testing.T) {
 	initBillingTestGlobals()
 	db := &billingTestAccount{saveErr: errors.New("insert failed")}
 	reconciler := &BillingReconciler{DBClient: db, AccountV2: &billingTestAccountV2{}}
-	err := reconciler.reconcileBilling("owner", []*resources.Billing{{OrderID: "id", Amount: 10}})
+	err := reconciler.reconcileBilling(
+		"owner", []*resources.Billing{{OrderID: "id", Amount: 10}}, time.Now(),
+	)
 	if err == nil {
 		t.Fatal("expected save failure")
 	}
@@ -491,7 +614,9 @@ func TestReconcileBillingDeductionFailureMayLeaveSettled(t *testing.T) {
 	account := &billingTestAccountV2{err: errors.New("deduction failed")}
 	billing := &resources.Billing{OrderID: "id", Amount: 10, Status: resources.Settled}
 	reconciler := &BillingReconciler{DBClient: db, AccountV2: account}
-	if err := reconciler.reconcileBilling("owner", []*resources.Billing{billing}); err == nil {
+	if err := reconciler.reconcileBilling(
+		"owner", []*resources.Billing{billing}, time.Now(),
+	); err == nil {
 		t.Fatal("expected deduction failure")
 	}
 	if len(db.saved) != 1 {
@@ -502,6 +627,31 @@ func TestReconcileBillingDeductionFailureMayLeaveSettled(t *testing.T) {
 	}
 	if status := db.statuses[billing.OrderID]; status != resources.Unsettled {
 		t.Fatalf("failed deduction status = %v", status)
+	}
+}
+
+func TestReconcileBillingReclassifiesSubscriptionBeforeDeduction(t *testing.T) {
+	initBillingTestGlobals()
+	SubscriptionWorkspaceMap.Set("ns-subscription")
+	db := &billingTestAccount{}
+	account := &billingTestAccountV2{}
+	billing := &resources.Billing{
+		OrderID:   "subscription-order",
+		Namespace: "ns-subscription",
+		Amount:    10,
+		Status:    resources.Unsettled,
+	}
+	reconciler := &BillingReconciler{DBClient: db, AccountV2: account}
+	if err := reconciler.reconcileBilling(
+		"owner", []*resources.Billing{billing}, time.Now(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if account.deductions != 0 {
+		t.Fatalf("subscription deductions = %d", account.deductions)
+	}
+	if billing.Status != resources.Subscription {
+		t.Fatalf("billing status = %v", billing.Status)
 	}
 }
 
@@ -547,7 +697,7 @@ func TestReconcileBillingRetryCanDeductAgain(t *testing.T) {
 	}
 	reconciler := &BillingReconciler{DBClient: db, AccountV2: account}
 	for range 2 {
-		if err := reconciler.reconcileBilling("owner", billings); err != nil {
+		if err := reconciler.reconcileBilling("owner", billings, time.Now()); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/controllers/account/controllers/billing_controller_test.go
+++ b/controllers/account/controllers/billing_controller_test.go
@@ -1,0 +1,604 @@
+package controllers
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	"github.com/labring/sealos/controllers/pkg/database"
+	"github.com/labring/sealos/controllers/pkg/resources"
+	"github.com/labring/sealos/controllers/pkg/types"
+	"github.com/labring/sealos/controllers/pkg/utils/maps"
+	userv1 "github.com/labring/sealos/controllers/user/api/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+type billingTestAccount struct {
+	database.Account
+	mu               sync.Mutex
+	checkpoint       time.Time
+	hasCheckpoint    bool
+	checkpointWrites []time.Time
+	monitorErr       error
+	existing         map[string][]*resources.Billing
+	unsettled        map[string][]*resources.Billing
+	generated        map[string][]*resources.Billing
+	saveErr          error
+	saved            []*resources.Billing
+	statuses         map[string]resources.BillingStatus
+}
+
+func (f *billingTestAccount) GetBillingCheckpoint() (time.Time, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.checkpoint, f.hasCheckpoint, nil
+}
+
+func (f *billingTestAccount) SaveBillingCheckpoint(value time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.checkpoint, f.hasCheckpoint = value, true
+	f.checkpointWrites = append(f.checkpointWrites, value)
+	return nil
+}
+
+func (f *billingTestAccount) GetTimeUsedNamespaceList(time.Time, time.Time) ([]string, error) {
+	return nil, f.monitorErr
+}
+
+func (f *billingTestAccount) GetOwnerBillingsAt(
+	[]string,
+	time.Time,
+) (map[string][]*resources.Billing, error) {
+	return f.existing, nil
+}
+
+func (f *billingTestAccount) GetUnsettledBillingsAt(
+	time.Time,
+) (map[string][]*resources.Billing, error) {
+	return f.unsettled, nil
+}
+
+func (f *billingTestAccount) GenerateBillingData(
+	time.Time, time.Time, *resources.PropertyTypeLS, map[string][]string,
+) (map[string][]*resources.Billing, error) {
+	return f.generated, nil
+}
+
+func (f *billingTestAccount) SaveBillings(billings ...*resources.Billing) error {
+	if f.saveErr != nil {
+		return f.saveErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.saved = append(f.saved, billings...)
+	return nil
+}
+
+func (f *billingTestAccount) UpdateBillingStatus(
+	orderIDs []string,
+	status resources.BillingStatus,
+) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.statuses == nil {
+		f.statuses = make(map[string]resources.BillingStatus)
+	}
+	for _, orderID := range orderIDs {
+		f.statuses[orderID] = status
+	}
+	return nil
+}
+
+type billingTestAccountV2 struct {
+	database.AccountV2
+	mu            sync.Mutex
+	err           error
+	deductionSeen map[string]struct{}
+	deductions    int
+}
+
+func (f *billingTestAccountV2) AddDeductionBalanceForBilling(
+	_ *types.UserQueryOpts, _ int64, orderIDs []string,
+) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.deductionSeen == nil {
+		f.deductionSeen = make(map[string]struct{})
+	}
+	if _, exists := f.deductionSeen[orderIDs[0]]; exists {
+		return nil
+	}
+	f.deductionSeen[orderIDs[0]] = struct{}{}
+	f.deductions++
+	return nil
+}
+
+func initBillingTestGlobals() {
+	DebtUserMap = maps.NewConcurrentNullValueMap()
+	SubscriptionWorkspaceMap = maps.NewConcurrentNullValueMap()
+}
+
+func TestBillingHourScheduling(t *testing.T) {
+	t.Run("normal hourly execution", func(t *testing.T) {
+		checkpoint := time.Date(2026, time.July, 7, 9, 0, 0, 0, time.UTC)
+		target := checkpoint.Add(time.Hour)
+		hours := billingHoursAfter(checkpoint, target)
+		if len(hours) != 1 || !hours[0].Equal(target) {
+			t.Fatalf("hours = %v", hours)
+		}
+	})
+
+	t.Run("start after half hour", func(t *testing.T) {
+		now := time.Date(2026, time.July, 7, 10, 37, 0, 0, time.UTC)
+		want := time.Date(2026, time.July, 7, 10, 0, 0, 0, time.UTC)
+		if got := latestReadyBillingHour(now); !got.Equal(want) {
+			t.Fatalf("ready hour = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("resume after several hours", func(t *testing.T) {
+		start := time.Date(2026, time.July, 7, 7, 0, 0, 0, time.UTC)
+		hours := billingHoursAfter(start, start.Add(4*time.Hour))
+		if len(hours) != 4 {
+			t.Fatalf("hours = %v", hours)
+		}
+	})
+
+	t.Run("task crosses next hour", func(t *testing.T) {
+		started := time.Date(2026, time.July, 7, 10, 6, 0, 0, time.UTC)
+		finished := started.Add(61 * time.Minute)
+		if !latestReadyBillingHour(finished).After(latestReadyBillingHour(started)) {
+			t.Fatalf("finished target did not advance")
+		}
+	})
+}
+
+func TestExecuteBillingTasksUntilPersistsEachSuccessfulHour(t *testing.T) {
+	start := time.Date(2026, time.July, 7, 7, 0, 0, 0, time.UTC)
+	db := &billingTestAccount{checkpoint: start, hasCheckpoint: true}
+	var executed []time.Time
+	reconciler := &BillingReconciler{
+		DBClient: db,
+		executeBillingHourFunc: func(hour time.Time) error {
+			executed = append(executed, hour)
+			return nil
+		},
+	}
+	if err := reconciler.ExecuteBillingTasksUntil(start.Add(3 * time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if len(executed) != 3 || len(db.checkpointWrites) != 3 {
+		t.Fatalf("executed=%v checkpoints=%v", executed, db.checkpointWrites)
+	}
+}
+
+func TestExecuteBillingTasksUntilFirstStartProcessesLatestHour(t *testing.T) {
+	target := time.Date(2026, time.July, 7, 10, 0, 0, 0, time.UTC)
+	db := &billingTestAccount{}
+	var executed []time.Time
+	reconciler := &BillingReconciler{
+		DBClient: db,
+		executeBillingHourFunc: func(hour time.Time) error {
+			executed = append(executed, hour)
+			return nil
+		},
+	}
+	if err := reconciler.ExecuteBillingTasksUntil(target); err != nil {
+		t.Fatal(err)
+	}
+	if len(executed) != 1 || !executed[0].Equal(target) {
+		t.Fatalf("executed = %v", executed)
+	}
+}
+
+func TestExecuteBillingTasksUntilStopsAtFailedHour(t *testing.T) {
+	start := time.Date(2026, time.July, 7, 7, 0, 0, 0, time.UTC)
+	db := &billingTestAccount{checkpoint: start, hasCheckpoint: true}
+	reconciler := &BillingReconciler{
+		DBClient: db,
+		executeBillingHourFunc: func(hour time.Time) error {
+			if hour.Equal(start.Add(2 * time.Hour)) {
+				return errors.New("monitor unavailable")
+			}
+			return nil
+		},
+	}
+	if err := reconciler.ExecuteBillingTasksUntil(start.Add(3 * time.Hour)); err == nil {
+		t.Fatal("expected failed hour error")
+	}
+	if !db.checkpoint.Equal(start.Add(time.Hour)) {
+		t.Fatalf("checkpoint = %v", db.checkpoint)
+	}
+}
+
+func TestExecuteBillingTasksUntilAdvancesCheckpointWhenMonitorDataIsEmpty(t *testing.T) {
+	start := time.Date(2026, time.July, 7, 7, 0, 0, 0, time.UTC)
+	db := &billingTestAccount{checkpoint: start, hasCheckpoint: true}
+	reconciler := &BillingReconciler{DBClient: db, Logger: logr.Discard()}
+	reconciler.executeBillingHourFunc = func(hour time.Time) error {
+		owners, err := reconciler.getRecentUsedOwnersAt(hour)
+		if len(owners) != 0 {
+			t.Fatalf("owners=%v", owners)
+		}
+		return err
+	}
+	target := start.Add(time.Hour)
+	if err := reconciler.ExecuteBillingTasksUntil(target); err != nil {
+		t.Fatal(err)
+	}
+	if !db.checkpoint.Equal(target) || len(db.checkpointWrites) != 1 {
+		t.Fatalf("checkpoint=%v writes=%v", db.checkpoint, db.checkpointWrites)
+	}
+}
+
+func TestGetRecentUsedOwnersReturnsMonitorError(t *testing.T) {
+	db := &billingTestAccount{monitorErr: errors.New("query failed")}
+	reconciler := &BillingReconciler{DBClient: db}
+	_, err := reconciler.getRecentUsedOwnersAt(time.Now())
+	if err == nil {
+		t.Fatal("expected monitor query error")
+	}
+}
+
+func TestDebtStatusAtBillingHour(t *testing.T) {
+	userUID := uuid.New()
+	hour := time.Date(2026, time.July, 7, 10, 0, 0, 0, time.UTC)
+	debt := types.Debt{
+		UserUID: userUID, AccountDebtStatus: types.DebtPeriod, UpdatedAt: hour.Add(time.Hour),
+	}
+
+	if got := debtStatusAt(debt, types.DebtStatusRecord{}); got != types.DebtPeriod {
+		t.Fatalf("status without a later transition = %s", got)
+	}
+
+	after := types.DebtStatusRecord{
+		UserUID: userUID, LastStatus: types.NormalPeriod, CurrentStatus: types.DebtPeriod,
+	}
+	if got := debtStatusAt(debt, after); got != types.NormalPeriod {
+		t.Fatalf("status from next record = %s", got)
+	}
+}
+
+func TestActiveWorkspaceSubscriptionsAtBillingHour(t *testing.T) {
+	hour := time.Date(2026, time.July, 7, 10, 0, 0, 0, time.UTC)
+	activeStart := hour.Add(-24 * time.Hour)
+	activeEnd := hour.Add(time.Hour)
+	expiredEnd := hour.Add(-time.Minute)
+	subscriptions := []types.WorkspaceSubscription{
+		{
+			Workspace: "active", CreateAt: activeStart,
+			CurrentPeriodStartAt: activeStart, CurrentPeriodEndAt: activeEnd,
+		},
+		{
+			Workspace: "purchased-later", CreateAt: hour.Add(time.Hour),
+			CurrentPeriodStartAt: hour.Add(time.Hour), CurrentPeriodEndAt: hour.Add(48 * time.Hour),
+		},
+		{
+			Workspace: "expired", CreateAt: activeStart,
+			CurrentPeriodStartAt: activeStart, CurrentPeriodEndAt: expiredEnd,
+		},
+		{
+			Workspace: "renewed-later", CreateAt: activeStart, UpdateAt: hour.Add(time.Hour),
+			CurrentPeriodStartAt: activeStart, CurrentPeriodEndAt: hour.Add(48 * time.Hour),
+		},
+	}
+	transactions := []types.WorkspaceSubscriptionTransaction{
+		{
+			ID:        uuid.New(),
+			Workspace: "previous-period",
+			Operator:  types.SubscriptionTransactionTypeCreated,
+			Status:    types.SubscriptionTransactionStatusCompleted,
+			PayStatus: types.SubscriptionPayStatusPaid,
+			StartAt:   hour.Add(-12 * time.Hour),
+			UpdatedAt: hour.Add(-11 * time.Hour),
+			Period:    types.DayPeriod(1),
+		},
+		{
+			ID:        uuid.New(),
+			Workspace: "delayed-activation",
+			Operator:  types.SubscriptionTransactionTypeUpgraded,
+			Status:    types.SubscriptionTransactionStatusCompleted,
+			PayStatus: types.SubscriptionPayStatusPaid,
+			StartAt:   hour.Add(-25 * time.Hour),
+			UpdatedAt: hour.Add(-23 * time.Hour),
+			Period:    types.DayPeriod(1),
+		},
+		{
+			ID:        uuid.New(),
+			Workspace: "completed-later",
+			Operator:  types.SubscriptionTransactionTypeCreated,
+			Status:    types.SubscriptionTransactionStatusCompleted,
+			PayStatus: types.SubscriptionPayStatusPaid,
+			StartAt:   hour.Add(-12 * time.Hour),
+			UpdatedAt: hour.Add(time.Hour),
+			Period:    types.DayPeriod(1),
+		},
+		{
+			ID:        uuid.New(),
+			Workspace: "canceled",
+			Operator:  types.SubscriptionTransactionTypeCreated,
+			Status:    types.SubscriptionTransactionStatusCompleted,
+			PayStatus: types.SubscriptionPayStatusPaid,
+			StartAt:   hour.Add(-12 * time.Hour),
+			UpdatedAt: hour.Add(-11 * time.Hour),
+			Period:    types.DayPeriod(1),
+		},
+		{
+			ID:        uuid.New(),
+			Workspace: "canceled",
+			Operator:  types.SubscriptionTransactionTypeCanceled,
+			Status:    types.SubscriptionTransactionStatusCompleted,
+			PayStatus: types.SubscriptionPayStatusCanceled,
+			StartAt:   hour.Add(-time.Hour),
+			UpdatedAt: hour.Add(-time.Hour),
+		},
+	}
+	workspaces, err := activeWorkspaceSubscriptionsAt(hour, subscriptions, transactions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make(map[string]struct{}, len(workspaces))
+	for _, workspace := range workspaces {
+		got[workspace] = struct{}{}
+	}
+	if _, exists := got["active"]; !exists {
+		t.Fatal("active current period is missing")
+	}
+	if _, exists := got["previous-period"]; !exists {
+		t.Fatal("active historical transaction period is missing")
+	}
+	if _, exists := got["delayed-activation"]; !exists {
+		t.Fatal("subscription completion time was not used as its period start")
+	}
+	if _, exists := got["purchased-later"]; exists {
+		t.Fatal("future subscription was applied to historical billing")
+	}
+	if _, exists := got["expired"]; exists {
+		t.Fatal("expired subscription was applied to billing")
+	}
+	if _, exists := got["renewed-later"]; exists {
+		t.Fatal("later subscription snapshot was applied to historical billing")
+	}
+	if _, exists := got["completed-later"]; exists {
+		t.Fatal("later transaction completion was applied to historical billing")
+	}
+	if _, exists := got["canceled"]; exists {
+		t.Fatal("canceled subscription was applied to billing")
+	}
+}
+
+func TestGetUsersForNamespacesUsesTargetedLookups(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := userv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	userA := &userv1.User{}
+	userA.Name = "a"
+	userA.Annotations = map[string]string{userv1.UserLabelOwnerKey: "owner-a"}
+	userB := &userv1.User{}
+	userB.Name = "b"
+	userB.Annotations = map[string]string{userv1.UserLabelOwnerKey: "owner-b"}
+	reconciler := &BillingReconciler{Client: fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(userA, userB).
+		Build()}
+
+	owners, err := reconciler.getUsersForNamespaces([]string{
+		"ns-a", "ns-b", "ns-missing", "workspace-without-user-prefix",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(owners) != 2 || owners["ns-a"] != "owner-a" || owners["ns-b"] != "owner-b" {
+		t.Fatalf("owners = %#v", owners)
+	}
+}
+
+func TestReconcileOwnerListReturnsPartialOwnerFailure(t *testing.T) {
+	initBillingTestGlobals()
+	end := time.Date(2026, time.July, 7, 10, 0, 0, 0, time.UTC)
+	db := &billingTestAccount{
+		existing: map[string][]*resources.Billing{},
+		generated: map[string][]*resources.Billing{
+			"owner-a": {{OrderID: "a", Owner: "owner-a", Namespace: "ns-a", Time: end, Amount: 1}},
+			"owner-b": {{OrderID: "b", Owner: "owner-b", Namespace: "ns-b", Time: end, Amount: 1}},
+		},
+	}
+	reconciler := &BillingReconciler{
+		DBClient:        db,
+		Logger:          logr.Discard(),
+		concurrentLimit: 2,
+		reconcileBillingFunc: func(owner string, _ []*resources.Billing) error {
+			db.mu.Lock()
+			if db.statuses == nil {
+				db.statuses = make(map[string]resources.BillingStatus)
+			}
+			db.statuses[owner] = resources.Settled
+			db.mu.Unlock()
+			if owner == "owner-b" {
+				return errors.New("save failed")
+			}
+			return nil
+		},
+	}
+	err := reconciler.reconcileOwnerList(map[string][]string{
+		"owner-a": {"ns-a"}, "owner-b": {"ns-b"},
+	}, end)
+	if err == nil {
+		t.Fatal("expected partial owner failure")
+	}
+	if len(db.statuses) != 2 {
+		t.Fatalf("reconciled owner count = %d", len(db.statuses))
+	}
+}
+
+func TestReconcileBillingSaveFailure(t *testing.T) {
+	initBillingTestGlobals()
+	db := &billingTestAccount{saveErr: errors.New("insert failed")}
+	reconciler := &BillingReconciler{DBClient: db, AccountV2: &billingTestAccountV2{}}
+	err := reconciler.reconcileBilling("owner", []*resources.Billing{{OrderID: "id", Amount: 10}})
+	if err == nil {
+		t.Fatal("expected save failure")
+	}
+}
+
+func TestReconcileOwnerListRecoversUnsettledWithoutRegeneratedBilling(t *testing.T) {
+	initBillingTestGlobals()
+	end := time.Date(2026, time.July, 7, 10, 0, 0, 0, time.UTC)
+	existing := &resources.Billing{
+		OrderID:   "bh_recover",
+		Owner:     "owner",
+		Namespace: "ns-owner",
+		Time:      end,
+		Amount:    10,
+		Status:    resources.Unsettled,
+	}
+	db := &billingTestAccount{
+		existing:  map[string][]*resources.Billing{"owner": {existing}},
+		generated: map[string][]*resources.Billing{},
+	}
+	var reconciled []*resources.Billing
+	reconciler := &BillingReconciler{
+		DBClient:        db,
+		Logger:          logr.Discard(),
+		concurrentLimit: 1,
+		reconcileBillingFunc: func(_ string, billings []*resources.Billing) error {
+			reconciled = append(reconciled, billings...)
+			return nil
+		},
+	}
+	if err := reconciler.reconcileOwnerList(
+		map[string][]string{"owner": {"ns-owner"}},
+		end,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if len(reconciled) != 1 || reconciled[0].OrderID != existing.OrderID {
+		t.Fatalf("reconciled = %#v", reconciled)
+	}
+}
+
+func TestReconcileBillingDeductionFailureLeavesUnsettled(t *testing.T) {
+	initBillingTestGlobals()
+	db := &billingTestAccount{}
+	account := &billingTestAccountV2{err: errors.New("deduction failed")}
+	billing := &resources.Billing{OrderID: "id", Amount: 10, Status: resources.Unsettled}
+	reconciler := &BillingReconciler{DBClient: db, AccountV2: account}
+	if err := reconciler.reconcileBilling("owner", []*resources.Billing{billing}); err == nil {
+		t.Fatal("expected deduction failure")
+	}
+	if len(db.saved) != 1 {
+		t.Fatalf("saved billing count = %d", len(db.saved))
+	}
+	if _, settled := db.statuses[billing.OrderID]; settled {
+		t.Fatal("failed deduction was marked settled")
+	}
+}
+
+func TestClassifyGeneratedBillingsDoesNotReclassifyExistingUnsettled(t *testing.T) {
+	initBillingTestGlobals()
+	SubscriptionWorkspaceMap.Set("ns-subscription")
+	generated := map[string][]*resources.Billing{"owner": {
+		{OrderID: "new-subscription", Namespace: "ns-subscription", AppName: "new"},
+		{OrderID: "new-usage", Namespace: "ns-usage", AppName: "usage"},
+	}}
+	existing := &resources.Billing{
+		OrderID: "bh_existing", Namespace: "ns-subscription", AppName: "existing",
+		Status: resources.Unsettled,
+	}
+
+	classifyGeneratedBillings(generated)
+	pending := pendingOwnerBillings(generated, map[string][]*resources.Billing{
+		"owner": {existing},
+	})["owner"]
+
+	statuses := make(map[string]resources.BillingStatus, len(pending))
+	for _, billing := range pending {
+		statuses[billing.OrderID] = billing.Status
+	}
+	if statuses["new-subscription"] != resources.Subscription {
+		t.Fatalf("new subscription status = %v", statuses["new-subscription"])
+	}
+	if statuses["new-usage"] != resources.Unsettled {
+		t.Fatalf("new usage status = %v", statuses["new-usage"])
+	}
+	if statuses[existing.OrderID] != resources.Unsettled {
+		t.Fatalf("existing unsettled status = %v", statuses[existing.OrderID])
+	}
+}
+
+func TestReconcileBillingIsIdempotentPerBillingID(t *testing.T) {
+	initBillingTestGlobals()
+	db := &billingTestAccount{}
+	account := &billingTestAccountV2{}
+	billing := &resources.Billing{OrderID: "stable-id", Amount: 10, Status: resources.Unsettled}
+	reconciler := &BillingReconciler{DBClient: db, AccountV2: account}
+	for range 2 {
+		if err := reconciler.reconcileBilling("owner", []*resources.Billing{billing}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if account.deductions != 1 {
+		t.Fatalf("deductions = %d", account.deductions)
+	}
+}
+
+func TestPendingOwnerBillingsRecoversOnlyMissingAndUnsettled(t *testing.T) {
+	generated := map[string][]*resources.Billing{"owner": {
+		{OrderID: "new-a", Namespace: "ns", AppType: 1, AppName: "a"},
+		{OrderID: "new-b", Namespace: "ns", AppType: 1, AppName: "b"},
+		{OrderID: "new-c", Namespace: "ns", AppType: 1, AppName: "c"},
+	}}
+	existing := map[string][]*resources.Billing{"owner": {
+		{OrderID: "legacy-a", Namespace: "ns", AppType: 1, AppName: "a", Status: resources.Settled},
+		{
+			OrderID:   "bh_existing-b",
+			Namespace: "ns",
+			AppType:   1,
+			AppName:   "b",
+			Status:    resources.Unsettled,
+		},
+		{
+			OrderID:   "bh_orphan-d",
+			Namespace: "ns",
+			AppType:   1,
+			AppName:   "d",
+			Status:    resources.Unsettled,
+		},
+	}}
+	pending := pendingOwnerBillings(generated, existing)["owner"]
+	got := make(map[string]struct{}, len(pending))
+	for _, billing := range pending {
+		got[billing.OrderID] = struct{}{}
+	}
+	if len(got) != 3 {
+		t.Fatalf("pending = %#v", pending)
+	}
+	for _, orderID := range []string{"bh_existing-b", "bh_orphan-d", "new-c"} {
+		if _, exists := got[orderID]; !exists {
+			t.Fatalf("pending billing %s is missing: %#v", orderID, pending)
+		}
+	}
+}
+
+func TestAddUnsettledBillingOwnersRestoresOwnersWithoutMonitorData(t *testing.T) {
+	owners := map[string][]string{}
+	addUnsettledBillingOwners(owners, map[string][]*resources.Billing{
+		"owner": {
+			{Namespace: "ns-a"},
+			{Namespace: "ns-a"},
+			{Namespace: "ns-b"},
+		},
+	})
+	if len(owners["owner"]) != 2 || owners["owner"][0] != "ns-a" || owners["owner"][1] != "ns-b" {
+		t.Fatalf("owners = %#v", owners)
+	}
+}

--- a/controllers/account/controllers/billing_controller_test.go
+++ b/controllers/account/controllers/billing_controller_test.go
@@ -106,28 +106,22 @@ func (f *billingTestAccount) UpdateBillingStatus(
 
 type billingTestAccountV2 struct {
 	database.AccountV2
-	mu            sync.Mutex
-	err           error
-	deductionSeen map[string]struct{}
-	deductions    int
+	mu         sync.Mutex
+	err        error
+	deductions int
+	amounts    []int64
 }
 
-func (f *billingTestAccountV2) AddDeductionBalanceForBilling(
-	_ *types.UserQueryOpts, _ int64, orderIDs []string,
+func (f *billingTestAccountV2) AddDeductionBalance(
+	_ *types.UserQueryOpts, amount int64,
 ) error {
 	if f.err != nil {
 		return f.err
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if f.deductionSeen == nil {
-		f.deductionSeen = make(map[string]struct{})
-	}
-	if _, exists := f.deductionSeen[orderIDs[0]]; exists {
-		return nil
-	}
-	f.deductionSeen[orderIDs[0]] = struct{}{}
 	f.deductions++
+	f.amounts = append(f.amounts, amount)
 	return nil
 }
 
@@ -491,47 +485,11 @@ func TestReconcileBillingSaveFailure(t *testing.T) {
 	}
 }
 
-func TestReconcileOwnerListRecoversUnsettledWithoutRegeneratedBilling(t *testing.T) {
-	initBillingTestGlobals()
-	end := time.Date(2026, time.July, 7, 10, 0, 0, 0, time.UTC)
-	existing := &resources.Billing{
-		OrderID:   "bh_recover",
-		Owner:     "owner",
-		Namespace: "ns-owner",
-		Time:      end,
-		Amount:    10,
-		Status:    resources.Unsettled,
-	}
-	db := &billingTestAccount{
-		existing:  map[string][]*resources.Billing{"owner": {existing}},
-		generated: map[string][]*resources.Billing{},
-	}
-	var reconciled []*resources.Billing
-	reconciler := &BillingReconciler{
-		DBClient:        db,
-		Logger:          logr.Discard(),
-		concurrentLimit: 1,
-		reconcileBillingFunc: func(_ string, billings []*resources.Billing) error {
-			reconciled = append(reconciled, billings...)
-			return nil
-		},
-	}
-	if err := reconciler.reconcileOwnerList(
-		map[string][]string{"owner": {"ns-owner"}},
-		end,
-	); err != nil {
-		t.Fatal(err)
-	}
-	if len(reconciled) != 1 || reconciled[0].OrderID != existing.OrderID {
-		t.Fatalf("reconciled = %#v", reconciled)
-	}
-}
-
-func TestReconcileBillingDeductionFailureLeavesUnsettled(t *testing.T) {
+func TestReconcileBillingDeductionFailureMayLeaveSettled(t *testing.T) {
 	initBillingTestGlobals()
 	db := &billingTestAccount{}
 	account := &billingTestAccountV2{err: errors.New("deduction failed")}
-	billing := &resources.Billing{OrderID: "id", Amount: 10, Status: resources.Unsettled}
+	billing := &resources.Billing{OrderID: "id", Amount: 10, Status: resources.Settled}
 	reconciler := &BillingReconciler{DBClient: db, AccountV2: account}
 	if err := reconciler.reconcileBilling("owner", []*resources.Billing{billing}); err == nil {
 		t.Fatal("expected deduction failure")
@@ -539,12 +497,15 @@ func TestReconcileBillingDeductionFailureLeavesUnsettled(t *testing.T) {
 	if len(db.saved) != 1 {
 		t.Fatalf("saved billing count = %d", len(db.saved))
 	}
-	if _, settled := db.statuses[billing.OrderID]; settled {
-		t.Fatal("failed deduction was marked settled")
+	if db.saved[0].Status != resources.Settled {
+		t.Fatalf("saved billing status = %v", db.saved[0].Status)
+	}
+	if status := db.statuses[billing.OrderID]; status != resources.Unsettled {
+		t.Fatalf("failed deduction status = %v", status)
 	}
 }
 
-func TestClassifyGeneratedBillingsDoesNotReclassifyExistingUnsettled(t *testing.T) {
+func TestClassifyGeneratedBillingsDefaultsToSettled(t *testing.T) {
 	initBillingTestGlobals()
 	SubscriptionWorkspaceMap.Set("ns-subscription")
 	generated := map[string][]*resources.Billing{"owner": {
@@ -568,31 +529,37 @@ func TestClassifyGeneratedBillingsDoesNotReclassifyExistingUnsettled(t *testing.
 	if statuses["new-subscription"] != resources.Subscription {
 		t.Fatalf("new subscription status = %v", statuses["new-subscription"])
 	}
-	if statuses["new-usage"] != resources.Unsettled {
+	if statuses["new-usage"] != resources.Settled {
 		t.Fatalf("new usage status = %v", statuses["new-usage"])
 	}
-	if statuses[existing.OrderID] != resources.Unsettled {
-		t.Fatalf("existing unsettled status = %v", statuses[existing.OrderID])
+	if _, exists := statuses[existing.OrderID]; exists {
+		t.Fatalf("existing billing was unexpectedly requeued: %v", existing.OrderID)
 	}
 }
 
-func TestReconcileBillingIsIdempotentPerBillingID(t *testing.T) {
+func TestReconcileBillingRetryCanDeductAgain(t *testing.T) {
 	initBillingTestGlobals()
 	db := &billingTestAccount{}
 	account := &billingTestAccountV2{}
-	billing := &resources.Billing{OrderID: "stable-id", Amount: 10, Status: resources.Unsettled}
+	billings := []*resources.Billing{
+		{OrderID: "stable-a", Amount: 10, Status: resources.Settled},
+		{OrderID: "stable-b", Amount: 15, Status: resources.Settled},
+	}
 	reconciler := &BillingReconciler{DBClient: db, AccountV2: account}
 	for range 2 {
-		if err := reconciler.reconcileBilling("owner", []*resources.Billing{billing}); err != nil {
+		if err := reconciler.reconcileBilling("owner", billings); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if account.deductions != 1 {
+	if account.deductions != 2 {
 		t.Fatalf("deductions = %d", account.deductions)
+	}
+	if len(account.amounts) != 2 || account.amounts[0] != 25 || account.amounts[1] != 25 {
+		t.Fatalf("deduction amounts = %#v", account.amounts)
 	}
 }
 
-func TestPendingOwnerBillingsRecoversOnlyMissingAndUnsettled(t *testing.T) {
+func TestPendingOwnerBillingsSkipsExistingBusinessKeys(t *testing.T) {
 	generated := map[string][]*resources.Billing{"owner": {
 		{OrderID: "new-a", Namespace: "ns", AppType: 1, AppName: "a"},
 		{OrderID: "new-b", Namespace: "ns", AppType: 1, AppName: "b"},
@@ -620,75 +587,12 @@ func TestPendingOwnerBillingsRecoversOnlyMissingAndUnsettled(t *testing.T) {
 	for _, billing := range pending {
 		got[billing.OrderID] = struct{}{}
 	}
-	if len(got) != 3 {
+	if len(got) != 1 {
 		t.Fatalf("pending = %#v", pending)
 	}
-	for _, orderID := range []string{"bh_existing-b", "bh_orphan-d", "new-c"} {
+	for _, orderID := range []string{"new-c"} {
 		if _, exists := got[orderID]; !exists {
 			t.Fatalf("pending billing %s is missing: %#v", orderID, pending)
 		}
-	}
-}
-
-func TestAddUnsettledBillingOwnersRestoresOwnersWithoutMonitorData(t *testing.T) {
-	owners := map[string][]string{}
-	addUnsettledBillingOwners(owners, map[string][]*resources.Billing{
-		"owner": {
-			{Namespace: "ns-a"},
-			{Namespace: "ns-a"},
-			{Namespace: "ns-b"},
-		},
-	})
-	if len(owners["owner"]) != 2 || owners["owner"][0] != "ns-a" || owners["owner"][1] != "ns-b" {
-		t.Fatalf("owners = %#v", owners)
-	}
-}
-
-func TestDebtOwnersOnlyGenerateRecoveredUnsettledBillings(t *testing.T) {
-	initBillingTestGlobals()
-	debtUserUID := uuid.New()
-	DebtUserMap.Set(debtUserUID.String())
-	db := &billingTestAccount{existing: map[string][]*resources.Billing{
-		"debt-owner": {{
-			OrderID: "bh_debt-recovery", Owner: "debt-owner", Namespace: "ns-debt",
-			Status: resources.Unsettled,
-		}},
-	}}
-	var reconciled []*resources.Billing
-	reconciler := &BillingReconciler{
-		DBClient:        db,
-		Logger:          logr.Discard(),
-		concurrentLimit: 1,
-		debtOwnerMap:    maps.NewConcurrentNullValueMap(),
-		reconcileBillingFunc: func(_ string, billings []*resources.Billing) error {
-			reconciled = append(reconciled, billings...)
-			return nil
-		},
-	}
-	owners := map[string][]string{
-		"debt-owner":   {"ns-debt"},
-		"normal-owner": {"ns-normal"},
-	}
-	reconciler.removeDebtOwners(owners, map[string]uuid.UUID{
-		"debt-owner": debtUserUID,
-	})
-	if _, exists := owners["debt-owner"]; exists {
-		t.Fatal("monitor-backed debt owner remained in generation input")
-	}
-
-	addUnsettledBillingOwners(owners, map[string][]*resources.Billing{
-		"debt-owner": {{Namespace: "ns-debt"}},
-	})
-	if err := reconciler.reconcileOwnerList(owners, time.Now()); err != nil {
-		t.Fatal(err)
-	}
-	if _, exists := db.generateInput["debt-owner"]; exists {
-		t.Fatal("recovered debt owner was included in new billing generation")
-	}
-	if _, exists := db.generateInput["normal-owner"]; !exists {
-		t.Fatal("normal owner was excluded from new billing generation")
-	}
-	if len(reconciled) != 1 || reconciled[0].OrderID != "bh_debt-recovery" {
-		t.Fatalf("reconciled = %#v", reconciled)
 	}
 }

--- a/controllers/account/controllers/billing_metrics.go
+++ b/controllers/account/controllers/billing_metrics.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2023 sealos.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	billingCheckpointTimestamp = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "sealos_account_billing_checkpoint_timestamp_seconds",
+		Help: "Unix timestamp of the last successfully persisted account billing checkpoint.",
+	})
+	billingTargetTimestamp = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "sealos_account_billing_target_timestamp_seconds",
+		Help: "Unix timestamp of the latest account billing hour ready for processing.",
+	})
+	billingCheckpointLagSeconds = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "sealos_account_billing_checkpoint_lag_seconds",
+		Help: "Duration of ready account billing hours after the persisted checkpoint.",
+	})
+	billingPendingCheckpoints = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "sealos_account_billing_pending_checkpoints",
+		Help: "Number of ready account billing hours after the persisted checkpoint.",
+	})
+	billingProcessing = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "sealos_account_billing_processing",
+		Help: "Whether the account billing runner is processing a billing hour.",
+	})
+	billingProcessingTimestamp = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "sealos_account_billing_processing_timestamp_seconds",
+		Help: "Unix timestamp of the account billing hour currently being processed.",
+	})
+	billingProcessingStartedTimestamp = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "sealos_account_billing_processing_started_timestamp_seconds",
+		Help: "Unix timestamp when processing of the current account billing hour started.",
+	})
+	billingLastSuccessTimestamp = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "sealos_account_billing_last_success_timestamp_seconds",
+		Help: "Unix timestamp when the account billing checkpoint was last advanced.",
+	})
+	billingReconcileFailures = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "sealos_account_billing_reconcile_failures_total",
+		Help: "Total account billing hour reconciliation failures.",
+	})
+	billingFailedOwners = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "sealos_account_billing_failed_owners",
+		Help: "Number of owners that failed in the most recent account billing batch.",
+	})
+)
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(
+		billingCheckpointTimestamp,
+		billingTargetTimestamp,
+		billingCheckpointLagSeconds,
+		billingPendingCheckpoints,
+		billingProcessing,
+		billingProcessingTimestamp,
+		billingProcessingStartedTimestamp,
+		billingLastSuccessTimestamp,
+		billingReconcileFailures,
+		billingFailedOwners,
+	)
+}
+
+func setBillingTargetMetrics(target time.Time) {
+	target = target.UTC().Truncate(time.Hour)
+	billingTargetTimestamp.Set(float64(target.Unix()))
+}
+
+func setBillingCheckpointMetrics(checkpoint, target time.Time) {
+	checkpoint = checkpoint.UTC().Truncate(time.Hour)
+	billingCheckpointTimestamp.Set(float64(checkpoint.Unix()))
+	setBillingPendingCheckpointMetrics(checkpoint, target)
+}
+
+func setBillingPendingCheckpointMetrics(checkpoint, target time.Time) {
+	checkpoint = checkpoint.UTC().Truncate(time.Hour)
+	target = target.UTC().Truncate(time.Hour)
+	lag := target.Sub(checkpoint).Seconds()
+	if lag < 0 {
+		lag = 0
+	}
+	billingCheckpointLagSeconds.Set(lag)
+	billingPendingCheckpoints.Set(lag / float64(time.Hour/time.Second))
+}
+
+func setBillingProcessingMetrics(hour time.Time, processing bool) {
+	if !processing {
+		billingProcessing.Set(0)
+		billingProcessingTimestamp.Set(0)
+		billingProcessingStartedTimestamp.Set(0)
+		return
+	}
+	billingProcessing.Set(1)
+	billingProcessingTimestamp.Set(float64(hour.UTC().Truncate(time.Hour).Unix()))
+	billingProcessingStartedTimestamp.Set(float64(time.Now().UTC().Unix()))
+}

--- a/controllers/account/deploy/charts/account-controller/templates/configmap.yaml
+++ b/controllers/account/deploy/charts/account-controller/templates/configmap.yaml
@@ -24,6 +24,7 @@ data:
       "DOMAIN" .Values.accountEnv.cloudDomain
       "PORT" .Values.accountEnv.cloudPort
       "ACCOUNT_API_JWT_SECRET" .Values.accountEnv.accountApiJwtSecret
+      "BILLING_MAX_CATCHUP_DURATION" .Values.accountEnv.billingMaxCatchupDuration
       "BASE_BALANCE" .Values.accountEnv.baseBalance
       "QUOTA_LIMITS_CPU" .Values.accountEnv.quotaLimitsCpu
       "QUOTA_LIMITS_MEMORY" .Values.accountEnv.quotaLimitsMemory

--- a/controllers/account/deploy/charts/account-controller/values.yaml
+++ b/controllers/account/deploy/charts/account-controller/values.yaml
@@ -60,6 +60,9 @@ accountEnv:
   # Authentication secrets (auto-configured from sealos-config)
   accountApiJwtSecret: "secret"  # Auto-fetched from sealos-config.jwtInternal
 
+  # Maximum historical billing window replayed from an existing checkpoint.
+  billingMaxCatchupDuration: "24h"
+
   # Kubernetes API whitelist (auto-generated from cloudDomain)
   whitelistKubernetesHosts: ""  # Auto-generated: https://${cloudDomain}:6443
 

--- a/controllers/pkg/database/cockroach/accountv2.go
+++ b/controllers/pkg/database/cockroach/accountv2.go
@@ -1063,8 +1063,22 @@ func (c *Cockroach) GetUserOauthProvider(ops *types.UserQueryOpts) ([]types.Oaut
 func (c *Cockroach) AddDeductionBalanceWithCredits(
 	ops *types.UserQueryOpts,
 	deductionAmount int64,
-	_ []string,
+	orderIDs []string,
 ) error {
+	return c.AddDeductionBalanceWithCreditsAt(
+		ops, deductionAmount, orderIDs, time.Now().UTC(),
+	)
+}
+
+func (c *Cockroach) AddDeductionBalanceWithCreditsAt(
+	ops *types.UserQueryOpts,
+	deductionAmount int64,
+	_ []string,
+	at time.Time,
+) error {
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
 	err := RetryTransaction(3, 2*time.Second, c.DB, func(tx *gorm.DB) error {
 		remainingAmount := deductionAmount
 		userUID, dErr := c.GetUserUID(ops)
@@ -1073,9 +1087,10 @@ func (c *Cockroach) AddDeductionBalanceWithCredits(
 		}
 		var credits []types.Credits
 		if dErr = tx.Where(
-			"user_uid = ? AND expire_at > ? AND status = ?",
+			"user_uid = ? AND start_at <= ? AND expire_at > ? AND status = ?",
 			userUID,
-			time.Now().UTC(),
+			at,
+			at,
 			types.CreditsStatusActive,
 		).Order("expire_at ASC").Find(&credits).Error; dErr != nil {
 			return fmt.Errorf("failed to get credits: %w", dErr)

--- a/controllers/pkg/database/cockroach/accountv2.go
+++ b/controllers/pkg/database/cockroach/accountv2.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1064,20 +1063,10 @@ func (c *Cockroach) GetUserOauthProvider(ops *types.UserQueryOpts) ([]types.Oaut
 func (c *Cockroach) AddDeductionBalanceWithCredits(
 	ops *types.UserQueryOpts,
 	deductionAmount int64,
-	orderIDs []string,
+	_ []string,
 ) error {
 	err := RetryTransaction(3, 2*time.Second, c.DB, func(tx *gorm.DB) error {
 		remainingAmount := deductionAmount
-		transactionID := billingTransactionID(c.LocalRegion.UID, orderIDs)
-		var existing int64
-		if dErr := tx.Model(&types.AccountTransaction{}).
-			Where("id = ?", transactionID).
-			Count(&existing).Error; dErr != nil {
-			return fmt.Errorf("failed to check account transaction: %w", dErr)
-		}
-		if existing > 0 {
-			return nil
-		}
 		userUID, dErr := c.GetUserUID(ops)
 		if dErr != nil {
 			return fmt.Errorf("failed to get user uid: %w", dErr)
@@ -1092,19 +1081,8 @@ func (c *Cockroach) AddDeductionBalanceWithCredits(
 			return fmt.Errorf("failed to get credits: %w", dErr)
 		}
 		now := time.Now().UTC()
-		accountTransaction := types.AccountTransaction{
-			ID:            transactionID,
-			RegionUID:     c.LocalRegion.UID,
-			Type:          "RESOURCE_BILLING",
-			UserUID:       userUID,
-			CreatedAt:     now,
-			UpdatedAt:     now,
-			BillingIDList: orderIDs,
-		}
 		var updateCredits []types.Credits
-		var updateCreditsIDs []string
 		// var creditTransactions []types.CreditsTransaction
-		var creditUsedAmountAll int64
 		for i := range credits {
 			creditAmt := credits[i].Amount - credits[i].UsedAmount
 			if creditAmt > 0 && remainingAmount > 0 {
@@ -1117,7 +1095,6 @@ func (c *Cockroach) AddDeductionBalanceWithCredits(
 					credits[i].Status = types.CreditsStatusUsedUp
 					usedAmount = creditAmt
 				}
-				creditUsedAmountAll += usedAmount
 				remainingAmount -= usedAmount
 				// creditTransactions = append(creditTransactions, types.CreditsTransaction{
 				//	ID:                   uuid.New(),
@@ -1131,7 +1108,6 @@ func (c *Cockroach) AddDeductionBalanceWithCredits(
 				// })
 				credits[i].UpdatedAt = now
 				updateCredits = append(updateCredits, credits[i])
-				updateCreditsIDs = append(updateCreditsIDs, credits[i].ID.String())
 			}
 		}
 		if len(updateCredits) > 0 {
@@ -1140,19 +1116,11 @@ func (c *Cockroach) AddDeductionBalanceWithCredits(
 					return fmt.Errorf("failed to update credits: %w", dErr)
 				}
 			}
-			accountTransaction.DeductionCredit = creditUsedAmountAll
-			accountTransaction.CreditIDList = updateCreditsIDs
 		}
 		if remainingAmount > 0 {
 			if dErr = c.updateBalance(tx, ops, remainingAmount, true, true); dErr != nil {
 				return fmt.Errorf("failed to update balance: %w", dErr)
 			}
-			accountTransaction.DeductionBalance = remainingAmount
-		} else {
-			accountTransaction.DeductionBalance = 0
-		}
-		if dErr = tx.Create(&accountTransaction).Error; dErr != nil {
-			return fmt.Errorf("failed to create account transaction: %w", dErr)
 		}
 		// if len(creditTransactions) > 0 {
 		//	if dErr = tx.Create(&creditTransactions).Error; dErr != nil {
@@ -1162,63 +1130,6 @@ func (c *Cockroach) AddDeductionBalanceWithCredits(
 		return nil
 	})
 	return err
-}
-
-func billingTransactionID(regionUID uuid.UUID, orderIDs []string) uuid.UUID {
-	ids := append([]string(nil), orderIDs...)
-	sort.Strings(ids)
-	key := "resource-billing\x00" + regionUID.String() + "\x00" + strings.Join(ids, "\x00")
-	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(key))
-}
-
-func (c *Cockroach) AddDeductionBalanceForBilling(
-	ops *types.UserQueryOpts,
-	amount int64,
-	orderIDs []string,
-) error {
-	if amount == 0 {
-		return nil
-	}
-	return c.DB.Transaction(func(tx *gorm.DB) error {
-		transactionID := billingTransactionID(c.LocalRegion.UID, orderIDs)
-		var existing int64
-		if err := tx.Model(&types.AccountTransaction{}).
-			Where("id = ?", transactionID).
-			Count(&existing).Error; err != nil {
-			return fmt.Errorf("failed to check account transaction: %w", err)
-		}
-		if existing > 0 {
-			return nil
-		}
-		userUID, err := c.GetUserUID(ops)
-		if err != nil {
-			return fmt.Errorf("failed to get user uid: %w", err)
-		}
-		if err := c.updateBalance(
-			tx,
-			&types.UserQueryOpts{UID: userUID},
-			amount,
-			true,
-			true,
-		); err != nil {
-			return fmt.Errorf("failed to update balance: %w", err)
-		}
-		now := time.Now().UTC()
-		transaction := types.AccountTransaction{
-			ID:               transactionID,
-			RegionUID:        c.LocalRegion.UID,
-			Type:             "RESOURCE_BILLING",
-			UserUID:          userUID,
-			DeductionBalance: amount,
-			BillingIDList:    orderIDs,
-			CreatedAt:        now,
-			UpdatedAt:        now,
-		}
-		if err := tx.Create(&transaction).Error; err != nil {
-			return fmt.Errorf("failed to create account transaction: %w", err)
-		}
-		return nil
-	})
 }
 
 func RetryTransaction(

--- a/controllers/pkg/database/cockroach/accountv2.go
+++ b/controllers/pkg/database/cockroach/accountv2.go
@@ -2256,15 +2256,45 @@ func (c *Cockroach) InitTables() error {
 	if err != nil {
 		return fmt.Errorf("failed to create index on WorkspaceSubscriptionTransaction: %w", err)
 	}
-	err = c.DB.Exec(`
-		CREATE INDEX IF NOT EXISTS idx_debt_record_time_user ON "DebtStatusRecord" (create_at, user_uid);`).Error
-	if err != nil {
-		return fmt.Errorf("failed to create index on DebtStatusRecord: %w", err)
+	if err := ensureBillingQueryIndexes(c.DB); err != nil {
+		return err
 	}
 
 	// TODO: remove this after migration
 	if err := c.migrateColumns(); err != nil {
 		return fmt.Errorf("failed to migrate columns: %w", err)
+	}
+	return nil
+}
+
+// ensureBillingQueryIndexes covers the billing queries that operate on
+// growing historical tables. Equality columns lead each index so a billing
+// request can avoid scanning rows belonging to other users or workspaces.
+func ensureBillingQueryIndexes(db *gorm.DB) error {
+	statements := []struct {
+		name string
+		sql  string
+	}{
+		{
+			name: "DebtStatusRecord first status",
+			sql: `CREATE INDEX IF NOT EXISTS idx_debt_record_user_time
+				ON "DebtStatusRecord" (user_uid, create_at, id, last_status);`,
+		},
+		{
+			name: "WorkspaceSubscriptionTransaction history",
+			sql: `CREATE INDEX IF NOT EXISTS idx_workspace_subscription_billing_history
+				ON "WorkspaceSubscriptionTransaction" (region_domain, workspace, status, updated_at);`,
+		},
+		{
+			name: "Credits active period",
+			sql: `CREATE INDEX IF NOT EXISTS idx_credits_active_period
+				ON "Credits" (user_uid, status, expire_at, start_at);`,
+		},
+	}
+	for _, statement := range statements {
+		if err := db.Exec(statement.sql).Error; err != nil {
+			return fmt.Errorf("failed to create billing history index on %s: %w", statement.name, err)
+		}
 	}
 	return nil
 }

--- a/controllers/pkg/database/cockroach/accountv2.go
+++ b/controllers/pkg/database/cockroach/accountv2.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1066,18 +1067,33 @@ func (c *Cockroach) AddDeductionBalanceWithCredits(
 	orderIDs []string,
 ) error {
 	err := RetryTransaction(3, 2*time.Second, c.DB, func(tx *gorm.DB) error {
+		remainingAmount := deductionAmount
+		transactionID := billingTransactionID(c.LocalRegion.UID, orderIDs)
+		var existing int64
+		if dErr := tx.Model(&types.AccountTransaction{}).
+			Where("id = ?", transactionID).
+			Count(&existing).Error; dErr != nil {
+			return fmt.Errorf("failed to check account transaction: %w", dErr)
+		}
+		if existing > 0 {
+			return nil
+		}
 		userUID, dErr := c.GetUserUID(ops)
 		if dErr != nil {
 			return fmt.Errorf("failed to get user uid: %w", dErr)
 		}
 		var credits []types.Credits
-		if dErr = c.DB.Where("user_uid = ? AND expire_at > ? AND status = ?", userUID, time.Now().UTC(), types.CreditsStatusActive).Order("expire_at ASC").Find(&credits).Error; dErr != nil {
+		if dErr = tx.Where(
+			"user_uid = ? AND expire_at > ? AND status = ?",
+			userUID,
+			time.Now().UTC(),
+			types.CreditsStatusActive,
+		).Order("expire_at ASC").Find(&credits).Error; dErr != nil {
 			return fmt.Errorf("failed to get credits: %w", dErr)
 		}
 		now := time.Now().UTC()
-		accountTransactionID := uuid.New()
 		accountTransaction := types.AccountTransaction{
-			ID:            accountTransactionID,
+			ID:            transactionID,
 			RegionUID:     c.LocalRegion.UID,
 			Type:          "RESOURCE_BILLING",
 			UserUID:       userUID,
@@ -1091,18 +1107,18 @@ func (c *Cockroach) AddDeductionBalanceWithCredits(
 		var creditUsedAmountAll int64
 		for i := range credits {
 			creditAmt := credits[i].Amount - credits[i].UsedAmount
-			if creditAmt > 0 && deductionAmount > 0 {
+			if creditAmt > 0 && remainingAmount > 0 {
 				var usedAmount int64
-				if creditAmt > deductionAmount {
-					credits[i].UsedAmount += deductionAmount
-					usedAmount = deductionAmount
+				if creditAmt > remainingAmount {
+					credits[i].UsedAmount += remainingAmount
+					usedAmount = remainingAmount
 				} else {
 					credits[i].UsedAmount = credits[i].Amount
 					credits[i].Status = types.CreditsStatusUsedUp
 					usedAmount = creditAmt
 				}
 				creditUsedAmountAll += usedAmount
-				deductionAmount -= usedAmount
+				remainingAmount -= usedAmount
 				// creditTransactions = append(creditTransactions, types.CreditsTransaction{
 				//	ID:                   uuid.New(),
 				//	UserUID:              userUID,
@@ -1127,17 +1143,17 @@ func (c *Cockroach) AddDeductionBalanceWithCredits(
 			accountTransaction.DeductionCredit = creditUsedAmountAll
 			accountTransaction.CreditIDList = updateCreditsIDs
 		}
-		if deductionAmount > 0 {
-			if dErr = c.updateBalance(tx, ops, deductionAmount, true, true); dErr != nil {
+		if remainingAmount > 0 {
+			if dErr = c.updateBalance(tx, ops, remainingAmount, true, true); dErr != nil {
 				return fmt.Errorf("failed to update balance: %w", dErr)
 			}
-			accountTransaction.DeductionBalance = deductionAmount
+			accountTransaction.DeductionBalance = remainingAmount
 		} else {
 			accountTransaction.DeductionBalance = 0
 		}
-		// if dErr = tx.Create(&accountTransaction).Error; dErr != nil {
-		//	return fmt.Errorf("failed to create account transaction: %v", dErr)
-		//}
+		if dErr = tx.Create(&accountTransaction).Error; dErr != nil {
+			return fmt.Errorf("failed to create account transaction: %w", dErr)
+		}
 		// if len(creditTransactions) > 0 {
 		//	if dErr = tx.Create(&creditTransactions).Error; dErr != nil {
 		//		return fmt.Errorf("failed to create credit transactions: %v", dErr)
@@ -1146,6 +1162,63 @@ func (c *Cockroach) AddDeductionBalanceWithCredits(
 		return nil
 	})
 	return err
+}
+
+func billingTransactionID(regionUID uuid.UUID, orderIDs []string) uuid.UUID {
+	ids := append([]string(nil), orderIDs...)
+	sort.Strings(ids)
+	key := "resource-billing\x00" + regionUID.String() + "\x00" + strings.Join(ids, "\x00")
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(key))
+}
+
+func (c *Cockroach) AddDeductionBalanceForBilling(
+	ops *types.UserQueryOpts,
+	amount int64,
+	orderIDs []string,
+) error {
+	if amount == 0 {
+		return nil
+	}
+	return c.DB.Transaction(func(tx *gorm.DB) error {
+		transactionID := billingTransactionID(c.LocalRegion.UID, orderIDs)
+		var existing int64
+		if err := tx.Model(&types.AccountTransaction{}).
+			Where("id = ?", transactionID).
+			Count(&existing).Error; err != nil {
+			return fmt.Errorf("failed to check account transaction: %w", err)
+		}
+		if existing > 0 {
+			return nil
+		}
+		userUID, err := c.GetUserUID(ops)
+		if err != nil {
+			return fmt.Errorf("failed to get user uid: %w", err)
+		}
+		if err := c.updateBalance(
+			tx,
+			&types.UserQueryOpts{UID: userUID},
+			amount,
+			true,
+			true,
+		); err != nil {
+			return fmt.Errorf("failed to update balance: %w", err)
+		}
+		now := time.Now().UTC()
+		transaction := types.AccountTransaction{
+			ID:               transactionID,
+			RegionUID:        c.LocalRegion.UID,
+			Type:             "RESOURCE_BILLING",
+			UserUID:          userUID,
+			DeductionBalance: amount,
+			BillingIDList:    orderIDs,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}
+		if err := tx.Create(&transaction).Error; err != nil {
+			return fmt.Errorf("failed to create account transaction: %w", err)
+		}
+		return nil
+	})
 }
 
 func RetryTransaction(
@@ -2256,6 +2329,11 @@ func (c *Cockroach) InitTables() error {
 		CREATE INDEX IF NOT EXISTS idx_pending_transactions ON "WorkspaceSubscriptionTransaction" (pay_status, start_at, status, region_domain);`).Error
 	if err != nil {
 		return fmt.Errorf("failed to create index on WorkspaceSubscriptionTransaction: %w", err)
+	}
+	err = c.DB.Exec(`
+		CREATE INDEX IF NOT EXISTS idx_debt_record_time_user ON "DebtStatusRecord" (create_at, user_uid);`).Error
+	if err != nil {
+		return fmt.Errorf("failed to create index on DebtStatusRecord: %w", err)
 	}
 
 	// TODO: remove this after migration

--- a/controllers/pkg/database/cockroach/billing_runtime_test.go
+++ b/controllers/pkg/database/cockroach/billing_runtime_test.go
@@ -2,9 +2,7 @@ package cockroach
 
 import (
 	"context"
-	"errors"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,7 +15,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func TestBillingDeductionIdempotencyWithPostgresRuntime(t *testing.T) {
+func TestBillingDeductionWithPostgresRuntimeDoesNotCreateTransaction(t *testing.T) {
 	testcontainers.SkipIfProviderIsNotHealthy(t)
 	ctx := context.Background()
 	container, err := postgrescontainer.Run(ctx, "postgres:16-alpine",
@@ -59,8 +57,8 @@ func TestBillingDeductionIdempotencyWithPostgresRuntime(t *testing.T) {
 		ownerUsrUIDMap: &sync.Map{}, ownerUsrIDMap: &sync.Map{},
 	}
 	for range 2 {
-		if err := account.AddDeductionBalanceForBilling(
-			&types.UserQueryOpts{UID: userUID}, 125, []string{"stable-order"},
+		if err := account.AddDeductionBalance(
+			&types.UserQueryOpts{UID: userUID}, 125,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -69,21 +67,19 @@ func TestBillingDeductionIdempotencyWithPostgresRuntime(t *testing.T) {
 	if err := db.First(&stored, `"userUid" = ?`, userUID).Error; err != nil {
 		t.Fatal(err)
 	}
-	if stored.DeductionBalance != 125 {
+	if stored.DeductionBalance != 250 {
 		t.Fatalf("deduction balance = %d", stored.DeductionBalance)
 	}
 	var transactionCount int64
-	if err := db.Model(&types.AccountTransaction{}).
-		Where("id = ?", billingTransactionID(regionUID, []string{"stable-order"})).
-		Count(&transactionCount).Error; err != nil {
+	if err := db.Model(&types.AccountTransaction{}).Count(&transactionCount).Error; err != nil {
 		t.Fatal(err)
 	}
-	if transactionCount != 1 {
+	if transactionCount != 0 {
 		t.Fatalf("transaction count = %d", transactionCount)
 	}
 }
 
-func TestBillingDeductionWithCreditsRetriesFullAmountWithPostgresRuntime(t *testing.T) {
+func TestBillingDeductionWithCreditsWithPostgresRuntime(t *testing.T) {
 	testcontainers.SkipIfProviderIsNotHealthy(t)
 	ctx := context.Background()
 	container, err := postgrescontainer.Run(ctx, "postgres:16-alpine",
@@ -128,18 +124,6 @@ func TestBillingDeductionWithCreditsRetriesFullAmountWithPostgresRuntime(t *test
 	}).Error; err != nil {
 		t.Fatal(err)
 	}
-	var createAttempts atomic.Int32
-	if err := db.Callback().Create().Before("gorm:create").Register(
-		"test:fail_first_account_transaction",
-		func(tx *gorm.DB) {
-			if _, ok := tx.Statement.Dest.(*types.AccountTransaction); ok &&
-				createAttempts.Add(1) == 1 {
-				_ = tx.AddError(errors.New("injected account transaction failure"))
-			}
-		},
-	); err != nil {
-		t.Fatal(err)
-	}
 	regionUID := uuid.New()
 	account := &Cockroach{
 		DB: db, Localdb: db, LocalRegion: &types.Region{UID: regionUID, Domain: "test"},
@@ -164,19 +148,11 @@ func TestBillingDeductionWithCreditsRetriesFullAmountWithPostgresRuntime(t *test
 	if storedAccount.DeductionBalance != 25 {
 		t.Fatalf("deduction balance = %d", storedAccount.DeductionBalance)
 	}
-	var transaction types.AccountTransaction
-	if err := db.First(
-		&transaction,
-		"id = ?",
-		billingTransactionID(regionUID, []string{"credit-retry-order"}),
-	).Error; err != nil {
+	var transactionCount int64
+	if err := db.Model(&types.AccountTransaction{}).Count(&transactionCount).Error; err != nil {
 		t.Fatal(err)
 	}
-	if transaction.DeductionCredit != 100 || transaction.DeductionBalance != 25 {
-		t.Fatalf(
-			"transaction credit=%d balance=%d",
-			transaction.DeductionCredit,
-			transaction.DeductionBalance,
-		)
+	if transactionCount != 0 {
+		t.Fatalf("transaction count = %d", transactionCount)
 	}
 }

--- a/controllers/pkg/database/cockroach/billing_runtime_test.go
+++ b/controllers/pkg/database/cockroach/billing_runtime_test.go
@@ -1,0 +1,182 @@
+package cockroach
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labring/sealos/controllers/pkg/types"
+	"github.com/testcontainers/testcontainers-go"
+	postgrescontainer "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func TestBillingDeductionIdempotencyWithPostgresRuntime(t *testing.T) {
+	testcontainers.SkipIfProviderIsNotHealthy(t)
+	ctx := context.Background()
+	container, err := postgrescontainer.Run(ctx, "postgres:16-alpine",
+		postgrescontainer.WithDatabase("account"),
+		postgrescontainer.WithUsername("account"),
+		postgrescontainer.WithPassword("account"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
+		),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := container.Terminate(ctx); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	})
+	dsn, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&types.Account{}, &types.AccountTransaction{}); err != nil {
+		t.Fatal(err)
+	}
+	userUID := uuid.New()
+	if err := db.Create(&types.Account{
+		UserUID: userUID, CreateRegionID: "test", Balance: 1000,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	regionUID := uuid.New()
+	account := &Cockroach{
+		DB: db, Localdb: db, LocalRegion: &types.Region{UID: regionUID, Domain: "test"},
+		ownerUsrUIDMap: &sync.Map{}, ownerUsrIDMap: &sync.Map{},
+	}
+	for range 2 {
+		if err := account.AddDeductionBalanceForBilling(
+			&types.UserQueryOpts{UID: userUID}, 125, []string{"stable-order"},
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var stored types.Account
+	if err := db.First(&stored, `"userUid" = ?`, userUID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if stored.DeductionBalance != 125 {
+		t.Fatalf("deduction balance = %d", stored.DeductionBalance)
+	}
+	var transactionCount int64
+	if err := db.Model(&types.AccountTransaction{}).
+		Where("id = ?", billingTransactionID(regionUID, []string{"stable-order"})).
+		Count(&transactionCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if transactionCount != 1 {
+		t.Fatalf("transaction count = %d", transactionCount)
+	}
+}
+
+func TestBillingDeductionWithCreditsRetriesFullAmountWithPostgresRuntime(t *testing.T) {
+	testcontainers.SkipIfProviderIsNotHealthy(t)
+	ctx := context.Background()
+	container, err := postgrescontainer.Run(ctx, "postgres:16-alpine",
+		postgrescontainer.WithDatabase("account"),
+		postgrescontainer.WithUsername("account"),
+		postgrescontainer.WithPassword("account"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
+		),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := container.Terminate(ctx); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	})
+	dsn, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(
+		&types.Account{}, &types.AccountTransaction{}, &types.Credits{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	userUID := uuid.New()
+	if err := db.Create(&types.Account{
+		UserUID: userUID, CreateRegionID: "test", Balance: 1000,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	creditID := uuid.New()
+	if err := db.Create(&types.Credits{
+		ID: creditID, UserUID: userUID, Amount: 100, Status: types.CreditsStatusActive,
+		StartAt: time.Now().Add(-time.Hour), ExpireAt: time.Now().Add(time.Hour),
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	var createAttempts atomic.Int32
+	if err := db.Callback().Create().Before("gorm:create").Register(
+		"test:fail_first_account_transaction",
+		func(tx *gorm.DB) {
+			if _, ok := tx.Statement.Dest.(*types.AccountTransaction); ok &&
+				createAttempts.Add(1) == 1 {
+				_ = tx.AddError(errors.New("injected account transaction failure"))
+			}
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+	regionUID := uuid.New()
+	account := &Cockroach{
+		DB: db, Localdb: db, LocalRegion: &types.Region{UID: regionUID, Domain: "test"},
+		ownerUsrUIDMap: &sync.Map{}, ownerUsrIDMap: &sync.Map{},
+	}
+	if err := account.AddDeductionBalanceWithCredits(
+		&types.UserQueryOpts{UID: userUID}, 125, []string{"credit-retry-order"},
+	); err != nil {
+		t.Fatal(err)
+	}
+	var storedCredit types.Credits
+	if err := db.First(&storedCredit, "id = ?", creditID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if storedCredit.UsedAmount != 100 {
+		t.Fatalf("used credits = %d", storedCredit.UsedAmount)
+	}
+	var storedAccount types.Account
+	if err := db.First(&storedAccount, `"userUid" = ?`, userUID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if storedAccount.DeductionBalance != 25 {
+		t.Fatalf("deduction balance = %d", storedAccount.DeductionBalance)
+	}
+	var transaction types.AccountTransaction
+	if err := db.First(
+		&transaction,
+		"id = ?",
+		billingTransactionID(regionUID, []string{"credit-retry-order"}),
+	).Error; err != nil {
+		t.Fatal(err)
+	}
+	if transaction.DeductionCredit != 100 || transaction.DeductionBalance != 25 {
+		t.Fatalf(
+			"transaction credit=%d balance=%d",
+			transaction.DeductionCredit,
+			transaction.DeductionBalance,
+		)
+	}
+}

--- a/controllers/pkg/database/cockroach/billing_runtime_test.go
+++ b/controllers/pkg/database/cockroach/billing_runtime_test.go
@@ -79,7 +79,7 @@ func TestBillingDeductionWithPostgresRuntimeDoesNotCreateTransaction(t *testing.
 	}
 }
 
-func TestBillingDeductionWithCreditsWithPostgresRuntime(t *testing.T) {
+func TestHistoricalBillingDeductionUsesCreditsActiveAtBillingTime(t *testing.T) {
 	testcontainers.SkipIfProviderIsNotHealthy(t)
 	ctx := context.Background()
 	container, err := postgrescontainer.Run(ctx, "postgres:16-alpine",
@@ -118,9 +118,10 @@ func TestBillingDeductionWithCreditsWithPostgresRuntime(t *testing.T) {
 		t.Fatal(err)
 	}
 	creditID := uuid.New()
+	billingTime := time.Now().UTC().Add(-2 * time.Hour)
 	if err := db.Create(&types.Credits{
 		ID: creditID, UserUID: userUID, Amount: 100, Status: types.CreditsStatusActive,
-		StartAt: time.Now().Add(-time.Hour), ExpireAt: time.Now().Add(time.Hour),
+		StartAt: billingTime.Add(-time.Hour), ExpireAt: billingTime.Add(time.Hour),
 	}).Error; err != nil {
 		t.Fatal(err)
 	}
@@ -129,8 +130,11 @@ func TestBillingDeductionWithCreditsWithPostgresRuntime(t *testing.T) {
 		DB: db, Localdb: db, LocalRegion: &types.Region{UID: regionUID, Domain: "test"},
 		ownerUsrUIDMap: &sync.Map{}, ownerUsrIDMap: &sync.Map{},
 	}
-	if err := account.AddDeductionBalanceWithCredits(
-		&types.UserQueryOpts{UID: userUID}, 125, []string{"credit-retry-order"},
+	if err := account.AddDeductionBalanceWithCreditsAt(
+		&types.UserQueryOpts{UID: userUID},
+		125,
+		[]string{"historical-credit-order"},
+		billingTime,
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/controllers/pkg/database/cockroach/billing_runtime_test.go
+++ b/controllers/pkg/database/cockroach/billing_runtime_test.go
@@ -2,6 +2,7 @@ package cockroach
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -159,4 +160,178 @@ func TestHistoricalBillingDeductionUsesCreditsActiveAtBillingTime(t *testing.T) 
 	if transactionCount != 0 {
 		t.Fatalf("transaction count = %d", transactionCount)
 	}
+}
+
+func TestBillingHistoryQueriesUseCompositeIndexes(t *testing.T) {
+	testcontainers.SkipIfProviderIsNotHealthy(t)
+	ctx := context.Background()
+	container, err := postgrescontainer.Run(ctx, "postgres:16-alpine",
+		postgrescontainer.WithDatabase("account"),
+		postgrescontainer.WithUsername("account"),
+		postgrescontainer.WithPassword("account"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
+		),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := container.Terminate(ctx); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	})
+	dsn, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(`
+		CREATE TABLE "Debt" (
+			user_uid TEXT PRIMARY KEY,
+			account_debt_status TEXT NOT NULL,
+			created_at TIMESTAMPTZ NOT NULL
+		);
+		CREATE TABLE "DebtStatusRecord" (
+			id BIGINT PRIMARY KEY,
+			user_uid TEXT NOT NULL,
+			last_status TEXT NOT NULL,
+			create_at TIMESTAMPTZ NOT NULL
+		);
+		CREATE TABLE "WorkspaceSubscriptionTransaction" (
+			id BIGINT PRIMARY KEY,
+			region_domain TEXT NOT NULL,
+			workspace TEXT NOT NULL,
+			status TEXT NOT NULL,
+			pay_status TEXT NOT NULL,
+			operator TEXT NOT NULL,
+			updated_at TIMESTAMPTZ NOT NULL
+		);
+		CREATE TABLE "Credits" (
+			id BIGINT PRIMARY KEY,
+			user_uid TEXT NOT NULL,
+			amount BIGINT NOT NULL,
+			used_amount BIGINT NOT NULL,
+			expire_at TIMESTAMPTZ NOT NULL,
+			start_at TIMESTAMPTZ NOT NULL,
+			status TEXT NOT NULL
+		);`).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureBillingQueryIndexes(db); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(`
+		INSERT INTO "Debt" (user_uid, account_debt_status, created_at)
+		SELECT CASE WHEN i = 1 THEN 'target-user' ELSE 'user-' || i::TEXT END,
+			'NormalPeriod',
+			now() - INTERVAL '1 day'
+		FROM generate_series(1, 1000) AS series(i);`).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(`
+		INSERT INTO "DebtStatusRecord" (id, user_uid, last_status, create_at)
+		SELECT i,
+			CASE WHEN i % 1000 = 0 THEN 'target-user' ELSE 'user-' || i::TEXT END,
+			'NormalPeriod',
+			now() - (i || ' seconds')::INTERVAL
+		FROM generate_series(1, 100000) AS series(i);`).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(`
+		INSERT INTO "WorkspaceSubscriptionTransaction" (
+			id, region_domain, workspace, status, pay_status, operator, updated_at
+		)
+		SELECT i,
+			'test-region',
+			CASE WHEN i % 1000 = 0 THEN 'target-workspace' ELSE 'workspace-' || i::TEXT END,
+			'completed',
+			CASE WHEN i % 2 = 0 THEN 'paid' ELSE 'no_need' END,
+			CASE WHEN i % 1000 = 0 THEN 'canceled' WHEN i % 2 = 0 THEN 'created' ELSE 'canceled' END,
+			now() - (i || ' seconds')::INTERVAL
+		FROM generate_series(1, 100000) AS series(i);`).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(`
+		INSERT INTO "Credits" (id, user_uid, amount, used_amount, expire_at, start_at, status)
+		SELECT i,
+			CASE WHEN i % 1000 = 0 THEN 'target-user' ELSE 'user-' || i::TEXT END,
+			100,
+			0,
+			now() + INTERVAL '1 day',
+			now() - INTERVAL '1 day',
+			'active'
+		FROM generate_series(1, 100000) AS series(i);`).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	plans := map[string]string{
+		"debt first status": `EXPLAIN (ANALYZE, COSTS OFF)
+			SELECT d.user_uid,
+				COALESCE(first_record.last_status, d.account_debt_status) AS account_debt_status
+			FROM "Debt" AS d
+			LEFT JOIN LATERAL (
+				SELECT r.last_status
+				FROM "DebtStatusRecord" AS r
+				WHERE r.user_uid = d.user_uid
+				  AND r.create_at > now() - INTERVAL '2 hours'
+				ORDER BY r.create_at ASC, r.id ASC
+				LIMIT 1
+			) AS first_record ON TRUE
+			WHERE d.created_at <= now()`,
+		"subscription period": `EXPLAIN (ANALYZE, COSTS OFF)
+			SELECT * FROM "WorkspaceSubscriptionTransaction"
+			WHERE region_domain = 'test-region'
+			  AND workspace IN ('target-workspace')
+			  AND status = 'completed'
+			  AND pay_status IN ('paid', 'no_need')
+			  AND updated_at <= now()`,
+		"subscription terminal": `EXPLAIN (ANALYZE, COSTS OFF)
+			SELECT * FROM "WorkspaceSubscriptionTransaction"
+			WHERE region_domain = 'test-region'
+			  AND workspace IN ('target-workspace')
+			  AND status = 'completed'
+			  AND operator IN ('canceled', 'deleted')
+			  AND updated_at <= now()`,
+		"credits active period": `EXPLAIN (ANALYZE, COSTS OFF)
+			SELECT * FROM "Credits"
+			WHERE user_uid = 'target-user'
+			  AND start_at <= now()
+			  AND expire_at > now()
+			  AND status = 'active'
+			ORDER BY expire_at ASC`,
+	}
+	wantIndexes := map[string]string{
+		"debt first status":     "idx_debt_record_user_time",
+		"subscription period":   "idx_workspace_subscription_billing_history",
+		"subscription terminal": "idx_workspace_subscription_billing_history",
+		"credits active period": "idx_credits_active_period",
+	}
+	for name, query := range plans {
+		rows, err := db.Raw(query).Rows()
+		if err != nil {
+			t.Fatalf("%s explain: %v", name, err)
+		}
+		var plan strings.Builder
+		for rows.Next() {
+			var line string
+			if err := rows.Scan(&line); err != nil {
+				rows.Close()
+				t.Fatalf("%s scan explain: %v", name, err)
+			}
+			plan.WriteString(line)
+		}
+		if err := rows.Close(); err != nil {
+			t.Fatalf("%s close explain: %v", name, err)
+		}
+		planText := plan.String()
+		t.Logf("%s: %s", name, planText)
+		if !strings.Contains(planText, wantIndexes[name]) {
+			t.Fatalf("%s did not use %s: %s", name, wantIndexes[name], planText)
+		}
+	}
+	t.Logf("indexed historical billing queries completed against 100000-row tables")
 }

--- a/controllers/pkg/database/interface.go
+++ b/controllers/pkg/database/interface.go
@@ -148,7 +148,6 @@ type AccountV2 interface {
 	) error
 	AddBalance(user *types.UserQueryOpts, balance int64) error
 	AddDeductionBalanceWithCredits(ops *types.UserQueryOpts, amount int64, orderIDs []string) error
-	AddDeductionBalanceForBilling(ops *types.UserQueryOpts, amount int64, orderIDs []string) error
 	ReduceBalance(ops *types.UserQueryOpts, amount int64) error
 	ReduceDeductionBalance(ops *types.UserQueryOpts, amount int64) error
 	NewAccount(user *types.UserQueryOpts) (*types.Account, error)

--- a/controllers/pkg/database/interface.go
+++ b/controllers/pkg/database/interface.go
@@ -47,6 +47,13 @@ type CVM interface {
 type Account interface {
 	GetBillingLastUpdateTime(owner string, _type common.Type) (bool, time.Time, error)
 	GetOwnersRecentUpdates(ownerList []string, checkTime time.Time) ([]string, error)
+	GetOwnerBillingsAt(
+		ownerList []string,
+		billingTime time.Time,
+	) (map[string][]*resources.Billing, error)
+	GetUnsettledBillingsAt(billingTime time.Time) (map[string][]*resources.Billing, error)
+	GetBillingCheckpoint() (time.Time, bool, error)
+	SaveBillingCheckpoint(billingTime time.Time) error
 	GetTimeUsedNamespaceList(startTime, endTime time.Time) ([]string, error)
 	SaveBillings(billing ...*resources.Billing) error
 	SaveObjTraffic(obs ...*types.ObjectStorageTraffic) error
@@ -141,6 +148,7 @@ type AccountV2 interface {
 	) error
 	AddBalance(user *types.UserQueryOpts, balance int64) error
 	AddDeductionBalanceWithCredits(ops *types.UserQueryOpts, amount int64, orderIDs []string) error
+	AddDeductionBalanceForBilling(ops *types.UserQueryOpts, amount int64, orderIDs []string) error
 	ReduceBalance(ops *types.UserQueryOpts, amount int64) error
 	ReduceDeductionBalance(ops *types.UserQueryOpts, amount int64) error
 	NewAccount(user *types.UserQueryOpts) (*types.Account, error)

--- a/controllers/pkg/database/interface.go
+++ b/controllers/pkg/database/interface.go
@@ -148,6 +148,12 @@ type AccountV2 interface {
 	) error
 	AddBalance(user *types.UserQueryOpts, balance int64) error
 	AddDeductionBalanceWithCredits(ops *types.UserQueryOpts, amount int64, orderIDs []string) error
+	AddDeductionBalanceWithCreditsAt(
+		ops *types.UserQueryOpts,
+		amount int64,
+		orderIDs []string,
+		at time.Time,
+	) error
 	ReduceBalance(ops *types.UserQueryOpts, amount int64) error
 	ReduceDeductionBalance(ops *types.UserQueryOpts, amount int64) error
 	NewAccount(user *types.UserQueryOpts) (*types.Account, error)

--- a/controllers/pkg/database/mongo/account.go
+++ b/controllers/pkg/database/mongo/account.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"math"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -908,9 +907,12 @@ func GenerateBillingDataFromRecords(
 	}
 
 	// 存储最终计费数据
-	// map[namespace]map[app_type | parent_type/parent_name][]resources.AppCost
-	appCostsMap := make(map[string]map[string][]resources.AppCost)
-	nsTypeAmount := make(map[string]map[string]int64)
+	type billingGroupKey struct {
+		appType uint8
+		appName string
+	}
+	appCostsMap := make(map[string]map[billingGroupKey][]resources.AppCost)
+	nsTypeAmount := make(map[string]map[billingGroupKey]int64)
 
 	calculateFinalUsed := func(values map[uint8][]int64, prols *resources.PropertyTypeLS, minutes float64) map[uint8]int64 {
 		finalUsed := make(map[uint8]int64)
@@ -949,18 +951,18 @@ func GenerateBillingDataFromRecords(
 			continue
 		}
 		appCost.Amount = totalAmount
-		groupKey := strconv.Itoa(int(agg.Type))
+		groupKey := billingGroupKey{appType: agg.Type}
 		if agg.ParentType != 0 && agg.ParentName != "" {
-			groupKey = strconv.Itoa(int(agg.ParentType)) + "/" + agg.ParentName
+			groupKey = billingGroupKey{appType: agg.ParentType, appName: agg.ParentName}
 		}
 		ns := agg.Category
 		if _, ok := nsTypeAmount[ns]; !ok {
-			nsTypeAmount[ns] = make(map[string]int64)
+			nsTypeAmount[ns] = make(map[billingGroupKey]int64)
 		}
 		nsTypeAmount[ns][groupKey] += totalAmount
 
 		if _, ok := appCostsMap[ns]; !ok {
-			appCostsMap[ns] = make(map[string][]resources.AppCost)
+			appCostsMap[ns] = make(map[billingGroupKey][]resources.AppCost)
 		}
 		appCostsMap[ns][groupKey] = append(appCostsMap[ns][groupKey], appCost)
 	}
@@ -968,24 +970,19 @@ func GenerateBillingDataFromRecords(
 
 	// 生成 Billing 数据
 	for ns, appCostMap := range appCostsMap {
-		for tp, appCostList := range appCostMap {
-			amount := nsTypeAmount[ns][tp]
+		for groupKey, appCostList := range appCostMap {
+			amount := nsTypeAmount[ns][groupKey]
 			if amount <= 0 {
 				continue
 			}
-			parts := strings.Split(tp, "/")
-			appType, _ := strconv.Atoi(parts[0])
-			appName := ""
-			if len(parts) > 1 {
-				appName = parts[1]
-			}
-			appTypeValue := uint8(appType) // #nosec G115
 			billings = append(billings, &resources.Billing{
-				OrderID:   stableBillingOrderID(owner, endTime, ns, appTypeValue, appName),
+				OrderID: stableBillingOrderID(
+					owner, endTime, ns, groupKey.appType, groupKey.appName,
+				),
 				Type:      Consumption,
 				Namespace: ns,
-				AppType:   appTypeValue,
-				AppName:   appName,
+				AppType:   groupKey.appType,
+				AppName:   groupKey.appName,
 				AppCosts:  appCostList,
 				Amount:    amount,
 				Owner:     owner,

--- a/controllers/pkg/database/mongo/account.go
+++ b/controllers/pkg/database/mongo/account.go
@@ -234,13 +234,15 @@ func (m *mongoDB) GetOwnerBillingsAt(
 			int(resources.AppType[resources.LLMToken]),
 		}},
 	}
-	cursor, err := m.getBillingCollection().Find(context.Background(), filter)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cursor, err := m.getBillingCollection().Find(ctx, filter)
 	if err != nil {
 		return nil, fmt.Errorf("find owner billings: %w", err)
 	}
-	defer cursor.Close(context.Background())
+	defer cursor.Close(ctx)
 	var billings []*resources.Billing
-	if err := cursor.All(context.Background(), &billings); err != nil {
+	if err := cursor.All(ctx, &billings); err != nil {
 		return nil, fmt.Errorf("decode owner billings: %w", err)
 	}
 	for _, billing := range billings {

--- a/controllers/pkg/database/mongo/account.go
+++ b/controllers/pkg/database/mongo/account.go
@@ -16,6 +16,7 @@ package mongo
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"math"
@@ -30,7 +31,6 @@ import (
 	"github.com/labring/sealos/controllers/pkg/types"
 	"github.com/labring/sealos/controllers/pkg/utils/env"
 	"github.com/labring/sealos/controllers/pkg/utils/logger"
-	gonanoid "github.com/matoous/go-nanoid/v2"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -47,18 +47,19 @@ const (
 )
 
 const (
-	DefaultAccountDBName  = "sealos-resources"
-	DefaultTrafficDBName  = "sealos-networkmanager"
-	DefaultAuthDBName     = "sealos-auth"
-	DefaultCVMDBName      = "sealos-cvm"
-	DefaultCVMConn        = "cvm"
-	DefaultMeteringConn   = "metering"
-	DefaultMonitorConn    = "monitor"
-	DefaultBillingConn    = "billing"
-	DefaultObjTrafficConn = "objectstorage-traffic"
-	DefaultUserConn       = "user"
-	DefaultPricesConn     = "prices"
-	DefaultPropertiesConn = "properties"
+	DefaultAccountDBName         = "sealos-resources"
+	DefaultTrafficDBName         = "sealos-networkmanager"
+	DefaultAuthDBName            = "sealos-auth"
+	DefaultCVMDBName             = "sealos-cvm"
+	DefaultCVMConn               = "cvm"
+	DefaultMeteringConn          = "metering"
+	DefaultMonitorConn           = "monitor"
+	DefaultBillingConn           = "billing"
+	DefaultObjTrafficConn        = "objectstorage-traffic"
+	DefaultUserConn              = "user"
+	DefaultPricesConn            = "prices"
+	DefaultPropertiesConn        = "properties"
+	DefaultBillingCheckpointConn = "billing-checkpoint"
 	// TODO fix
 	DefaultTrafficConn = "traffic"
 )
@@ -216,6 +217,101 @@ func (m *mongoDB) GetOwnersRecentUpdates(
 	return updatedOwners, nil
 }
 
+func (m *mongoDB) GetOwnerBillingsAt(
+	ownerList []string,
+	billingTime time.Time,
+) (map[string][]*resources.Billing, error) {
+	result := make(map[string][]*resources.Billing)
+	if len(ownerList) == 0 {
+		return result, nil
+	}
+	filter := bson.M{
+		"owner": ownerListFilter(ownerList),
+		"time":  billingTime,
+		"type":  common.Consumption,
+		"app_type": bson.M{"$nin": []int{
+			int(resources.AppType[resources.CVM]),
+			int(resources.AppType[resources.LLMToken]),
+		}},
+	}
+	cursor, err := m.getBillingCollection().Find(context.Background(), filter)
+	if err != nil {
+		return nil, fmt.Errorf("find owner billings: %w", err)
+	}
+	defer cursor.Close(context.Background())
+	var billings []*resources.Billing
+	if err := cursor.All(context.Background(), &billings); err != nil {
+		return nil, fmt.Errorf("decode owner billings: %w", err)
+	}
+	for _, billing := range billings {
+		result[billing.Owner] = append(result[billing.Owner], billing)
+	}
+	return result, nil
+}
+
+func (m *mongoDB) GetUnsettledBillingsAt(
+	billingTime time.Time,
+) (map[string][]*resources.Billing, error) {
+	filter := bson.M{
+		"time":     billingTime,
+		"type":     common.Consumption,
+		"status":   resources.Unsettled,
+		"order_id": primitive.Regex{Pattern: "^bh_"},
+		"app_type": bson.M{"$nin": []int{
+			int(resources.AppType[resources.CVM]),
+			int(resources.AppType[resources.LLMToken]),
+		}},
+	}
+	cursor, err := m.getBillingCollection().Find(context.Background(), filter)
+	if err != nil {
+		return nil, fmt.Errorf("find unsettled billings: %w", err)
+	}
+	defer cursor.Close(context.Background())
+	var billings []*resources.Billing
+	if err := cursor.All(context.Background(), &billings); err != nil {
+		return nil, fmt.Errorf("decode unsettled billings: %w", err)
+	}
+	result := make(map[string][]*resources.Billing)
+	for _, billing := range billings {
+		result[billing.Owner] = append(result[billing.Owner], billing)
+	}
+	return result, nil
+}
+
+func ownerListFilter(ownerList []string) bson.M {
+	return bson.M{"$in": ownerList}
+}
+
+const billingCheckpointID = "account-hourly-billing"
+
+func (m *mongoDB) GetBillingCheckpoint() (time.Time, bool, error) {
+	var checkpoint resources.BillingCheckpoint
+	err := m.getBillingCheckpointCollection().FindOne(
+		context.Background(),
+		bson.M{"_id": billingCheckpointID},
+	).Decode(&checkpoint)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return time.Time{}, false, nil
+	}
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("get billing checkpoint: %w", err)
+	}
+	return checkpoint.Time.UTC(), true, nil
+}
+
+func (m *mongoDB) SaveBillingCheckpoint(billingTime time.Time) error {
+	_, err := m.getBillingCheckpointCollection().UpdateOne(
+		context.Background(),
+		bson.M{"_id": billingCheckpointID},
+		bson.M{"$set": bson.M{"time": billingTime.UTC(), "updated_at": time.Now().UTC()}},
+		options.Update().SetUpsert(true),
+	)
+	if err != nil {
+		return fmt.Errorf("save billing checkpoint: %w", err)
+	}
+	return nil
+}
+
 func (m *mongoDB) GetTimeUsedNamespaceList(startTime, endTime time.Time) ([]string, error) {
 	pipeline := mongo.Pipeline{
 		{
@@ -308,11 +404,19 @@ func (m *mongoDB) UpdateBillingStatus(orderIDs []string, status resources.Billin
 }
 
 func (m *mongoDB) SaveBillings(billing ...*resources.Billing) error {
-	billings := make([]any, len(billing))
-	for i, b := range billing {
-		billings[i] = b
+	if len(billing) == 0 {
+		return nil
 	}
-	_, err := m.getBillingCollection().InsertMany(context.Background(), billings)
+	models := make([]mongo.WriteModel, 0, len(billing))
+	for _, b := range billing {
+		models = append(models, mongo.NewUpdateOneModel().
+			SetFilter(bson.M{"owner": b.Owner, "order_id": b.OrderID}).
+			SetUpdate(bson.M{"$setOnInsert": b}).
+			SetUpsert(true))
+	}
+	_, err := m.getBillingCollection().BulkWrite(
+		context.Background(), models, options.BulkWrite().SetOrdered(false),
+	)
 	return err
 }
 
@@ -709,15 +813,15 @@ func (m *mongoDB) FetchOwnerMonitorRecords(
 	startTime, endTime time.Time,
 	ownerToNS map[string][]string,
 ) (map[string][]resources.Monitor, error) {
-	// collect all namespaces to avoid repetition
-	nsSet := make(map[string]struct{})
-	for _, nsList := range ownerToNS {
+	// Build the reverse index once so each monitor record has an O(1) owner lookup.
+	nsToOwner := make(map[string]string)
+	for owner, nsList := range ownerToNS {
 		for _, ns := range nsList {
-			nsSet[ns] = struct{}{}
+			nsToOwner[ns] = owner
 		}
 	}
-	namespaces := make([]string, 0, len(nsSet))
-	for ns := range nsSet {
+	namespaces := make([]string, 0, len(nsToOwner))
+	for ns := range nsToOwner {
 		namespaces = append(namespaces, ns)
 	}
 
@@ -740,21 +844,20 @@ func (m *mongoDB) FetchOwnerMonitorRecords(
 		return nil, fmt.Errorf("failed to decode monitor records: %w", err)
 	}
 
-	// build the mapping of owner monitor data
+	return groupMonitorRecordsByOwner(allRecords, nsToOwner), nil
+}
+
+func groupMonitorRecordsByOwner(
+	records []resources.Monitor,
+	nsToOwner map[string]string,
+) map[string][]resources.Monitor {
 	ownerMonitorRecords := make(map[string][]resources.Monitor)
-	for _, record := range allRecords {
-		for owner, nsList := range ownerToNS {
-			// Only the records of the namespace that belong to the owner are saved
-			for _, ns := range nsList {
-				if record.Category == ns {
-					ownerMonitorRecords[owner] = append(ownerMonitorRecords[owner], record)
-					break // avoid duplicate additions
-				}
-			}
+	for _, record := range records {
+		if owner, ok := nsToOwner[record.Category]; ok {
+			ownerMonitorRecords[owner] = append(ownerMonitorRecords[owner], record)
 		}
 	}
-
-	return ownerMonitorRecords, nil
+	return ownerMonitorRecords
 }
 
 func GenerateBillingDataFromRecords(
@@ -868,21 +971,18 @@ func GenerateBillingDataFromRecords(
 			if amount <= 0 {
 				continue
 			}
-			id, err := gonanoid.New(12)
-			if err != nil {
-				return nil, fmt.Errorf("generate billing id error: %w", err)
-			}
 			parts := strings.Split(tp, "/")
 			appType, _ := strconv.Atoi(parts[0])
 			appName := ""
 			if len(parts) > 1 {
 				appName = parts[1]
 			}
+			appTypeValue := uint8(appType) // #nosec G115
 			billings = append(billings, &resources.Billing{
-				OrderID:   id,
+				OrderID:   stableBillingOrderID(owner, endTime, ns, appTypeValue, appName),
 				Type:      Consumption,
 				Namespace: ns,
-				AppType:   uint8(appType), // #nosec G115
+				AppType:   appTypeValue,
 				AppName:   appName,
 				AppCosts:  appCostList,
 				Amount:    amount,
@@ -893,6 +993,25 @@ func GenerateBillingDataFromRecords(
 		}
 	}
 	return billings, nil
+}
+
+func stableBillingOrderID(
+	owner string,
+	endTime time.Time,
+	namespace string,
+	appType uint8,
+	appName string,
+) string {
+	key := fmt.Sprintf(
+		"%s\x00%s\x00%s\x00%d\x00%s",
+		owner,
+		endTime.UTC().Format(time.RFC3339),
+		namespace,
+		appType,
+		appName,
+	)
+	sum := sha256.Sum256([]byte(key))
+	return fmt.Sprintf("bh_%x", sum[:12])
 }
 
 func computeUsedValue(usedValues []int64, prop resources.PropertyType, minutes float64) int64 {
@@ -1009,6 +1128,10 @@ func (m *mongoDB) getBillingCollection() *mongo.Collection {
 	return m.Client.Database(m.AccountDB).Collection(m.BillingConn)
 }
 
+func (m *mongoDB) getBillingCheckpointCollection() *mongo.Collection {
+	return m.Client.Database(m.AccountDB).Collection(DefaultBillingCheckpointConn)
+}
+
 func (m *mongoDB) getObjTrafficCollection() *mongo.Collection {
 	return m.Client.Database(m.AccountDB).Collection(m.ObjTrafficConn)
 }
@@ -1018,13 +1141,15 @@ func (m *mongoDB) getPropertiesCollection() *mongo.Collection {
 }
 
 func (m *mongoDB) CreateBillingIfNotExist() error {
-	if exist, err := m.collectionExist(m.AccountDB, m.BillingConn); exist || err != nil {
+	ctx := context.Background()
+	exist, err := m.collectionExist(m.AccountDB, m.BillingConn)
+	if err != nil {
 		return err
 	}
-	ctx := context.Background()
-	err := m.Client.Database(m.AccountDB).CreateCollection(ctx, m.BillingConn)
-	if err != nil {
-		return fmt.Errorf("failed to create collection for billing: %w", err)
+	if !exist {
+		if err := m.Client.Database(m.AccountDB).CreateCollection(ctx, m.BillingConn); err != nil {
+			return fmt.Errorf("failed to create collection for billing: %w", err)
+		}
 	}
 
 	// create index
@@ -1043,6 +1168,15 @@ func (m *mongoDB) CreateBillingIfNotExist() error {
 				primitive.E{Key: "owner", Value: 1},
 				primitive.E{Key: "time", Value: 1},
 				primitive.E{Key: "type", Value: 1},
+			},
+		},
+		{
+			// recover stable unsettled billings for one billing hour
+			Keys: bson.D{
+				primitive.E{Key: "time", Value: 1},
+				primitive.E{Key: "status", Value: 1},
+				primitive.E{Key: "type", Value: 1},
+				primitive.E{Key: "order_id", Value: 1},
 			},
 		},
 	})

--- a/controllers/pkg/database/mongo/account_test.go
+++ b/controllers/pkg/database/mongo/account_test.go
@@ -30,6 +30,41 @@ import (
 
 var testTime = time.Date(2023, time.May, 9, 5, 0, 0, 0, time.UTC)
 
+func TestGenerateBillingDataPreservesTypedGroupKey(t *testing.T) {
+	start := time.Date(2026, time.July, 29, 1, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	properties := resources.NewPropertyTypeLS([]resources.PropertyType{
+		{
+			Name: "cpu", Enum: 0, PriceType: resources.AVG, UnitPrice: 1,
+		},
+	})
+	records := []resources.Monitor{
+		{
+			Time: start, Category: "ns-owner", Type: 1,
+			ParentType: 255, ParentName: "parent/name", Name: "child",
+			Used: resources.EnumUsedMap{0: 60},
+		},
+	}
+
+	billings, err := GenerateBillingDataFromRecords(
+		records, properties, start, end, "owner",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(billings) != 1 {
+		t.Fatalf("billing count = %d, want 1", len(billings))
+	}
+	if billings[0].AppType != 255 || billings[0].AppName != "parent/name" {
+		t.Fatalf(
+			"billing group = (%d, %q), want (255, %q)",
+			billings[0].AppType,
+			billings[0].AppName,
+			"parent/name",
+		)
+	}
+}
+
 func TestMongoDB_SaveBillingsWithAccountBalance(t *testing.T) {
 	type fields struct {
 		URL          string

--- a/controllers/pkg/database/mongo/billing_runtime_test.go
+++ b/controllers/pkg/database/mongo/billing_runtime_test.go
@@ -2,7 +2,9 @@ package mongo
 
 import (
 	"context"
+	"fmt"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,7 +12,20 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
+
+func explainBillingFind(ctx context.Context, account *mongoDB, filter bson.D) (bson.M, error) {
+	var explain bson.M
+	err := account.Client.Database(account.AccountDB).RunCommand(ctx, bson.D{
+		{Key: "explain", Value: bson.D{
+			{Key: "find", Value: account.BillingConn},
+			{Key: "filter", Value: filter},
+		}},
+		{Key: "verbosity", Value: "executionStats"},
+	}).Decode(&explain)
+	return explain, err
+}
 
 func TestBillingPersistenceWithMongoRuntime(t *testing.T) {
 	testcontainers.SkipIfProviderIsNotHealthy(t)
@@ -49,6 +64,16 @@ func TestBillingPersistenceWithMongoRuntime(t *testing.T) {
 			t.Errorf("disconnect MongoDB: %v", err)
 		}
 	})
+	mongoAccount, ok := account.(*mongoDB)
+	if !ok {
+		t.Fatalf("account type = %T", account)
+	}
+	// Simulate an existing production collection so initialization must add
+	// indexes during an upgrade.
+	if err := mongoAccount.Client.Database(mongoAccount.AccountDB).
+		CreateCollection(ctx, mongoAccount.BillingConn); err != nil {
+		t.Fatal(err)
+	}
 	if err := account.CreateBillingIfNotExist(); err != nil {
 		t.Fatal(err)
 	}
@@ -69,9 +94,12 @@ func TestBillingPersistenceWithMongoRuntime(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mongoAccount, ok := account.(*mongoDB)
-	if !ok {
-		t.Fatalf("account type = %T", account)
+	indexSpecs, err := mongoAccount.getBillingCollection().Indexes().ListSpecifications(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(indexSpecs) != 4 {
+		t.Fatalf("billing index count = %d, want 4", len(indexSpecs))
 	}
 	monitorTime := end.Add(-time.Hour)
 	namespaces, err := account.GetTimeUsedNamespaceList(monitorTime, end)
@@ -135,6 +163,107 @@ func TestBillingPersistenceWithMongoRuntime(t *testing.T) {
 	checkpoint, exists, err := account.GetBillingCheckpoint()
 	if err != nil || !exists || !checkpoint.Equal(end) {
 		t.Fatalf("checkpoint=%v exists=%v err=%v", checkpoint, exists, err)
+	}
+}
+
+func TestBillingQueriesUseIndexesWithMongoRuntime(t *testing.T) {
+	testcontainers.SkipIfProviderIsNotHealthy(t)
+	ctx := context.Background()
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "mongo:7.0",
+			ExposedPorts: []string{"27017/tcp"},
+			WaitingFor: wait.ForListeningPort("27017/tcp").
+				WithStartupTimeout(2 * time.Minute),
+		},
+		Started: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := container.Terminate(ctx); err != nil {
+			t.Errorf("terminate MongoDB: %v", err)
+		}
+	})
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := container.MappedPort(ctx, "27017/tcp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	account, err := NewMongoInterface(ctx, "mongodb://"+net.JoinHostPort(host, port.Port()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := account.Disconnect(ctx); err != nil {
+			t.Errorf("disconnect MongoDB: %v", err)
+		}
+	})
+	if err := account.CreateBillingIfNotExist(); err != nil {
+		t.Fatal(err)
+	}
+
+	mongoAccount, ok := account.(*mongoDB)
+	if !ok {
+		t.Fatalf("account type = %T", account)
+	}
+	end := time.Date(2026, time.July, 7, 10, 0, 0, 0, time.UTC)
+	documents := make([]any, 0, 50000)
+	for i := 0; i < 50000; i++ {
+		owner := "owner-other"
+		billingTime := end.Add(time.Duration(i%24) * time.Hour)
+		status := resources.Settled
+		if i%1000 == 0 {
+			owner = "owner-target"
+			billingTime = end
+			status = resources.Unsettled
+		}
+		documents = append(documents, &resources.Billing{
+			Time:      billingTime,
+			OrderID:   fmt.Sprintf("bh_%05d", i),
+			Type:      Consumption,
+			Namespace: "ns-owner",
+			AppType:   1,
+			Amount:    1,
+			Owner:     owner,
+			Status:    status,
+		})
+	}
+	if _, err := mongoAccount.getBillingCollection().InsertMany(ctx, documents); err != nil {
+		t.Fatal(err)
+	}
+
+	ownerFilter := bson.D{
+		{Key: "owner", Value: bson.M{"$in": []string{"owner-target"}}},
+		{Key: "time", Value: end},
+		{Key: "type", Value: Consumption},
+		{Key: "app_type", Value: bson.M{"$nin": []int{int(resources.AppType[resources.CVM]), int(resources.AppType[resources.LLMToken])}}},
+	}
+	unsettledFilter := bson.D{
+		{Key: "time", Value: end},
+		{Key: "status", Value: resources.Unsettled},
+		{Key: "type", Value: Consumption},
+		{Key: "order_id", Value: primitive.Regex{Pattern: "^bh_"}},
+		{Key: "app_type", Value: bson.M{"$nin": []int{int(resources.AppType[resources.CVM]), int(resources.AppType[resources.LLMToken])}}},
+	}
+	for name, filter := range map[string]bson.D{
+		"owner billing lookup":      ownerFilter,
+		"unsettled recovery lookup": unsettledFilter,
+	} {
+		explain, err := explainBillingFind(ctx, mongoAccount, filter)
+		if err != nil {
+			t.Fatalf("%s explain: %v", name, err)
+		}
+		plan := fmt.Sprint(explain["queryPlanner"])
+		if !strings.Contains(plan, "IXSCAN") {
+			t.Fatalf("%s did not use an index: %s", name, plan)
+		}
+		stats := fmt.Sprint(explain["executionStats"])
+		t.Logf("%s: %s", name, stats)
 	}
 }
 

--- a/controllers/pkg/database/mongo/billing_runtime_test.go
+++ b/controllers/pkg/database/mongo/billing_runtime_test.go
@@ -1,0 +1,167 @@
+package mongo
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/labring/sealos/controllers/pkg/resources"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestBillingPersistenceWithMongoRuntime(t *testing.T) {
+	testcontainers.SkipIfProviderIsNotHealthy(t)
+	ctx := context.Background()
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "mongo:7.0",
+			ExposedPorts: []string{"27017/tcp"},
+			WaitingFor: wait.ForListeningPort("27017/tcp").
+				WithStartupTimeout(2 * time.Minute),
+		},
+		Started: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := container.Terminate(ctx); err != nil {
+			t.Errorf("terminate MongoDB: %v", err)
+		}
+	})
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := container.MappedPort(ctx, "27017/tcp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	account, err := NewMongoInterface(ctx, "mongodb://"+net.JoinHostPort(host, port.Port()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := account.Disconnect(ctx); err != nil {
+			t.Errorf("disconnect MongoDB: %v", err)
+		}
+	})
+	if err := account.CreateBillingIfNotExist(); err != nil {
+		t.Fatal(err)
+	}
+	if err := account.CreateBillingIfNotExist(); err != nil {
+		t.Fatalf("repeat index initialization: %v", err)
+	}
+
+	end := time.Date(2026, time.July, 7, 10, 0, 0, 0, time.UTC)
+	billing := &resources.Billing{
+		Time: end, OrderID: "stable-order", Owner: "owner", Namespace: "ns-owner",
+		Type: Consumption, AppType: 1, Amount: 100, Status: resources.Unsettled,
+	}
+	if err := account.SaveBillings(billing); err != nil {
+		t.Fatal(err)
+	}
+	billing.Status = resources.Settled
+	if err := account.SaveBillings(billing); err != nil {
+		t.Fatal(err)
+	}
+
+	mongoAccount, ok := account.(*mongoDB)
+	if !ok {
+		t.Fatalf("account type = %T", account)
+	}
+	monitorTime := end.Add(-time.Hour)
+	namespaces, err := account.GetTimeUsedNamespaceList(monitorTime, end)
+	if err != nil || len(namespaces) != 0 {
+		t.Fatalf("missing monitor collection namespaces=%v err=%v", namespaces, err)
+	}
+	count, err := mongoAccount.getBillingCollection().CountDocuments(ctx, bson.M{
+		"owner": "owner", "order_id": "stable-order",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("billing count = %d", count)
+	}
+	var stored resources.Billing
+	if err := mongoAccount.getBillingCollection().FindOne(ctx, bson.M{
+		"owner": "owner", "order_id": "stable-order",
+	}).Decode(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored.Status != resources.Unsettled {
+		t.Fatalf("stored status = %v", stored.Status)
+	}
+	recoveryBillings := []*resources.Billing{
+		{
+			Time: end, OrderID: "bh_recover", Owner: "recover-owner", Namespace: "ns-recover",
+			Type: Consumption, AppType: 1, Amount: 50, Status: resources.Unsettled,
+		},
+		{
+			Time: end, OrderID: "bh_settled", Owner: "settled-owner", Namespace: "ns-settled",
+			Type: Consumption, AppType: 1, Amount: 50, Status: resources.Settled,
+		},
+		{
+			Time: end, OrderID: "legacy-random", Owner: "legacy-owner", Namespace: "ns-legacy",
+			Type: Consumption, AppType: 1, Amount: 50, Status: resources.Unsettled,
+		},
+		{
+			Time:      end.Add(time.Hour),
+			OrderID:   "bh_other-hour",
+			Owner:     "other-owner",
+			Namespace: "ns-other",
+			Type:      Consumption, AppType: 1, Amount: 50, Status: resources.Unsettled,
+		},
+	}
+	if err := account.SaveBillings(recoveryBillings...); err != nil {
+		t.Fatal(err)
+	}
+	unsettled, err := account.GetUnsettledBillingsAt(end)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unsettled) != 1 || len(unsettled["recover-owner"]) != 1 ||
+		unsettled["recover-owner"][0].OrderID != "bh_recover" {
+		t.Fatalf("unsettled billings = %#v", unsettled)
+	}
+
+	if err := account.SaveBillingCheckpoint(end); err != nil {
+		t.Fatal(err)
+	}
+	checkpoint, exists, err := account.GetBillingCheckpoint()
+	if err != nil || !exists || !checkpoint.Equal(end) {
+		t.Fatalf("checkpoint=%v exists=%v err=%v", checkpoint, exists, err)
+	}
+}
+
+func TestStableBillingOrderID(t *testing.T) {
+	end := time.Date(2026, time.July, 7, 10, 0, 0, 0, time.UTC)
+	first := stableBillingOrderID("owner", end, "ns-owner", 1, "app")
+	second := stableBillingOrderID("owner", end, "ns-owner", 1, "app")
+	if first != second {
+		t.Fatalf("IDs differ: %q %q", first, second)
+	}
+	if first == stableBillingOrderID("owner", end.Add(time.Hour), "ns-owner", 1, "app") {
+		t.Fatal("different billing windows share an ID")
+	}
+}
+
+func TestGroupMonitorRecordsByOwner(t *testing.T) {
+	records := []resources.Monitor{
+		{Category: "ns-a", Name: "a-1"},
+		{Category: "ns-b", Name: "b-1"},
+		{Category: "ns-a", Name: "a-2"},
+		{Category: "unmapped", Name: "ignored"},
+	}
+	grouped := groupMonitorRecordsByOwner(records, map[string]string{
+		"ns-a": "owner-a",
+		"ns-b": "owner-b",
+	})
+	if len(grouped) != 2 || len(grouped["owner-a"]) != 2 || len(grouped["owner-b"]) != 1 {
+		t.Fatalf("grouped records = %#v", grouped)
+	}
+}

--- a/controllers/pkg/resources/resources.go
+++ b/controllers/pkg/resources/resources.go
@@ -137,6 +137,12 @@ type Billing struct {
 	// UserUID  uuid.UUID `json:"user_uid" bson:"user_uid,omitempty"`
 }
 
+type BillingCheckpoint struct {
+	ID        string    `json:"id"         bson:"_id"`
+	Time      time.Time `json:"time"       bson:"time"`
+	UpdatedAt time.Time `json:"updated_at" bson:"updated_at"`
+}
+
 type Payment struct {
 	Method  string `json:"method"            bson:"method"`
 	UserID  string `json:"user_id"           bson:"user_id"`


### PR DESCRIPTION
- schedule every ready billing hour from a persisted Mongo checkpoint
- retry failed owner reconciliation and preserve checkpoint progress
- use stable billing IDs with Mongo upsert semantics
- recover stable unsettled billings independently from monitor data
- make Cockroach balance and credits deductions idempotent
- reconstruct historical debt and subscription state using transaction UpdatedAt
- scope subscription history queries to active workspaces in the target hour
- add focused unit and Testcontainers runtime coverage
