### PR TITLE
fix(template): use chart repository URL key

### DIFF
--- a/.github/workflows/frontends.yml
+++ b/.github/workflows/frontends.yml
@@ -168,6 +168,10 @@ jobs:
         env:
           MODULE: ${{ matrix.module }}
         run: |
+          if [[ "${MODULE}" == "providers/template" ]]; then
+            bash frontend/providers/template/deploy/verify-template-repo-config.sh
+          fi
+
           chart_root="frontend/${MODULE}/deploy/charts"
           if [[ ! -d "${chart_root}" ]]; then
             echo "No Helm chart found for ${MODULE}; skipping"

--- a/frontend/providers/template/deploy/template-frontend-entrypoint.sh
+++ b/frontend/providers/template/deploy/template-frontend-entrypoint.sh
@@ -116,9 +116,9 @@ add_set_string templateConfig.cloudPort "${SEALOS_CLOUD_PORT}"
 add_set_string templateConfig.certSecretName "${SEALOS_CERT_SECRET_NAME}"
 
 if [ "${SEALOS_CERT_MODE}" = "https" ] || [ "${SEALOS_CERT_MODE}" = "acme" ]; then
-  add_set_string templateConfig.templateUrl "https://github.com/labring-actions/templates"
+  add_set_string templateConfig.templateRepoUrl "https://github.com/labring-actions/templates"
 else
-  add_set_string templateConfig.templateUrl "https://gogs.${SEALOS_CLOUD_DOMAIN}/sealos-admin/templates"
+  add_set_string templateConfig.templateRepoUrl "https://gogs.${SEALOS_CLOUD_DOMAIN}/sealos-admin/templates"
 fi
 
 adopt_namespaced_resource() {

--- a/frontend/providers/template/deploy/verify-template-repo-config.sh
+++ b/frontend/providers/template/deploy/verify-template-repo-config.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+entrypoint="${script_dir}/template-frontend-entrypoint.sh"
+chart="${script_dir}/charts/template-frontend"
+repo_key="templateConfig.templateRepoUrl"
+repo_url="https://gogs.example.test/sealos-admin/templates"
+
+key_count="$(grep -Fc "add_set_string ${repo_key} " "${entrypoint}" || true)"
+if [[ "${key_count}" -ne 2 ]]; then
+  echo "expected both repository branches to set ${repo_key}, found ${key_count}" >&2
+  exit 1
+fi
+
+if grep -Eq 'add_set_string templateConfig\.templateUrl ' "${entrypoint}"; then
+  echo "entrypoint still sets unused templateConfig.templateUrl" >&2
+  exit 1
+fi
+
+rendered="$(
+  helm template template-frontend "${chart}" \
+    --namespace template-frontend \
+    --set-string "${repo_key}=${repo_url}"
+)"
+
+if ! grep -Fq "TEMPLATE_REPO_URL=${repo_url}" <<<"${rendered}"; then
+  echo "chart did not render ${repo_key} into TEMPLATE_REPO_URL" >&2
+  exit 1
+fi
+
+echo "template repository configuration verified"


### PR DESCRIPTION
## What changed

- pass the Template repository URL through the Helm value consumed by the chart
- add a regression check for the entrypoint-to-ConfigMap configuration contract
- run the regression check in the existing frontend Helm validation job

## Why

The entrypoint set `templateConfig.templateUrl`, while the chart reads
`templateConfig.templateRepoUrl`. Helm accepted the unused value and kept the
default public GitHub repository, so self-signed deployments did not consume
their cluster-local template repository.

## Verification

- `bash -n frontend/providers/template/deploy/template-frontend-entrypoint.sh frontend/providers/template/deploy/verify-template-repo-config.sh`
- `bash frontend/providers/template/deploy/verify-template-repo-config.sh`
- `helm lint` and `helm template` with default and user values
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/frontends.yml`
