### PR TITLE
ci(lifecycle): keep lint incremental on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Resolve Modules
         id: set-matrix
         run: |
+          # Use a diff base when available so lifecycle pushes stay incremental.
           BASE_REF=""
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             BASE_REF="${{ github.event.pull_request.base.sha }}"
@@ -97,6 +98,7 @@ jobs:
         id: lint-args
         run: |
           args="--color=always --config=${{ github.workspace }}/.golangci.yml"
+          # Match module resolution so historical lifecycle lint debt does not fail unrelated pushes.
           new_from_rev=""
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             new_from_rev="${{ github.event.pull_request.base.sha }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,15 +55,18 @@ jobs:
       - name: Resolve Modules
         id: set-matrix
         run: |
+          BASE_REF=""
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             BASE_REF="${{ github.event.pull_request.base.sha }}"
             HEAD_REF="${{ github.sha }}"
-          else
+          elif [[ "${{ github.event_name }}" == "push" && "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]]; then
             BASE_REF="${{ github.event.before }}"
+            HEAD_REF="${{ github.sha }}"
+          else
             HEAD_REF="${{ github.sha }}"
           fi
 
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [[ -n "${BASE_REF}" ]]; then
             bash ./scripts/resolve-modules.sh ./lifecycle --changed "${BASE_REF}" "${HEAD_REF}"
           else
             bash ./scripts/resolve-modules.sh ./lifecycle
@@ -94,8 +97,14 @@ jobs:
         id: lint-args
         run: |
           args="--color=always --config=${{ github.workspace }}/.golangci.yml"
+          new_from_rev=""
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            args="${args} --new-from-rev=${{ github.event.pull_request.base.sha }}"
+            new_from_rev="${{ github.event.pull_request.base.sha }}"
+          elif [[ "${{ github.event_name }}" == "push" && "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]]; then
+            new_from_rev="${{ github.event.before }}"
+          fi
+          if [[ -n "${new_from_rev}" ]]; then
+            args="${args} --new-from-rev=${new_from_rev}"
           fi
           echo "args=${args}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Background

After #7119 was merged, the CI workflow on `main` failed for commit `17eb3112f2d8c02abe65ccf3e35563ed662ce1dc`. The pull request path linted only new lifecycle issues, but the `push` path still ran full lifecycle lint. That exposed existing lifecycle lint debt and made the post-merge CI red.

This replaces #7128, which has stale failed title-check runs from its original title.

## Changes

- Resolve lifecycle modules from `github.event.before` to `github.sha` on push events, matching the pull request scoped module behavior.
- Pass `--new-from-rev` to `golangci-lint` for push events with a valid before SHA, so post-merge lint checks only issues introduced by the merged commit range.
- Keep full lifecycle lint as the fallback for workflow events without a usable diff base.

## Verification

- Loaded `.github/workflows/ci.yml` with PyYAML.
- Ran `git diff --check -- .github/workflows/ci.yml`.
- Simulated the failed merge commit range with `scripts/resolve-modules.sh ./lifecycle --changed HEAD^ HEAD`; it resolves to `./lifecycle`.
- Ran lifecycle `golangci-lint v2.12.2 --new-from-rev=HEAD^`; it reported 0 issues.
