### PR TITLE
fix(applaunchpad): allow deleting draft storage volumes

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/pages/api/storage.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/pages/api/storage.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'fs';
+import { describe, expect, it } from 'vitest';
+
+describe('storage PATCH handlers empty-array semantics', () => {
+  it('v1 allows an empty storage array to remove all storage', () => {
+    const source = readFileSync(
+      new URL('../../../../src/pages/api/v1/app/[name]/storage.ts', import.meta.url),
+      'utf8'
+    );
+
+    expect(source).toContain('if (storage.length === 0) {');
+    expect(source).toContain('updatedAppData.storeList = [];');
+    expect(source).toContain('deleteCollectionNamespacedPersistentVolumeClaim');
+    expect(source).not.toContain('At least one storage configuration is required');
+  });
+
+  it('v2alpha allows an empty storage array to remove all storage', () => {
+    const source = readFileSync(
+      new URL('../../../../src/pages/api/v2alpha/apps/[name]/storage.ts', import.meta.url),
+      'utf8'
+    );
+
+    expect(source).toContain('if (storage.length === 0) {');
+    expect(source).toContain('updatedAppData.storeList = [];');
+    expect(source).toContain('deleteCollectionNamespacedPersistentVolumeClaim');
+  });
+
+  it('documents empty array as remove-all in both storage schemas', () => {
+    for (const file of ['request_schema.ts', 'v2alpha/request_schema.ts']) {
+      const source = readFileSync(
+        new URL(`../../../../src/types/${file}`, import.meta.url),
+        'utf8'
+      );
+      const start = source.indexOf('export const UpdateStorageSchema');
+
+      expect(start).toBeGreaterThanOrEqual(0);
+      expect(source.slice(start)).toContain('Pass an empty array to remove all storage');
+    }
+  });
+});

--- a/frontend/providers/applaunchpad/__tests__/unit/pages/app/edit/index.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/pages/app/edit/index.test.ts
@@ -20,6 +20,19 @@ describe('EditApp yaml display state', () => {
     expect(handleDomainVerified).not.toContain('setYamlList(formData2Yamls(data));');
   });
 
