### PR TITLE
fix(desktop): source balance from account service

### DIFF
--- a/frontend/desktop/src/__tests__/unit/api/account/getAmount.test.ts
+++ b/frontend/desktop/src/__tests__/unit/api/account/getAmount.test.ts
@@ -1,0 +1,146 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import handler from '@/pages/api/account/getAmount';
+import { generateBillingToken, verifyAccessToken } from '@/services/backend/auth';
+
+jest.mock('@/services/backend/auth', () => ({
+  generateBillingToken: jest.fn(),
+  verifyAccessToken: jest.fn()
+}));
+
+const mockedVerifyAccessToken = jest.mocked(verifyAccessToken);
+const mockedGenerateBillingToken = jest.mocked(generateBillingToken);
+
+const createResponse = () => {
+  const res = {
+    json: jest.fn()
+  } as unknown as NextApiResponse;
+  return res;
+};
+
+const createRequest = () =>
+  ({
+    headers: {
+      authorization: 'encoded-access-token'
+    }
+  }) as unknown as NextApiRequest;
+
+describe('GET /api/account/getAmount', () => {
+  const originalFetch = global.fetch;
+  const originalAppConfig = global.AppConfig;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.AppConfig = {
+      desktop: {
+        auth: {
+          billingUrl: 'http://account-service.account-system.svc:2333'
+        }
+      }
+    } as any;
+    global.fetch = jest.fn();
+    mockedVerifyAccessToken.mockResolvedValue({
+      regionUid: 'region-uid',
+      userUid: 'real-user-uid',
+      userId: 'manager70',
+      userCrUid: 'user-cr-uid',
+      userCrName: 'user-cr-name',
+      workspaceUid: 'workspace-uid',
+      workspaceId: 'ns-manager70'
+    });
+    mockedGenerateBillingToken.mockReturnValue('billing-token');
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+    global.AppConfig = originalAppConfig;
+  });
+
+  it('returns the balance from account-service', async () => {
+    jest.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        account: {
+          Balance: 1000,
+          DeductionBalance: 25
+        }
+      })
+    } as Response);
+
+    const res = createResponse();
+    await handler(createRequest(), res);
+
+    expect(mockedVerifyAccessToken).toHaveBeenCalledWith({ authorization: 'encoded-access-token' });
+    expect(mockedGenerateBillingToken).toHaveBeenCalledWith({
+      userUid: 'real-user-uid',
+      userId: 'manager70'
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://account-service.account-system.svc:2333/account/v1alpha1/account',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer billing-token',
+          'Content-Type': 'application/json',
+          'Accept-Encoding': 'gzip,deflate,compress'
+        },
+        body: '{}'
+      }
+    );
+    expect(res.json).toHaveBeenCalledWith({
+      code: 200,
+      message: '',
+      data: {
+        balance: 1000,
+        deductionBalance: 25
+      }
+    });
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    mockedVerifyAccessToken.mockResolvedValue(null);
+
+    const res = createResponse();
+    await handler(createRequest(), res);
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({
+      code: 401,
+      message: 'token is invaild',
+      data: null
+    });
+  });
+
+  it('fails when billing service is not configured', async () => {
+    global.AppConfig = {
+      desktop: {
+        auth: {}
+      }
+    } as any;
+
+    const res = createResponse();
+    await handler(createRequest(), res);
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({
+      code: 500,
+      message: 'Billing service not configured',
+      data: null
+    });
+  });
+
+  it('forwards account-service failures as API errors', async () => {
+    jest.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      status: 401
+    } as Response);
+
+    const res = createResponse();
+    await handler(createRequest(), res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      code: 401,
+      message: 'failed to get account balance',
+      data: null
+    });
+  });
+});

--- a/frontend/desktop/src/pages/api/account/getAmount.ts
+++ b/frontend/desktop/src/pages/api/account/getAmount.ts
@@ -1,27 +1,50 @@
-import { verifyAccessToken } from '@/services/backend/auth';
-import { globalPrisma } from '@/services/backend/db/init';
+import { generateBillingToken, verifyAccessToken } from '@/services/backend/auth';
 import { jsonRes } from '@/services/backend/response';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
-type accountStatus = {
-  balance: number;
-  deductionBalance: number;
+type AccountServiceResponse = {
+  account?: {
+    Balance?: number;
+    DeductionBalance?: number;
+  };
 };
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
     const payload = await verifyAccessToken(req.headers);
     if (!payload) return jsonRes(res, { code: 401, message: 'token is invaild' });
-    const status = await globalPrisma.account.findUnique({
-      where: {
-        userUid: payload.userUid
-      }
+
+    const billingUrl = global.AppConfig.desktop.auth.billingUrl;
+    if (!billingUrl) {
+      return jsonRes(res, { code: 500, message: 'Billing service not configured' });
+    }
+
+    const billingToken = generateBillingToken({
+      userUid: payload.userUid,
+      userId: payload.userId
     });
-    if (!status) return jsonRes(res, { code: 404, message: 'user is not found' });
+
+    const response = await fetch(`${billingUrl}/account/v1alpha1/account`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${billingToken}`,
+        'Content-Type': 'application/json',
+        'Accept-Encoding': 'gzip,deflate,compress'
+      },
+      body: JSON.stringify({})
+    });
+
+    if (!response.ok) {
+      return jsonRes(res, { code: response.status, message: 'failed to get account balance' });
+    }
+
+    const data = (await response.json()) as AccountServiceResponse;
+    if (!data?.account) return jsonRes(res, { code: 404, message: 'user is not found' });
+
     return jsonRes<{ balance: number; deductionBalance: number }>(res, {
       data: {
-        balance: Number(status.balance || 0),
-        deductionBalance: Number(status.deduction_balance || 0)
+        balance: Number(data.account.Balance || 0),
+        deductionBalance: Number(data.account.DeductionBalance || 0)
       }
     });
   } catch (error) {


### PR DESCRIPTION
## Summary

This fixes the desktop balance endpoint so it reads the authenticated user's balance from account-service instead of querying the local Prisma account table by `userUid`.
It signs the account-service request with a billing token, preserves unauthenticated and missing-service error handling, and adds unit coverage for success and failure paths.

## Sequence Diagram

```mermaid
sequenceDiagram
    participant Browser
    participant DesktopAPI as Desktop API
    participant Auth
    participant AccountService as Account Service

    Browser->>DesktopAPI: GET /api/account/getAmount
    DesktopAPI->>Auth: Verify access token
    Auth-->>DesktopAPI: User identity
    DesktopAPI->>Auth: Generate billing token
    DesktopAPI->>AccountService: POST /account/v1alpha1/account
    AccountService-->>DesktopAPI: Balance and deduction balance
    DesktopAPI-->>Browser: Return account balance response
```

## Verification

`NODE_PATH=/Users/mlhiter/conductor/workspaces/sealos/chisinau/frontend/node_modules/.pnpm/node_modules node -e "const Module=require('module'); const orig=Module._load; Module._load=function(request,parent,isMain){ if(request==='next-pwa/cache') return []; if(request==='next-pwa') return () => (cfg)=>cfg; return orig.apply(this,arguments); }; process.argv=['node','jest','src/__tests__/unit/api/account/getAmount.test.ts','--runInBand']; require('jest/bin/jest');"`

`git diff --check origin/release-v5.1...HEAD`
