### PR TITLE
fix(terminal): prevent initial tab readiness race

### DIFF
--- a/frontend/providers/terminal/__tests__/components/terminal-message-routing.test.tsx
+++ b/frontend/providers/terminal/__tests__/components/terminal-message-routing.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import Terminal from '@/components/terminal';
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({ query: {} })
+}));
+
+vi.mock('@/store/session', () => ({
+  default: (selector: (state: { session: { user: { nsid: string } } }) => unknown) =>
+    selector({ session: { user: { nsid: 'ns-test' } } })
+}));
+
+vi.mock('@/components/iconfont', () => ({
+  default: () => null
+}));
+
+vi.mock('@chakra-ui/react', () => ({
+  Box: ({ children, className }: React.PropsWithChildren<{ className?: string }>) => (
+    <div className={className}>{children}</div>
+  ),
+  Flex: ({
+    children,
+    className,
+    onClick
+  }: React.PropsWithChildren<{ className?: string; onClick?: () => void }>) => (
+    <div className={className} onClick={onClick}>
+      {children}
+    </div>
+  ),
+  Text: ({ children }: React.PropsWithChildren) => <span>{children}</span>
+}));
+
+vi.mock('@/components/terminal/index.module.scss', () => ({
+  default: {
+    containerLeft: 'containerLeft',
+    tabs: 'tabs',
+    closeIcon: 'closeIcon',
+    iframeWindow: 'iframeWindow'
+  }
+}));
+
+const terminalOrigin = window.location.origin;
+const terminalUrl = `${terminalOrigin}/terminal-frame?authorization=test`;
+
+const dispatchMessage = (source: MessageEventSource, origin: string, data: unknown) => {
+  window.dispatchEvent(new MessageEvent('message', { source, origin, data }));
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  flushSync(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+const renderTerminal = () => {
+  flushSync(() => root.render(<Terminal url={terminalUrl} site={terminalOrigin} />));
+};
+
+describe('Terminal message routing', () => {
+  test('initializes the first iframe when it reports ready', () => {
+    renderTerminal();
+    const iframe = container.querySelector('iframe');
+
+    expect(iframe?.contentWindow).toBeTruthy();
+    const postMessage = vi
+      .spyOn(iframe!.contentWindow!, 'postMessage')
+      .mockImplementation(() => {});
+
+    dispatchMessage(iframe!.contentWindow!, terminalOrigin, { ttyd: 'ready' });
+
+    expect(postMessage).toHaveBeenCalledTimes(3);
+    expect(postMessage).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ command: expect.stringContaining('namespace=ns-test') }),
+      terminalOrigin
+    );
+  });
+
+  test('sends initialization commands only to the iframe that reports ready', () => {
+    renderTerminal();
+
+    flushSync(() => {
+      dispatchMessage(window, terminalOrigin, {
+        type: 'new terminal',
+        command: encodeURIComponent('pwd')
+      });
+    });
+
+    const iframes = container.querySelectorAll<HTMLIFrameElement>('iframe');
+    expect(iframes).toHaveLength(2);
+    const firstIframe = iframes[0];
+    const secondIframe = iframes[1];
+    const firstPostMessage = vi
+      .spyOn(firstIframe.contentWindow!, 'postMessage')
+      .mockImplementation(() => {});
+    const secondPostMessage = vi
+      .spyOn(secondIframe.contentWindow!, 'postMessage')
+      .mockImplementation(() => {});
+
+    dispatchMessage(firstIframe.contentWindow!, terminalOrigin, { ttyd: 'ready' });
+
+    expect(firstPostMessage).toHaveBeenCalledTimes(3);
+    expect(secondPostMessage).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/providers/terminal/src/components/terminal/index.tsx
+++ b/frontend/providers/terminal/src/components/terminal/index.tsx
@@ -3,7 +3,7 @@ import { Box, Flex, Text } from '@chakra-ui/react';
 import { debounce } from 'lodash';
 import { nanoid } from 'nanoid';
 import { useRouter } from 'next/router';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import styles from './index.module.scss';
 import useSessionStore from '@/store/session';
 
@@ -15,7 +15,7 @@ type Terminal = {
 function Terminal({ url, site }: { url: string; site: string }) {
   const [tabId, setTabId] = useState(nanoid(6));
   const router = useRouter();
-  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const iframeRefs = useRef(new Map<string, HTMLIFrameElement>());
   const { query } = router;
   const session = useSessionStore((s) => s.session);
   const nsid = session?.user?.nsid;
@@ -29,9 +29,15 @@ function Terminal({ url, site }: { url: string; site: string }) {
     }
   ]);
 
-  useEffect(() => {
-    const event = async (e: MessageEvent) => {
-      const urlOrigin = new URL(url).origin;
+  const newTerminal = useCallback((command?: string) => {
+    const id = nanoid(6);
+    setTabContents((previous) => [...previous, { id, command }]);
+    setTabId(id);
+  }, []);
+
+  useLayoutEffect(() => {
+    const urlOrigin = new URL(url, window.location.origin).origin;
+    const event = (e: MessageEvent) => {
       const whitelist = [urlOrigin, site];
 
       if (!whitelist.includes(e.origin)) return;
@@ -39,21 +45,28 @@ function Terminal({ url, site }: { url: string; site: string }) {
         if (e.data.type === 'new terminal' && e.data.command) {
           newTerminal(decodeURIComponent(e.data.command));
         }
-        if (e.data?.ttyd === 'ready') {
-          iframeRef.current?.contentWindow?.postMessage(
+        if (e.data?.ttyd === 'ready' && e.origin === urlOrigin) {
+          const iframe = Array.from(iframeRefs.current.values()).find(
+            (item) => item.contentWindow === e.source
+          );
+          const target = iframe?.contentWindow;
+
+          if (!iframe || !target) return;
+
+          target.postMessage(
             {
               command: `kubectl config set-context --current --namespace=${nsid} && export PS1="\\u@(${nsid}) \\W\\$ " && clear`
             },
-            url
+            urlOrigin
           );
-          iframeRef.current?.contentWindow?.postMessage(
+          target.postMessage(
             {
               command: `clear && echo -e "\\033[36mThis is a temporary terminal for debugging and testing. The session will automatically end \\033[1m30 minutes\\033[22m after you leave.\\033[0m\\n\\nYou are now working in namespace: \\033[1;32m${nsid}\\033[0m" && history -c`
             },
-            url
+            urlOrigin
           );
-          const command = iframeRef.current?.getAttribute('data-command');
-          iframeRef?.current?.contentWindow?.postMessage({ command }, url);
+          const command = iframe.getAttribute('data-command');
+          target.postMessage({ command }, urlOrigin);
         }
       } catch (error) {
         console.log(error, 'error');
@@ -61,21 +74,7 @@ function Terminal({ url, site }: { url: string; site: string }) {
     };
     window.addEventListener('message', event);
     return () => window.removeEventListener('message', event);
-  }, [site, url, nsid]);
-
-  const newTerminal = (command?: string) => {
-    const temp = nanoid(6);
-    setTabContents((pre) => {
-      return [
-        ...pre,
-        {
-          id: temp,
-          command: command
-        }
-      ];
-    });
-    setTabId(temp);
-  };
+  }, [site, url, nsid, newTerminal]);
 
   const deleteTerminal = (key: string) => {
     if (tabContents.length <= 1) return;
@@ -163,10 +162,16 @@ function Terminal({ url, site }: { url: string; site: string }) {
         return (
           <Box flexGrow={1} key={item?.id} display={item?.id === tabId ? 'block' : 'none'}>
             <iframe
-              ref={iframeRef}
+              ref={(iframe) => {
+                if (iframe) {
+                  iframeRefs.current.set(item.id, iframe);
+                } else {
+                  iframeRefs.current.delete(item.id);
+                }
+              }}
               data-command={item?.command}
               className={styles.iframeWindow}
-              id={tabId}
+              id={item.id}
               src={url}
               allow="camera;microphone;clipboard-write;"
             />


### PR DESCRIPTION
## What changed

- register the terminal message listener during the layout phase so the first iframe cannot lose its one-shot `ready` message
- route initialization commands back to the iframe that emitted `ready` instead of a shared iframe ref
- give each terminal iframe its own ID and validate both message origin and source
- add Chromium component coverage for first-load initialization and multi-tab isolation

## Why

The initial terminal iframe was rendered before the `message` listener was registered by `useEffect`. If ttyd emitted `ready` during that gap, the message was lost and the first terminal remained blank. A newly opened tab worked because the listener was already active by then.

The shared iframe ref also pointed to the last rendered tab, so a `ready` event from one terminal could initialize another terminal.

## Impact

The first terminal now initializes immediately, and each tab receives only its own initialization commands. No API or configuration changes are required.

## Validation

- `pnpm test:components:ci` (2 Chromium tests passed)
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src/components/terminal/index.tsx __tests__/components/terminal-message-routing.test.tsx`
- `pnpm build`
