### PR TITLE
fix(costcenter): improve payment QR scanning

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -1097,8 +1097,8 @@ importers:
         specifier: ^8.5.6
         version: 8.5.6
       qrcode.react:
-        specifier: ^3.1.0
-        version: 3.1.0(react@18.3.1)
+        specifier: ^4.2.0
+        version: 4.2.0(react@18.3.1)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -19857,6 +19857,14 @@ packages:
     resolution: {integrity: sha512-oyF+Urr3oAMUG/OiOuONL3HXM+53wvuH3mtIWQrYmsXoAq0DkvZp2RYUWFSMFtbdOpuS++9v+WAkzNVkMlNW6Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.3.1
+    dev: false
+
+  /qrcode.react@4.2.0(react@18.3.1):
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     dependencies:
       react: 18.3.1
     dev: false

--- a/frontend/providers/costcenter/package.json
+++ b/frontend/providers/costcenter/package.json
@@ -54,7 +54,7 @@
     "next-i18next": "^15.3.0",
     "nprogress": "^0.2.0",
     "postcss": "^8.5.6",
-    "qrcode.react": "^3.1.0",
+    "qrcode.react": "^4.2.0",
     "react": "18.3.1",
     "react-activation": "^0.12.4",
     "react-day-picker": "^8.8.2",

--- a/frontend/providers/costcenter/src/components/RechargeModal.tsx
+++ b/frontend/providers/costcenter/src/components/RechargeModal.tsx
@@ -95,6 +95,8 @@ function WechatPayment(props: { complete: number; codeURL?: string; tradeNO?: st
           <QRCodeSVG
             size={185}
             value={props.codeURL}
+            level="Q"
+            minVersion={4}
             style={{ margin: '0 auto' }}
             imageSettings={{
               // 二维码中间的logo图片
@@ -146,6 +148,8 @@ function AlipayPayment(props: { complete: number; codeURL?: string; tradeNO?: st
           <QRCodeSVG
             size={185}
             value={props.codeURL}
+            level="Q"
+            minVersion={4}
             style={{ margin: '0 auto' }}
             imageSettings={{
               // 二维码中间的logo图片


### PR DESCRIPTION
## Summary
- Upgrade costcenter from qrcode.react 3.1.0 to 4.2.0.
- Set WeChat and Alipay QR codes to level="Q" with minVersion={4}.
- Increase error correction and minimum QR version for embedded payment logos.

## Validation
- costcenter lint passes with existing React Hook warnings.
- costcenter unit tests pass: 17 tests.
- Full TypeScript check remains blocked by the existing refetch-after-payment.test.ts Vitest mock type error.