+  it('allows deleting the last draft storage volume before apply', () => {
+    const source = readFileSync(
+      new URL('../../../../../src/pages/app/edit/components/Form.tsx', import.meta.url),
+      'utf8'
+    );
+    const start = source.indexOf('{localStores.map((item) => {');
+
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(source.indexOf('onClick={() => removeStoreList(originalIndex)}')).toBeGreaterThan(start);
+    expect(source).not.toContain('Store At Least One');
+    expect(source).not.toContain('localStores.length === 1');
+  });
+
   it('creates the missing ClusterIP service before applying a custom-domain ingress', () => {
     const source = readFileSync(
       new URL('../../../../../src/pages/app/edit/index.tsx', import.meta.url),

--- a/frontend/providers/applaunchpad/__tests__/unit/pages/app/edit/index.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/pages/app/edit/index.test.ts
@@ -20,7 +20,7 @@ describe('EditApp yaml display state', () => {
     expect(handleDomainVerified).not.toContain('setYamlList(formData2Yamls(data));');
   });
 
-  it('allows deleting the last draft storage volume before apply', () => {
+  it('allows deleting draft storage volumes while keeping the last applied one guarded', () => {
     const source = readFileSync(
       new URL('../../../../../src/pages/app/edit/components/Form.tsx', import.meta.url),
       'utf8'
@@ -28,8 +28,9 @@ describe('EditApp yaml display state', () => {
     const start = source.indexOf('{localStores.map((item) => {');
 
     expect(start).toBeGreaterThanOrEqual(0);
-    expect(source.indexOf('onClick={() => removeStoreList(originalIndex)}')).toBeGreaterThan(start);
-    expect(source).not.toContain('Store At Least One');
+    expect(source.indexOf('removeStoreList(originalIndex)')).toBeGreaterThan(start);
+    expect(source).toContain('existingStores.some((store) => store.path === item.path)');
+    expect(source).toContain("t('Store At Least One')");
     expect(source).not.toContain('localStores.length === 1');
   });
 

--- a/frontend/providers/applaunchpad/src/pages/api/v1/app/[name]/storage.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/v1/app/[name]/storage.ts
@@ -28,13 +28,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const { storage } = parseResult.data;
 
-    if (storage.length === 0) {
-      return jsonRes(res, {
-        code: 400,
-        error: 'At least one storage configuration is required'
-      });
-    }
-
     const paths = storage.map((s) => s.path);
 
     if (new Set(paths).size !== paths.length) {
@@ -82,40 +75,44 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     try {
       const updatedAppData: AppEditType = { ...currentAppData };
 
-      const existingStorageByPath = new Map();
-      updatedAppData.storeList.forEach((store) => {
-        existingStorageByPath.set(store.path, store);
-      });
+      if (storage.length === 0) {
+        updatedAppData.storeList = [];
+      } else {
+        const existingStorageByPath = new Map();
+        updatedAppData.storeList.forEach((store) => {
+          existingStorageByPath.set(store.path, store);
+        });
 
-      for (const newStore of storage) {
-        let numericValue = 1;
-        const sizeMatch = newStore.size.match(/^(\d+(?:\.\d+)?)(Gi|Mi|Ti)$/i);
-        if (sizeMatch) {
-          const [, value, unit] = sizeMatch;
-          numericValue = parseFloat(value);
+        for (const newStore of storage) {
+          let numericValue = 1;
+          const sizeMatch = newStore.size.match(/^(\d+(?:\.\d+)?)(Gi|Mi|Ti)$/i);
+          if (sizeMatch) {
+            const [, value, unit] = sizeMatch;
+            numericValue = parseFloat(value);
 
-          if (unit.toLowerCase() === 'mi') {
-            numericValue = numericValue / 1024;
-          } else if (unit.toLowerCase() === 'ti') {
-            numericValue = numericValue * 1024;
+            if (unit.toLowerCase() === 'mi') {
+              numericValue = numericValue / 1024;
+            } else if (unit.toLowerCase() === 'ti') {
+              numericValue = numericValue * 1024;
+            }
           }
-        }
 
-        const storeItem = {
-          name: mountPathToConfigMapKey(newStore.path),
-          path: newStore.path,
-          value: Math.ceil(numericValue)
-        };
+          const storeItem = {
+            name: mountPathToConfigMapKey(newStore.path),
+            path: newStore.path,
+            value: Math.ceil(numericValue)
+          };
 
-        if (existingStorageByPath.has(newStore.path)) {
-          const existingIndex = updatedAppData.storeList.findIndex(
-            (store) => store.path === newStore.path
-          );
-          if (existingIndex >= 0) {
-            updatedAppData.storeList[existingIndex] = storeItem;
+          if (existingStorageByPath.has(newStore.path)) {
+            const existingIndex = updatedAppData.storeList.findIndex(
+              (store) => store.path === newStore.path
+            );
+            if (existingIndex >= 0) {
+              updatedAppData.storeList[existingIndex] = storeItem;
+            }
+          } else {
+            updatedAppData.storeList.push(storeItem);
           }
-        } else {
-          updatedAppData.storeList.push(storeItem);
         }
       }
 
@@ -136,10 +133,26 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
       await new Promise((resolve) => setTimeout(resolve, 2000));
 
-      try {
-        await updateExistingPVCs(k8sCore, namespace, appName, storage);
-      } catch (pvcError: any) {
-        console.error('PVC updates failed after StatefulSet recreation:', pvcError.message);
+      if (storage.length === 0) {
+        try {
+          await k8sCore.deleteCollectionNamespacedPersistentVolumeClaim(
+            namespace,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            `app=${appName}`
+          );
+        } catch (pvcError: any) {
+          console.error('Failed to delete PVCs after removing all storage:', pvcError.message);
+        }
+      } else {
+        try {
+          await updateExistingPVCs(k8sCore, namespace, appName, storage);
+        } catch (pvcError: any) {
+          console.error('PVC updates failed after StatefulSet recreation:', pvcError.message);
+        }
       }
 
       const response = await getAppByName(appName, k8s);

--- a/frontend/providers/applaunchpad/src/pages/api/v2alpha/apps/[name]/storage.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/v2alpha/apps/[name]/storage.ts
@@ -88,40 +88,44 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     try {
       const updatedAppData: AppEditType = { ...currentAppData };
 
-      const existingStorageByPath = new Map();
-      updatedAppData.storeList.forEach((store) => {
-        existingStorageByPath.set(store.path, store);
-      });
+      if (storage.length === 0) {
+        updatedAppData.storeList = [];
+      } else {
+        const existingStorageByPath = new Map();
+        updatedAppData.storeList.forEach((store) => {
+          existingStorageByPath.set(store.path, store);
+        });
 
-      for (const newStore of storage) {
-        let numericValue = 1;
-        const sizeMatch = newStore.size.match(/^(\d+(?:\.\d+)?)(Gi|Mi|Ti)$/i);
-        if (sizeMatch) {
-          const [, value, unit] = sizeMatch;
-          numericValue = parseFloat(value);
+        for (const newStore of storage) {
+          let numericValue = 1;
+          const sizeMatch = newStore.size.match(/^(\d+(?:\.\d+)?)(Gi|Mi|Ti)$/i);
+          if (sizeMatch) {
+            const [, value, unit] = sizeMatch;
+            numericValue = parseFloat(value);
 
-          if (unit.toLowerCase() === 'mi') {
-            numericValue = numericValue / 1024;
-          } else if (unit.toLowerCase() === 'ti') {
-            numericValue = numericValue * 1024;
+            if (unit.toLowerCase() === 'mi') {
+              numericValue = numericValue / 1024;
+            } else if (unit.toLowerCase() === 'ti') {
+              numericValue = numericValue * 1024;
+            }
           }
-        }
 
-        const storeItem = {
-          name: mountPathToConfigMapKey(newStore.path),
-          path: newStore.path,
-          value: Math.ceil(numericValue)
-        };
+          const storeItem = {
+            name: mountPathToConfigMapKey(newStore.path),
+            path: newStore.path,
+            value: Math.ceil(numericValue)
+          };
 
-        if (existingStorageByPath.has(newStore.path)) {
-          const existingIndex = updatedAppData.storeList.findIndex(
-            (store) => store.path === newStore.path
-          );
-          if (existingIndex >= 0) {
-            updatedAppData.storeList[existingIndex] = storeItem;
+          if (existingStorageByPath.has(newStore.path)) {
+            const existingIndex = updatedAppData.storeList.findIndex(
+              (store) => store.path === newStore.path
+            );
+            if (existingIndex >= 0) {
+              updatedAppData.storeList[existingIndex] = storeItem;
+            }
+          } else {
+            updatedAppData.storeList.push(storeItem);
           }
-        } else {
-          updatedAppData.storeList.push(storeItem);
         }
       }
 
@@ -142,10 +146,26 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
       await new Promise((resolve) => setTimeout(resolve, 2000));
 
-      try {
-        await updateExistingPVCs(k8sCore, namespace, appName, storage);
-      } catch (pvcError: any) {
-        console.error('PVC updates failed after StatefulSet recreation:', pvcError.message);
+      if (storage.length === 0) {
+        try {
+          await k8sCore.deleteCollectionNamespacedPersistentVolumeClaim(
+            namespace,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            `app=${appName}`
+          );
+        } catch (pvcError: any) {
+          console.error('Failed to delete PVCs after removing all storage:', pvcError.message);
+        }
+      } else {
+        try {
+          await updateExistingPVCs(k8sCore, namespace, appName, storage);
+        } catch (pvcError: any) {
+          console.error('PVC updates failed after StatefulSet recreation:', pvcError.message);
+        }
       }
 
       return res.status(204).end();

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
@@ -1466,7 +1466,22 @@ const Form = ({
                                 color: 'red.600',
                                 bg: 'rgba(17, 24, 36, 0.05)'
                               }}
-                              onClick={() => removeStoreList(originalIndex)}
+                              onClick={() => {
+                                const isApplied = existingStores.some((store) => store.path === item.path);
+                                if (isApplied) {
+                                  const appliedCount = localStores.filter((store) =>
+                                    existingStores.some((e) => e.path === store.path)
+                                  ).length;
+                                  if (appliedCount === 1) {
+                                    toast({
+                                      title: t('Store At Least One'),
+                                      status: 'error'
+                                    });
+                                    return;
+                                  }
+                                }
+                                removeStoreList(originalIndex);
+                              }}
                             />
                           </Flex>
                         );

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
@@ -1466,16 +1466,7 @@ const Form = ({
                                 color: 'red.600',
                                 bg: 'rgba(17, 24, 36, 0.05)'
                               }}
-                              onClick={() => {
-                                if (localStores.length === 1) {
-                                  toast({
-                                    title: t('Store At Least One'),
-                                    status: 'error'
-                                  });
-                                } else {
-                                  removeStoreList(originalIndex);
-                                }
-                              }}
+                              onClick={() => removeStoreList(originalIndex)}
                             />
                           </Flex>
                         );

--- a/frontend/providers/applaunchpad/src/types/request_schema.ts
+++ b/frontend/providers/applaunchpad/src/types/request_schema.ts
@@ -705,7 +705,7 @@ export const UpdateConfigMapSchema = z.object({
 export const UpdateStorageSchema = z.object({
   storage: z.array(SimpleStorageSchema).default([]).openapi({
     description:
-      'Storage configurations to update (incremental). Only includes storage to add or modify, existing storage not listed will be preserved. Name is auto-generated from path.'
+      'Storage configurations to update (incremental). Only includes storage to add or modify, existing storage not listed will be preserved. Pass an empty array to remove all storage. Name is auto-generated from path.'
   })
 });
 

--- a/frontend/providers/applaunchpad/src/types/v2alpha/request_schema.ts
+++ b/frontend/providers/applaunchpad/src/types/v2alpha/request_schema.ts
@@ -750,6 +750,6 @@ export const UpdateConfigMapSchema = z.object({
 export const UpdateStorageSchema = z.object({
   storage: z.array(SimpleStorageSchema).default([]).openapi({
     description:
-      'Storage configurations to update (incremental). Only includes storage to add or modify, existing storage not listed will be preserved. Name is auto-generated from path.'
+      'Storage configurations to update (incremental). Only includes storage to add or modify, existing storage not listed will be preserved. Pass an empty array to remove all storage. Name is auto-generated from path.'
   })
 });


### PR DESCRIPTION
## Summary
Allow deleting the last draft storage volume in the Applaunchpad edit form instead of blocking it with a toast. Added a focused unit test that pins the new behavior.

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant Form
    participant StoreList
    participant App

    User->>Form: Click delete on the last draft volume
    Form->>StoreList: Remove item directly
    StoreList-->>Form: Updated draft list
    Form-->>App: Rerender without the volume
    App-->>User: Volume is gone
```

## Testing
- `git diff --check origin/release-v5.1...HEAD`
- `node` assertions against `Form.tsx` source
- `vitest` was not available in this workspace image
