### PR TITLE
fix(applaunchpad): preserve start permission errors

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/pages/api/startApp.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/pages/api/startApp.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import handler from '@/pages/api/startApp';
+import { ResponseCode, ResponseMessages } from '@/types/response';
+
+const createK8sContextMock = vi.hoisted(() => vi.fn());
+const startAppMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/services/backend', () => ({
+  createK8sContext: createK8sContextMock,
+  startApp: startAppMock
+}));
+
+function createResponse() {
+  return {
+    json: vi.fn((payload) => payload)
+  } as any;
+}
+
+describe('/api/startApp', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createK8sContextMock.mockResolvedValue({ namespace: 'ns-demo' });
+  });
+
+  it('returns a permission error when Kubernetes rejects the start operation', async () => {
+    startAppMock.mockRejectedValue({
+      body: {
+        kind: 'Status',
+        apiVersion: 'v1',
+        status: 'Failure',
+        code: 403,
+        message: 'deployments.apps "demo" is forbidden'
+      }
+    });
+    const res = createResponse();
+
+    await handler(
+      {
+        query: { appName: 'demo' }
+      } as any,
+      res
+    );
+
+    expect(createK8sContextMock).toHaveBeenCalled();
+    expect(startAppMock).toHaveBeenCalledWith('demo', { namespace: 'ns-demo' });
+    expect(res.json).toHaveBeenCalledWith({
+      code: ResponseCode.FORBIDDEN,
+      message: ResponseMessages[ResponseCode.FORBIDDEN],
+      data: undefined,
+      error: undefined
+    });
+  });
+});

--- a/frontend/providers/applaunchpad/src/pages/api/startApp.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/startApp.ts
@@ -1,7 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { ApiResp } from '@/services/kubernet';
-import { jsonRes } from '@/services/backend/response';
+import { handleK8sError, jsonRes } from '@/services/backend/response';
 import { startApp, createK8sContext } from '@/services/backend';
+import { ResponseCode } from '@/types/response';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
   try {
@@ -22,9 +23,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     });
   } catch (err: any) {
     console.log('Start app error:', err);
-    jsonRes(res, {
-      code: 500,
-      error: err.message || err
-    });
+    jsonRes(res, handleK8sError(err, { forbiddenCode: ResponseCode.FORBIDDEN }));
   }
 }


### PR DESCRIPTION
## What changed

- Map Kubernetes permission failures from `/api/startApp` through the shared `handleK8sError` helper.
- Add a route regression test for nested Kubernetes 403 responses.

## Why

Developer-role users are read-only. Starting a paused app requires updating workload and ingress resources, but `/api/startApp` returned a generic 500 while the other restricted App Launchpad actions already preserved permission errors.

## Verification

- `pnpm dlx vitest@3.2.4 run __tests__/unit/services/backend/response.test.ts __tests__/unit/pages/api/startApp.test.ts --config vitest.config.ts`
- `pnpm exec prettier --check src/pages/api/startApp.ts __tests__/unit/pages/api/startApp.test.ts`
- `pnpm build`
- Confirmed the regression test fails with the previous generic 500 response and passes with the fixed 403 mapping.

## Related

Follow-up to #7010. Internal BUG-18.