### PR TITLE
feat(service): add health endpoints and Kubernetes probes

### DIFF
--- a/service/database/deploy/manifests/deploy.yaml
+++ b/service/database/deploy/manifests/deploy.yaml
@@ -43,6 +43,19 @@ spec:
         ports:
         - containerPort: 9090
           protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 9090
+          initialDelaySeconds: 3
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 9090
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          failureThreshold: 6
         resources:
           limits:
             cpu: 500m

--- a/service/launchpad/deploy/manifests/deploy.yaml
+++ b/service/launchpad/deploy/manifests/deploy.yaml
@@ -43,6 +43,19 @@ spec:
           ports:
             - containerPort: 8428
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8428
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8428
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            failureThreshold: 6
           resources:
             limits:
               cpu: 500m

--- a/service/launchpad/server/server.go
+++ b/service/launchpad/server/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labring/sealos/service/launchpad/request"
 	"github.com/labring/sealos/service/pkg/api"
 	"github.com/labring/sealos/service/pkg/auth"
+	commonserver "github.com/labring/sealos/service/pkg/server"
 )
 
 type VMServer struct {
@@ -102,6 +103,8 @@ func isNetworkServiceRequest(queryType string) bool {
 func (vs *VMServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	pathPrefix := ""
 	switch req.URL.Path {
+	case commonserver.HealthPath:
+		commonserver.ServeHealth(rw, req)
 	case pathPrefix + "/query":
 		vs.doReqNew(rw, req)
 	default:

--- a/service/launchpad/server/server_test.go
+++ b/service/launchpad/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,7 +12,15 @@ import (
 func TestVMServerHealth(t *testing.T) {
 	t.Parallel()
 
-	req := httptest.NewRequest(http.MethodGet, commonserver.HealthPath, nil)
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		commonserver.HealthPath,
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rw := httptest.NewRecorder()
 
 	(&VMServer{}).ServeHTTP(rw, req)

--- a/service/launchpad/server/server_test.go
+++ b/service/launchpad/server/server_test.go
@@ -1,0 +1,22 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	commonserver "github.com/labring/sealos/service/pkg/server"
+)
+
+func TestVMServerHealth(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, commonserver.HealthPath, nil)
+	rw := httptest.NewRecorder()
+
+	(&VMServer{}).ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rw.Code)
+	}
+}

--- a/service/minio/deploy/manifests/deploy.yaml.tmpl
+++ b/service/minio/deploy/manifests/deploy.yaml.tmpl
@@ -100,6 +100,19 @@ spec:
         ports:
         - containerPort: 9090
           protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 9090
+          initialDelaySeconds: 3
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 9090
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          failureThreshold: 6
         resources:
           limits:
             cpu: 50m

--- a/service/pkg/server/health.go
+++ b/service/pkg/server/health.go
@@ -1,0 +1,26 @@
+package server
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+const HealthPath = "/health"
+
+type healthResponse struct {
+	Status string `json:"status"`
+}
+
+func ServeHealth(rw http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet {
+		rw.Header().Set("Allow", http.MethodGet)
+		http.Error(rw, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	rw.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(rw).Encode(healthResponse{Status: "healthy"}); err != nil {
+		log.Printf("Failed to write health response: %s", err)
+	}
+}

--- a/service/pkg/server/health_test.go
+++ b/service/pkg/server/health_test.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPromServerHealth(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, HealthPath, nil)
+	rw := httptest.NewRecorder()
+
+	(&PromServer{}).ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rw.Code)
+	}
+	if got := rw.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("expected JSON content type, got %q", got)
+	}
+
+	var response healthResponse
+	if err := json.NewDecoder(rw.Body).Decode(&response); err != nil {
+		t.Fatalf("decode health response: %v", err)
+	}
+	if response.Status != "healthy" {
+		t.Fatalf("expected healthy status, got %q", response.Status)
+	}
+}
+
+func TestServeHealthRejectsNonGET(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodPost, HealthPath, nil)
+	rw := httptest.NewRecorder()
+
+	ServeHealth(rw, req)
+
+	if rw.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected status %d, got %d", http.StatusMethodNotAllowed, rw.Code)
+	}
+	if got := rw.Header().Get("Allow"); got != http.MethodGet {
+		t.Fatalf("expected Allow header %q, got %q", http.MethodGet, got)
+	}
+}

