### PR TITLE
feat(dbprovider): add configurable Kafka visibility

### DIFF
--- a/frontend/providers/dbprovider/README.md
+++ b/frontend/providers/dbprovider/README.md
@@ -1,5 +1,21 @@
 # sealos app launchpad
 
+## Deployment configuration
+
+`dbproviderConfig.kafkaEnabled` controls whether Kafka is available in the database creation
+form. It defaults to `"true"`. Set it to `"false"` in the user values file to hide Kafka while
+leaving existing Kafka instances manageable:
+
+```yaml
+dbproviderConfig:
+  kafkaEnabled: 'false'
+```
+
+The installer seeds `/root/.sealos/cloud/values/apps/dataflow/dbprovider-values.yaml` from
+`dbprovider-frontend-values.yaml` only when the user values file does not exist. Existing
+installations must update their persisted user values explicitly. This setting does not block
+Kafka creation through the database APIs.
+
 ## project tree
 
 ```bash

--- a/frontend/providers/dbprovider/deploy/charts/dbprovider-frontend/dbprovider-frontend-values.yaml
+++ b/frontend/providers/dbprovider/deploy/charts/dbprovider-frontend/dbprovider-frontend-values.yaml
@@ -41,6 +41,7 @@ dbproviderConfig:
   backupEnabled: "false"
   showDocument: "true"
   guideEnabled: "true"
+  kafkaEnabled: "true"
   billingUrl: "http://account-service.account-system.svc:2333"
   managedDbEnabled: "false"
   vlogsBaseUrl: "http://vlogs.sealos.svc.cluster.local:8428"

--- a/frontend/providers/dbprovider/deploy/charts/dbprovider-frontend/templates/configmap.yaml
+++ b/frontend/providers/dbprovider/deploy/charts/dbprovider-frontend/templates/configmap.yaml
@@ -15,6 +15,7 @@ data:
     BACKUP_ENABLED={{ .Values.dbproviderConfig.backupEnabled }}
     SHOW_DOCUMENT={{ .Values.dbproviderConfig.showDocument }}
     GUIDE_ENABLED={{ .Values.dbproviderConfig.guideEnabled }}
+    KAFKA_ENABLED={{ .Values.dbproviderConfig.kafkaEnabled }}
     BILLING_URL={{ .Values.dbproviderConfig.billingUrl }}
     MANAGED_DB_ENABLED={{ .Values.dbproviderConfig.managedDbEnabled }}
     VLOGS_BASE_URL={{ .Values.dbproviderConfig.vlogsBaseUrl }}

--- a/frontend/providers/dbprovider/deploy/charts/dbprovider-frontend/values.yaml
+++ b/frontend/providers/dbprovider/deploy/charts/dbprovider-frontend/values.yaml
@@ -75,6 +75,7 @@ dbproviderConfig:
   backupEnabled: "false"
   showDocument: "true"
   guideEnabled: "true"
+  kafkaEnabled: "true"
   billingUrl: "http://account-service.account-system.svc:2333"
   managedDbEnabled: "false"
   vlogsBaseUrl: ""

--- a/frontend/providers/dbprovider/src/pages/api/getEnv.ts
+++ b/frontend/providers/dbprovider/src/pages/api/getEnv.ts
@@ -11,6 +11,7 @@ export type SystemEnvResponse = {
   minio_url: string;
   BACKUP_ENABLED: boolean;
   SHOW_DOCUMENT: boolean;
+  KAFKA_ENABLED: boolean;
   CurrencySymbol: 'shellCoin' | 'cny' | 'usd';
   STORAGE_MAX_SIZE: number;
   DATAFLOW_ENABLED: boolean;
@@ -36,6 +37,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       minio_url: process.env.MINIO_URL || '',
       BACKUP_ENABLED: process.env.BACKUP_ENABLED === 'true',
       SHOW_DOCUMENT: process.env.SHOW_DOCUMENT === 'true',
+      KAFKA_ENABLED: process.env.KAFKA_ENABLED !== 'false',
       CurrencySymbol: (process.env.CURRENCY_SYMBOL || 'shellCoin') as 'shellCoin' | 'cny' | 'usd',
       STORAGE_MAX_SIZE: Number(process.env.STORAGE_MAX_SIZE) || 300,
       DATAFLOW_ENABLED

--- a/frontend/providers/dbprovider/src/pages/db/edit/components/Form.tsx
+++ b/frontend/providers/dbprovider/src/pages/db/edit/components/Form.tsx
@@ -487,8 +487,15 @@ const Form = ({
   };
 
   const availableDBTypes = useMemo(() => {
+    const configFilteredTypes = DBTypeList.filter(
+      (item) =>
+        item.id !== DBTypeEnum.kafka ||
+        SystemEnv.KAFKA_ENABLED ||
+        (isEdit && dbType === DBTypeEnum.kafka)
+    );
+
     if (addonLoading) {
-      return DBTypeList;
+      return configFilteredTypes;
     }
 
     const addonStatusMap = new Map<string, string>();
@@ -496,20 +503,24 @@ const Form = ({
       addonStatusMap.set(addon.name, addon.status);
     });
 
-    const filtered = DBTypeList.filter((dbType) => {
+    const filtered = configFilteredTypes.filter((item) => {
       // Exclude weaviate from create form
-      if (dbType.id === DBTypeEnum.weaviate) {
+      if (item.id === DBTypeEnum.weaviate) {
         return false;
       }
 
-      const addonName = dbType.id;
+      if (isEdit && item.id === DBTypeEnum.kafka && dbType === DBTypeEnum.kafka) {
+        return true;
+      }
+
+      const addonName = item.id;
       const addonStatus = addonStatusMap.get(addonName);
       const shouldInclude = addonStatus !== 'Disabled';
       return shouldInclude;
     });
 
     return filtered;
-  }, [addonList, addonLoading]);
+  }, [SystemEnv.KAFKA_ENABLED, addonList, addonLoading, dbType, isEdit]);
 
   return (
     <>

--- a/frontend/providers/dbprovider/src/store/env.ts
+++ b/frontend/providers/dbprovider/src/store/env.ts
@@ -21,6 +21,7 @@ const useEnvStore = create<EnvState>()(
       minio_url: '',
       BACKUP_ENABLED: false,
       SHOW_DOCUMENT: true,
+      KAFKA_ENABLED: true,
       CurrencySymbol: 'shellCoin',
       STORAGE_MAX_SIZE: 300,
       DATAFLOW_ENABLED: false

--- a/frontend/providers/dbprovider/src/utils/healthz.ts
+++ b/frontend/providers/dbprovider/src/utils/healthz.ts
@@ -6,6 +6,7 @@ export function assertReady() {
   readNonEmptyEnv('BILLING_URL');
   readOptionalBooleanEnv('BACKUP_ENABLED');
   readOptionalBooleanEnv('GUIDE_ENABLED');
+  readOptionalBooleanEnv('KAFKA_ENABLED');
   readOptionalBooleanEnv('MANAGED_DB_ENABLED');
   readOptionalNumberEnv('STORAGE_MAX_SIZE');
 }


### PR DESCRIPTION
<!--
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR,
because it will be placed in the release note.
-->

## Summary

- Add `dbproviderConfig.kafkaEnabled`, defaulting to `"true"`, to control Kafka visibility in the database creation form.
- Preserve management of existing Kafka instances when creation is disabled, and document the persisted user-values behavior.

## Sequence Diagram

```mermaid
sequenceDiagram
    participant Operator
    participant Helm
    participant EnvAPI as /api/getEnv
    participant Form as Database Form

    Operator->>Helm: Set dbproviderConfig.kafkaEnabled
    Helm->>EnvAPI: Render KAFKA_ENABLED through ConfigMap
    EnvAPI->>Form: Return runtime feature flag
    alt Kafka disabled for creation
        Form-->>Operator: Hide Kafka from available database types
    else Kafka enabled or editing existing Kafka
        Form-->>Operator: Show or manage Kafka
    end
```

## Verification

- `pnpm --dir frontend/providers/dbprovider typecheck`
- `pnpm --dir frontend/providers/dbprovider build`
- `helm lint frontend/providers/dbprovider/deploy/charts/dbprovider-frontend`
- Helm rendering with the default and `dbproviderConfig.kafkaEnabled=false`
- `/healthz` runtime checks for valid and invalid `KAFKA_ENABLED` values
- Sealos deployment audit matched the existing `release-v5.1` baseline findings
