### PR TITLE
fix(applaunchpad): reject duplicate environment variable names

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/types/env-schema.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/types/env-schema.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { UpdateAppResourcesSchema as V1UpdateAppResourcesSchema } from '@/types/request_schema';
+import { UpdateAppResourcesSchema as V2AlphaUpdateAppResourcesSchema } from '@/types/v2alpha/request_schema';
+
+describe('app env schema', () => {
+  it('rejects duplicate v1 environment variable names', () => {
+    const result = V1UpdateAppResourcesSchema.safeParse({
+      env: [
+        { name: 'DATABASE_URL', value: 'postgres://first' },
+        { name: ' DATABASE_URL ', value: 'postgres://second' }
+      ]
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]).toMatchObject({
+      message: 'Duplicate environment variable name: DATABASE_URL',
+      path: ['env', 1, 'name']
+    });
+  });
+
+  it('rejects duplicate v2alpha environment variable names', () => {
+    const result = V2AlphaUpdateAppResourcesSchema.safeParse({
+      env: [
+        { name: 'DATABASE_URL', value: 'postgres://first' },
+        { name: ' DATABASE_URL ', value: 'postgres://second' }
+      ]
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]).toMatchObject({
+      message: 'Duplicate environment variable name: DATABASE_URL',
+      path: ['env', 1, 'name']
+    });
+  });
+
+  it('accepts distinct environment variable names', () => {
+    const result = V1UpdateAppResourcesSchema.safeParse({
+      env: [
+        { name: 'DATABASE_URL', value: 'postgres://first' },
+        { name: 'REDIS_URL', value: 'redis://cache' }
+      ]
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/frontend/providers/applaunchpad/public/locales/en/common.json
+++ b/frontend/providers/applaunchpad/public/locales/en/common.json
@@ -80,6 +80,7 @@
   "Edit Env Variable": "Edit Environment Variables",
   "Edit Environment Variables": "Edit Environment Variables",
   "Env Placeholder": "one per line, key and value separated by colon or equals sign, e.g.:\nmongoUrl=127.0.0.1:8000\nredisUrl:127.0.0.0:8001\n-env1 =test",
+  "Env Variable Name Conflict": "Environment variable name {{name}} cannot be duplicated",
   "Environment Variables": "Environment Variables",
   "Export": "Export",
   "Export Domain": "Assigned Domain",

--- a/frontend/providers/applaunchpad/public/locales/zh/common.json
+++ b/frontend/providers/applaunchpad/public/locales/zh/common.json
@@ -80,6 +80,7 @@
   "Edit Env Variable": "编辑环境变量",
   "Edit Environment Variables": "编辑环境变量",
   "Env Placeholder": "环境变量，每行一个，可用冒号或等号分隔，例如：\nmongoUrl=127.0.0.1:8000\nredisUrl:127.0.0.0:8001\n- env1=test",
+  "Env Variable Name Conflict": "环境变量名 {{name}} 不能重复",
   "Environment Variables": "环境变量",
   "Export": "导出",
   "Export Domain": "出口域名",

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/EditEnvs.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/EditEnvs.tsx
@@ -1,3 +1,5 @@
+import { useToast } from '@/hooks/useToast';
+import { parseDotenvEnvs, stringifyDotenvEnvs } from '@/utils/dotenvEnv';
 import React, { useState, useCallback } from 'react';
 import {
   Modal,
@@ -13,7 +15,25 @@ import {
 } from '@chakra-ui/react';
 import { useTranslation } from 'next-i18next';
 import { AppEditType } from '@/types/app';
-import { parseDotenvEnvs, stringifyDotenvEnvs } from '@/utils/dotenvEnv';
+
+type EditableEnv = {
+  key: string;
+  value: string;
+  valueFrom?: any;
+};
+
+const findDuplicateEnvKey = (envs: EditableEnv[]) => {
+  const seenKeys = new Set<string>();
+
+  for (const env of envs) {
+    const key = env.key.trim();
+    if (!key) continue;
+    if (seenKeys.has(key)) return key;
+    seenKeys.add(key);
+  }
+
+  return '';
+};
 
 const EditEnvs = ({
   defaultEnv = [],
@@ -25,6 +45,7 @@ const EditEnvs = ({
   onClose: () => void;
 }) => {
   const { t } = useTranslation();
+  const { toast } = useToast();
   const [inputVal, setInputVal] = useState(
     stringifyDotenvEnvs(
       defaultEnv
@@ -36,11 +57,21 @@ const EditEnvs = ({
 
   const onSubmit = useCallback(() => {
     const result = parseDotenvEnvs(inputVal);
+    const nextEnv = [...defaultEnv.filter((item) => item.valueFrom), ...result];
+    const duplicateKey = findDuplicateEnvKey(nextEnv);
+
+    if (duplicateKey) {
+      toast({
+        title: t('Env Variable Name Conflict', { name: duplicateKey }),
+        status: 'error'
+      });
+      return;
+    }
 
     // concat valueFrom env
-    successCb([...defaultEnv.filter((item) => item.valueFrom), ...result]);
+    successCb(nextEnv);
     onClose();
-  }, [defaultEnv, inputVal, onClose, successCb]);
+  }, [defaultEnv, inputVal, onClose, successCb, t, toast]);
 
   return (
     <Modal isOpen onClose={onClose} lockFocusAcrossFrames={false}>

--- a/frontend/providers/applaunchpad/src/types/request_schema.ts
+++ b/frontend/providers/applaunchpad/src/types/request_schema.ts
@@ -203,6 +203,29 @@ export const PortUpdateSchema = z
     }
   });
 
+const validateUniqueEnvNames = (
+  envs: z.infer<typeof StandardEnvSchema>[],
+  ctx: z.RefinementCtx
+) => {
+  const seenNames = new Set<string>();
+
+  envs.forEach((env, index) => {
+    const name = env.name.trim();
+    if (!name) return;
+    if (seenNames.has(name)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Duplicate environment variable name: ${name}`,
+        path: [index, 'name']
+      });
+      return;
+    }
+    seenNames.add(name);
+  });
+};
+
+const EnvArraySchema = z.array(StandardEnvSchema).superRefine(validateUniqueEnvNames);
+
 export const UpdateImageSchema = z
   .object({
     imageName: z.string().openapi({
@@ -323,7 +346,7 @@ export const UpdateAppResourcesSchema = z
         'Container image configuration. Set imageRegistry to null to switch to public image.'
     }),
 
-    env: z.array(StandardEnvSchema).optional().openapi({
+    env: EnvArraySchema.optional().openapi({
       description: 'Environment variables'
     }),
 
@@ -432,7 +455,7 @@ export const CreateLaunchpadRequestSchema = z
         description: 'Port/Network configurations for the application'
       }),
 
-    env: z.array(StandardEnvSchema).default([]).openapi({
+    env: EnvArraySchema.default([]).openapi({
       description: 'Environment variables - was: envs'
     }),
 

--- a/frontend/providers/applaunchpad/src/types/v2alpha/request_schema.ts
+++ b/frontend/providers/applaunchpad/src/types/v2alpha/request_schema.ts
@@ -224,6 +224,29 @@ export const PortUpdateSchema = z
     }
   });
 
+const validateUniqueEnvNames = (
+  envs: z.infer<typeof StandardEnvSchema>[],
+  ctx: z.RefinementCtx
+) => {
+  const seenNames = new Set<string>();
+
+  envs.forEach((env, index) => {
+    const name = env.name.trim();
+    if (!name) return;
+    if (seenNames.has(name)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Duplicate environment variable name: ${name}`,
+        path: [index, 'name']
+      });
+      return;
+    }
+    seenNames.add(name);
+  });
+};
+
+const EnvArraySchema = z.array(StandardEnvSchema).superRefine(validateUniqueEnvNames);
+
 export const UpdateImageSchema = z
   .object({
     imageName: z.string().openapi({
@@ -358,7 +381,7 @@ export const UpdateAppResourcesSchema = z
         'Container image configuration. Set imageRegistry to null to switch to public image.'
     }),
 
-    env: z.array(StandardEnvSchema).optional().openapi({
+    env: EnvArraySchema.optional().openapi({
       description: 'Environment variables'
     }),
 
@@ -429,7 +452,7 @@ export const CreateLaunchpadRequestSchema = z
         description: 'Port/Network configurations for the application'
       }),
 
-    env: z.array(StandardEnvSchema).default([]).openapi({
+    env: EnvArraySchema.default([]).openapi({
       description: 'Environment variables - was: envs'
     }),
 


### PR DESCRIPTION
## Summary
Reject duplicate environment variable names in Applaunchpad at both the edit modal and API schema level, and add localized error text plus unit coverage.

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant EditModal as EditEnvs Modal
    participant Schema as Zod Schema
    participant API as App Save API
    participant K8s as App Config

    User->>EditModal: Save env entries
    EditModal->>EditModal: Block duplicate names
    EditModal->>Schema: Validate env array
    Schema-->>API: Accept unique env names
    API-->>K8s: Persist the app update
```

## Verification
- `./node_modules/.bin/vitest run __tests__/unit/types/env-schema.test.ts`
- `pnpm --dir frontend/providers/applaunchpad exec tsc --noEmit --pretty false`
- `pnpm --dir frontend/providers/applaunchpad lint --file src/pages/app/edit/components/EditEnvs.tsx --file src/types/request_schema.ts --file src/types/v2alpha/request_schema.ts`
