### PR TITLE
fix(applaunchpad): use browser timezone for date ranges

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/utils/timeRange.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/timeRange.test.ts
@@ -1,27 +1,40 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  formatUtcDateTime,
-  getUtcDayBounds,
+  formatShanghaiDateTime,
+  getBoundedRangeStart,
+  getBoundedShanghaiDayRange,
+  getShanghaiDayBounds,
+  getUtcTimestamp,
   normalizeTimeInput,
-  parseUtcDateTime
+  orderDateRange,
+  parseShanghaiDateTime
 } from '@/utils/timeRange';
 
-describe('UTC date time helpers', () => {
-  it('parses HH:mm input as a UTC instant', () => {
-    expect(parseUtcDateTime('2026-07-27', '12:00')?.toISOString()).toBe('2026-07-27T12:00:00.000Z');
+describe('Asia/Shanghai date time helpers', () => {
+  it('parses Beijing HH:mm input as the matching UTC instant', () => {
+    expect(parseShanghaiDateTime('2026-07-28', '00:00')?.toISOString()).toBe(
+      '2026-07-27T16:00:00.000Z'
+    );
   });
 
-  it('keeps an exact 10:00 to 12:00 range in UTC', () => {
-    const start = parseUtcDateTime('2026-07-27', '10:00');
-    const end = parseUtcDateTime('2026-07-27', '12:00');
+  it('keeps an exact 10:00 to 12:00 range in Beijing time', () => {
+    const start = parseShanghaiDateTime('2026-07-28', '10:00');
+    const end = parseShanghaiDateTime('2026-07-28', '12:00');
 
-    expect(start?.toISOString()).toBe('2026-07-27T10:00:00.000Z');
-    expect(end?.toISOString()).toBe('2026-07-27T12:00:00.000Z');
+    expect(start?.toISOString()).toBe('2026-07-28T02:00:00.000Z');
+    expect(end?.toISOString()).toBe('2026-07-28T04:00:00.000Z');
   });
 
-  it('formats instants in UTC regardless of the browser timezone', () => {
-    expect(formatUtcDateTime('2026-07-27T12:00:00.000Z')).toBe('2026-07-27 12:00:00');
+  it('formats instants in Beijing time regardless of the browser timezone', () => {
+    expect(formatShanghaiDateTime('2026-07-27T12:00:00.000Z')).toBe('2026-07-27 20:00:00');
+  });
+
+  it('treats backend timestamps without a timezone suffix as UTC', () => {
+    expect(formatShanghaiDateTime('2026-07-27 12:00:00')).toBe('2026-07-27 20:00:00');
+    expect(getUtcTimestamp('2026-07-27 12:00:00')).toBe(
+      new Date('2026-07-27T12:00:00.000Z').getTime()
+    );
   });
 
   it('normalizes short time input without changing full time input', () => {
@@ -30,13 +43,50 @@ describe('UTC date time helpers', () => {
   });
 
   it('rejects invalid exact times', () => {
-    expect(parseUtcDateTime('2026-07-27', '25:00')).toBeNull();
+    expect(parseShanghaiDateTime('2026-07-27', '25:00')).toBeNull();
   });
 
-  it('derives calendar day bounds from the UTC date, not the browser timezone', () => {
-    const bounds = getUtcDayBounds(new Date('2026-07-27T01:00:00.000Z'));
+  it('derives calendar day bounds in Asia/Shanghai', () => {
+    const bounds = getShanghaiDayBounds(new Date('2026-07-27T17:00:00.000Z'));
 
-    expect(bounds.start.toISOString()).toBe('2026-07-27T00:00:00.000Z');
-    expect(bounds.end.toISOString()).toBe('2026-07-27T23:59:59.999Z');
+    expect(bounds.start.toISOString()).toBe('2026-07-27T16:00:00.000Z');
+    expect(bounds.end.toISOString()).toBe('2026-07-28T15:59:59.999Z');
+  });
+
+  it('clamps calendar days to the exact seven-day and current-time boundaries', () => {
+    const min = new Date('2026-07-21T04:00:00.000Z');
+    const max = new Date('2026-07-28T04:00:00.000Z');
+    const range = getBoundedShanghaiDayRange(
+      new Date('2026-07-20T16:00:00.000Z'),
+      new Date('2026-07-27T16:00:00.000Z'),
+      min,
+      max
+    );
+
+    expect(range.from?.toISOString()).toBe(min.toISOString());
+    expect(range.to?.toISOString()).toBe(max.toISOString());
+  });
+
+  it('keeps the earliest selectable day usable as the seven-day boundary advances', () => {
+    const min = new Date('2026-07-21T04:00:00.500Z');
+    const start = new Date('2026-07-21T04:00:00.000Z');
+    const end = new Date('2026-07-21T05:00:00.000Z');
+
+    expect(getBoundedRangeStart(start, end, min)).toEqual(min);
+  });
+
+  it('rejects ranges that are entirely before the seven-day boundary', () => {
+    const min = new Date('2026-07-21T04:00:00.000Z');
+    const start = new Date('2026-07-21T02:00:00.000Z');
+    const end = new Date('2026-07-21T03:00:00.000Z');
+
+    expect(getBoundedRangeStart(start, end, min)).toBeNull();
+  });
+
+  it('orders reversed manual range endpoints', () => {
+    const later = new Date('2026-07-28T04:00:00.000Z');
+    const earlier = new Date('2026-07-28T02:00:00.000Z');
+
+    expect(orderDateRange(later, earlier)).toEqual({ from: earlier, to: later });
   });
 });

--- a/frontend/providers/applaunchpad/__tests__/unit/utils/timeRange.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/timeRange.test.ts
@@ -60,6 +60,10 @@ describe('time zone date time helpers', () => {
     expect(parseDateTimeInTimeZone('2026-07-27', '25:00', shanghaiTimeZone)).toBeNull();
   });
 
+  it('rejects nonexistent local times during DST spring-forward', () => {
+    expect(parseDateTimeInTimeZone('2026-03-08', '02:30', 'America/Los_Angeles')).toBeNull();
+  });
+
   it('derives calendar day bounds in the selected time zone', () => {
     const bounds = getDayBoundsInTimeZone(new Date('2026-07-27T17:00:00.000Z'), shanghaiTimeZone);
 

--- a/frontend/providers/applaunchpad/__tests__/unit/utils/timeRange.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/timeRange.test.ts
@@ -1,37 +1,51 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  formatShanghaiDateTime,
+  formatDateTimeInTimeZone,
+  getBrowserTimeZone,
   getBoundedRangeStart,
-  getBoundedShanghaiDayRange,
-  getShanghaiDayBounds,
+  getBoundedDayRangeInTimeZone,
+  getDayBoundsInTimeZone,
   getUtcTimestamp,
   normalizeTimeInput,
   orderDateRange,
-  parseShanghaiDateTime
+  parseDateTimeInTimeZone
 } from '@/utils/timeRange';
 
-describe('Asia/Shanghai date time helpers', () => {
-  it('parses Beijing HH:mm input as the matching UTC instant', () => {
-    expect(parseShanghaiDateTime('2026-07-28', '00:00')?.toISOString()).toBe(
+describe('time zone date time helpers', () => {
+  const shanghaiTimeZone = 'Asia/Shanghai';
+
+  it('uses UTC as the server-rendering fallback', () => {
+    expect(getBrowserTimeZone()).toBe('UTC');
+  });
+
+  it('parses local HH:mm input in the selected time zone', () => {
+    expect(parseDateTimeInTimeZone('2026-07-28', '00:00', shanghaiTimeZone)?.toISOString()).toBe(
       '2026-07-27T16:00:00.000Z'
     );
   });
 
-  it('keeps an exact 10:00 to 12:00 range in Beijing time', () => {
-    const start = parseShanghaiDateTime('2026-07-28', '10:00');
-    const end = parseShanghaiDateTime('2026-07-28', '12:00');
+  it('converts the same wall-clock time differently for each user time zone', () => {
+    const start = parseDateTimeInTimeZone('2026-07-28', '10:00', shanghaiTimeZone);
+    const end = parseDateTimeInTimeZone('2026-07-28', '10:00', 'America/Los_Angeles');
 
     expect(start?.toISOString()).toBe('2026-07-28T02:00:00.000Z');
-    expect(end?.toISOString()).toBe('2026-07-28T04:00:00.000Z');
+    expect(end?.toISOString()).toBe('2026-07-28T17:00:00.000Z');
   });
 
-  it('formats instants in Beijing time regardless of the browser timezone', () => {
-    expect(formatShanghaiDateTime('2026-07-27T12:00:00.000Z')).toBe('2026-07-27 20:00:00');
+  it('formats instants in the selected user time zone', () => {
+    expect(formatDateTimeInTimeZone('2026-07-27T12:00:00.000Z', shanghaiTimeZone)).toBe(
+      '2026-07-27 20:00:00'
+    );
+    expect(formatDateTimeInTimeZone('2026-07-27T12:00:00.000Z', 'America/Los_Angeles')).toBe(
+      '2026-07-27 05:00:00'
+    );
   });
 
   it('treats backend timestamps without a timezone suffix as UTC', () => {
-    expect(formatShanghaiDateTime('2026-07-27 12:00:00')).toBe('2026-07-27 20:00:00');
+    expect(formatDateTimeInTimeZone('2026-07-27 12:00:00', shanghaiTimeZone)).toBe(
+      '2026-07-27 20:00:00'
+    );
     expect(getUtcTimestamp('2026-07-27 12:00:00')).toBe(
       new Date('2026-07-27T12:00:00.000Z').getTime()
     );
@@ -43,11 +57,11 @@ describe('Asia/Shanghai date time helpers', () => {
   });
 
   it('rejects invalid exact times', () => {
-    expect(parseShanghaiDateTime('2026-07-27', '25:00')).toBeNull();
+    expect(parseDateTimeInTimeZone('2026-07-27', '25:00', shanghaiTimeZone)).toBeNull();
   });
 
-  it('derives calendar day bounds in Asia/Shanghai', () => {
-    const bounds = getShanghaiDayBounds(new Date('2026-07-27T17:00:00.000Z'));
+  it('derives calendar day bounds in the selected time zone', () => {
+    const bounds = getDayBoundsInTimeZone(new Date('2026-07-27T17:00:00.000Z'), shanghaiTimeZone);
 
     expect(bounds.start.toISOString()).toBe('2026-07-27T16:00:00.000Z');
     expect(bounds.end.toISOString()).toBe('2026-07-28T15:59:59.999Z');
@@ -56,11 +70,12 @@ describe('Asia/Shanghai date time helpers', () => {
   it('clamps calendar days to the exact seven-day and current-time boundaries', () => {
     const min = new Date('2026-07-21T04:00:00.000Z');
     const max = new Date('2026-07-28T04:00:00.000Z');
-    const range = getBoundedShanghaiDayRange(
+    const range = getBoundedDayRangeInTimeZone(
       new Date('2026-07-20T16:00:00.000Z'),
       new Date('2026-07-27T16:00:00.000Z'),
       min,
-      max
+      max,
+      shanghaiTimeZone
     );
 
     expect(range.from?.toISOString()).toBe(min.toISOString());
@@ -72,7 +87,7 @@ describe('Asia/Shanghai date time helpers', () => {
     const start = new Date('2026-07-21T04:00:00.000Z');
     const end = new Date('2026-07-21T05:00:00.000Z');
 
-    expect(getBoundedRangeStart(start, end, min)).toEqual(min);
+    expect(getBoundedRangeStart(start, end, min, shanghaiTimeZone)).toEqual(min);
   });
 
   it('rejects ranges that are entirely before the seven-day boundary', () => {
@@ -80,7 +95,7 @@ describe('Asia/Shanghai date time helpers', () => {
     const start = new Date('2026-07-21T02:00:00.000Z');
     const end = new Date('2026-07-21T03:00:00.000Z');
 
-    expect(getBoundedRangeStart(start, end, min)).toBeNull();
+    expect(getBoundedRangeStart(start, end, min, shanghaiTimeZone)).toBeNull();
   });
 
   it('orders reversed manual range endpoints', () => {

--- a/frontend/providers/applaunchpad/src/components/DatePicker/index.tsx
+++ b/frontend/providers/applaunchpad/src/components/DatePicker/index.tsx
@@ -7,17 +7,17 @@ import { ChangeEventHandler, useMemo, useState } from 'react';
 import { DateRange, DayPicker } from 'react-day-picker';
 import useDateTimeStore from '@/store/date';
 import {
-  formatShanghaiDate,
-  formatShanghaiDateTime,
-  formatShanghaiTime,
+  formatDateInTimeZone,
+  formatDateTimeInTimeZone,
+  formatTimeInTimeZone,
+  getBrowserTimeZone,
   getBoundedRangeStart,
-  getBoundedShanghaiDayRange,
-  getShanghaiDayBounds,
+  getBoundedDayRangeInTimeZone,
+  getDayBoundsInTimeZone,
   normalizeTimeInput,
   orderDateRange,
   parseTimeRange,
-  parseShanghaiDateTime,
-  SHANGHAI_TIME_ZONE
+  parseDateTimeInTimeZone
 } from '@/utils/timeRange';
 import { Button } from '@sealos/shadcn-ui/button';
 import { Calendar, RefreshCw } from 'lucide-react';
@@ -41,6 +41,7 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
   const { t, i18n } = useTranslation();
   const currentLang = i18n.language;
   const [isOpen, setIsOpen] = useState(false);
+  const timeZone = useMemo(() => getBrowserTimeZone(), []);
 
   const {
     startDateTime,
@@ -53,8 +54,8 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
 
   const now = new Date();
   const sevenDaysAgo = subDays(now, 7);
-  const earliestCalendarDay = getShanghaiDayBounds(sevenDaysAgo).start;
-  const latestCalendarDay = getShanghaiDayBounds(now).start;
+  const earliestCalendarDay = getDayBoundsInTimeZone(sevenDaysAgo, timeZone).start;
+  const latestCalendarDay = getDayBoundsInTimeZone(now, timeZone).start;
 
   const initState = {
     from: startDateTime,
@@ -142,10 +143,18 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
   const [inputState, setInputState] = useState<0 | 1>(0);
   const [recentDate, setRecentDate] = useState<RecentDate | null>(defaultRecentDate);
 
-  const [fromDateString, setFromDateString] = useState<string>(formatShanghaiDate(initState.from));
-  const [toDateString, setToDateString] = useState<string>(formatShanghaiDate(initState.to));
-  const [fromTimeString, setFromTimeString] = useState<string>(formatShanghaiTime(initState.from));
-  const [toTimeString, setToTimeString] = useState<string>(formatShanghaiTime(initState.to));
+  const [fromDateString, setFromDateString] = useState<string>(
+    formatDateInTimeZone(initState.from, timeZone)
+  );
+  const [toDateString, setToDateString] = useState<string>(
+    formatDateInTimeZone(initState.to, timeZone)
+  );
+  const [fromTimeString, setFromTimeString] = useState<string>(
+    formatTimeInTimeZone(initState.from, timeZone)
+  );
+  const [toTimeString, setToTimeString] = useState<string>(
+    formatTimeInTimeZone(initState.to, timeZone)
+  );
 
   const [fromDateError, setFromDateError] = useState<string | null>(null);
   const [toDateError, setToDateError] = useState<string | null>(null);
@@ -160,10 +169,10 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
 
   const syncRange = ({ from, to }: { from: Date; to: Date }) => {
     setSelectedRange({ from, to });
-    setFromDateString(formatShanghaiDate(from));
-    setFromTimeString(formatShanghaiTime(from));
-    setToDateString(formatShanghaiDate(to));
-    setToTimeString(formatShanghaiTime(to));
+    setFromDateString(formatDateInTimeZone(from, timeZone));
+    setFromTimeString(formatTimeInTimeZone(from, timeZone));
+    setToDateString(formatDateInTimeZone(to, timeZone));
+    setToTimeString(formatTimeInTimeZone(to, timeZone));
   };
 
   const onSubmit = () => {
@@ -181,8 +190,8 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
 
       return;
     }
-    const start = parseShanghaiDateTime(fromDateString, fromTimeString);
-    const end = parseShanghaiDateTime(toDateString, toTimeString);
+    const start = parseDateTimeInTimeZone(fromDateString, fromTimeString, timeZone);
+    const end = parseDateTimeInTimeZone(toDateString, toTimeString, timeZone);
 
     if (!start || !end) {
       if (!start) setFromTimeError('Invalid start time range');
@@ -198,7 +207,7 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
 
     const submitNow = new Date();
     const earliestStart = subDays(submitNow, 7);
-    const boundedStart = getBoundedRangeStart(start, end, earliestStart);
+    const boundedStart = getBoundedRangeStart(start, end, earliestStart, timeZone);
 
     if (!boundedStart) {
       setFromTimeError('start time cannot be before 7 days ago');
@@ -230,9 +239,10 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
       setFromTimeString(normalizedValue);
     }
 
-    const date = parseShanghaiDateTime(
+    const date = parseDateTimeInTimeZone(
       type === 'date' ? value : fromDateString,
-      type === 'time' ? normalizedValue : fromTimeString
+      type === 'time' ? normalizedValue : fromTimeString,
+      timeZone
     );
 
     if (!date) {
@@ -275,9 +285,10 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
       setToTimeString(normalizedValue);
     }
 
-    const date = parseShanghaiDateTime(
+    const date = parseDateTimeInTimeZone(
       type === 'date' ? value : toDateString,
-      type === 'time' ? normalizedValue : toTimeString
+      type === 'time' ? normalizedValue : toTimeString,
+      timeZone
     );
 
     if (!date) {
@@ -327,23 +338,23 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
       } else {
         setInputState(0);
       }
-      const boundedRange = getBoundedShanghaiDayRange(from, to, sevenDaysAgo, now);
+      const boundedRange = getBoundedDayRangeInTimeZone(from, to, sevenDaysAgo, now, timeZone);
 
       setSelectedRange(boundedRange);
       if (boundedRange.from) {
-        setFromDateString(formatShanghaiDate(boundedRange.from));
-        setFromTimeString(formatShanghaiTime(boundedRange.from));
+        setFromDateString(formatDateInTimeZone(boundedRange.from, timeZone));
+        setFromTimeString(formatTimeInTimeZone(boundedRange.from, timeZone));
       } else {
-        setFromDateString(formatShanghaiDate(now));
-        setFromTimeString(formatShanghaiTime(now));
+        setFromDateString(formatDateInTimeZone(now, timeZone));
+        setFromTimeString(formatTimeInTimeZone(now, timeZone));
       }
       if (boundedRange.to) {
-        setToDateString(formatShanghaiDate(boundedRange.to));
-        setToTimeString(formatShanghaiTime(boundedRange.to));
+        setToDateString(formatDateInTimeZone(boundedRange.to, timeZone));
+        setToTimeString(formatTimeInTimeZone(boundedRange.to, timeZone));
       } else {
         const fallback = boundedRange.from || now;
-        setToDateString(formatShanghaiDate(fallback));
-        setToTimeString(formatShanghaiTime(fallback));
+        setToDateString(formatDateInTimeZone(fallback, timeZone));
+        setToTimeString(formatTimeInTimeZone(fallback, timeZone));
       }
 
       setRecentDate(null);
@@ -372,21 +383,22 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
     setRecentDate({ ...item, value: nextRange });
     setSelectedRange(nextRange);
     if (nextRange.from) {
-      setFromDateString(formatShanghaiDate(nextRange.from));
-      setFromTimeString(formatShanghaiTime(nextRange.from));
+      setFromDateString(formatDateInTimeZone(nextRange.from, timeZone));
+      setFromTimeString(formatTimeInTimeZone(nextRange.from, timeZone));
     }
     if (nextRange.to) {
-      setToDateString(formatShanghaiDate(nextRange.to));
-      setToTimeString(formatShanghaiTime(nextRange.to));
+      setToDateString(formatDateInTimeZone(nextRange.to, timeZone));
+      setToTimeString(formatTimeInTimeZone(nextRange.to, timeZone));
     }
   };
 
   // format date time display
   const formatDateTimeDisplay = () => {
-    return `${formatShanghaiDateTime(startDateTime, 'HH:mm, MMM DD')} - ${formatShanghaiDateTime(
-      endDateTime,
+    return `${formatDateTimeInTimeZone(
+      startDateTime,
+      timeZone,
       'HH:mm, MMM DD'
-    )}`;
+    )} - ${formatDateTimeInTimeZone(endDateTime, timeZone, 'HH:mm, MMM DD')}`;
   };
 
   return (
@@ -414,14 +426,14 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
           <div className="w-[242px] h-fit flex flex-col">
             <DayPicker
               mode="range"
-              timeZone={SHANGHAI_TIME_ZONE}
+              timeZone={timeZone}
               navLayout="around"
               selected={selectedRange}
               onSelect={handleRangeSelect}
               locale={currentLang === 'zh' ? zhCN : enUS}
               weekStartsOn={0}
               disabled={(date) => {
-                const dayStart = getShanghaiDayBounds(date).start;
+                const dayStart = getDayBoundsInTimeZone(date, timeZone).start;
                 return (
                   isAfter(dayStart, latestCalendarDay) || isBefore(dayStart, earliestCalendarDay)
                 );
@@ -490,7 +502,8 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
           </div>
         </div>
 
-        <div className="flex justify-end items-center py-2 border-t border-zinc-100">
+        <div className="flex justify-between items-center px-3 py-2 border-t border-zinc-100">
+          <span className="text-xs text-zinc-500">{timeZone}</span>
           <div className="flex gap-2 px-2.5">
             <Button
               variant="outline"

--- a/frontend/providers/applaunchpad/src/components/DatePicker/index.tsx
+++ b/frontend/providers/applaunchpad/src/components/DatePicker/index.tsx
@@ -7,26 +7,22 @@ import { ChangeEventHandler, useMemo, useState } from 'react';
 import { DateRange, DayPicker } from 'react-day-picker';
 import useDateTimeStore from '@/store/date';
 import {
-  formatUtcDate,
-  formatUtcDateTime,
-  formatUtcTime,
-  getUtcDayBounds,
+  formatShanghaiDate,
+  formatShanghaiDateTime,
+  formatShanghaiTime,
+  getBoundedRangeStart,
+  getBoundedShanghaiDayRange,
+  getShanghaiDayBounds,
   normalizeTimeInput,
+  orderDateRange,
   parseTimeRange,
-  parseUtcDateTime
+  parseShanghaiDateTime,
+  SHANGHAI_TIME_ZONE
 } from '@/utils/timeRange';
 import { Button } from '@sealos/shadcn-ui/button';
 import { Calendar, RefreshCw } from 'lucide-react';
 import { Input } from '@sealos/shadcn-ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@sealos/shadcn-ui/popover';
-import { Separator } from '@sealos/shadcn-ui/separator';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue
-} from '@sealos/shadcn-ui/select';
 import { cn } from '@sealos/shadcn-ui';
 import 'react-day-picker/style.css';
 
@@ -51,14 +47,14 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
     endDateTime,
     setStartDateTime,
     setEndDateTime,
-    timeZone,
-    setTimeZone,
     setManualRange,
     setAutoRange
   } = useDateTimeStore();
 
   const now = new Date();
   const sevenDaysAgo = subDays(now, 7);
+  const earliestCalendarDay = getShanghaiDayBounds(sevenDaysAgo).start;
+  const latestCalendarDay = getShanghaiDayBounds(now).start;
 
   const initState = {
     from: startDateTime,
@@ -146,10 +142,10 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
   const [inputState, setInputState] = useState<0 | 1>(0);
   const [recentDate, setRecentDate] = useState<RecentDate | null>(defaultRecentDate);
 
-  const [fromDateString, setFromDateString] = useState<string>(formatUtcDate(initState.from));
-  const [toDateString, setToDateString] = useState<string>(formatUtcDate(initState.to));
-  const [fromTimeString, setFromTimeString] = useState<string>(formatUtcTime(initState.from));
-  const [toTimeString, setToTimeString] = useState<string>(formatUtcTime(initState.to));
+  const [fromDateString, setFromDateString] = useState<string>(formatShanghaiDate(initState.from));
+  const [toDateString, setToDateString] = useState<string>(formatShanghaiDate(initState.to));
+  const [fromTimeString, setFromTimeString] = useState<string>(formatShanghaiTime(initState.from));
+  const [toTimeString, setToTimeString] = useState<string>(formatShanghaiTime(initState.to));
 
   const [fromDateError, setFromDateError] = useState<string | null>(null);
   const [toDateError, setToDateError] = useState<string | null>(null);
@@ -161,6 +157,14 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
   const [toTimeShake, setToTimeShake] = useState(false);
 
   const [selectedRange, setSelectedRange] = useState<DateRange | undefined>(initState);
+
+  const syncRange = ({ from, to }: { from: Date; to: Date }) => {
+    setSelectedRange({ from, to });
+    setFromDateString(formatShanghaiDate(from));
+    setFromTimeString(formatShanghaiTime(from));
+    setToDateString(formatShanghaiDate(to));
+    setToTimeString(formatShanghaiTime(to));
+  };
 
   const onSubmit = () => {
     if (fromDateError || fromTimeError || toDateError || toTimeError) {
@@ -177,8 +181,8 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
 
       return;
     }
-    const start = parseUtcDateTime(fromDateString, fromTimeString);
-    const end = parseUtcDateTime(toDateString, toTimeString);
+    const start = parseShanghaiDateTime(fromDateString, fromTimeString);
+    const end = parseShanghaiDateTime(toDateString, toTimeString);
 
     if (!start || !end) {
       if (!start) setFromTimeError('Invalid start time range');
@@ -192,7 +196,16 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
       return;
     }
 
-    if (isAfter(end, new Date())) {
+    const submitNow = new Date();
+    const earliestStart = subDays(submitNow, 7);
+    const boundedStart = getBoundedRangeStart(start, end, earliestStart);
+
+    if (!boundedStart) {
+      setFromTimeError('start time cannot be before 7 days ago');
+      return;
+    }
+
+    if (isAfter(end, submitNow)) {
       setToTimeError('end time cannot be after current time');
       return;
     }
@@ -201,7 +214,8 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
     setFromTimeError(null);
     setToDateError(null);
     setToTimeError(null);
-    setStartDateTime(start);
+    syncRange({ from: boundedStart, to: end });
+    setStartDateTime(boundedStart);
     setEndDateTime(end);
     setIsOpen(false);
   };
@@ -216,7 +230,7 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
       setFromTimeString(normalizedValue);
     }
 
-    const date = parseUtcDateTime(
+    const date = parseShanghaiDateTime(
       type === 'date' ? value : fromDateString,
       type === 'time' ? normalizedValue : fromTimeString
     );
@@ -245,13 +259,9 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
     setRecentDate(null);
 
     if (selectedRange?.to) {
-      if (isAfter(date, selectedRange.to)) {
-        setSelectedRange({ from: selectedRange.to, to: date });
-      } else {
-        setSelectedRange({ from: date, to: selectedRange?.to });
-      }
+      syncRange(orderDateRange(date, selectedRange.to));
     } else {
-      setSelectedRange({ from: date, to: date });
+      syncRange({ from: date, to: date });
     }
   };
 
@@ -265,7 +275,7 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
       setToTimeString(normalizedValue);
     }
 
-    const date = parseUtcDateTime(
+    const date = parseShanghaiDateTime(
       type === 'date' ? value : toDateString,
       type === 'time' ? normalizedValue : toTimeString
     );
@@ -294,13 +304,9 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
     setRecentDate(null);
 
     if (selectedRange?.from) {
-      if (isBefore(date, selectedRange.from)) {
-        setSelectedRange({ from: date, to: selectedRange.from });
-      } else {
-        setSelectedRange({ from: selectedRange?.from, to: date });
-      }
+      syncRange(orderDateRange(selectedRange.from, date));
     } else {
-      setSelectedRange({ from: date, to: date });
+      syncRange({ from: date, to: date });
     }
   };
 
@@ -308,13 +314,6 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
     setManualRange();
     if (range) {
       let { from, to } = range;
-
-      if (from && isBefore(from, sevenDaysAgo)) {
-        from = sevenDaysAgo;
-      }
-      if (to && isAfter(to, now)) {
-        to = now;
-      }
 
       if (inputState === 0) {
         // from
@@ -328,28 +327,23 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
       } else {
         setInputState(0);
       }
-      const utcFrom = from ? getUtcDayBounds(from).start : undefined;
-      const utcTo = to ? getUtcDayBounds(to).end : undefined;
-      const boundedUtcTo = utcTo && isAfter(utcTo, now) ? now : utcTo;
+      const boundedRange = getBoundedShanghaiDayRange(from, to, sevenDaysAgo, now);
 
-      setSelectedRange({
-        from: utcFrom,
-        to: boundedUtcTo
-      });
-      if (utcFrom) {
-        setFromDateString(formatUtcDate(utcFrom));
-        setFromTimeString(formatUtcTime(utcFrom));
+      setSelectedRange(boundedRange);
+      if (boundedRange.from) {
+        setFromDateString(formatShanghaiDate(boundedRange.from));
+        setFromTimeString(formatShanghaiTime(boundedRange.from));
       } else {
-        setFromDateString(formatUtcDate(now));
-        setFromTimeString(formatUtcTime(now));
+        setFromDateString(formatShanghaiDate(now));
+        setFromTimeString(formatShanghaiTime(now));
       }
-      if (boundedUtcTo) {
-        setToDateString(formatUtcDate(boundedUtcTo));
-        setToTimeString(formatUtcTime(boundedUtcTo));
+      if (boundedRange.to) {
+        setToDateString(formatShanghaiDate(boundedRange.to));
+        setToTimeString(formatShanghaiTime(boundedRange.to));
       } else {
-        const fallback = utcFrom || now;
-        setToDateString(formatUtcDate(fallback));
-        setToTimeString(formatUtcTime(fallback));
+        const fallback = boundedRange.from || now;
+        setToDateString(formatShanghaiDate(fallback));
+        setToTimeString(formatShanghaiTime(fallback));
       }
 
       setRecentDate(null);
@@ -378,18 +372,18 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
     setRecentDate({ ...item, value: nextRange });
     setSelectedRange(nextRange);
     if (nextRange.from) {
-      setFromDateString(formatUtcDate(nextRange.from));
-      setFromTimeString(formatUtcTime(nextRange.from));
+      setFromDateString(formatShanghaiDate(nextRange.from));
+      setFromTimeString(formatShanghaiTime(nextRange.from));
     }
     if (nextRange.to) {
-      setToDateString(formatUtcDate(nextRange.to));
-      setToTimeString(formatUtcTime(nextRange.to));
+      setToDateString(formatShanghaiDate(nextRange.to));
+      setToTimeString(formatShanghaiTime(nextRange.to));
     }
   };
 
   // format date time display
   const formatDateTimeDisplay = () => {
-    return `${formatUtcDateTime(startDateTime, 'HH:mm, MMM DD')} - ${formatUtcDateTime(
+    return `${formatShanghaiDateTime(startDateTime, 'HH:mm, MMM DD')} - ${formatShanghaiDateTime(
       endDateTime,
       'HH:mm, MMM DD'
     )}`;
@@ -420,14 +414,17 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
           <div className="w-[242px] h-fit flex flex-col">
             <DayPicker
               mode="range"
-              timeZone="UTC"
+              timeZone={SHANGHAI_TIME_ZONE}
               navLayout="around"
               selected={selectedRange}
               onSelect={handleRangeSelect}
               locale={currentLang === 'zh' ? zhCN : enUS}
               weekStartsOn={0}
               disabled={(date) => {
-                return isAfter(date, now) || isBefore(date, sevenDaysAgo);
+                const dayStart = getShanghaiDayBounds(date).start;
+                return (
+                  isAfter(dayStart, latestCalendarDay) || isBefore(dayStart, earliestCalendarDay)
+                );
               }}
               formatters={{
                 formatWeekdayName: (date) =>
@@ -493,20 +490,7 @@ const DatePicker = ({ isDisabled = false, className }: DatePickerProps) => {
           </div>
         </div>
 
-        <div className="flex justify-between pl-3 items-center py-2 border-t border-zinc-100">
-          <Select value={timeZone} onValueChange={(val: 'local' | 'utc') => setTimeZone(val)}>
-            <SelectTrigger className="h-8 w-fit border-none rounded-lg bg-transparent shadow-none text-zinc-600 text-xs font-normal px-0">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent
-              position="popper"
-              className="border-[0.5px] border-zinc-200 rounded-xl p-0.5"
-            >
-              <SelectItem value="utc" className="text-sm rounded-lg py-[10px]">
-                UTC
-              </SelectItem>
-            </SelectContent>
-          </Select>
+        <div className="flex justify-end items-center py-2 border-t border-zinc-100">
           <div className="flex gap-2 px-2.5">
             <Button
               variant="outline"

--- a/frontend/providers/applaunchpad/src/components/LogBarChart/index.tsx
+++ b/frontend/providers/applaunchpad/src/components/LogBarChart/index.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useMemo, useRef } from 'react';
 
 import { useGlobalStore } from '@/store/global';
 import { MonitorDataResult } from '@/types/monitor';
-import { formatShanghaiDateTime } from '@/utils/timeRange';
+import { formatDateTimeInTimeZone, getBrowserTimeZone } from '@/utils/timeRange';
 
 const map = {
   blue: {
@@ -105,11 +105,12 @@ const LogBarChart = ({
   visible?: boolean;
 }) => {
   const { screenWidth } = useGlobalStore();
+  const timeZone = useMemo(() => getBrowserTimeZone(), []);
   const xData = useMemo(
     () =>
-      data?.xData?.map((time) => formatShanghaiDateTime(time * 1000, 'MM-DD HH:mm')) ||
+      data?.xData?.map((time) => formatDateTimeInTimeZone(time * 1000, timeZone, 'MM-DD HH:mm')) ||
       new Array(30).fill(0),
-    [data?.xData]
+    [data?.xData, timeZone]
   );
   const yData = data?.yData || new Array(30).fill(null);
 

--- a/frontend/providers/applaunchpad/src/components/LogBarChart/index.tsx
+++ b/frontend/providers/applaunchpad/src/components/LogBarChart/index.tsx
@@ -1,9 +1,9 @@
-import dayjs from 'dayjs';
 import * as echarts from 'echarts';
 import React, { useEffect, useMemo, useRef } from 'react';
 
 import { useGlobalStore } from '@/store/global';
 import { MonitorDataResult } from '@/types/monitor';
+import { formatShanghaiDateTime } from '@/utils/timeRange';
 
 const map = {
   blue: {
@@ -107,7 +107,8 @@ const LogBarChart = ({
   const { screenWidth } = useGlobalStore();
   const xData = useMemo(
     () =>
-      data?.xData?.map((time) => dayjs(time * 1000).format('MM-DD HH:mm')) || new Array(30).fill(0),
+      data?.xData?.map((time) => formatShanghaiDateTime(time * 1000, 'MM-DD HH:mm')) ||
+      new Array(30).fill(0),
     [data?.xData]
   );
   const yData = data?.yData || new Array(30).fill(null);

--- a/frontend/providers/applaunchpad/src/components/Monitor/Time.tsx
+++ b/frontend/providers/applaunchpad/src/components/Monitor/Time.tsx
@@ -1,9 +1,9 @@
-import { formatShanghaiDateTime } from '@/utils/timeRange';
+import { formatDateTimeInTimeZone, getBrowserTimeZone } from '@/utils/timeRange';
 
 export default function DynamicTime({ lastRefreshTime }: { lastRefreshTime?: number }) {
   if (!lastRefreshTime) {
     return <span>--:--:--</span>;
   }
 
-  return <span>{formatShanghaiDateTime(lastRefreshTime, 'HH:mm:ss')}</span>;
+  return <span>{formatDateTimeInTimeZone(lastRefreshTime, getBrowserTimeZone(), 'HH:mm:ss')}</span>;
 }

--- a/frontend/providers/applaunchpad/src/components/Monitor/Time.tsx
+++ b/frontend/providers/applaunchpad/src/components/Monitor/Time.tsx
@@ -1,9 +1,9 @@
-import dayjs from 'dayjs';
+import { formatShanghaiDateTime } from '@/utils/timeRange';
 
 export default function DynamicTime({ lastRefreshTime }: { lastRefreshTime?: number }) {
   if (!lastRefreshTime) {
     return <span>--:--:--</span>;
   }
 
-  return <span>{dayjs(lastRefreshTime).format('HH:mm:ss')}</span>;
+  return <span>{formatShanghaiDateTime(lastRefreshTime, 'HH:mm:ss')}</span>;
 }

--- a/frontend/providers/applaunchpad/src/components/MonitorChart/index.tsx
+++ b/frontend/providers/applaunchpad/src/components/MonitorChart/index.tsx
@@ -2,12 +2,12 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Check } from 'lucide-react';
 import * as echarts from 'echarts';
 import { useGlobalStore } from '@/store/global';
-import dayjs from 'dayjs';
 import { LineStyleMap, NetworkLineStyleMap } from '@/constants/monitor';
 import { Button } from '@sealos/shadcn-ui/button';
 import { cn } from '@sealos/shadcn-ui';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@sealos/shadcn-ui/tooltip';
 import { useTranslation } from 'next-i18next';
+import { formatShanghaiDateTime } from '@/utils/timeRange';
 
 type MonitorChartProps = React.HTMLAttributes<HTMLDivElement> & {
   data: {
@@ -181,7 +181,7 @@ const MonitorChart = ({
           const axisValue = rawTime
             ? xAxisTooltipFormatter
               ? xAxisTooltipFormatter(rawTime)
-              : dayjs(parseFloat(rawTime) * 1000).format('YYYY-MM-DD HH:mm')
+              : formatShanghaiDateTime(parseFloat(rawTime) * 1000, 'YYYY-MM-DD HH:mm')
             : params[0]?.axisValue;
           const isCpuOrMemory = type === 'cpu' || type === 'memory';
           const isNetwork = type === 'network';
@@ -313,7 +313,7 @@ const MonitorChart = ({
           formatter: (value: string) =>
             xAxisLabelFormatter
               ? xAxisLabelFormatter(value)
-              : dayjs(parseFloat(value) * 1000).format('MM-DD HH:mm'),
+              : formatShanghaiDateTime(parseFloat(value) * 1000, 'MM-DD HH:mm'),
           textStyle: {
             fontSize: 14,
             fontWeight: 400,

--- a/frontend/providers/applaunchpad/src/components/MonitorChart/index.tsx
+++ b/frontend/providers/applaunchpad/src/components/MonitorChart/index.tsx
@@ -7,7 +7,7 @@ import { Button } from '@sealos/shadcn-ui/button';
 import { cn } from '@sealos/shadcn-ui';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@sealos/shadcn-ui/tooltip';
 import { useTranslation } from 'next-i18next';
-import { formatShanghaiDateTime } from '@/utils/timeRange';
+import { formatDateTimeInTimeZone, getBrowserTimeZone } from '@/utils/timeRange';
 
 type MonitorChartProps = React.HTMLAttributes<HTMLDivElement> & {
   data: {
@@ -70,6 +70,7 @@ const MonitorChart = ({
 }: MonitorChartProps) => {
   const { t } = useTranslation();
   const { screenWidth } = useGlobalStore();
+  const timeZone = useMemo(() => getBrowserTimeZone(), []);
   const chartDom = useRef<HTMLDivElement>(null);
   const myChart = useRef<echarts.ECharts>();
   const seriesNames = useMemo(() => data?.yData?.map((item) => item.name) || [], [data?.yData]);
@@ -181,7 +182,7 @@ const MonitorChart = ({
           const axisValue = rawTime
             ? xAxisTooltipFormatter
               ? xAxisTooltipFormatter(rawTime)
-              : formatShanghaiDateTime(parseFloat(rawTime) * 1000, 'YYYY-MM-DD HH:mm')
+              : formatDateTimeInTimeZone(parseFloat(rawTime) * 1000, timeZone, 'YYYY-MM-DD HH:mm')
             : params[0]?.axisValue;
           const isCpuOrMemory = type === 'cpu' || type === 'memory';
           const isNetwork = type === 'network';
@@ -313,7 +314,7 @@ const MonitorChart = ({
           formatter: (value: string) =>
             xAxisLabelFormatter
               ? xAxisLabelFormatter(value)
-              : formatShanghaiDateTime(parseFloat(value) * 1000, 'MM-DD HH:mm'),
+              : formatDateTimeInTimeZone(parseFloat(value) * 1000, timeZone, 'MM-DD HH:mm'),
           textStyle: {
             fontSize: 14,
             fontWeight: 400,
@@ -415,6 +416,7 @@ const MonitorChart = ({
       selectedSeries,
       seriesIndexMap,
       type,
+      timeZone,
       unit,
       xAxisLabelFormatter,
       xAxisTooltipFormatter,

--- a/frontend/providers/applaunchpad/src/components/app/detail/logs/LogCounts.tsx
+++ b/frontend/providers/applaunchpad/src/components/app/detail/logs/LogCounts.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'next-i18next';
 import { useState } from 'react';
 import EmptyChart from '@/components/Icon/icons/emptyChart.svg';
 import { ChevronRight, BarChart3 } from 'lucide-react';
+import { getUtcTimestamp } from '@/utils/timeRange';
 
 export const LogCounts = ({
   logCountsData,
@@ -20,9 +21,9 @@ export const LogCounts = ({
 
   const processChartData = (rawData: Array<{ _time: string; logs_total: string }>) => {
     const sortedData = [...rawData].sort(
-      (a, b) => new Date(a._time).getTime() - new Date(b._time).getTime()
+      (a, b) => getUtcTimestamp(a._time) - getUtcTimestamp(b._time)
     );
-    const xData = sortedData.map((item) => Math.floor(new Date(item._time).getTime() / 1000));
+    const xData = sortedData.map((item) => Math.floor(getUtcTimestamp(item._time) / 1000));
     const yData = sortedData.map((item) => item.logs_total);
 
     return {

--- a/frontend/providers/applaunchpad/src/components/app/detail/logs/LogTable.tsx
+++ b/frontend/providers/applaunchpad/src/components/app/detail/logs/LogTable.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'next-i18next';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Download, ScrollText, Filter as FilterIcon } from 'lucide-react';
 
-import { formatShanghaiDateTime } from '@/utils/timeRange';
+import { formatDateTimeInTimeZone, getBrowserTimeZone } from '@/utils/timeRange';
 import { LogsFormData } from '@/pages/app/detail/logs';
 import { UseFormReturn } from 'react-hook-form';
 import { useLogStore } from '@/store/logStore';
@@ -42,6 +42,7 @@ export const LogTable = ({
 }) => {
   const { t, i18n } = useTranslation();
   const lang = i18n.language;
+  const timeZone = useMemo(() => getBrowserTimeZone(), []);
 
   const [onOpenField, setOnOpenField] = useState(false);
   const [hiddenFieldCount, setHiddenFieldCount] = useState(0);
@@ -104,7 +105,7 @@ export const LogTable = ({
           let value = get(row.original, field.accessorKey, '');
 
           if (field.accessorKey === '_time') {
-            value = formatShanghaiDateTime(value);
+            value = formatDateTimeInTimeZone(value, timeZone);
           }
 
           return (
@@ -127,7 +128,7 @@ export const LogTable = ({
           isError: (row: any) => row.stream === 'stderr'
         }
       }));
-  }, [fieldList, isOnlyStderr, t]);
+  }, [fieldList, isOnlyStderr, t, timeZone]);
 
   const table = useReactTable({
     data: data,

--- a/frontend/providers/applaunchpad/src/components/app/detail/logs/LogTable.tsx
+++ b/frontend/providers/applaunchpad/src/components/app/detail/logs/LogTable.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'next-i18next';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Download, ScrollText, Filter as FilterIcon } from 'lucide-react';
 
-import { formatUtcDateTime } from '@/utils/timeRange';
+import { formatShanghaiDateTime } from '@/utils/timeRange';
 import { LogsFormData } from '@/pages/app/detail/logs';
 import { UseFormReturn } from 'react-hook-form';
 import { useLogStore } from '@/store/logStore';
@@ -104,7 +104,7 @@ export const LogTable = ({
           let value = get(row.original, field.accessorKey, '');
 
           if (field.accessorKey === '_time') {
-            value = formatUtcDateTime(value);
+            value = formatShanghaiDateTime(value);
           }
 
           return (

--- a/frontend/providers/applaunchpad/src/store/date.ts
+++ b/frontend/providers/applaunchpad/src/store/date.ts
@@ -5,13 +5,11 @@ import { immer } from 'zustand/middleware/immer';
 type DateTimeState = {
   startDateTime: Date;
   endDateTime: Date;
-  timeZone: 'local' | 'utc';
   refreshInterval: number;
   isManualRange: boolean;
   autoRange: string | null;
   setStartDateTime: (time: Date) => void;
   setEndDateTime: (time: Date) => void;
-  setTimeZone: (timeZone: 'local' | 'utc') => void;
   setRefreshInterval: (val: number) => void;
   setManualRange: () => void;
   setAutoRange: (range: string | null) => void;
@@ -21,13 +19,11 @@ const useDateTimeStore = create<DateTimeState>()(
   immer((set, get) => ({
     startDateTime: subMinutes(new Date(), 30),
     endDateTime: new Date(),
-    timeZone: 'utc',
     refreshInterval: 0,
     isManualRange: false,
     autoRange: '30m',
     setStartDateTime: (datetime) => set({ startDateTime: datetime }),
     setEndDateTime: (datetime) => set({ endDateTime: datetime }),
-    setTimeZone: (timeZone) => set({ timeZone }),
     setRefreshInterval: (val) => set({ refreshInterval: val }),
     setManualRange: () => set({ isManualRange: true }),
     setAutoRange: (range) => set({ autoRange: range, isManualRange: false })

--- a/frontend/providers/applaunchpad/src/utils/timeRange.ts
+++ b/frontend/providers/applaunchpad/src/utils/timeRange.ts
@@ -68,7 +68,10 @@ export function parseDateTimeInTimeZone(date: string, time: string, timeZone: st
     return null;
   }
 
-  return dayjs.tz(input, format, timeZone).toDate();
+  const parsed = dayjs.tz(input, format, timeZone);
+
+  // Day.js normalizes nonexistent wall-clock times during DST spring-forward.
+  return parsed.format(format) === input ? parsed.toDate() : null;
 }
 
 export function getDayBoundsInTimeZone(date: Date, timeZone: string): { start: Date; end: Date } {

--- a/frontend/providers/applaunchpad/src/utils/timeRange.ts
+++ b/frontend/providers/applaunchpad/src/utils/timeRange.ts
@@ -18,7 +18,15 @@ interface TimeRange {
 const DATE_FORMAT = 'YYYY-MM-DD';
 const TIME_FORMAT = 'HH:mm:ss';
 
-export const SHANGHAI_TIME_ZONE = 'Asia/Shanghai';
+const FALLBACK_TIME_ZONE = 'UTC';
+
+export function getBrowserTimeZone(): string {
+  if (typeof window === 'undefined') {
+    return FALLBACK_TIME_ZONE;
+  }
+
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || FALLBACK_TIME_ZONE;
+}
 
 function parseInstant(date: Date | string | number) {
   if (typeof date !== 'string') {
@@ -29,19 +37,20 @@ function parseInstant(date: Date | string | number) {
   return hasTimeZone ? dayjs(date) : dayjs.utc(date);
 }
 
-export function formatShanghaiDate(date: Date): string {
-  return dayjs(date).tz(SHANGHAI_TIME_ZONE).format(DATE_FORMAT);
+export function formatDateInTimeZone(date: Date, timeZone: string): string {
+  return dayjs(date).tz(timeZone).format(DATE_FORMAT);
 }
 
-export function formatShanghaiTime(date: Date): string {
-  return dayjs(date).tz(SHANGHAI_TIME_ZONE).format(TIME_FORMAT);
+export function formatTimeInTimeZone(date: Date, timeZone: string): string {
+  return dayjs(date).tz(timeZone).format(TIME_FORMAT);
 }
 
-export function formatShanghaiDateTime(
+export function formatDateTimeInTimeZone(
   date: Date | string | number,
+  timeZone: string,
   format = 'YYYY-MM-DD HH:mm:ss'
 ) {
-  return parseInstant(date).tz(SHANGHAI_TIME_ZONE).format(format);
+  return parseInstant(date).tz(timeZone).format(format);
 }
 
 export function getUtcTimestamp(date: Date | string | number): number {
@@ -52,18 +61,18 @@ export function normalizeTimeInput(value: string): string {
   return /^\d{2}:\d{2}$/.test(value) ? `${value}:00` : value;
 }
 
-export function parseShanghaiDateTime(date: string, time: string): Date | null {
+export function parseDateTimeInTimeZone(date: string, time: string, timeZone: string): Date | null {
   const input = `${date} ${normalizeTimeInput(time)}`;
   const format = `${DATE_FORMAT} ${TIME_FORMAT}`;
   if (!dayjs(input, format, true).isValid()) {
     return null;
   }
 
-  return dayjs.tz(input, format, SHANGHAI_TIME_ZONE).toDate();
+  return dayjs.tz(input, format, timeZone).toDate();
 }
 
-export function getShanghaiDayBounds(date: Date): { start: Date; end: Date } {
-  const zonedDate = dayjs(date).tz(SHANGHAI_TIME_ZONE);
+export function getDayBoundsInTimeZone(date: Date, timeZone: string): { start: Date; end: Date } {
+  const zonedDate = dayjs(date).tz(timeZone);
 
   return {
     start: zonedDate.startOf('day').toDate(),
@@ -77,14 +86,15 @@ export function orderDateRange(first: Date, second: Date): { from: Date; to: Dat
     : { from: second, to: first };
 }
 
-export function getBoundedShanghaiDayRange(
+export function getBoundedDayRangeInTimeZone(
   from: Date | undefined,
   to: Date | undefined,
   min: Date,
-  max: Date
+  max: Date,
+  timeZone: string
 ): { from: Date | undefined; to: Date | undefined } {
-  const dayStart = from ? getShanghaiDayBounds(from).start : undefined;
-  const dayEnd = to ? getShanghaiDayBounds(to).end : undefined;
+  const dayStart = from ? getDayBoundsInTimeZone(from, timeZone).start : undefined;
+  const dayEnd = to ? getDayBoundsInTimeZone(to, timeZone).end : undefined;
 
   return {
     from: dayStart && dayStart < min ? min : dayStart && dayStart > max ? max : dayStart,
@@ -92,12 +102,17 @@ export function getBoundedShanghaiDayRange(
   };
 }
 
-export function getBoundedRangeStart(start: Date, end: Date, min: Date): Date | null {
+export function getBoundedRangeStart(
+  start: Date,
+  end: Date,
+  min: Date,
+  timeZone: string
+): Date | null {
   if (start >= min) {
     return start;
   }
 
-  const earliestDayStart = getShanghaiDayBounds(min).start;
+  const earliestDayStart = getDayBoundsInTimeZone(min, timeZone).start;
   return start >= earliestDayStart && end >= min ? min : null;
 }
 

--- a/frontend/providers/applaunchpad/src/utils/timeRange.ts
+++ b/frontend/providers/applaunchpad/src/utils/timeRange.ts
@@ -1,10 +1,12 @@
 import { subHours, subDays, subMinutes, subMonths } from 'date-fns';
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
+import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 
 dayjs.extend(customParseFormat);
 dayjs.extend(utc);
+dayjs.extend(timezone);
 
 type TimeUnit = 'h' | 'm' | 'd' | 'M';
 
@@ -13,44 +15,90 @@ interface TimeRange {
   endTime: Date;
 }
 
-const UTC_DATE_FORMAT = 'YYYY-MM-DD';
-const UTC_TIME_FORMAT = 'HH:mm:ss';
+const DATE_FORMAT = 'YYYY-MM-DD';
+const TIME_FORMAT = 'HH:mm:ss';
 
-export function formatUtcDate(date: Date): string {
-  return dayjs(date).utc().format(UTC_DATE_FORMAT);
+export const SHANGHAI_TIME_ZONE = 'Asia/Shanghai';
+
+function parseInstant(date: Date | string | number) {
+  if (typeof date !== 'string') {
+    return dayjs(date);
+  }
+
+  const hasTimeZone = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(date);
+  return hasTimeZone ? dayjs(date) : dayjs.utc(date);
 }
 
-export function formatUtcTime(date: Date): string {
-  return dayjs(date).utc().format(UTC_TIME_FORMAT);
+export function formatShanghaiDate(date: Date): string {
+  return dayjs(date).tz(SHANGHAI_TIME_ZONE).format(DATE_FORMAT);
 }
 
-export function formatUtcDateTime(date: Date | string | number, format = 'YYYY-MM-DD HH:mm:ss') {
-  return dayjs(date).utc().format(format);
+export function formatShanghaiTime(date: Date): string {
+  return dayjs(date).tz(SHANGHAI_TIME_ZONE).format(TIME_FORMAT);
+}
+
+export function formatShanghaiDateTime(
+  date: Date | string | number,
+  format = 'YYYY-MM-DD HH:mm:ss'
+) {
+  return parseInstant(date).tz(SHANGHAI_TIME_ZONE).format(format);
+}
+
+export function getUtcTimestamp(date: Date | string | number): number {
+  return parseInstant(date).valueOf();
 }
 
 export function normalizeTimeInput(value: string): string {
   return /^\d{2}:\d{2}$/.test(value) ? `${value}:00` : value;
 }
 
-export function parseUtcDateTime(date: string, time: string): Date | null {
-  const parsed = dayjs.utc(
-    `${date} ${normalizeTimeInput(time)}`,
-    `${UTC_DATE_FORMAT} ${UTC_TIME_FORMAT}`,
-    true
-  );
+export function parseShanghaiDateTime(date: string, time: string): Date | null {
+  const input = `${date} ${normalizeTimeInput(time)}`;
+  const format = `${DATE_FORMAT} ${TIME_FORMAT}`;
+  if (!dayjs(input, format, true).isValid()) {
+    return null;
+  }
 
-  return parsed.isValid() ? parsed.toDate() : null;
+  return dayjs.tz(input, format, SHANGHAI_TIME_ZONE).toDate();
 }
 
-export function getUtcDayBounds(date: Date): { start: Date; end: Date } {
-  const year = date.getUTCFullYear();
-  const month = date.getUTCMonth();
-  const day = date.getUTCDate();
+export function getShanghaiDayBounds(date: Date): { start: Date; end: Date } {
+  const zonedDate = dayjs(date).tz(SHANGHAI_TIME_ZONE);
 
   return {
-    start: new Date(Date.UTC(year, month, day, 0, 0, 0)),
-    end: new Date(Date.UTC(year, month, day, 23, 59, 59, 999))
+    start: zonedDate.startOf('day').toDate(),
+    end: zonedDate.endOf('day').toDate()
   };
+}
+
+export function orderDateRange(first: Date, second: Date): { from: Date; to: Date } {
+  return first.getTime() <= second.getTime()
+    ? { from: first, to: second }
+    : { from: second, to: first };
+}
+
+export function getBoundedShanghaiDayRange(
+  from: Date | undefined,
+  to: Date | undefined,
+  min: Date,
+  max: Date
+): { from: Date | undefined; to: Date | undefined } {
+  const dayStart = from ? getShanghaiDayBounds(from).start : undefined;
+  const dayEnd = to ? getShanghaiDayBounds(to).end : undefined;
+
+  return {
+    from: dayStart && dayStart < min ? min : dayStart && dayStart > max ? max : dayStart,
+    to: dayEnd && dayEnd > max ? max : dayEnd && dayEnd < min ? min : dayEnd
+  };
+}
+
+export function getBoundedRangeStart(start: Date, end: Date, min: Date): Date | null {
+  if (start >= min) {
+    return start;
+  }
+
+  const earliestDayStart = getShanghaiDayBounds(min).start;
+  return start >= earliestDayStart && end >= min ? min : null;
 }
 
 /**

--- a/frontend/providers/costcenter/__tests__/unit/gtm.test.ts
+++ b/frontend/providers/costcenter/__tests__/unit/gtm.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  gtmSubscribeCheckout,
+  gtmSubscribeSuccess,
+  gtmTopupCheckout,
+  gtmTopupSuccess
+} from '@/utils/gtm';
+
+describe('Cost Center GTM payment events', () => {
+  const dataLayer = { push: vi.fn() };
+
+  beforeEach(() => {
+    dataLayer.push.mockClear();
+    vi.stubGlobal('window', { dataLayer });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the currency field for top-up checkout', () => {
+    gtmTopupCheckout({ amount: 20 });
+
+    expect(dataLayer.push).toHaveBeenCalledWith({
+      event: 'topup_checkout',
+      method: 'stripe',
+      module: 'costcenter',
+      context: 'app',
+      currency: 'USD',
+      amount: 20
+    });
+  });
+
+  it('uses the currency field for top-up success', () => {
+    gtmTopupSuccess({ amount: 25, paid: 20 });
+
+    expect(dataLayer.push).toHaveBeenCalledWith({
+      event: 'topup_success',
+      method: 'stripe',
+      module: 'costcenter',
+      context: 'app',
+      currency: 'USD',
+      amount: 25,
+      paid: 20
+    });
+  });
+
+  it('uses the currency field for subscription checkout', () => {
+    gtmSubscribeCheckout({ amount: 15, plan: 'professional', type: 'new' });
+
+    expect(dataLayer.push).toHaveBeenCalledWith({
+      event: 'subscribe_checkout',
+      method: 'stripe',
+      module: 'costcenter',
+      context: 'app',
+      currency: 'USD',
+      amount: 15,
+      plan: 'professional',
+      type: 'new'
+    });
+  });
+
+  it('uses the currency field for subscription success', () => {
+    gtmSubscribeSuccess({ amount: 15, paid: 12, plan: 'professional', type: 'upgrade' });
+
+    expect(dataLayer.push).toHaveBeenCalledWith({
+      event: 'subscribe_success',
+      method: 'stripe',
+      module: 'costcenter',
+      context: 'app',
+      currency: 'USD',
+      amount: 15,
+      paid: 12,
+      plan: 'professional',
+      type: 'upgrade'
+    });
+  });
+});

--- a/frontend/providers/costcenter/src/utils/gtm.ts
+++ b/frontend/providers/costcenter/src/utils/gtm.ts
@@ -10,7 +10,7 @@ export const gtmTopupCheckout = ({ amount }: { amount: number }) =>
     method: 'stripe',
     module: 'costcenter',
     context: 'app',
-    curreny: 'USD',
+    currency: 'USD',
     amount
   });
 export const gtmTopupSuccess = ({ amount, paid }: { amount: number; paid: number }) =>
@@ -19,7 +19,7 @@ export const gtmTopupSuccess = ({ amount, paid }: { amount: number; paid: number
     module: 'costcenter',
     method: 'stripe',
     context: 'app',
-    curreny: 'USD',
+    currency: 'USD',
     amount,
     paid
   });
@@ -38,7 +38,7 @@ export const gtmSubscribeCheckout = ({
     method: 'stripe',
     module: 'costcenter',
     context: 'app',
-    curreny: 'USD',
+    currency: 'USD',
     amount,
     plan,
     type
@@ -60,7 +60,7 @@ export const gtmSubscribeSuccess = ({
     module: 'costcenter',
     method: 'stripe',
     context: 'app',
-    curreny: 'USD',
+    currency: 'USD',
     amount,
     paid,
     plan,


### PR DESCRIPTION
## Summary

- use the browser IANA timezone for DatePicker input, calendar boundaries, log timestamps, monitor charts, and refresh timestamps
- replace the former UTC control area in DatePicker with the detected browser timezone label
- preserve UTC instants for log and monitor query payloads; backend timestamps without an explicit offset continue to be interpreted as UTC
- preserve the seven-day query boundary, including reversed manual endpoints and the moving earliest-time edge
- include the existing CostCenter GTM currency-field correction on this branch

## Validation

- `pnpm exec tsc --noEmit` in `frontend/providers/applaunchpad`
- `pnpm test:unit` in `frontend/providers/applaunchpad` (165 tests)
- `pnpm lint` in `frontend/providers/applaunchpad`
- `TZ=UTC pnpm exec vitest run --project unit __tests__/unit/utils/timeRange.test.ts`
- `TZ=America/Los_Angeles pnpm exec vitest run --project unit __tests__/unit/utils/timeRange.test.ts`
- `git diff upstream/main...HEAD --check`