--- a/service/pkg/server/health_test.go
+++ b/service/pkg/server/health_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -10,7 +11,10 @@ import (
 func TestPromServerHealth(t *testing.T) {
 	t.Parallel()
 
-	req := httptest.NewRequest(http.MethodGet, HealthPath, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, HealthPath, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rw := httptest.NewRecorder()
 
 	(&PromServer{}).ServeHTTP(rw, req)
@@ -34,7 +38,10 @@ func TestPromServerHealth(t *testing.T) {
 func TestServeHealthRejectsNonGET(t *testing.T) {
 	t.Parallel()
 
-	req := httptest.NewRequest(http.MethodPost, HealthPath, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, HealthPath, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rw := httptest.NewRecorder()
 
 	ServeHealth(rw, req)

--- a/service/pkg/server/server.go
+++ b/service/pkg/server/server.go
@@ -102,6 +102,8 @@ func (ps *PromServer) ParseRequest(req *http.Request) (*api.PromRequest, error) 
 func (ps *PromServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	pathPrefix := ""
 	switch req.URL.Path {
+	case HealthPath:
+		ServeHealth(rw, req)
 	case pathPrefix + "/query": // 将废弃
 		ps.doReqPre(rw, req)
 	case pathPrefix + "/q":

--- a/service/vlogs/deploy/manifests/deploy.yaml
+++ b/service/vlogs/deploy/manifests/deploy.yaml
@@ -40,6 +40,19 @@ spec:
           ports:
             - containerPort: 8428
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8428
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8428
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            failureThreshold: 6
           resources:
             limits:
               cpu: 500m

--- a/service/vlogs/server/server.go
+++ b/service/vlogs/server/server.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	commonserver "github.com/labring/sealos/service/pkg/server"
 	"github.com/labring/sealos/service/vlogs/config"
 )
 
@@ -25,6 +26,11 @@ func NewVLogsServer(config *config.Config) (*VLogsServer, error) {
 }
 
 func (vl *VLogsServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	if req.URL.Path == commonserver.HealthPath {
+		commonserver.ServeHealth(rw, req)
+		return
+	}
+
 	query, err := vl.queryConvert(req)
 	if err != nil {
 		http.Error(

--- a/service/vlogs/server/server_test.go
+++ b/service/vlogs/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,7 +12,15 @@ import (
 func TestVLogsServerHealth(t *testing.T) {
 	t.Parallel()
 
-	req := httptest.NewRequest(http.MethodGet, commonserver.HealthPath, nil)
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		commonserver.HealthPath,
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rw := httptest.NewRecorder()
 
 	(&VLogsServer{}).ServeHTTP(rw, req)

--- a/service/vlogs/server/server_test.go
+++ b/service/vlogs/server/server_test.go
@@ -1,0 +1,22 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	commonserver "github.com/labring/sealos/service/pkg/server"
+)
+
+func TestVLogsServerHealth(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, commonserver.HealthPath, nil)
+	rw := httptest.NewRecorder()
+
+	(&VLogsServer{}).ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rw.Code)
+	}
+}


### PR DESCRIPTION
## Summary

- add a lightweight GET /health endpoint for database, minio, launchpad, and vlogs services
- add livenessProbe and readinessProbe HTTP checks to the corresponding service deployments
- add handler-level tests for the shared, launchpad, and vlogs health routes

## Validation

- go test ./... passed in service, service/database, service/launchpad, and service/vlogs
- go vet ./... passed in the same modules
- golangci-lint passed for database, launchpad, and vlogs
- Helm rendering and YAML probe assertions passed for all five service projects, including the existing account chart
- kubectl client dry-run passed for database, launchpad, and vlogs

The full account test suite still requires its existing external MongoDB/Cockroach, kubeconfig, and local API test prerequisites; those failures are unrelated to this change. The minio deployment template also contains existing VictoriaMetrics VMProbe resources, which require their CRD for a complete cluster dry-run.