### PR TITLE
fix(applaunchpad): surface restart pod error message

### DIFF
--- a/frontend/providers/applaunchpad/src/components/app/detail/index/Pods.tsx
+++ b/frontend/providers/applaunchpad/src/components/app/detail/index/Pods.tsx
@@ -62,8 +62,8 @@ const Pods = ({ pods = [], appName }: { pods: PodDetailType[]; appName: string }
         });
       } catch (err) {
         toast({
-          title: `${t('Restart')}  ${podName} 出现异常`,
-          status: 'warning'
+          title: t(getErrText(err), 'Restart Failed'),
+          status: 'error'
         });
         console.log(err);
       }


### PR DESCRIPTION
<!--
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR,
because it will be placed in the release note.
-->

## Summary

When a developer (non-admin) user restarts a pod in App Management, the restart fails silently with a generic "something went wrong" toast. The real backend error (e.g. "Insufficient permissions") is swallowed by the hardcoded catch branch in `handleRestartPod`.

This PR surfaces the actual error message via `getErrText`, matching the pattern already used by the app restart/pause/start handlers and pod terminal permission checks.

## Sequence Diagram

```mermaid
sequenceDiagram
    participant Dev as Developer user
    participant Pods as Pods.tsx handleRestartPod
    participant API as /api/restartPod
    participant K8s as Kubernetes API

    Dev->>Pods: Click restart pod
    Pods->>API: DELETE pod (restartPodByName)
    API->>K8s: deleteNamespacedPod
    K8s-->>API: 403 Forbidden
    API-->>Pods: { code: 403, message: 'Insufficient permissions' }
    Pods-->>Dev: toast(getErrText(err), 'Restart Failed')
```
