### PR TITLE
fix(desktop): unify password login failure message

### DIFF
--- a/frontend/desktop/src/pages/api/auth/password/index.ts
+++ b/frontend/desktop/src/pages/api/auth/password/index.ts
@@ -81,7 +81,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           code: 400
         });
       }
-      if (err.errorCode === 'USER_NOT_FOUND' || err.errorCode === 'INCORRECT_PASSWORD') {
+      if (
+        err.errorCode === 'USER_NOT_FOUND' ||
+        err.errorCode === 'INCORRECT_PASSWORD' ||
+        err.errorCode === 'SIGNUP_FAILED'
+      ) {
         return jsonRes(res, {
           message: 'Unauthorized',
           code: 401


### PR DESCRIPTION
## Summary
- Normalize password login failures on the release-v5.1 line so user-not-found, failed auto signup, and incorrect-password cases all return the generic unauthorized path instead of exposing signup internals.
- Keep the existing password username validation and auth diagnostics in the release branch.

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant SignIn as UsernamePasswordSignin
    participant API as /api/auth/password
    participant Auth as getGlobalToken

    User->>SignIn: Submit username and password
    SignIn->>API: POST credentials
    API->>Auth: Resolve PASSWORD provider token
    Auth-->>API: AuthError for user not found, signup failed, or incorrect password
    API-->>SignIn: Unauthorized
    SignIn-->>User: Show generic invalid username or password message
```

## Tests
- `git diff --check`
- `pnpm dlx prettier@2.8.8 --check frontend/desktop/src/pages/api/auth/password/index.ts`
- `pnpm -C frontend/desktop lint` could not run because local node_modules are not installed and next is unavailable.
