### PR TITLE
fix(dbprovider): prevent creation when quota is insufficient

### DIFF
--- a/frontend/providers/dbprovider/__tests__/unit/quota.test.ts
+++ b/frontend/providers/dbprovider/__tests__/unit/quota.test.ts
@@ -1,0 +1,154 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { before, describe, it } from 'node:test';
+import * as React from 'react';
+import * as ts from 'typescript';
+import type { DBEditType } from '@/types/db';
+import type { UserQuotaItemType } from '@/types/user';
+import type * as QuotaModule from '@/utils/quota';
+
+let quotaModule: typeof QuotaModule;
+
+before(async () => {
+  Object.assign(globalThis, { React });
+  quotaModule = await import('@/utils/quota');
+});
+
+const createDatabaseForm = (overrides: Partial<DBEditType> = {}): DBEditType => ({
+  dbType: 'postgresql',
+  dbVersion: 'postgresql-14.8.0',
+  dbName: 'test-db',
+  replicas: 3,
+  cpu: 1000,
+  memory: 1024,
+  storage: 10,
+  labels: {},
+  terminationPolicy: 'Delete',
+  ...overrides
+});
+
+describe('database quota guard', () => {
+  it('keeps the quota check in the submit path before createDB', () => {
+    const filename = resolve(process.cwd(), 'src/pages/db/edit/index.tsx');
+    const sourceFile = ts.createSourceFile(
+      filename,
+      readFileSync(filename, 'utf8'),
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TSX
+    );
+    const callPositions = new Map<string, number>();
+
+    const visit = (node: ts.Node) => {
+      if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+        if (node.expression.text === 'checkQuotaAllow' || node.expression.text === 'createDB') {
+          callPositions.set(node.expression.text, node.getStart(sourceFile));
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+
+    const quotaCheckPosition = callPositions.get('checkQuotaAllow');
+    const createDBPosition = callPositions.get('createDB');
+    assert.notEqual(quotaCheckPosition, undefined);
+    assert.notEqual(createDBPosition, undefined);
+    assert.ok(quotaCheckPosition! < createDBPosition!);
+  });
+
+  it('counts every PostgreSQL replica, including Pod quota', () => {
+    assert.deepEqual(quotaModule.calculateDatabaseQuotaRequest(createDatabaseForm()), {
+      cpu: 3,
+      memory: 3,
+      storage: 30,
+      pods: 3
+    });
+  });
+
+  it('uses the real PolarDB-X component replica distribution', () => {
+    const request = quotaModule.calculateDatabaseQuotaRequest(
+      createDatabaseForm({
+        dbType: 'polardbx',
+        dbVersion: 'polardbx-8.4.19',
+        cpu: 8000,
+        memory: 8192,
+        storage: 12
+      })
+    );
+
+    assert.deepEqual(request, {
+      cpu: 18,
+      memory: 18,
+      storage: 30,
+      pods: 6
+    });
+  });
+
+  it('checks only the additional resources when editing', () => {
+    const previous = createDatabaseForm({ replicas: 1 });
+    const next = createDatabaseForm({ replicas: 3 });
+
+    assert.deepEqual(quotaModule.calculateDatabaseQuotaDelta(next, previous), {
+      cpu: 2,
+      memory: 2,
+      storage: 20,
+      pods: 2
+    });
+  });
+
+  it('blocks the BUG-45 case when Pod quota is already overused', async () => {
+    const quota: UserQuotaItemType[] = [
+      { type: 'cpu', used: 1, limit: 100 },
+      { type: 'memory', used: 1, limit: 100 },
+      { type: 'storage', used: 1, limit: 100 },
+      { type: 'pods', used: 15, limit: 1 }
+    ];
+
+    const tip = await quotaModule.checkQuotaAvailability({
+      loadQuota: async () => quota,
+      request: quotaModule.calculateDatabaseQuotaRequest(createDatabaseForm())
+    });
+
+    assert.equal(tip, 'app.pods_exceeds_quota');
+  });
+
+  it('blocks creation when ephemeral storage has no headroom', async () => {
+    const quota: UserQuotaItemType[] = [{ type: 'ephemeral-storage', used: 8, limit: 8 }];
+
+    const tip = await quotaModule.checkQuotaAvailability({
+      loadQuota: async () => quota,
+      request: quotaModule.calculateDatabaseQuotaRequest(createDatabaseForm()),
+      requireHeadroom: ['ephemeral-storage']
+    });
+
+    assert.equal(tip, 'app.ephemeral_storage_exceeds_quota');
+  });
+
+  it('fails closed when current quota cannot be loaded', async () => {
+    const tip = await quotaModule.checkQuotaAvailability({
+      loadQuota: async () => Promise.reject(new Error('quota unavailable')),
+      request: { pods: 1 }
+    });
+
+    assert.equal(tip, 'app.quota_check_failed');
+  });
+
+  it('allows a request that reaches the quota exactly', async () => {
+    const tip = await quotaModule.checkQuotaAvailability({
+      loadQuota: async () => [{ type: 'pods', used: 1, limit: 4 }],
+      request: { pods: 3 }
+    });
+
+    assert.equal(tip, undefined);
+  });
+
+  it('allows a scale-down while the namespace is already over quota', async () => {
+    const tip = await quotaModule.checkQuotaAvailability({
+      loadQuota: async () => [{ type: 'pods', used: 15, limit: 1 }],
+      request: { pods: -2 }
+    });
+
+    assert.equal(tip, undefined);
+  });
+});

--- a/frontend/providers/dbprovider/public/locales/en/common.json
+++ b/frontend/providers/dbprovider/public/locales/en/common.json
@@ -73,7 +73,11 @@
   "anticipated_price": "Projected Cost",
   "app": {
     "cpu_exceeds_quota": "CPU requested exceeds quota. Contact admin.",
+    "ephemeral_storage_exceeds_quota": "Ephemeral storage quota is exhausted. Contact admin.",
     "memory_exceeds_quota": "Memory requested exceeds quota. Contact admin.",
+    "nodeports_exceeds_quota": "NodePort requested exceeds quota. Contact admin.",
+    "pods_exceeds_quota": "Pod count requested exceeds quota. Contact admin.",
+    "quota_check_failed": "Unable to verify the current resource quota. Try again later.",
     "resource_quota": "Resource Limits",
     "storage_exceeds_quota": "Storage requested exceeds quota. Contact admin."
   },

--- a/frontend/providers/dbprovider/public/locales/zh/common.json
+++ b/frontend/providers/dbprovider/public/locales/zh/common.json
@@ -74,7 +74,11 @@
   "anticipated_price": "预估价格",
   "app": {
     "cpu_exceeds_quota": "申请的 CPU 超出限制，请联系管理员",
+    "ephemeral_storage_exceeds_quota": "临时存储配额已用尽，请联系管理员",
     "memory_exceeds_quota": "申请的 '内存' 超出限制，请联系管理员",
+    "nodeports_exceeds_quota": "申请的 NodePort 超出限制，请联系管理员",
+    "pods_exceeds_quota": "申请的实例数超出限制，请联系管理员",
+    "quota_check_failed": "暂时无法校验当前资源配额，请稍后重试",
     "resource_quota": "资源配额",
     "storage_exceeds_quota": "申请的 '存储' 超出限制，请联系管理员"
   },

--- a/frontend/providers/dbprovider/src/components/QuotaBox/index.tsx
+++ b/frontend/providers/dbprovider/src/components/QuotaBox/index.tsx
@@ -1,5 +1,6 @@
 import MyTooltip from '@/components/MyTooltip';
 import { useUserStore } from '@/store/user';
+import type { UserQuotaItemType } from '@/types/user';
 import { Box, Flex, Progress, css, useTheme } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'next-i18next';
@@ -24,6 +25,8 @@ const sourceMap = {
   }
 };
 
+type DisplayQuotaType = Extract<UserQuotaItemType['type'], keyof typeof sourceMap>;
+
 const QuotaBox = ({ showBorder = true }: { showBorder?: boolean }) => {
   const { t } = useTranslation();
   const { userQuota, loadUserQuota } = useUserStore();
@@ -34,11 +37,14 @@ const QuotaBox = ({ showBorder = true }: { showBorder?: boolean }) => {
     if (!userQuota) return [];
 
     return userQuota
-      .filter((item) => item.limit > 0)
+      .filter(
+        (item): item is UserQuotaItemType & { type: DisplayQuotaType } =>
+          item.limit > 0 && item.type in sourceMap
+      )
       .map((item) => {
         const { limit, used, type } = item;
-        const unit = sourceMap[type]?.unit;
-        const color = sourceMap[type]?.color;
+        const unit = sourceMap[type].unit;
+        const color = sourceMap[type].color;
         const tip = `${t('common.Total')}: ${limit} ${unit}
 ${t('common.Used')}: ${used.toFixed(2)} ${unit}
 ${t('common.Surplus')}: ${Math.max(0, limit - used).toFixed(2)} ${unit}`;

--- a/frontend/providers/dbprovider/src/pages/db/detail/components/AppBaseInfo.tsx
+++ b/frontend/providers/dbprovider/src/pages/db/detail/components/AppBaseInfo.tsx
@@ -13,6 +13,7 @@ import { startDriver, detailDriverObj } from '@/hooks/driver';
 import useEnvStore from '@/store/env';
 import { useGuideStore } from '@/store/guide';
 import { SOURCE_PRICE } from '@/store/static';
+import { useUserStore } from '@/store/user';
 import type { DBDetailType, DBType } from '@/types/db';
 import { I18nCommonKey } from '@/types/i18next';
 import { json2NetworkService } from '@/utils/json2Yaml';
@@ -116,6 +117,7 @@ const AppBaseInfo = ({ db = defaultDBDetail }: { db: DBDetailType }) => {
   const [isChecked, setIsChecked] = useState(false);
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { message: toast } = useMessage();
+  const { checkQuotaRequest } = useUserStore();
   const [scenario, setScenario] = useState<'externalNetwork' | 'editPassword'>('externalNetwork');
   const router = useRouter();
   const { detailCompleted, applistCompleted } = useGuideStore();
@@ -316,6 +318,13 @@ const AppBaseInfo = ({ db = defaultDBDetail }: { db: DBDetailType }) => {
       if (!dbStatefulSet || !db) {
         return toast({
           title: 'Missing Parameters',
+          status: 'error'
+        });
+      }
+      const quotaTip = await checkQuotaRequest({ nodeports: 1 });
+      if (quotaTip) {
+        return toast({
+          title: t(quotaTip),
           status: 'error'
         });
       }

--- a/frontend/providers/dbprovider/src/pages/db/edit/index.tsx
+++ b/frontend/providers/dbprovider/src/pages/db/edit/index.tsx
@@ -167,6 +167,15 @@ const EditApp = ({ dbName, tabType }: { dbName?: string; tabType?: 'form' | 'yam
       return router.push('/db/detail?name=hello-db&guide=true');
     }
 
+    const quotaTip = await checkQuotaAllow(formData, isEdit ? oldDBEditData.current : undefined);
+    if (quotaTip) {
+      toast({
+        title: t(quotaTip),
+        status: 'error'
+      });
+      return;
+    }
+
     const needMongoAdapter =
       formData.dbType === 'mongodb' && formData.replicas !== oldDBEditData.current?.replicas;
     setIsLoading(true);

--- a/frontend/providers/dbprovider/src/services/backend/kubernetes.ts
+++ b/frontend/providers/dbprovider/src/services/backend/kubernetes.ts
@@ -222,28 +222,60 @@ export async function getUserQuota(
     body: { status }
   } = await k8sApi.readNamespacedResourceQuota(`quota-${namespace}`, namespace);
 
-  return [
+  const quotaResources: Array<{
+    type: UserQuotaItemType['type'];
+    resourceName: string;
+    parse: (value: string) => number;
+  }> = [
     {
       type: 'cpu',
-      limit: cpuFormatToM(status?.hard?.['limits.cpu'] || '') / 1000,
-      used: cpuFormatToM(status?.used?.['limits.cpu'] || '') / 1000
+      resourceName: 'limits.cpu',
+      parse: (value) => cpuFormatToM(value) / 1000
     },
     {
       type: 'memory',
-      limit: memoryFormatToMi(status?.hard?.['limits.memory'] || '') / 1024,
-      used: memoryFormatToMi(status?.used?.['limits.memory'] || '') / 1024
+      resourceName: 'limits.memory',
+      parse: (value) => memoryFormatToMi(value) / 1024
     },
     {
       type: 'storage',
-      limit: storageQuantityToMi(status?.hard?.['requests.storage'] || '') / 1024,
-      used: storageQuantityToMi(status?.used?.['requests.storage'] || '') / 1024
+      resourceName: 'requests.storage',
+      parse: (value) => storageQuantityToMi(value) / 1024
+    },
+    {
+      type: 'pods',
+      resourceName: 'pods',
+      parse: Number
+    },
+    {
+      type: 'nodeports',
+      resourceName: 'services.nodeports',
+      parse: Number
+    },
+    {
+      type: 'ephemeral-storage',
+      resourceName: 'limits.ephemeral-storage',
+      parse: (value) => storageQuantityToMi(value) / 1024
+    },
+    {
+      type: 'ephemeral-storage',
+      resourceName: 'requests.ephemeral-storage',
+      parse: (value) => storageQuantityToMi(value) / 1024
     }
-    // {
-    //   type: 'gpu',
-    //   limit: Number(status?.hard?.['requests.nvidia.com/gpu'] || 0),
-    //   used: Number(status?.used?.['requests.nvidia.com/gpu'] || 0)
-    // }
   ];
+
+  return quotaResources.flatMap(({ type, resourceName, parse }) => {
+    const hardLimit = status?.hard?.[resourceName];
+    if (hardLimit === undefined) return [];
+
+    return [
+      {
+        type,
+        limit: parse(String(hardLimit)),
+        used: parse(String(status?.used?.[resourceName] || ''))
+      }
+    ];
+  });
 }
 
 export async function getUserBalance(kc: k8s.KubeConfig) {

--- a/frontend/providers/dbprovider/src/store/user.ts
+++ b/frontend/providers/dbprovider/src/store/user.ts
@@ -2,6 +2,11 @@ import { getUserQuota } from '@/api/platform';
 import { DBEditType } from '@/types/db';
 import { I18nCommonKey } from '@/types/i18next';
 import { UserQuotaItemType } from '@/types/user';
+import {
+  calculateDatabaseQuotaDelta,
+  checkQuotaAvailability,
+  type QuotaRequest
+} from '@/utils/quota';
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
@@ -10,12 +15,16 @@ type State = {
   balance: number;
   userQuota: UserQuotaItemType[];
   loadUserQuota: () => Promise<null>;
-  checkQuotaAllow: (request: DBEditType, usedData?: DBEditType) => I18nCommonKey | undefined;
+  checkQuotaAllow: (
+    request: DBEditType,
+    usedData?: DBEditType
+  ) => Promise<I18nCommonKey | undefined>;
+  checkQuotaRequest: (request: QuotaRequest) => Promise<I18nCommonKey | undefined>;
 };
 
 export const useUserStore = create<State>()(
   devtools(
-    immer((set, get) => ({
+    immer((set) => ({
       balance: 5,
       userQuota: [],
       loadUserQuota: async () => {
@@ -26,39 +35,25 @@ export const useUserStore = create<State>()(
         });
         return null;
       },
-      checkQuotaAllow: (
-        { cpu, memory, storage, replicas },
-        usedData
-      ): I18nCommonKey | undefined => {
-        const quote = get().userQuota;
-
-        const request = {
-          cpu: (cpu / 1000) * replicas,
-          memory: (memory / 1024) * replicas,
-          storage: storage * replicas
-        };
-
-        if (usedData) {
-          const { cpu, memory, storage, replicas } = usedData;
-          request.cpu -= (cpu / 1000) * replicas;
-          request.memory -= (memory / 1024) * replicas;
-          request.storage -= storage * replicas;
-        }
-
-        const overLimitTip: { [key: string]: I18nCommonKey } = {
-          cpu: 'app.cpu_exceeds_quota',
-          memory: 'app.memory_exceeds_quota',
-          storage: 'app.storage_exceeds_quota'
-        };
-
-        const exceedQuota = quote.find((item) => {
-          if (item.used + request[item.type] > item.limit) {
-            return true;
-          }
-        });
-
-        return exceedQuota?.type ? overLimitTip[exceedQuota.type] : undefined;
-      }
+      checkQuotaAllow: async (request, usedData) =>
+        checkQuotaAvailability({
+          loadQuota: async () => {
+            const response = await getUserQuota();
+            set({ userQuota: response.quota });
+            return response.quota;
+          },
+          request: calculateDatabaseQuotaDelta(request, usedData),
+          requireHeadroom: usedData ? [] : ['ephemeral-storage']
+        }),
+      checkQuotaRequest: async (request) =>
+        checkQuotaAvailability({
+          loadQuota: async () => {
+            const response = await getUserQuota();
+            set({ userQuota: response.quota });
+            return response.quota;
+          },
+          request
+        })
     }))
   )
 );

--- a/frontend/providers/dbprovider/src/types/user.d.ts
+++ b/frontend/providers/dbprovider/src/types/user.d.ts
@@ -30,7 +30,7 @@ export type userPriceType = {
 };
 
 export type UserQuotaItemType = {
-  type: 'cpu' | 'memory' | 'storage';
+  type: 'cpu' | 'memory' | 'storage' | 'pods' | 'nodeports' | 'ephemeral-storage';
   used: number;
   limit: number;
 };

--- a/frontend/providers/dbprovider/src/utils/quota.ts
+++ b/frontend/providers/dbprovider/src/utils/quota.ts
@@ -1,0 +1,80 @@
+import type { DBEditType } from '@/types/db';
+import type { I18nCommonKey } from '@/types/i18next';
+import type { UserQuotaItemType } from '@/types/user';
+import { distributeResources } from './database';
+
+export type QuotaRequest = Partial<Record<UserQuotaItemType['type'], number>>;
+
+const quotaTipMap: Record<UserQuotaItemType['type'], I18nCommonKey> = {
+  cpu: 'app.cpu_exceeds_quota',
+  memory: 'app.memory_exceeds_quota',
+  storage: 'app.storage_exceeds_quota',
+  pods: 'app.pods_exceeds_quota',
+  nodeports: 'app.nodeports_exceeds_quota',
+  'ephemeral-storage': 'app.ephemeral_storage_exceeds_quota'
+};
+
+export const calculateDatabaseQuotaRequest = (data: DBEditType): QuotaRequest => {
+  const components = distributeResources({ ...data, forDisplay: false });
+
+  return Object.values(components).reduce<
+    Required<Pick<QuotaRequest, 'cpu' | 'memory' | 'storage' | 'pods'>>
+  >(
+    (request, component) => {
+      const replicas = Number(component.other?.replicas ?? data.replicas);
+
+      request.cpu += (Number(component.cpuMemory.limits.cpu.replace('m', '')) / 1000) * replicas;
+      request.memory +=
+        (Number(component.cpuMemory.limits.memory.replace('Mi', '')) / 1024) * replicas;
+      request.storage += component.storage * replicas;
+      request.pods += replicas;
+
+      return request;
+    },
+    { cpu: 0, memory: 0, storage: 0, pods: 0 }
+  );
+};
+
+export const calculateDatabaseQuotaDelta = (
+  request: DBEditType,
+  usedData?: DBEditType
+): QuotaRequest => {
+  const requestedQuota = calculateDatabaseQuotaRequest(request);
+  if (!usedData) return requestedQuota;
+
+  const usedQuota = calculateDatabaseQuotaRequest(usedData);
+
+  return {
+    cpu: (requestedQuota.cpu || 0) - (usedQuota.cpu || 0),
+    memory: (requestedQuota.memory || 0) - (usedQuota.memory || 0),
+    storage: (requestedQuota.storage || 0) - (usedQuota.storage || 0),
+    pods: (requestedQuota.pods || 0) - (usedQuota.pods || 0)
+  };
+};
+
+export const checkQuotaAvailability = async ({
+  loadQuota,
+  request,
+  requireHeadroom = []
+}: {
+  loadQuota: () => Promise<UserQuotaItemType[]>;
+  request: QuotaRequest;
+  requireHeadroom?: UserQuotaItemType['type'][];
+}): Promise<I18nCommonKey | undefined> => {
+  try {
+    const quota = await loadQuota();
+    const exceededQuota = quota.find((item) => {
+      const requested = request[item.type] || 0;
+
+      if (requireHeadroom.includes(item.type) && item.used >= item.limit) {
+        return true;
+      }
+
+      return requested > 0 && item.used + requested > item.limit;
+    });
+
+    return exceededQuota ? quotaTipMap[exceededQuota.type] : undefined;
+  } catch {
+    return 'app.quota_check_failed';
+  }
+};


### PR DESCRIPTION
## What does this PR do?

- Restores a quota guard immediately before database create/update submission.
- Refreshes quota data for every guarded action and fails closed when quota lookup fails.
- Calculates CPU, memory, storage, and Pod requirements from the actual database component replica distribution; updates check only the positive delta.
- Reads Pod, NodePort, and ephemeral-storage quotas from the namespace ResourceQuota.
- Guards external network enablement with a NodePort quota check.
- Adds localized quota errors and regression coverage for BUG-45.

## Why is this needed?

The database API returns after the KubeBlocks Cluster custom resource is created. Pods and PVCs are created asynchronously, so ResourceQuota rejection could leave the database at zero ready instances while the UI had already shown a successful deployment.

Related issue: BUG-45 (internal Veges tracker).

## Verification

- `pnpm dlx tsx --test __tests__/unit/quota.test.ts` - 9 tests passed.
- Targeted TypeScript check for the changed dependency graph passed.
- `next lint` passed for all changed TypeScript files; only two pre-existing Hook dependency warnings remain.
- Prettier check passed for all changed files.

The repository does not define a `preflight` script. The full `pnpm typecheck` remains blocked by the existing missing `*.svg` declaration for `emptyChart.svg`; no changed file reports a TypeScript error.

## Notes

- Requests that exactly reach a quota are allowed.
- Scale-down operations are allowed even if the namespace is already over quota.
- Ephemeral storage is guarded conservatively when it is exhausted or overused because the database form does not expose an ephemeral-storage request amount.
