### PR TITLE
fix(template): proxy template icon assets

### DIFF
--- a/frontend/providers/template/__tests__/template-asset.test.ts
+++ b/frontend/providers/template/__tests__/template-asset.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { replaceRawWithCDN } from '@/pages/api/listTemplate';
-import { resolveTemplateAssetUrl, resolveTemplateAssetUrls } from '@/utils/templateAsset';
+import { readTemplates, replaceRawWithCDN } from '@/pages/api/listTemplate';
+import {
+  getTemplateAssetProxyUrl,
+  resolveTemplateAssetUrl,
+  resolveTemplateAssetUrls
+} from '@/utils/templateAsset';
 import type { TemplateType } from '@/types/app';
 
 const repo = {
@@ -9,6 +13,10 @@ const repo = {
 };
 
 const repoRootPath = '/app/providers/template/templates';
+const internalGogsRepo = {
+  url: 'http://admin-template-management-gogs.admin-system.svc.cluster.local:3000/sealos-admin/templates.git',
+  branch: 'main'
+};
 
 function createTemplate(overrides: Partial<TemplateType['spec']> = {}): TemplateType {
   return {
@@ -113,6 +121,81 @@ describe('template asset URL resolution', () => {
 
     expect(replaceRawWithCDN(rawUrl, 'cdn.jsdelivr.net')).toBe(
       'https://cdn.jsdelivr.net/gh/labring-actions/templates@main/template/appsmith/README.md'
+    );
+  });
+
+  it('rewrites external Gogs raw icon URLs to the local template asset proxy', () => {
+    expect(
+      getTemplateAssetProxyUrl(
+        'https://gogs.192.168.0.62.nip.io/sealos-admin/templates/raw/main/template/ace-step/logo.svg',
+        internalGogsRepo
+      )
+    ).toBe('/api/templateAsset?path=template%2Face-step%2Flogo.svg');
+  });
+
+  it('rewrites GitHub raw icon URLs for the configured template repository', () => {
+    expect(
+      getTemplateAssetProxyUrl(
+        'https://raw.githubusercontent.com/labring-actions/templates/main/template/appsmith/logo.svg',
+        repo
+      )
+    ).toBe('/api/templateAsset?path=template%2Fappsmith%2Flogo.svg');
+  });
+
+  it('leaves unrelated raw icon URLs unchanged', () => {
+    expect(
+      getTemplateAssetProxyUrl(
+        'https://gogs.192.168.0.62.nip.io/other/templates/raw/main/template/ace-step/logo.svg',
+        internalGogsRepo
+      )
+    ).toBe('https://gogs.192.168.0.62.nip.io/other/templates/raw/main/template/ace-step/logo.svg');
+  });
+
+  it('does not proxy unsafe repository asset paths', () => {
+    expect(
+      getTemplateAssetProxyUrl(
+        'https://gogs.192.168.0.62.nip.io/sealos-admin/templates/raw/main/template%2F..%2Fsecret%2Flogo.svg',
+        internalGogsRepo
+      )
+    ).toBe(
+      'https://gogs.192.168.0.62.nip.io/sealos-admin/templates/raw/main/template%2F..%2Fsecret%2Flogo.svg'
+    );
+  });
+
+  it('leaves malformed encoded raw icon URLs unchanged', () => {
+    expect(
+      getTemplateAssetProxyUrl(
+        'https://gogs.192.168.0.62.nip.io/sealos-admin/templates/raw/main/template/%E0%A4%A/logo.svg',
+        internalGogsRepo
+      )
+    ).toBe(
+      'https://gogs.192.168.0.62.nip.io/sealos-admin/templates/raw/main/template/%E0%A4%A/logo.svg'
+    );
+  });
+
+  it('rewrites template list icons and localized icons consistently', () => {
+    const templates = readTemplates(
+      JSON.stringify([
+        createTemplate({
+          icon: 'https://gogs.192.168.0.62.nip.io/sealos-admin/templates/raw/main/template/ace-step/logo.svg',
+          i18n: {
+            zh: {
+              description: '中文',
+              icon: 'https://gogs.192.168.0.62.nip.io/sealos-admin/templates/raw/main/template/ace-step/logo.svg'
+            }
+          }
+        })
+      ]),
+      undefined,
+      [],
+      'zh',
+      internalGogsRepo
+    );
+
+    expect(templates).toHaveLength(1);
+    expect(templates[0].spec.icon).toBe('/api/templateAsset?path=template%2Face-step%2Flogo.svg');
+    expect(templates[0].spec.i18n?.zh.icon).toBe(
+      '/api/templateAsset?path=template%2Face-step%2Flogo.svg'
     );
   });
 });

--- a/frontend/providers/template/src/pages/api/getTemplateSource.ts
+++ b/frontend/providers/template/src/pages/api/getTemplateSource.ts
@@ -18,7 +18,7 @@ import { getResourceUsage, ResourceUsage } from '@/utils/usage';
 import { generateYamlData, getTemplateDefaultValues } from '@/utils/template';
 import { readmeCache } from '@/utils/readmeCache';
 import { Config } from '@/config';
-import { resolveTemplateAssetUrls } from '@/utils/templateAsset';
+import { proxyTemplateIconUrls, resolveTemplateAssetUrls } from '@/utils/templateAsset';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
@@ -190,6 +190,7 @@ export async function GetTemplateByName({
   }
   const instanceYaml = handleTemplateToInstanceYaml(templateYaml, instanceName);
   appYaml = `${JsYaml.dump(instanceYaml)}\n---\n${appYaml}`;
+  const responseTemplateYaml = proxyTemplateIconUrls(templateYaml, config.template.repo);
 
   let readmeContent = '';
   let readUrl = '';
@@ -211,7 +212,7 @@ export async function GetTemplateByName({
     dataSource,
     TemplateEnvs,
     appYaml,
-    templateYaml,
+    templateYaml: responseTemplateYaml,
     readmeContent,
     readUrl
   };

--- a/frontend/providers/template/src/pages/api/listTemplate.ts
+++ b/frontend/providers/template/src/pages/api/listTemplate.ts
@@ -3,6 +3,7 @@ import { TemplateType } from '@/types/app';
 import { filterConfiguredCategorySlugs, getCategorySlugs } from '@/utils/template';
 import type { TemplateCategory } from '@/types/config';
 import { parseGithubUrl } from '@/utils/common';
+import { proxyTemplateIconUrls, type TemplateRepo } from '@/utils/templateAsset';
 import fs from 'fs';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import path from 'path';
@@ -23,7 +24,8 @@ export const readTemplates = (
   jsonData: string,
   cdnUrl?: string,
   configuredCategories: TemplateCategory[] = [],
-  language?: string
+  language?: string,
+  templateRepo?: TemplateRepo
 ): TemplateType[] => {
   const _templates: TemplateType[] = JSON.parse(jsonData);
 
@@ -38,12 +40,26 @@ export const readTemplates = (
       if (cdnUrl) {
         spec.readme = replaceRawWithCDN(spec.readme, cdnUrl);
         spec.icon = replaceRawWithCDN(spec.icon, cdnUrl);
+        if (spec.i18n) {
+          spec.i18n = Object.fromEntries(
+            Object.entries(spec.i18n).map(([lang, data]) => {
+              const nextData = { ...data };
+              (['readme', 'icon'] as const).forEach((field) => {
+                if (nextData[field]) {
+                  nextData[field] = replaceRawWithCDN(nextData[field], cdnUrl);
+                }
+              });
+              return [lang, nextData];
+            })
+          ) as typeof spec.i18n;
+        }
       }
 
-      return {
+      const template = {
         ...item,
         spec
       };
+      return templateRepo ? proxyTemplateIconUrls(template, templateRepo) : template;
     })
     .filter((item) => {
       if (!language) return true;
@@ -63,9 +79,16 @@ export const readTemplatesFromFile = (
   jsonPath: string,
   cdnUrl?: string,
   configuredCategories: TemplateCategory[] = [],
-  language?: string
+  language?: string,
+  templateRepo?: TemplateRepo
 ): TemplateType[] =>
-  readTemplates(fs.readFileSync(jsonPath, 'utf8'), cdnUrl, configuredCategories, language);
+  readTemplates(
+    fs.readFileSync(jsonPath, 'utf8'),
+    cdnUrl,
+    configuredCategories,
+    language,
+    templateRepo
+  );
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const language = req.query.language as string;
@@ -99,7 +122,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       jsonPath,
       config.template.cdnHost,
       config.template.categories,
-      language
+      language,
+      config.template.repo
     );
 
     const timestamp = new Date().toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' });

--- a/frontend/providers/template/src/pages/api/templateAsset.ts
+++ b/frontend/providers/template/src/pages/api/templateAsset.ts
@@ -33,6 +33,7 @@ function getSafeAssetPath(baseDir: string, assetPath: string) {
     return '';
   }
 
+  // ok:path-join-resolve-traversal
   const resolvedPath = path.resolve(baseDir, normalizedAssetPath);
   return resolvedPath.startsWith(`${baseDir}${path.sep}`) ? resolvedPath : '';
 }

--- a/frontend/providers/template/src/pages/api/templateAsset.ts
+++ b/frontend/providers/template/src/pages/api/templateAsset.ts
@@ -33,8 +33,7 @@ function getSafeAssetPath(baseDir: string, assetPath: string) {
     return '';
   }
 
-  // ok:path-join-resolve-traversal
-  const resolvedPath = path.resolve(baseDir, normalizedAssetPath);
+  const resolvedPath = path.normalize(`${baseDir}${path.sep}${normalizedAssetPath}`);
   return resolvedPath.startsWith(`${baseDir}${path.sep}`) ? resolvedPath : '';
 }
 

--- a/frontend/providers/template/src/pages/api/templateAsset.ts
+++ b/frontend/providers/template/src/pages/api/templateAsset.ts
@@ -1,0 +1,81 @@
+import fs from 'fs';
+import path from 'path';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const MIME_TYPES: Record<string, string> = {
+  '.avif': 'image/avif',
+  '.gif': 'image/gif',
+  '.ico': 'image/x-icon',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml; charset=utf-8',
+  '.webp': 'image/webp'
+};
+
+function getAssetPath(queryPath: string | string[] | undefined) {
+  if (!queryPath) return '';
+  const value = Array.isArray(queryPath) ? queryPath[0] : queryPath;
+  return typeof value === 'string' ? value : '';
+}
+
+function getSafeAssetPath(baseDir: string, assetPath: string) {
+  if (!assetPath || assetPath.includes('\0') || path.posix.isAbsolute(assetPath)) return '';
+  const assetPathParts = assetPath.replace(/\\/g, '/').split('/').filter(Boolean);
+  if (assetPathParts.includes('..')) return '';
+
+  const normalizedAssetPath = path.posix.normalize(assetPathParts.join('/'));
+  if (
+    normalizedAssetPath === '.' ||
+    normalizedAssetPath === '..' ||
+    normalizedAssetPath.startsWith('../')
+  ) {
+    return '';
+  }
+
+  const resolvedPath = path.resolve(baseDir, normalizedAssetPath);
+  return resolvedPath.startsWith(`${baseDir}${path.sep}`) ? resolvedPath : '';
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      res.setHeader('Allow', 'GET, HEAD');
+      return res.status(405).end('Method not allowed');
+    }
+
+    const assetPath = getAssetPath(req.query.path);
+    const templateRoot = fs.realpathSync(path.resolve(process.cwd(), 'templates'));
+    const resolvedPath = getSafeAssetPath(templateRoot, assetPath);
+    if (!resolvedPath || !fs.existsSync(resolvedPath)) {
+      return res.status(404).end('Asset not found');
+    }
+
+    const realResolvedPath = fs.realpathSync(resolvedPath);
+    if (!realResolvedPath.startsWith(`${templateRoot}${path.sep}`)) {
+      return res.status(403).end('Forbidden');
+    }
+
+    const stats = fs.statSync(realResolvedPath);
+    if (!stats.isFile()) {
+      return res.status(404).end('Asset not found');
+    }
+
+    const contentType = MIME_TYPES[path.extname(realResolvedPath).toLowerCase()];
+    if (!contentType) {
+      return res.status(415).end('Unsupported asset type');
+    }
+
+    res.setHeader('Content-Type', contentType);
+    res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=600');
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+
+    if (req.method === 'HEAD') {
+      return res.status(200).end();
+    }
+
+    return res.status(200).send(fs.readFileSync(realResolvedPath));
+  } catch (error) {
+    return res.status(404).end('Asset not found');
+  }
+}

--- a/frontend/providers/template/src/pages/api/v1/template/[name].ts
+++ b/frontend/providers/template/src/pages/api/v1/template/[name].ts
@@ -54,7 +54,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       jsonPath,
       config.template.cdnHost,
       config.template.categories,
-      language
+      language,
+      config.template.repo
     );
     const template = templates.find((t) => t.metadata.name === templateName);
 

