### PR TITLE
fix(stargz): build image and disable leader election

### DIFF
--- a/.github/workflows/webhooks.yml
+++ b/.github/workflows/webhooks.yml
@@ -111,7 +111,13 @@ jobs:
       packages: write
     strategy:
       matrix:
-        module: [admission]
+        include:
+          - module: admission
+            binary: manager
+            ghcr_repository: sealos-admission-webhook
+          - module: stargz
+            binary: stargz-webhook
+            ghcr_repository: sealos/stargz-webhook
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -127,26 +133,29 @@ jobs:
         working-directory: webhooks/${{ matrix.module }}
         env:
           MODULE: ${{ matrix.module }}
+          BINARY: ${{ matrix.binary }}
         run: |
           GOARCH=amd64 make build
-          mv bin/manager "bin/webhook-${MODULE}-amd64"
+          mv "bin/${BINARY}" "bin/webhook-${MODULE}-amd64"
           chmod +x "bin/webhook-${MODULE}-amd64"
 
       - name: Build ${{ matrix.module }} arm64
         working-directory: webhooks/${{ matrix.module }}
         env:
           MODULE: ${{ matrix.module }}
+          BINARY: ${{ matrix.binary }}
         run: |
           GOARCH=arm64 make build
-          mv bin/manager "bin/webhook-${MODULE}-arm64"
+          mv "bin/${BINARY}" "bin/webhook-${MODULE}-arm64"
           chmod +x "bin/webhook-${MODULE}-arm64"
 
       - name: Set image repo
         env:
           REPO_OWNER: ${{ github.repository_owner }}
           MODULE_NAME: ${{ matrix.module }}
+          GHCR_REPOSITORY: ${{ matrix.ghcr_repository }}
         run: |
-          echo "GHCR_REPO=ghcr.io/${REPO_OWNER}/sealos-${MODULE_NAME}-webhook" >> $GITHUB_ENV
+          echo "GHCR_REPO=ghcr.io/${REPO_OWNER}/${GHCR_REPOSITORY}" >> $GITHUB_ENV
           if [[ -n "${{ env.ALIYUN_REPO_PREFIX }}" ]]; then
             echo "ALIYUN_REPO=${{ env.ALIYUN_REPO_PREFIX }}/sealos-${MODULE_NAME}-webhook" >> $GITHUB_ENV
           fi

--- a/webhooks/stargz/config/manager/manager.yaml
+++ b/webhooks/stargz/config/manager/manager.yaml
@@ -53,7 +53,6 @@ spec:
       - command:
         - /stargz-webhook
         args:
-          - --leader-elect
           - --health-probe-bind-address=:8081
           - --runtime-class=stargz
           - --registries=sealos.hub:5000

--- a/webhooks/stargz/deploy/manifest.yaml
+++ b/webhooks/stargz/deploy/manifest.yaml
@@ -195,7 +195,6 @@ spec:
       containers:
       - args:
         - --metrics-bind-address=:8443
-        - --leader-elect
         - --health-probe-bind-address=:8081
         - --runtime-class=stargz
         - --registries=<REGISTRY_URL>


### PR DESCRIPTION
## Summary

- add the stargz webhook to the image-build matrix
- support module-specific binary names during amd64 and arm64 validation builds
- publish the stargz image to the GHCR path already referenced by its Makefile and deployment manifests
- disable leader election in the default stargz Deployment and consolidated manifest
- keep the optional `--leader-elect` flag available for non-default deployments
- keep the cluster-image matrix limited to admission, which has the required Kubefile layout

## Root cause

The webhooks workflow dynamically resolved stargz for linting, but its image-build matrix was hard-coded to admission. As a result, stargz changes triggered the workflow without ever creating an image-build job for stargz.

The binary defaults leader election to false, but both shipped deployment manifests explicitly passed `--leader-elect`. This unnecessarily restricted webhook serving to the elected manager.

## Validation

- `actionlint` (no new findings; existing workflow warnings excluded)
- `git diff --check`
- `go test ./internal/webhook/...`
- rendered `webhooks/stargz/config/default` with `kubectl kustomize` and verified the Deployment does not contain `--leader-elect`
- stargz `make build` for amd64 and arm64
- `docker buildx build --platform linux/amd64 --load -f webhooks/stargz/Dockerfile webhooks/stargz`
- inspected the built image: linux/amd64, `/stargz-webhook` entrypoint, user `65532:65532`

## Publishing behavior

Pull request runs build without pushing. Push/create events, or manual runs with `push_image=true`, publish the image.