### PR TITLE
feat(desktop): add guide button environment toggle

### DIFF
--- a/frontend/desktop/README.md
+++ b/frontend/desktop/README.md
@@ -214,6 +214,8 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 5. 环境变量说明
 
+- 引导按钮默认显示。部署时显式设置 `GUIDE_BUTTON_ENABLED=false` 可隐藏按钮；不设置或设置为 `true` 时保持显示。`GUIDE_ENABLED` 仍用于控制完整的用户引导功能。
+
 - 登录功能的开关, 部署时要用`true`配置想要使用的登录方式。
 
   ```

--- a/frontend/desktop/deploy/HELM_VALUES_GUIDE.md
+++ b/frontend/desktop/deploy/HELM_VALUES_GUIDE.md
@@ -99,6 +99,7 @@ desktopConfig:
 ```yaml
 desktopConfig:
   guideEnabled: false # 启用用户引导
+  guideButtonEnabled: true # 显示引导按钮；GUIDE_BUTTON_ENABLED=false 时隐藏
   apiEnabled: false # 启用 API 访问
   rechargeEnabled: false # 启用充值功能
   enterpriseRealNameAuthEnabled: false # 启用企业实名认证

--- a/frontend/desktop/deploy/HELM_VALUES_GUIDE_CN.md
+++ b/frontend/desktop/deploy/HELM_VALUES_GUIDE_CN.md
@@ -99,6 +99,7 @@ desktopConfig:
 ```yaml
 desktopConfig:
   guideEnabled: false                         # 启用用户引导
+  guideButtonEnabled: true                    # 显示引导按钮；GUIDE_BUTTON_ENABLED=false 时隐藏
   apiEnabled: false                           # 启用 API 访问
   rechargeEnabled: false                      # 启用充值功能
   enterpriseRealNameAuthEnabled: false        # 启用企业实名认证

--- a/frontend/desktop/deploy/README.md
+++ b/frontend/desktop/deploy/README.md
@@ -53,7 +53,7 @@ Contains the template for user-customizable configurations. On the first install
 
 **Modification**: ✅ Modify as needed
 
-**Note**: The entrypoint applies values in this order: `values.yaml`, persisted user values, optional `global.yaml`, auto-configuration from `sealos-system/sealos-config`, explicit `HELM_OPTIONS` / `HELM_OPTS`, then enforced TLS trust config from synced cloud tools. Later sources win.
+**Note**: The entrypoint applies values in this order: `values.yaml`, persisted user values, optional `global.yaml`, auto-configuration from `sealos-system/sealos-config`, explicit `HELM_OPTIONS` / `HELM_OPTS`, direct environment overrides such as `GUIDE_BUTTON_ENABLED`, then enforced TLS trust config from synced cloud tools. Later sources win.
 
 For detailed documentation, see [HELM_VALUES_GUIDE.md](./HELM_VALUES_GUIDE.md).
 
@@ -70,6 +70,7 @@ For detailed documentation, see [HELM_VALUES_GUIDE.md](./HELM_VALUES_GUIDE.md).
 | Variable                            | Default | Description                                |
 | ----------------------------------- | ------- | ------------------------------------------ |
 | `GUIDE_ENABLED`                     | `false` | Enable user guide                          |
+| `GUIDE_BUTTON_ENABLED`              | `true`  | Show the guide button; set `false` to hide |
 | `API_ENABLED`                       | `false` | Enable API access                          |
 | `RECHARGE_ENABLED`                  | `false` | Enable recharge feature                    |
 | `ENTERPRISE_REAL_NAME_AUTH_ENABLED` | `false` | Enable enterprise real-name authentication |
@@ -464,7 +465,7 @@ sealos run desktop-frontend:latest \
 
 - **UI customization**: `layoutTitle`, `layoutLogo`, `metaTitle`, `metaDescription`, `customerServiceURL`, `protocol.enabled`
 - **OAuth providers**: `githubEnabled`, `googleEnabled`, `wechatEnabled`, `oauth2Enabled` and their `*ClientId`, `*ClientSecret`
-- **Features**: `guideEnabled`, `rechargeEnabled`, `trackingEnabled`, `apiEnabled`, `realNameAuthEnabled`
+- **Features**: `guideEnabled`, `guideButtonEnabled`, `rechargeEnabled`, `trackingEnabled`, `apiEnabled`, `realNameAuthEnabled`
 - **Communication**: `smsEnabled`, `emailEnabled`, `emailHost`, `emailPort`, `emailUser`, `emailPassword`
 - **URLs**: `workorderUrl` and service URLs auto-generated from `cloudDomain` (`template`, `applaunchpad`, `dbprovider`, `objectstorage`)
 - **Database**: `databaseGlobalCockroachdbURI`, `databaseLocalCockroachdbURI`

--- a/frontend/desktop/deploy/README_CN.md
+++ b/frontend/desktop/deploy/README_CN.md
@@ -53,7 +53,7 @@ Helm Chart 使用两个 values 文件来管理配置：
 
 **是否修改**: ✅ 根据需要修改
 
-**注意**: entrypoint 按以下顺序应用配置：`values.yaml`、持久化用户 values、可选 `global.yaml`、来自 `sealos-system/sealos-config` 的自动配置、显式 `HELM_OPTIONS` / `HELM_OPTS`、由同步后的 cloud tools 强制注入的 TLS trust 配置。后面的配置优先。
+**注意**: entrypoint 按以下顺序应用配置：`values.yaml`、持久化用户 values、可选 `global.yaml`、来自 `sealos-system/sealos-config` 的自动配置、显式 `HELM_OPTIONS` / `HELM_OPTS`、`GUIDE_BUTTON_ENABLED` 等直接环境变量覆盖、由同步后的 cloud tools 强制注入的 TLS trust 配置。后面的配置优先。
 
 详细文档请参考 [HELM_VALUES_GUIDE_CN.md](./HELM_VALUES_GUIDE_CN.md)。
 
@@ -67,15 +67,16 @@ Helm Chart 使用两个 values 文件来管理配置：
 
 ### 功能开关
 
-| 变量                                | 默认值  | 描述              |
-| ----------------------------------- | ------- | ----------------- |
-| `GUIDE_ENABLED`                     | `false` | 启用用户引导      |
-| `API_ENABLED`                       | `false` | 启用 API 访问     |
-| `RECHARGE_ENABLED`                  | `false` | 启用充值功能      |
-| `ENTERPRISE_REAL_NAME_AUTH_ENABLED` | `false` | 启用企业实名认证  |
-| `TRACKING_ENABLED`                  | `false` | 启用追踪/统计     |
-| `REAL_NAME_AUTH_ENABLED`            | `false` | 启用实名认证      |
-| `LICENSE_CHECK_ENABLED`             | `false` | 启用 License 检查 |
+| 变量                                | 默认值  | 描述                              |
+| ----------------------------------- | ------- | --------------------------------- |
+| `GUIDE_ENABLED`                     | `false` | 启用用户引导                      |
+| `GUIDE_BUTTON_ENABLED`              | `true`  | 显示引导按钮；设为 `false` 时隐藏 |
+| `API_ENABLED`                       | `false` | 启用 API 访问                     |
+| `RECHARGE_ENABLED`                  | `false` | 启用充值功能                      |
+| `ENTERPRISE_REAL_NAME_AUTH_ENABLED` | `false` | 启用企业实名认证                  |
+| `TRACKING_ENABLED`                  | `false` | 启用追踪/统计                     |
+| `REAL_NAME_AUTH_ENABLED`            | `false` | 启用实名认证                      |
+| `LICENSE_CHECK_ENABLED`             | `false` | 启用 License 检查                 |
 
 ### OAuth 提供商
 
@@ -464,7 +465,7 @@ sealos run desktop-frontend:latest \
 
 - **UI 自定义**: `layoutTitle`, `layoutLogo`, `metaTitle`, `metaDescription`, `customerServiceURL`, `protocol.enabled`
 - **OAuth 提供商**: `githubEnabled`, `googleEnabled`, `wechatEnabled`, `oauth2Enabled` 及其对应的 `*ClientId`, `*ClientSecret`
-- **功能开关**: `guideEnabled`, `rechargeEnabled`, `trackingEnabled`, `apiEnabled`, `realNameAuthEnabled`
+- **功能开关**: `guideEnabled`, `guideButtonEnabled`, `rechargeEnabled`, `trackingEnabled`, `apiEnabled`, `realNameAuthEnabled`
 - **通讯配置**: `smsEnabled`, `emailEnabled`, `emailHost`, `emailPort`, `emailUser`, `emailPassword`
 - **URL 配置**: `workorderUrl`，以及基于 `cloudDomain` 自动生成的服务地址（`template`、`applaunchpad`、`dbprovider`、`objectstorage`）
 - **数据库配置**: `databaseGlobalCockroachdbURI`, `databaseLocalCockroachdbURI`

--- a/frontend/desktop/deploy/charts/desktop-frontend/desktop-frontend-values.yaml
+++ b/frontend/desktop/deploy/charts/desktop-frontend/desktop-frontend-values.yaml
@@ -55,6 +55,7 @@ desktopConfig:
 
   # Feature flags
   guideEnabled: false
+  guideButtonEnabled: true
   apiEnabled: false
   rechargeEnabled: false
   enterpriseRealNameAuthEnabled: false

--- a/frontend/desktop/deploy/charts/desktop-frontend/templates/deployment.yaml
+++ b/frontend/desktop/deploy/charts/desktop-frontend/templates/deployment.yaml
@@ -70,6 +70,8 @@ spec:
               value: {{ .Values.desktopConfig.tlsRejectUnauthorized | quote }}
             - name: PRISMA_DB_PROVIDER
               value: "{{ .Values.desktopConfig.databaseType }}"
+            - name: GUIDE_BUTTON_ENABLED
+              value: {{ .Values.desktopConfig.guideButtonEnabled | quote }}
           command: ["/bin/sh", "-c"]
           args:
             - |

--- a/frontend/desktop/deploy/charts/desktop-frontend/values.yaml
+++ b/frontend/desktop/deploy/charts/desktop-frontend/values.yaml
@@ -47,6 +47,9 @@ autoConfigEnabled: true
 # ============================================================================
 
 desktopConfig:
+  # Runtime UI toggle. The installer defaults GUIDE_BUTTON_ENABLED to true.
+  guideButtonEnabled: true
+
   # Basic cloud configuration (auto-configured from sealos-config)
   cloudDomain: "127.0.0.1.nip.io"  # Auto-fetched from sealos-config.cloudDomain
   cloudPort: ""                     # Auto-fetched from sealos-config.cloudPort

--- a/frontend/desktop/deploy/desktop-frontend-entrypoint.sh
+++ b/frontend/desktop/deploy/desktop-frontend-entrypoint.sh
@@ -10,6 +10,7 @@ USER_VALUES_PATH="/root/.sealos/cloud/values/core/desktop-values.yaml"
 TOOLS_FILE=${TOOLS_FILE:-"/root/.sealos/cloud/scripts/tools.sh"}
 
 AUTO_CONFIG_HELM_ARGS=()
+ENV_CONFIG_HELM_ARGS=()
 ENFORCED_CONFIG_HELM_ARGS=()
 HELM_EXTRA_ARGS=()
 if [ -n "${HELM_OPTIONS:-}" ]; then
@@ -19,6 +20,18 @@ fi
 if [ -n "${HELM_OPTS:-}" ]; then
   read -r -a PARSED_HELM_OPTS <<< "${HELM_OPTS}"
   HELM_EXTRA_ARGS+=("${PARSED_HELM_OPTS[@]}")
+fi
+
+if [ "${GUIDE_BUTTON_ENABLED+x}" = "x" ]; then
+  case "${GUIDE_BUTTON_ENABLED}" in
+    true|false)
+      ENV_CONFIG_HELM_ARGS+=(--set-string "desktopConfig.guideButtonEnabled=${GUIDE_BUTTON_ENABLED}")
+      ;;
+    *)
+      echo "GUIDE_BUTTON_ENABLED must be either true or false" >&2
+      exit 1
+      ;;
+  esac
 fi
 
 get_cm_value() {
@@ -234,4 +247,5 @@ helm upgrade -i "${RELEASE_NAME}" -n "${RELEASE_NAMESPACE}" --create-namespace "
   "${VALUES_ARGS[@]}" \
   "${AUTO_CONFIG_HELM_ARGS[@]}" \
   "${HELM_EXTRA_ARGS[@]}" \
+  "${ENV_CONFIG_HELM_ARGS[@]}" \
   "${ENFORCED_CONFIG_HELM_ARGS[@]}"

--- a/frontend/desktop/src/__tests__/unit/guideButtonEnv.test.ts
+++ b/frontend/desktop/src/__tests__/unit/guideButtonEnv.test.ts
@@ -1,0 +1,13 @@
+import { getGuideButtonEnabled } from '@/pages/api/platform/getCommonConfig';
+
+describe('guide button environment flag', () => {
+  it('defaults to enabled', () => {
+    expect(getGuideButtonEnabled(undefined)).toBe(true);
+  });
+
+  it('is disabled only by an explicit false value', () => {
+    expect(getGuideButtonEnabled('false')).toBe(false);
+    expect(getGuideButtonEnabled(' FALSE ')).toBe(false);
+    expect(getGuideButtonEnabled('true')).toBe(true);
+  });
+});

--- a/frontend/desktop/src/__tests__/unit/guideDriverFlag.test.ts
+++ b/frontend/desktop/src/__tests__/unit/guideDriverFlag.test.ts
@@ -1,0 +1,50 @@
+/** @jest-environment jsdom */
+
+import { driver } from '@sealos/driver';
+import { destroyDriver, startQuitGuideDriver } from '@/components/account/driver';
+import { useConfigStore } from '@/stores/config';
+import { useGuideModalStore } from '@/stores/guideModal';
+import type { TFunction } from 'next-i18next';
+
+jest.mock('@sealos/driver', () => ({
+  driver: jest.fn()
+}));
+
+jest.mock('@sealos/gtm', () => ({
+  track: jest.fn()
+}));
+
+const mockedDriver = driver as jest.MockedFunction<typeof driver>;
+const t = ((key: string) => key) as TFunction;
+
+describe('guide exit driver flag', () => {
+  beforeEach(() => {
+    destroyDriver();
+    jest.clearAllMocks();
+    mockedDriver.mockReturnValue({
+      destroy: jest.fn(),
+      drive: jest.fn()
+    } as ReturnType<typeof driver>);
+    useConfigStore.setState({ commonConfig: undefined });
+    useGuideModalStore.getState().setIsDriverActive(false);
+  });
+
+  it('does not point to the guide button when the button is hidden', () => {
+    useConfigStore.setState({
+      commonConfig: { guideButtonEnabled: false } as NonNullable<
+        ReturnType<typeof useConfigStore.getState>['commonConfig']
+      >
+    });
+
+    expect(startQuitGuideDriver(t)).toBeNull();
+    expect(mockedDriver).not.toHaveBeenCalled();
+    expect(useGuideModalStore.getState().isDriverActive).toBe(false);
+  });
+
+  it('keeps the exit hint enabled when older config omits the flag', () => {
+    startQuitGuideDriver(t);
+
+    expect(mockedDriver).toHaveBeenCalledTimes(1);
+    expect(useGuideModalStore.getState().isDriverActive).toBe(true);
+  });
+});

--- a/frontend/desktop/src/__tests__/unit/guideFeatureFlag.test.ts
+++ b/frontend/desktop/src/__tests__/unit/guideFeatureFlag.test.ts
@@ -48,13 +48,20 @@ const mockedUseBreakpointValue = useBreakpointValue as jest.MockedFunction<
   typeof useBreakpointValue
 >;
 
-function renderSecondaryLinks(guideEnabled: boolean) {
+function renderSecondaryLinks({
+  guideEnabled,
+  guideButtonEnabled
+}: {
+  guideEnabled: boolean;
+  guideButtonEnabled?: boolean;
+}) {
   mockedUseConfigStore.mockReturnValue({
     layoutConfig: {
       common: {}
     },
     commonConfig: {
-      guideEnabled
+      guideEnabled,
+      guideButtonEnabled
     }
   } as ReturnType<typeof useConfigStore>);
 
@@ -84,13 +91,19 @@ describe('guide feature flag', () => {
   });
 
   it('hides the guide entry when the feature is disabled', () => {
-    renderSecondaryLinks(false);
+    renderSecondaryLinks({ guideEnabled: false });
 
     expect(screen.queryByText('common:guide')).toBeNull();
   });
 
-  it('shows the guide entry and opens the guide when enabled', () => {
-    renderSecondaryLinks(true);
+  it('hides the guide entry when the button is disabled', () => {
+    renderSecondaryLinks({ guideEnabled: true, guideButtonEnabled: false });
+
+    expect(screen.queryByText('common:guide')).toBeNull();
+  });
+
+  it('shows the guide entry by default and opens the guide when enabled', () => {
+    renderSecondaryLinks({ guideEnabled: true });
 
     fireEvent.click(screen.getByText('common:guide'));
 

--- a/frontend/desktop/src/components/SecondaryLinks/index.tsx
+++ b/frontend/desktop/src/components/SecondaryLinks/index.tsx
@@ -277,7 +277,7 @@ export default function SecondaryLinks() {
           </Portal>
         </Popover>
 
-        {commonConfig?.guideEnabled ? (
+        {commonConfig?.guideEnabled && commonConfig.guideButtonEnabled !== false ? (
           <Center
             className="guide-button"
             cursor={'pointer'}

--- a/frontend/desktop/src/components/account/GuideModal.tsx
+++ b/frontend/desktop/src/components/account/GuideModal.tsx
@@ -20,8 +20,8 @@ import { useCallback, useEffect } from 'react';
 import useAppStore from '@/stores/app';
 import {
   devboxDriverObj,
-  quitGuideDriverObj,
   startDriver,
+  startQuitGuideDriver,
   appLaunchpadDriverObj,
   templateDriverObj,
   databaseDriverObj
@@ -291,7 +291,7 @@ const GuideModal = () => {
   const handleCloseGuideModal = () => {
     setInitGuide(false);
     closeGuideModal();
-    startDriver(quitGuideDriverObj(t));
+    startQuitGuideDriver(t);
 
     track('guide_exit', {
       module: 'guide',

--- a/frontend/desktop/src/components/account/driver.tsx
+++ b/frontend/desktop/src/components/account/driver.tsx
@@ -3,6 +3,7 @@ import { driver } from '@sealos/driver';
 import { Config } from '@sealos/driver/src/config';
 import { X } from 'lucide-react';
 import { TFunction } from 'next-i18next';
+import { useConfigStore } from '@/stores/config';
 import { useGuideModalStore } from '@/stores/guideModal';
 import { track } from '@sealos/gtm';
 
@@ -25,6 +26,14 @@ export function startDriver(config: Config) {
   useGuideModalStore.getState().setIsDriverActive(true);
   driverObj.drive();
   return driverObj;
+}
+
+export function startQuitGuideDriver(t: TFunction) {
+  if (useConfigStore.getState().commonConfig?.guideButtonEnabled === false) {
+    useGuideModalStore.getState().setIsDriverActive(false);
+    return null;
+  }
+  return startDriver(quitGuideDriverObj(t));
 }
 
 export const devboxDriverObj = (openDesktopApp: any, t: TFunction): Config => ({
@@ -69,7 +78,7 @@ export const devboxDriverObj = (openDesktopApp: any, t: TFunction): Config => ({
 
                   currentDriver.destroy();
                   currentDriver = null;
-                  startDriver(quitGuideDriverObj(t));
+                  startQuitGuideDriver(t);
                 }}
               >
                 <X width={'16px'} height={'16px'} />
@@ -179,7 +188,7 @@ export const appLaunchpadDriverObj = (openDesktopApp: any, t: TFunction): Config
 
                   currentDriver.destroy();
                   currentDriver = null;
-                  startDriver(quitGuideDriverObj(t));
+                  startQuitGuideDriver(t);
                 }}
               >
                 <X width={'16px'} height={'16px'} />
@@ -288,7 +297,7 @@ export const templateDriverObj = (openDesktopApp: any, t: TFunction): Config => 
 
                   currentDriver.destroy();
                   currentDriver = null;
-                  startDriver(quitGuideDriverObj(t));
+                  startQuitGuideDriver(t);
                 }}
               >
                 <X width={'16px'} height={'16px'} />
@@ -397,7 +406,7 @@ export const databaseDriverObj = (openDesktopApp: any, t: TFunction): Config => 
 
                   currentDriver.destroy();
                   currentDriver = null;
-                  startDriver(quitGuideDriverObj(t));
+                  startQuitGuideDriver(t);
                 }}
               >
                 <X width={'16px'} height={'16px'} />

--- a/frontend/desktop/src/pages/api/platform/getCommonConfig.ts
+++ b/frontend/desktop/src/pages/api/platform/getCommonConfig.ts
@@ -16,6 +16,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     code: 200
   });
 }
+
+export function getGuideButtonEnabled(value: string | undefined): boolean {
+  return value?.trim().toLowerCase() !== 'false';
+}
+
 function genResCommonClientConfig(common: CommonConfigType): CommonClientConfigType {
   return {
     trackingEnabled: !!common.trackingEnabled,
@@ -23,6 +28,7 @@ function genResCommonClientConfig(common: CommonConfigType): CommonClientConfigT
     realNameAuthEnabled: !!common.realNameAuthEnabled,
     realNameReward: common.realNameReward || 0,
     guideEnabled: !!common.guideEnabled,
+    guideButtonEnabled: getGuideButtonEnabled(process.env.GUIDE_BUTTON_ENABLED),
     rechargeEnabled: !!common.rechargeEnabled,
     cfSiteKey: common.cfSiteKey || ''
   };

--- a/frontend/desktop/src/types/system.ts
+++ b/frontend/desktop/src/types/system.ts
@@ -34,7 +34,9 @@ export type CommonClientConfigType = DeepRequired<
     | 'templateUrl'
     | 'realNameCallbackUrl'
   >
->;
+> & {
+  guideButtonEnabled: boolean;
+};
 export type DatabaseConfigType = {
   globalCockroachdbURI: string;
   regionalCockroachdbURI: string;
@@ -288,6 +290,7 @@ export const DefaultCommonClientConfig: CommonClientConfigType = {
   realNameAuthEnabled: false,
   realNameReward: 0,
   guideEnabled: false,
+  guideButtonEnabled: true,
   rechargeEnabled: false,
   cfSiteKey: ''
 };


### PR DESCRIPTION
## Summary

- add `GUIDE_BUTTON_ENABLED` as a runtime configuration option that defaults to `true` and hides the Desktop guide button only when explicitly set to `false`
- keep `guideEnabled` as the global guide feature gate, preserve compatibility with older common-config payloads, and skip exit hints that would target a hidden guide button
- wire the option through the installer, Helm chart, container environment, common-config API, UI, tests, and deployment documentation

## Testing

- `pnpm exec jest src/__tests__/unit/guideFeatureFlag.test.ts src/__tests__/unit/guideButtonEnv.test.ts src/__tests__/unit/guideDriverFlag.test.ts --runInBand`
- `helm lint deploy/charts/desktop-frontend`
- Helm template assertions for the default `true` value and explicit `false` override
- `bash -n frontend/desktop/deploy/desktop-frontend-entrypoint.sh`
- `pnpm build`
