### PR TITLE
fix(template): proxy template icons locally

### DIFF
--- a/frontend/providers/template/src/pages/api/getTemplateSource.ts
+++ b/frontend/providers/template/src/pages/api/getTemplateSource.ts
@@ -17,7 +17,7 @@ import { getTemplateEnvs } from '@/utils/tools';
 import { getResourceUsage, ResourceUsage } from '@/utils/usage';
 import { generateYamlData, getTemplateDefaultValues } from '@/utils/template';
 import { readmeCache } from '@/utils/readmeCache';
-import { resolveTemplateAssetUrls } from '@/utils/templateAsset';
+import { proxyTemplateIconUrls, resolveTemplateAssetUrls } from '@/utils/templateAsset';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
@@ -143,6 +143,12 @@ export async function GetTemplateByName({
   }
   const instanceYaml = handleTemplateToInstanceYaml(templateYaml, instanceName);
   appYaml = `${JsYaml.dump(instanceYaml)}\n---\n${appYaml}`;
+  const templateRepo = {
+    url: TemplateEnvs.TEMPLATE_REPO_URL,
+    branch: TemplateEnvs.TEMPLATE_REPO_BRANCH,
+    provider: TemplateEnvs.TEMPLATE_REPO_PROVIDER
+  };
+  const responseTemplateYaml = proxyTemplateIconUrls(templateYaml, templateRepo);
 
   let readmeContent = '';
   let readUrl = '';
@@ -164,7 +170,7 @@ export async function GetTemplateByName({
     dataSource,
     TemplateEnvs,
     appYaml,
-    templateYaml,
+    templateYaml: responseTemplateYaml,
     readmeContent,
     readUrl
   };
@@ -230,12 +236,13 @@ function getTemplateYamlByName(
   const { appYaml, templateYaml: rawTemplateYaml } = getYamlTemplate(yamlString);
   let templateYaml = rawTemplateYaml;
   templateYaml.spec.deployCount = template?.spec?.deployCount;
+  const templateRepo = {
+    url: TemplateEnvs.TEMPLATE_REPO_URL,
+    branch: TemplateEnvs.TEMPLATE_REPO_BRANCH,
+    provider: TemplateEnvs.TEMPLATE_REPO_PROVIDER
+  };
   templateYaml = resolveTemplateAssetUrls(templateYaml, {
-    repo: {
-      url: TemplateEnvs.TEMPLATE_REPO_URL,
-      branch: TemplateEnvs.TEMPLATE_REPO_BRANCH,
-      provider: TemplateEnvs.TEMPLATE_REPO_PROVIDER
-    },
+    repo: templateRepo,
     templateFilePath,
     repoRootPath
   });

--- a/frontend/providers/template/src/pages/api/listTemplate.ts
+++ b/frontend/providers/template/src/pages/api/listTemplate.ts
@@ -6,7 +6,8 @@ import {
   parseTemplateCategories
 } from '@/utils/template';
 import type { TemplateCategory } from '@/types/config';
-import { parseGithubUrl } from '@/utils/tools';
+import { getTemplateEnvs, parseGithubUrl } from '@/utils/tools';
+import { proxyTemplateIconUrls, type TemplateRepo } from '@/utils/templateAsset';
 import fs from 'fs';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import path from 'path';
@@ -26,7 +27,8 @@ export const readTemplates = (
   jsonData: string,
   cdnUrl?: string,
   configuredCategories: TemplateCategory[] = [],
-  language?: string
+  language?: string,
+  templateRepo?: TemplateRepo
 ): TemplateType[] => {
   const _templates: TemplateType[] = JSON.parse(jsonData);
 
@@ -43,10 +45,11 @@ export const readTemplates = (
         spec.icon = replaceRawWithCDN(spec.icon, cdnUrl);
       }
 
-      return {
+      const template = {
         ...item,
         spec
       };
+      return templateRepo ? proxyTemplateIconUrls(template, templateRepo) : template;
     })
     .filter((item) => {
       if (!language) return true;
@@ -66,9 +69,16 @@ export const readTemplatesFromFile = (
   jsonPath: string,
   cdnUrl?: string,
   configuredCategories: TemplateCategory[] = [],
-  language?: string
+  language?: string,
+  templateRepo?: TemplateRepo
 ): TemplateType[] =>
-  readTemplates(fs.readFileSync(jsonPath, 'utf8'), cdnUrl, configuredCategories, language);
+  readTemplates(
+    fs.readFileSync(jsonPath, 'utf8'),
+    cdnUrl,
+    configuredCategories,
+    language,
+    templateRepo
+  );
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const language = req.query.language as string;
@@ -78,6 +88,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const cdnUrl = process.env.CDN_URL;
   const baseurl = `http://${process.env.HOSTNAME || 'localhost'}:${process.env.PORT || 3000}`;
   const configuredCategories = parseTemplateCategories(process.env.TEMPLATE_CATEGORIES);
+  const templateEnvs = getTemplateEnvs();
+  const templateRepo = {
+    url: templateEnvs.TEMPLATE_REPO_URL,
+    branch: templateEnvs.TEMPLATE_REPO_BRANCH,
+    provider: templateEnvs.TEMPLATE_REPO_PROVIDER
+  };
 
   try {
     if (!global.updateRepoCronJob) {
@@ -99,7 +115,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       await fetch(`${baseurl}/api/updateRepo`);
     }
 
-    const templates = readTemplatesFromFile(jsonPath, cdnUrl, configuredCategories, language);
+    const templates = readTemplatesFromFile(
+      jsonPath,
+      cdnUrl,
+      configuredCategories,
+      language,
+      templateRepo
+    );
 
     const timestamp = new Date().toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' });
     console.log(`[${timestamp}] language: ${language}, templates count: ${templates.length}`);

--- a/frontend/providers/template/src/pages/api/templateAsset.ts
+++ b/frontend/providers/template/src/pages/api/templateAsset.ts
@@ -1,0 +1,81 @@
+import fs from 'fs';
+import path from 'path';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const MIME_TYPES: Record<string, string> = {
+  '.avif': 'image/avif',
+  '.gif': 'image/gif',
+  '.ico': 'image/x-icon',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml; charset=utf-8',
+  '.webp': 'image/webp'
+};
+
+function getAssetPath(queryPath: string | string[] | undefined) {
+  if (!queryPath) return '';
+  const value = Array.isArray(queryPath) ? queryPath[0] : queryPath;
+  return typeof value === 'string' ? value : '';
+}
+
+function getSafeAssetPath(baseDir: string, assetPath: string) {
+  if (!assetPath || assetPath.includes('\0') || path.posix.isAbsolute(assetPath)) return '';
+  const assetPathParts = assetPath.replace(/\\/g, '/').split('/').filter(Boolean);
+  if (assetPathParts.includes('..')) return '';
+
+  const normalizedAssetPath = path.posix.normalize(assetPathParts.join('/'));
+  if (
+    normalizedAssetPath === '.' ||
+    normalizedAssetPath === '..' ||
+    normalizedAssetPath.startsWith('../')
+  ) {
+    return '';
+  }
+
+  const resolvedPath = path.normalize(`${baseDir}${path.sep}${normalizedAssetPath}`);
+  return resolvedPath.startsWith(`${baseDir}${path.sep}`) ? resolvedPath : '';
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      res.setHeader('Allow', 'GET, HEAD');
+      return res.status(405).end('Method not allowed');
+    }
+
+    const assetPath = getAssetPath(req.query.path);
+    const templateRoot = fs.realpathSync(path.resolve(process.cwd(), 'templates'));
+    const resolvedPath = getSafeAssetPath(templateRoot, assetPath);
+    if (!resolvedPath || !fs.existsSync(resolvedPath)) {
+      return res.status(404).end('Asset not found');
+    }
+
+    const realResolvedPath = fs.realpathSync(resolvedPath);
+    if (!realResolvedPath.startsWith(`${templateRoot}${path.sep}`)) {
+      return res.status(403).end('Forbidden');
+    }
+
+    const stats = fs.statSync(realResolvedPath);
+    if (!stats.isFile()) {
+      return res.status(404).end('Asset not found');
+    }
+
+    const contentType = MIME_TYPES[path.extname(realResolvedPath).toLowerCase()];
+    if (!contentType) {
+      return res.status(415).end('Unsupported asset type');
+    }
+
+    res.setHeader('Content-Type', contentType);
+    res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=600');
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+
+    if (req.method === 'HEAD') {
+      return res.status(200).end();
+    }
+
+    return res.status(200).send(fs.readFileSync(realResolvedPath));
+  } catch (error) {
+    return res.status(404).end('Asset not found');
+  }
+}

--- a/frontend/providers/template/src/pages/api/v1/template/[name].ts
+++ b/frontend/providers/template/src/pages/api/v1/template/[name].ts
@@ -7,6 +7,7 @@ import { getResourceUsage, ResourceUsage } from '@/utils/usage';
 import { readTemplatesFromFile } from '../../listTemplate';
 import { GetTemplateByName } from '../../getTemplateSource';
 import { parseTemplateCategories } from '@/utils/template';
+import { getTemplateEnvs } from '@/utils/tools';
 
 function simplifyResourceValue(
   resource: { min: number; max: number },
@@ -49,11 +50,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       });
     }
 
+    const configuredCategories = parseTemplateCategories(process.env.TEMPLATE_CATEGORIES);
+    const templateEnvs = getTemplateEnvs();
+    const templateRepo = {
+      url: templateEnvs.TEMPLATE_REPO_URL,
+      branch: templateEnvs.TEMPLATE_REPO_BRANCH,
+      provider: templateEnvs.TEMPLATE_REPO_PROVIDER
+    };
     const templates = readTemplatesFromFile(
       jsonPath,
       process.env.CDN_URL,
-      parseTemplateCategories(process.env.TEMPLATE_CATEGORIES),
-      language
+      configuredCategories,
+      language,
+      templateRepo
     );
     const template = templates.find((t) => t.metadata.name === templateName);
 

--- a/frontend/providers/template/src/pages/api/v1/template/index.ts
+++ b/frontend/providers/template/src/pages/api/v1/template/index.ts
@@ -4,6 +4,7 @@ import { getCategorySlugs, parseTemplateCategories } from '@/utils/template';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import path from 'path';
 import { readTemplatesFromFile } from '../../listTemplate';
+import { getTemplateEnvs } from '@/utils/tools';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const language = (req.query.language as string) || 'en';
@@ -12,11 +13,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   try {
     const configuredCategories = parseTemplateCategories(process.env.TEMPLATE_CATEGORIES);
+    const templateEnvs = getTemplateEnvs();
+    const templateRepo = {
+      url: templateEnvs.TEMPLATE_REPO_URL,
+      branch: templateEnvs.TEMPLATE_REPO_BRANCH,
+      provider: templateEnvs.TEMPLATE_REPO_PROVIDER
+    };
     const templates = readTemplatesFromFile(
       jsonPath,
       process.env.CDN_URL,
       configuredCategories,
-      language
+      language,
+      templateRepo
     );
 
     const timestamp = new Date().toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' });

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/[name].ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/[name].ts
@@ -12,6 +12,7 @@ import {
 } from './templateCache';
 import { parseTemplateCategories } from '@/utils/template';
 import { sendError, ErrorType, ErrorCode } from '@/types/v2alpha/error';
+import { getTemplateEnvs } from '@/utils/tools';
 
 // estimate min—max equality
 function simplifyResourceValue(
@@ -128,11 +129,18 @@ async function handleTemplateDetails(
         message: 'Templates catalog not found.'
       });
     }
+    const templateEnvs = getTemplateEnvs();
+    const templateRepo = {
+      url: templateEnvs.TEMPLATE_REPO_URL,
+      branch: templateEnvs.TEMPLATE_REPO_BRANCH,
+      provider: templateEnvs.TEMPLATE_REPO_PROVIDER
+    };
     getCachedTemplates(
       jsonPath,
       process.env.CDN_URL,
       parseTemplateCategories(process.env.TEMPLATE_CATEGORIES),
-      language
+      language,
+      templateRepo
     );
     const template = getTemplateFromCache(templateName);
 

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/index.ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/index.ts
@@ -4,6 +4,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import path from 'path';
 import { getCachedTemplates } from './templateCache';
 import { sendError, ErrorType, ErrorCode } from '@/types/v2alpha/error';
+import { getTemplateEnvs } from '@/utils/tools';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
@@ -26,11 +27,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   try {
     // Use shared cache instead of directly reading templates
     const configuredCategories = parseTemplateCategories(process.env.TEMPLATE_CATEGORIES);
+    const templateEnvs = getTemplateEnvs();
+    const templateRepo = {
+      url: templateEnvs.TEMPLATE_REPO_URL,
+      branch: templateEnvs.TEMPLATE_REPO_BRANCH,
+      provider: templateEnvs.TEMPLATE_REPO_PROVIDER
+    };
     const cacheResult = getCachedTemplates(
       jsonPath,
       process.env.CDN_URL,
       configuredCategories,
-      language
+      language,
+      templateRepo
     );
     const templates = cacheResult.data;
 

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/templateCache.ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/templateCache.ts
@@ -1,6 +1,7 @@
 import { readTemplatesFromFile } from '../../listTemplate';
 import { TemplateType } from '@/types/app';
 import type { TemplateCategory } from '@/types/config';
+import type { TemplateRepo } from '@/utils/templateAsset';
 
 interface TemplatesCache {
   data: TemplateType[];
@@ -22,7 +23,8 @@ export function getCachedTemplates(
   jsonPath: string,
   cdnUrl?: string,
   configuredCategories: TemplateCategory[] = [],
-  language?: string
+  language?: string,
+  templateRepo?: TemplateRepo
 ) {
   const now = Date.now();
 
@@ -37,7 +39,13 @@ export function getCachedTemplates(
   try {
     isRefreshingCache = true;
 
-    const templates = readTemplatesFromFile(jsonPath, cdnUrl, configuredCategories, language);
+    const templates = readTemplatesFromFile(
+      jsonPath,
+      cdnUrl,
+      configuredCategories,
+      language,
+      templateRepo
+    );
     const templateMap = new Map<string, TemplateType>();
 
     templates.forEach((template) => {

--- a/frontend/providers/template/src/utils/templateAsset.ts
+++ b/frontend/providers/template/src/utils/templateAsset.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { TemplateType } from '@/types/app';
 import type { TemplateRepoProvider } from '@/types';
 
-type TemplateRepo = {
+export type TemplateRepo = {
   url: string;
   branch: string;
   provider?: TemplateRepoProvider;
@@ -16,13 +16,24 @@ type ResolveTemplateAssetUrlOptions = {
 };
 
 const ASSET_FIELDS = ['readme', 'icon'] as const;
-
-function normalizeTemplateRepoProvider(provider?: TemplateRepoProvider): TemplateRepoProvider {
-  return provider || 'auto';
-}
+const TEMPLATE_ASSET_PROXY_PREFIX = '/api/templateAsset?path=';
+const SAFE_ICON_EXTENSIONS = new Set([
+  '.svg',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.ico',
+  '.avif'
+]);
 
 function isHttpUrl(value: string) {
   return /^https?:\/\//i.test(value);
+}
+
+function isProxyUrl(value: string) {
+  return value.startsWith(TEMPLATE_ASSET_PROXY_PREFIX);
 }
 
 function isRelativeAssetUrl(value: string) {
@@ -31,6 +42,27 @@ function isRelativeAssetUrl(value: string) {
 
 function normalizeUrlPath(value: string) {
   return value.replace(/\\/g, '/').split('/').filter(Boolean).map(encodeURIComponent).join('/');
+}
+
+function normalizeSafeAssetPath(value: string) {
+  const parts = value.replace(/\\/g, '/').split('/').filter(Boolean);
+  if (parts.includes('..')) return '';
+
+  const normalized = path.posix.normalize(parts.join('/'));
+  if (
+    !normalized ||
+    normalized === '.' ||
+    normalized === '..' ||
+    normalized.startsWith('../') ||
+    path.posix.isAbsolute(normalized)
+  ) {
+    return '';
+  }
+  return normalized;
+}
+
+function hasSafeIconExtension(assetPath: string) {
+  return SAFE_ICON_EXTENSIONS.has(path.posix.extname(assetPath).toLowerCase());
 }
 
 function getRelativeBasePath(templateFilePath?: string, repoRootPath?: string) {
@@ -54,7 +86,7 @@ function resolveRepoAssetPath(assetUrl: string, templateFilePath?: string, repoR
   );
 }
 
-function parseGitRepoUrl(repoUrl: string) {
+export function parseGitRepoUrl(repoUrl: string) {
   try {
     const url = new URL(repoUrl.replace(/\.git$/, ''));
     const parts = url.pathname.split('/').filter(Boolean);
@@ -72,10 +104,28 @@ function parseGitRepoUrl(repoUrl: string) {
   }
 }
 
-function inferTemplateRepoProvider(host: string): Exclude<TemplateRepoProvider, 'auto'> {
-  if (host === 'github.com') return 'github';
-  if (host === 'gitlab.com' || host.includes('gitlab')) return 'gitlab';
-  return 'gogs';
+function findSubsequence(haystack: string[], needle: string[]) {
+  if (needle.length === 0 || haystack.length < needle.length) return -1;
+  outer: for (let start = 0; start <= haystack.length - needle.length; start++) {
+    for (let offset = 0; offset < needle.length; offset++) {
+      if (haystack[start + offset] !== needle[offset]) {
+        continue outer;
+      }
+    }
+    return start;
+  }
+  return -1;
+}
+
+function decodeUrlPathParts(pathname: string) {
+  try {
+    return pathname
+      .split('/')
+      .filter(Boolean)
+      .map((segment) => decodeURIComponent(segment));
+  } catch (error) {
+    return null;
+  }
 }
 
 function getRepoAssetRawUrl(repo: TemplateRepo, assetPath: string) {
@@ -84,18 +134,89 @@ function getRepoAssetRawUrl(repo: TemplateRepo, assetPath: string) {
 
   const encodedRef = encodeURIComponent(repo.branch);
   const projectPath = [...parsedRepo.ownerPath, parsedRepo.repo].map(encodeURIComponent).join('/');
-  const provider = normalizeTemplateRepoProvider(repo.provider);
-  const resolvedProvider = provider === 'auto' ? inferTemplateRepoProvider(parsedRepo.host) : provider;
 
-  if (resolvedProvider === 'github') {
+  if (parsedRepo.host === 'github.com') {
     return `https://raw.githubusercontent.com/${projectPath}/${encodedRef}/${assetPath}`;
   }
 
-  if (resolvedProvider === 'gitlab') {
+  if (parsedRepo.host === 'gitlab.com' || parsedRepo.host.includes('gitlab')) {
     return `${parsedRepo.origin}/${projectPath}/-/raw/${encodedRef}/${assetPath}`;
   }
 
-  return `${parsedRepo.origin}/${projectPath}/raw/${encodedRef}/${assetPath}`;
+  return `${parsedRepo.origin}/${projectPath}/raw/branch/${encodedRef}/${assetPath}`;
+}
+
+function getProxyableTemplateAssetPath(assetUrl: string, repo: TemplateRepo) {
+  if (!assetUrl || isProxyUrl(assetUrl)) return '';
+  if (/^(data|blob):/i.test(assetUrl)) return '';
+
+  const parsedRepo = parseGitRepoUrl(repo.url);
+  if (!parsedRepo) return '';
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(assetUrl);
+  } catch (error) {
+    return '';
+  }
+
+  const pathParts = decodeUrlPathParts(parsedUrl.pathname);
+  if (!pathParts) return '';
+
+  const repoPath = [...parsedRepo.ownerPath, parsedRepo.repo];
+  const repoIndex = findSubsequence(pathParts, repoPath);
+  if (repoIndex < 0) return '';
+
+  let afterRepo = pathParts.slice(repoIndex + repoPath.length);
+  if (parsedRepo.host === 'github.com' && parsedUrl.hostname === 'raw.githubusercontent.com') {
+    const branch = afterRepo[0];
+    if (!branch || (repo.branch && branch !== repo.branch)) return '';
+    const assetPath = normalizeSafeAssetPath(afterRepo.slice(1).join('/'));
+    return assetPath && hasSafeIconExtension(assetPath) ? assetPath : '';
+  }
+
+  if (afterRepo[0] === '-' && afterRepo[1] === 'raw') {
+    afterRepo = afterRepo.slice(1);
+  }
+  if (afterRepo[0] !== 'raw') return '';
+
+  const branchOffset = afterRepo[1] === 'branch' ? 2 : 1;
+  const branch = afterRepo[branchOffset];
+  if (!branch || (repo.branch && branch !== repo.branch)) return '';
+
+  const assetPath = normalizeSafeAssetPath(afterRepo.slice(branchOffset + 1).join('/'));
+  return assetPath && hasSafeIconExtension(assetPath) ? assetPath : '';
+}
+
+export function getTemplateAssetProxyUrl(assetUrl: string, repo: TemplateRepo) {
+  if (!assetUrl || isProxyUrl(assetUrl)) return assetUrl || '';
+  const proxyablePath = getProxyableTemplateAssetPath(assetUrl, repo);
+  if (!proxyablePath) return assetUrl;
+  return `${TEMPLATE_ASSET_PROXY_PREFIX}${encodeURIComponent(proxyablePath)}`;
+}
+
+export function proxyTemplateIconUrls(template: TemplateType, repo: TemplateRepo) {
+  const spec = {
+    ...template.spec,
+    icon: getTemplateAssetProxyUrl(template.spec.icon || '', repo)
+  };
+
+  if (template.spec.i18n) {
+    spec.i18n = Object.fromEntries(
+      Object.entries(template.spec.i18n).map(([lang, data]) => {
+        const nextData = { ...data };
+        if (nextData.icon) {
+          nextData.icon = getTemplateAssetProxyUrl(nextData.icon, repo);
+        }
+        return [lang, nextData];
+      })
+    ) as typeof template.spec.i18n;
+  }
+
+  return {
+    ...template,
+    spec
+  };
 }
 
 export function resolveTemplateAssetUrl({


### PR DESCRIPTION
## Summary
- Proxy template icon URLs through the local `/api/templateAsset` route.
- Keep README and existing raw/CDN handling unchanged.
- Add a local asset endpoint that serves safe template image assets with the correct content type.

## Verification
- `pnpm run build-packages`
- `pnpm build` in `frontend/providers/template`
