### PR TITLE
fix(frontend): disable libuv io_uring in runtime images

### DIFF
--- a/.github/workflows/frontends.yml
+++ b/.github/workflows/frontends.yml
@@ -40,6 +40,7 @@ on:
       - "frontend/pnpm-lock.yaml"
       - "frontend/pnpm-workspace.yaml"
       - "frontend/tsconfig*.json"
+      - "frontend/Dockerfile"
       - ".github/workflows/frontend.yml"
       - ".github/workflows/frontends.yml"
       - "!**/*.md"
@@ -53,6 +54,7 @@ on:
       - "frontend/pnpm-lock.yaml"
       - "frontend/pnpm-workspace.yaml"
       - "frontend/tsconfig*.json"
+      - "frontend/Dockerfile"
       - ".github/workflows/frontend.yml"
       - ".github/workflows/frontends.yml"
       - "!**/*.md"
@@ -69,6 +71,8 @@ jobs:
       modules: ${{ steps.set-matrix.outputs.modules }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Verify shared frontend runtime settings
+        run: grep -qx 'ENV UV_USE_IO_URING=0' frontend/Dockerfile
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:
@@ -80,6 +84,7 @@ jobs:
               - 'frontend/pnpm-lock.yaml'
               - 'frontend/pnpm-workspace.yaml'
               - 'frontend/tsconfig*.json'
+              - 'frontend/Dockerfile'
               - '.github/workflows/frontend.yml'
               - '.github/workflows/frontends.yml'
             license:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -73,6 +73,8 @@ FROM base AS runner
 ENV NODE_ENV=production
 # Uncomment the following line in case you want to disable telemetry during runtime.
 ENV NEXT_TELEMETRY_DISABLED=1
+# Avoid io_uring SQPOLL hangs on affected Linux kernels.
+ENV UV_USE_IO_URING=0
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -79,6 +79,10 @@ make -j
 - you can use `make all DOCKER_USERNAME=<your_account>` to build all apps for your account.
 - you can user `make all IMAGE_TAG=<tag>` to build all apps and customize tag (default:dev)
 
+Production frontend images set `UV_USE_IO_URING=0` so libuv uses its thread pool
+for file system operations instead of io_uring SQPOLL. This avoids process-exit
+hangs on affected Linux kernels while leaving network I/O on the normal event loop.
+
 ## how to publish image
 
 ```bash


### PR DESCRIPTION
## What

- Set `UV_USE_IO_URING=0` in the shared frontend runtime image.
- Trigger all frontend image builds when the shared Dockerfile changes.
- Add a CI assertion and document the runtime behavior.

## Why

Affected Linux kernels can hang during process teardown in `io_uring_del_tctx_node`. Disabling libuv io_uring makes filesystem operations use the libuv thread pool while network I/O remains on the normal event loop.

## Verification

- `git diff --check`
- Parsed `.github/workflows/frontends.yml` as YAML
- `actionlint .github/workflows/frontends.yml`
- Built a frontend image from the shared Dockerfile for `linux/amd64`
- Verified the OCI image config and running container contain `UV_USE_IO_URING=0`