### PR TITLE
fix(dbprovider): keep status details modal open

### DIFF
--- a/frontend/providers/dbprovider/src/components/DBStatusTag/index.tsx
+++ b/frontend/providers/dbprovider/src/components/DBStatusTag/index.tsx
@@ -21,18 +21,89 @@ import { I18nCommonKey } from '@/types/i18next';
 import { DBStatusEnum } from '@/constants/db';
 import { Maximize2 } from 'lucide-react';
 
+type DBStatusDetailsModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  conditions?: DBConditionItemType[];
+  details?: string;
+};
+
+export const DBStatusDetailsModal = ({
+  isOpen,
+  onClose,
+  title,
+  conditions = [],
+  details
+}: DBStatusDetailsModalProps) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} lockFocusAcrossFrames={false}>
+      <ModalOverlay />
+      <ModalContent minW={'520px'}>
+        <ModalHeader display={'flex'} alignItems={'center'}>
+          <Box flex={1}>{title}</Box>
+          <ModalCloseButton top={'10px'} right={'10px'} />
+        </ModalHeader>
+        <ModalBody>
+          {conditions.length > 0 ? (
+            conditions.map((item, i) => (
+              <Box
+                key={i}
+                pl={6}
+                pb={6}
+                ml={4}
+                borderLeft={`2px solid ${i === conditions.length - 1 ? 'transparent' : '#DCE7F1'}`}
+                position={'relative'}
+                _before={{
+                  content: '""',
+                  position: 'absolute',
+                  left: '-6.5px',
+                  w: '8px',
+                  h: '8px',
+                  borderRadius: '8px',
+                  backgroundColor: '#fff',
+                  border: '2px solid',
+                  borderColor: item.status === 'False' ? '#D92D20' : '#039855'
+                }}
+              >
+                <Flex lineHeight={1} mb={2} alignItems={'center'}>
+                  <Box fontWeight={'bold'}>
+                    {item.reason},&ensp;Last Occur:{' '}
+                    {formatPodTime(item.lastTransitionTime as unknown as Date)}
+                  </Box>
+                </Flex>
+                <Box color={'blackAlpha.700'}>{item.message}</Box>
+              </Box>
+            ))
+          ) : (
+            <Box whiteSpace={'pre-wrap'} color={'gray.700'}>
+              {details || ''}
+            </Box>
+          )}
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};
+
 const DBStatusTag = ({
   conditions = [],
   status,
   showBorder = false,
   alertReason,
-  alertDetails
+  alertDetails,
+  onOpenDetails,
+  onOpenQuestionDetails,
+  renderInternalModals = true
 }: {
   conditions: DBConditionItemType[];
   status: DBStatusMapType;
   showBorder?: boolean;
   alertReason?: string;
   alertDetails?: string;
+  onOpenDetails?: () => void;
+  onOpenQuestionDetails?: () => void;
+  renderInternalModals?: boolean;
 }) => {
   const { t } = useTranslation();
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -46,6 +117,8 @@ const DBStatusTag = ({
   // Check if status is not Running or Stopped
   const shouldShowQuestionIcon =
     status.value !== DBStatusEnum.Running && status.value !== DBStatusEnum.Stopped && alertReason;
+  const openDetails = onOpenDetails ?? onOpen;
+  const openQuestionDetails = onOpenQuestionDetails ?? onQuestionOpen;
 
   return (
     <>
@@ -81,7 +154,7 @@ const DBStatusTag = ({
           >
             {label}
           </Box>
-          <Maximize2 size={14} color="#71717A" cursor={'pointer'} onClick={onOpen} />
+          <Maximize2 size={14} color="#71717A" cursor={'pointer'} onClick={openDetails} />
         </Flex>
         {shouldShowQuestionIcon && (
           <Tooltip label={t('click_for_details')} placement="top">
@@ -91,7 +164,7 @@ const DBStatusTag = ({
               variant="ghost"
               aria-label="Question mark"
               icon={<MyIcon name="help" w="14px" h="14px" color="#F04438" />}
-              onClick={onQuestionOpen}
+              onClick={openQuestionDetails}
               color="#F04438"
               backgroundColor="#FEF3F2"
               w="14px"
@@ -102,65 +175,24 @@ const DBStatusTag = ({
           </Tooltip>
         )}
 
-        {/* Status details modal */}
-        <Modal isOpen={isOpen} onClose={onClose} lockFocusAcrossFrames={false}>
-          <ModalOverlay />
-          <ModalContent minW={'520px'}>
-            <ModalHeader display={'flex'} alignItems={'center'}>
-              <Box flex={1}>{label}</Box>
-              <ModalCloseButton top={'10px'} right={'10px'} />
-            </ModalHeader>
-            <ModalBody>
-              {conditions.map((item, i) => (
-                <Box
-                  key={i}
-                  pl={6}
-                  pb={6}
-                  ml={4}
-                  borderLeft={`2px solid ${
-                    i === conditions.length - 1 ? 'transparent' : '#DCE7F1'
-                  }`}
-                  position={'relative'}
-                  _before={{
-                    content: '""',
-                    position: 'absolute',
-                    left: '-6.5px',
-                    w: '8px',
-                    h: '8px',
-                    borderRadius: '8px',
-                    backgroundColor: '#fff',
-                    border: '2px solid',
-                    borderColor: item.status === 'False' ? '#D92D20' : '#039855'
-                  }}
-                >
-                  <Flex lineHeight={1} mb={2} alignItems={'center'}>
-                    <Box fontWeight={'bold'}>
-                      {item.reason},&ensp;Last Occur:{' '}
-                      {formatPodTime(item.lastTransitionTime as unknown as Date)}
-                    </Box>
-                  </Flex>
-                  <Box color={'blackAlpha.700'}>{item.message}</Box>
-                </Box>
-              ))}
-            </ModalBody>
-          </ModalContent>
-        </Modal>
+        {renderInternalModals && (
+          <DBStatusDetailsModal
+            isOpen={isOpen}
+            onClose={onClose}
+            title={label}
+            conditions={conditions}
+          />
+        )}
 
         {/* Question mark modal */}
-        <Modal isOpen={isQuestionOpen} onClose={onQuestionClose} lockFocusAcrossFrames={false}>
-          <ModalOverlay />
-          <ModalContent minW={'520px'}>
-            <ModalHeader display={'flex'} alignItems={'center'}>
-              <Box flex={1}>{alertReason || 'Status Details'}</Box>
-              <ModalCloseButton top={'10px'} right={'10px'} />
-            </ModalHeader>
-            <ModalBody>
-              <Box whiteSpace={'pre-wrap'} color={'gray.700'}>
-                {alertDetails || ''}
-              </Box>
-            </ModalBody>
-          </ModalContent>
-        </Modal>
+        {renderInternalModals && (
+          <DBStatusDetailsModal
+            isOpen={isQuestionOpen}
+            onClose={onQuestionClose}
+            title={alertReason || 'Status Details'}
+            details={alertDetails}
+          />
+        )}
       </Flex>
     </>
   );

--- a/frontend/providers/dbprovider/src/pages/dbs/components/dbList.tsx
+++ b/frontend/providers/dbprovider/src/pages/dbs/components/dbList.tsx
@@ -1,7 +1,7 @@
 import { pauseDBByName, restartDB, startDBByName } from '@/api/db';
 import { BaseTable } from '@/components/BaseTable/baseTable';
 import { CustomMenu } from '@/components/BaseTable/customMenu';
-import DBStatusTag from '@/components/DBStatusTag';
+import DBStatusTag, { DBStatusDetailsModal } from '@/components/DBStatusTag';
 import type { DatabaseAlertItem } from '@/api/db';
 import MyIcon from '@/components/Icon';
 import { DBStatusEnum, DBTypeList } from '@/constants/db';
@@ -48,6 +48,7 @@ import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { getLangStore } from '@/utils/cookieUtils';
+import { I18nCommonKey } from '@/types/i18next';
 import { sealosApp } from 'sealos-desktop-sdk/app';
 
 import {
@@ -95,6 +96,12 @@ const DBList = ({
   const [delAppName, setDelAppName] = useState('');
   const [updateAppName, setUpdateAppName] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
+  const [statusDetailModal, setStatusDetailModal] = useState<{
+    dbName: string;
+    title: string;
+    conditions?: DBListItemType['conditions'];
+    details?: string;
+  } | null>(null);
 
   const { openConfirm: onOpenPause, ConfirmChild: PauseChild } = useConfirm({
     content: t('pause_hint')
@@ -361,6 +368,21 @@ const DBList = ({
             status={row.original.status}
             alertReason={alerts[row.original.name]?.reason}
             alertDetails={alerts[row.original.name]?.details}
+            onOpenDetails={() =>
+              setStatusDetailModal({
+                dbName: row.original.name,
+                title: t(row.original.status.label as I18nCommonKey),
+                conditions: row.original.conditions
+              })
+            }
+            onOpenQuestionDetails={() =>
+              setStatusDetailModal({
+                dbName: row.original.name,
+                title: alerts[row.original.name]?.reason || t('status'),
+                details: alerts[row.original.name]?.details || ''
+              })
+            }
+            renderInternalModals={false}
           />
         )
       },
@@ -644,6 +666,13 @@ const DBList = ({
   }, [applistCompleted, t, router, isClientSide, _hasHydrated]);
 
   const delApp = dbList.find((i) => i.name === delAppName);
+
+  useEffect(() => {
+    if (statusDetailModal && !dbList.some((item) => item.name === statusDetailModal.dbName)) {
+      setStatusDetailModal(null);
+    }
+  }, [dbList, statusDetailModal]);
+
   return (
     <Box
       backgroundColor={'white'}
@@ -723,6 +752,16 @@ const DBList = ({
           }
         }}
       />
+
+      {statusDetailModal && (
+        <DBStatusDetailsModal
+          isOpen={true}
+          onClose={() => setStatusDetailModal(null)}
+          title={statusDetailModal.title}
+          conditions={statusDetailModal.conditions}
+          details={statusDetailModal.details}
+        />
+      )}
 
       <PauseChild />
       {!!delApp && (

--- a/frontend/providers/dbprovider/src/pages/dbs/components/dbList.tsx
+++ b/frontend/providers/dbprovider/src/pages/dbs/components/dbList.tsx
@@ -98,9 +98,7 @@ const DBList = ({
   const [searchQuery, setSearchQuery] = useState('');
   const [statusDetailModal, setStatusDetailModal] = useState<{
     dbName: string;
-    title: string;
-    conditions?: DBListItemType['conditions'];
-    details?: string;
+    kind: 'status' | 'alert';
   } | null>(null);
 
   const { openConfirm: onOpenPause, ConfirmChild: PauseChild } = useConfirm({
@@ -371,15 +369,13 @@ const DBList = ({
             onOpenDetails={() =>
               setStatusDetailModal({
                 dbName: row.original.name,
-                title: t(row.original.status.label as I18nCommonKey),
-                conditions: row.original.conditions
+                kind: 'status'
               })
             }
             onOpenQuestionDetails={() =>
               setStatusDetailModal({
                 dbName: row.original.name,
-                title: alerts[row.original.name]?.reason || t('status'),
-                details: alerts[row.original.name]?.details || ''
+                kind: 'alert'
               })
             }
             renderInternalModals={false}
@@ -666,12 +662,16 @@ const DBList = ({
   }, [applistCompleted, t, router, isClientSide, _hasHydrated]);
 
   const delApp = dbList.find((i) => i.name === delAppName);
+  const selectedStatusDb = statusDetailModal
+    ? dbList.find((item) => item.name === statusDetailModal.dbName)
+    : undefined;
+  const selectedStatusAlert = statusDetailModal ? alerts[statusDetailModal.dbName] : undefined;
 
   useEffect(() => {
-    if (statusDetailModal && !dbList.some((item) => item.name === statusDetailModal.dbName)) {
+    if (statusDetailModal && !selectedStatusDb) {
       setStatusDetailModal(null);
     }
-  }, [dbList, statusDetailModal]);
+  }, [selectedStatusDb, statusDetailModal]);
 
   return (
     <Box
@@ -753,13 +753,19 @@ const DBList = ({
         }}
       />
 
-      {statusDetailModal && (
+      {statusDetailModal && selectedStatusDb && (
         <DBStatusDetailsModal
           isOpen={true}
           onClose={() => setStatusDetailModal(null)}
-          title={statusDetailModal.title}
-          conditions={statusDetailModal.conditions}
-          details={statusDetailModal.details}
+          title={
+            statusDetailModal.kind === 'status'
+              ? t(selectedStatusDb.status.label as I18nCommonKey)
+              : selectedStatusAlert?.reason || t('status')
+          }
+          conditions={statusDetailModal.kind === 'status' ? selectedStatusDb.conditions : undefined}
+          details={
+            statusDetailModal.kind === 'alert' ? selectedStatusAlert?.details || '' : undefined
+          }
         />
       )}
 


### PR DESCRIPTION
<!--
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR,
because it will be placed in the release note.
-->

## Summary
- Keeps database status detail modals mounted at the list page level so the 3-second database list refresh no longer closes them.
- Reuses the status details modal for both status conditions and alert details while preserving the detail page's existing internal modal behavior.
- Resolves the open modal content from the latest selected database and alert state, and closes it when the database disappears from the list.

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant DBStatusTag
    participant DBList
    participant DBStore

    User->>DBStatusTag: Open status or alert details
    DBStatusTag->>DBList: Set selected database and modal kind
    DBList->>DBStore: Receive refreshed database list
    DBStore-->>DBList: Return updated status and alert state
    DBList-->>User: Keep the modal open with current details
```

## Verification
- `pnpm --dir frontend/providers/dbprovider exec tsc --noEmit --pretty false`
- `pnpm --dir frontend/providers/dbprovider exec next lint --file src/components/DBStatusTag/index.tsx --file src/pages/dbs/components/dbList.tsx`
- `pnpm --dir frontend/providers/dbprovider build`
- `git diff --check origin/release-v5.1...HEAD`