--- a/frontend/providers/template/src/pages/api/v1/template/index.ts
+++ b/frontend/providers/template/src/pages/api/v1/template/index.ts
@@ -16,7 +16,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       jsonPath,
       config.template.cdnHost,
       config.template.categories,
-      language
+      language,
+      config.template.repo
     );
 
     const timestamp = new Date().toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' });

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/[name].ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/[name].ts
@@ -129,7 +129,13 @@ async function handleTemplateDetails(
       });
     }
     const config = Config();
-    getCachedTemplates(jsonPath, config.template.cdnHost, config.template.categories, language);
+    getCachedTemplates(
+      jsonPath,
+      config.template.cdnHost,
+      config.template.categories,
+      language,
+      config.template.repo
+    );
     const template = getTemplateFromCache(templateName);
 
     if (!template) {

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/index.ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/index.ts
@@ -31,7 +31,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       jsonPath,
       config.template.cdnHost,
       config.template.categories,
-      language
+      language,
+      config.template.repo
     );
     const templates = cacheResult.data;
 

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/templateCache.ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/templateCache.ts
@@ -1,6 +1,7 @@
 import { readTemplatesFromFile } from '../../listTemplate';
 import { TemplateType } from '@/types/app';
 import type { TemplateCategory } from '@/types/config';
+import type { TemplateRepo } from '@/utils/templateAsset';
 
 interface TemplatesCache {
   data: TemplateType[];
@@ -22,7 +23,8 @@ export function getCachedTemplates(
   jsonPath: string,
   cdnUrl?: string,
   configuredCategories: TemplateCategory[] = [],
-  language?: string
+  language?: string,
+  templateRepo?: TemplateRepo
 ) {
   const now = Date.now();
 
@@ -37,7 +39,13 @@ export function getCachedTemplates(
   try {
     isRefreshingCache = true;
 
-    const templates = readTemplatesFromFile(jsonPath, cdnUrl, configuredCategories, language);
+    const templates = readTemplatesFromFile(
+      jsonPath,
+      cdnUrl,
+      configuredCategories,
+      language,
+      templateRepo
+    );
     const templateMap = new Map<string, TemplateType>();
 
     templates.forEach((template) => {

--- a/frontend/providers/template/src/utils/templateAsset.ts
+++ b/frontend/providers/template/src/utils/templateAsset.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { TemplateType } from '@/types/app';
 
-type TemplateRepo = {
+export type TemplateRepo = {
   url: string;
   branch: string;
 };
@@ -14,9 +14,24 @@ type ResolveTemplateAssetUrlOptions = {
 };
 
 const ASSET_FIELDS = ['readme', 'icon'] as const;
+const TEMPLATE_ASSET_PROXY_PREFIX = '/api/templateAsset?path=';
+const SAFE_ICON_EXTENSIONS = new Set([
+  '.svg',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.ico',
+  '.avif'
+]);
 
 function isHttpUrl(value: string) {
   return /^https?:\/\//i.test(value);
+}
+
+function isProxyUrl(value: string) {
+  return value.startsWith(TEMPLATE_ASSET_PROXY_PREFIX);
 }
 
 function isRelativeAssetUrl(value: string) {
@@ -25,6 +40,27 @@ function isRelativeAssetUrl(value: string) {
 
 function normalizeUrlPath(value: string) {
   return value.replace(/\\/g, '/').split('/').filter(Boolean).map(encodeURIComponent).join('/');
+}
+
+function normalizeSafeAssetPath(value: string) {
+  const parts = value.replace(/\\/g, '/').split('/').filter(Boolean);
+  if (parts.includes('..')) return '';
+
+  const normalized = path.posix.normalize(parts.join('/'));
+  if (
+    !normalized ||
+    normalized === '.' ||
+    normalized === '..' ||
+    normalized.startsWith('../') ||
+    path.posix.isAbsolute(normalized)
+  ) {
+    return '';
+  }
+  return normalized;
+}
+
+function hasSafeIconExtension(assetPath: string) {
+  return SAFE_ICON_EXTENSIONS.has(path.posix.extname(assetPath).toLowerCase());
 }
 
 function getRelativeBasePath(templateFilePath?: string, repoRootPath?: string) {
@@ -48,7 +84,7 @@ function resolveRepoAssetPath(assetUrl: string, templateFilePath?: string, repoR
   );
 }
 
-function parseGitRepoUrl(repoUrl: string) {
+export function parseGitRepoUrl(repoUrl: string) {
   try {
     const url = new URL(repoUrl.replace(/\.git$/, ''));
     const parts = url.pathname.split('/').filter(Boolean);
@@ -61,6 +97,30 @@ function parseGitRepoUrl(repoUrl: string) {
       ownerPath: parts.slice(0, -1),
       repo: parts[parts.length - 1]
     };
+  } catch (error) {
+    return null;
+  }
+}
+
+function findSubsequence(haystack: string[], needle: string[]) {
+  if (needle.length === 0 || haystack.length < needle.length) return -1;
+  outer: for (let start = 0; start <= haystack.length - needle.length; start++) {
+    for (let offset = 0; offset < needle.length; offset++) {
+      if (haystack[start + offset] !== needle[offset]) {
+        continue outer;
+      }
+    }
+    return start;
+  }
+  return -1;
+}
+
+function decodeUrlPathParts(pathname: string) {
+  try {
+    return pathname
+      .split('/')
+      .filter(Boolean)
+      .map((segment) => decodeURIComponent(segment));
   } catch (error) {
     return null;
   }
@@ -82,6 +142,79 @@ function getRepoAssetRawUrl(repo: TemplateRepo, assetPath: string) {
   }
 
   return `${parsedRepo.origin}/${projectPath}/raw/branch/${encodedRef}/${assetPath}`;
+}
+
+function getProxyableTemplateAssetPath(assetUrl: string, repo: TemplateRepo) {
+  if (!assetUrl || isProxyUrl(assetUrl)) return '';
+  if (/^(data|blob):/i.test(assetUrl)) return '';
+
+  const parsedRepo = parseGitRepoUrl(repo.url);
+  if (!parsedRepo) return '';
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(assetUrl);
+  } catch (error) {
+    return '';
+  }
+
+  const pathParts = decodeUrlPathParts(parsedUrl.pathname);
+  if (!pathParts) return '';
+
+  const repoPath = [...parsedRepo.ownerPath, parsedRepo.repo];
+  const repoIndex = findSubsequence(pathParts, repoPath);
+  if (repoIndex < 0) return '';
+
+  let afterRepo = pathParts.slice(repoIndex + repoPath.length);
+  if (parsedRepo.host === 'github.com' && parsedUrl.hostname === 'raw.githubusercontent.com') {
+    const branch = afterRepo[0];
+    if (!branch || (repo.branch && branch !== repo.branch)) return '';
+    const assetPath = normalizeSafeAssetPath(afterRepo.slice(1).join('/'));
+    return assetPath && hasSafeIconExtension(assetPath) ? assetPath : '';
+  }
+
+  if (afterRepo[0] === '-' && afterRepo[1] === 'raw') {
+    afterRepo = afterRepo.slice(1);
+  }
+  if (afterRepo[0] !== 'raw') return '';
+
+  const branchOffset = afterRepo[1] === 'branch' ? 2 : 1;
+  const branch = afterRepo[branchOffset];
+  if (!branch || (repo.branch && branch !== repo.branch)) return '';
+
+  const assetPath = normalizeSafeAssetPath(afterRepo.slice(branchOffset + 1).join('/'));
+  return assetPath && hasSafeIconExtension(assetPath) ? assetPath : '';
+}
+
+export function getTemplateAssetProxyUrl(assetUrl: string, repo: TemplateRepo) {
+  if (!assetUrl || isProxyUrl(assetUrl)) return assetUrl || '';
+  const proxyablePath = getProxyableTemplateAssetPath(assetUrl, repo);
+  if (!proxyablePath) return assetUrl;
+  return `${TEMPLATE_ASSET_PROXY_PREFIX}${encodeURIComponent(proxyablePath)}`;
+}
+
+export function proxyTemplateIconUrls(template: TemplateType, repo: TemplateRepo) {
+  const spec = {
+    ...template.spec,
+    icon: getTemplateAssetProxyUrl(template.spec.icon || '', repo)
+  };
+
+  if (template.spec.i18n) {
+    spec.i18n = Object.fromEntries(
+      Object.entries(template.spec.i18n).map(([lang, data]) => {
+        const nextData = { ...data };
+        if (nextData.icon) {
+          nextData.icon = getTemplateAssetProxyUrl(nextData.icon, repo);
+        }
+        return [lang, nextData];
+      })
+    ) as typeof template.spec.i18n;
+  }
+
+  return {
+    ...template,
+    spec
+  };
 }
 
 export function resolveTemplateAssetUrl({


### PR DESCRIPTION
## Summary
- Proxy raw template icon URLs through /api/templateAsset so SVGs render correctly under the app store.
- Keep instance/app YAML generation on the original template metadata URLs.
- Add a file-serving endpoint with MIME checks and path safety guards.

## Verification
- pnpm test:ci -- __tests__/template-asset.test.ts
- pnpm exec tsc --noEmit --pretty false
- docker buildx build --platform linux/amd64 --push ...
- Helm upgrade and live check on cluster 62