### PR TITLE
fix(applaunchpad): gate public access by backend readiness

### DIFF
--- a/frontend/providers/applaunchpad/Dockerfile
+++ b/frontend/providers/applaunchpad/Dockerfile
@@ -1,13 +1,13 @@
 # Install dependencies only when needed
 FROM node:current-alpine AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk add --no-cache libc6-compat && npm install -g pnpm@8.9.0
+RUN apk add --no-cache libc6-compat && npm install -g pnpm
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
 COPY package.json pnpm-lock.yaml* ./
 RUN \
-  [ -f pnpm-lock.yaml ] && pnpm install --frozen-lockfile --ignore-scripts || \
+  [ -f pnpm-lock.yaml ] && pnpm install || \
   (echo "Lockfile not found." && exit 1)
 
 # Rebuild the source code only when needed
@@ -22,7 +22,7 @@ COPY . .
 ENV NEXT_TELEMETRY_DISABLED 1
 ENV NEXT_PUBLIC_MOCK_USER ''
 
-RUN npm install -g pnpm@8.9.0 && pnpm run gen:theme-typings && pnpm run build-packages && pnpm --dir providers/applaunchpad run build
+RUN npm install -g pnpm && pnpm run build
 
 # Production image, copy all the files and run next
 FROM node:current-alpine AS runner

--- a/frontend/providers/applaunchpad/Dockerfile
+++ b/frontend/providers/applaunchpad/Dockerfile
@@ -1,7 +1,7 @@
 # Install dependencies only when needed
 FROM node:current-alpine AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk add --no-cache libc6-compat && npm install -g pnpm
+RUN apk add --no-cache libc6-compat && npm install -g pnpm@8.9.0
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
@@ -22,7 +22,7 @@ COPY . .
 ENV NEXT_TELEMETRY_DISABLED 1
 ENV NEXT_PUBLIC_MOCK_USER ''
 
-RUN npm install -g pnpm && pnpm run build
+RUN npm install -g pnpm@8.9.0 && pnpm run build
 
 # Production image, copy all the files and run next
 FROM node:current-alpine AS runner

--- a/frontend/providers/applaunchpad/Dockerfile
+++ b/frontend/providers/applaunchpad/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 # Install dependencies based on the preferred package manager
 COPY package.json pnpm-lock.yaml* ./
 RUN \
-  [ -f pnpm-lock.yaml ] && pnpm install || \
+  [ -f pnpm-lock.yaml ] && pnpm install --frozen-lockfile --ignore-scripts || \
   (echo "Lockfile not found." && exit 1)
 
 # Rebuild the source code only when needed
@@ -22,7 +22,7 @@ COPY . .
 ENV NEXT_TELEMETRY_DISABLED 1
 ENV NEXT_PUBLIC_MOCK_USER ''
 
-RUN npm install -g pnpm@8.9.0 && pnpm run build
+RUN npm install -g pnpm@8.9.0 && pnpm run gen:theme-typings && pnpm run build-packages && pnpm --dir providers/applaunchpad run build
 
 # Production image, copy all the files and run next
 FROM node:current-alpine AS runner

--- a/frontend/providers/applaunchpad/__tests__/unit/utils/publicAccess.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/publicAccess.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { appStatusMap } from '@/constants/app';
+import {
+  getPublicAddressReadyResult,
+  hasAvailableBackend,
+  isPublicAddressAccessible
+} from '@/utils/publicAccess';
+import type { AppDetailType } from '@/types/app';
+
+const makeApp = ({
+  status = appStatusMap.waiting,
+  availableReplicas = 0
+}: {
+  status?: AppDetailType['status'];
+  availableReplicas?: number;
+}) =>
+  ({
+    status,
+    openapi: {
+      status: {
+        observedGeneration: 1,
+        replicas: availableReplicas,
+        availableReplicas,
+        updatedReplicas: availableReplicas,
+        isPause: false
+      }
+    }
+  } as Pick<AppDetailType, 'status' | 'openapi'>);
+
+describe('public access readiness', () => {
+  it('requires a ready network and an available backend before showing accessible', () => {
+    const networkStatus = { ready: true, url: 'https://app.example.com' };
+
+    expect(
+      isPublicAddressAccessible({
+        app: makeApp({ status: appStatusMap.waiting, availableReplicas: 0 }),
+        status: networkStatus
+      })
+    ).toBe(false);
+
+    expect(
+      isPublicAddressAccessible({
+        app: makeApp({ status: appStatusMap.running, availableReplicas: 1 }),
+        status: networkStatus
+      })
+    ).toBe(true);
+  });
+
+  it('treats available replicas as a usable backend even before the status label catches up', () => {
+    expect(
+      hasAvailableBackend(makeApp({ status: appStatusMap.creating, availableReplicas: 1 }))
+    ).toBe(true);
+  });
+
+  it('treats no healthy upstream as not ready', async () => {
+    const result = await getPublicAddressReadyResult(
+      new Response('no healthy upstream', { status: 503 }),
+      'https://app.example.com'
+    );
+
+    expect(result).toEqual({
+      ready: false,
+      url: 'https://app.example.com',
+      error: 'Upstream not healthy'
+    });
+  });
+
+  it('does not mark arbitrary non-success responses ready', async () => {
+    const result = await getPublicAddressReadyResult(
+      new Response('bad gateway', { status: 502 }),
+      'https://app.example.com'
+    );
+
+    expect(result).toEqual({
+      ready: false,
+      url: 'https://app.example.com',
+      error: 'HTTP 502'
+    });
+  });
+});

--- a/frontend/providers/applaunchpad/__tests__/unit/utils/ready-check.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/ready-check.test.ts
@@ -1,18 +1,23 @@
 import { describe, expect, it } from 'vitest';
-import { getReadyCheckTarget } from '@/utils/ready-check';
+import {
+  getIngressServiceBackends,
+  getReadyCheckTarget,
+  hasReadyEndpointForBackend
+} from '@/utils/ready-check';
 
 describe('ready check target helpers', () => {
-  it('keeps CNAME mode probing the public host directly', () => {
+  it('keeps CNAME mode displaying the public URL while probing the internal gateway', () => {
     const target = getReadyCheckTarget({
       host: 'app.example.com',
       backendProtocol: 'HTTP',
-      config: { disableHttps: false, cloudPort: ':443', httpPort: ':80' },
-      customDomainMode: 'cname'
+      config: { disableHttps: false, cloudPort: ':443', httpPort: ':80' }
     });
 
     expect(target).toEqual({
-      fetchUrl: 'https://app.example.com:443',
-      url: 'https://app.example.com:443'
+      fetchUrl: 'http://higress-gateway.higress-system.svc.cluster.local',
+      url: 'https://app.example.com:443',
+      hostHeader: 'app.example.com',
+      servername: 'app.example.com'
     });
   });
 
@@ -20,12 +25,11 @@ describe('ready check target helpers', () => {
     const target = getReadyCheckTarget({
       host: 'test.com',
       backendProtocol: 'HTTP',
-      config: { disableHttps: false, cloudPort: ':443', httpPort: ':80' },
-      customDomainMode: 'certificate'
+      config: { disableHttps: false, cloudPort: ':443', httpPort: ':80' }
     });
 
     expect(target).toEqual({
-      fetchUrl: 'https://higress-gateway.higress-system.svc.cluster.local',
+      fetchUrl: 'http://higress-gateway.higress-system.svc.cluster.local',
       url: 'https://test.com:443',
       hostHeader: 'test.com',
       servername: 'test.com'
@@ -37,7 +41,6 @@ describe('ready check target helpers', () => {
       host: 'test.com',
       backendProtocol: 'HTTP',
       config: { disableHttps: true, cloudPort: ':443', httpPort: ':80' },
-      customDomainMode: 'certificate',
       gatewayHost: 'gateway.local'
     });
 
@@ -47,5 +50,76 @@ describe('ready check target helpers', () => {
       hostHeader: 'test.com',
       servername: 'test.com'
     });
+  });
+
+  it('extracts ingress service backends from all paths', () => {
+    expect(
+      getIngressServiceBackends({
+        spec: {
+          rules: [
+            {
+              http: {
+                paths: [
+                  {
+                    backend: {
+                      service: {
+                        name: 'app-service',
+                        port: {
+                          number: 80
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      })
+    ).toEqual([
+      {
+        serviceName: 'app-service',
+        servicePortName: undefined,
+        servicePortNumber: 80
+      }
+    ]);
+  });
+
+  it('requires a ready endpoint address for the ingress backend port', () => {
+    expect(
+      hasReadyEndpointForBackend(
+        [
+          {
+            addresses: [{ ip: '10.0.0.1' }],
+            ports: [{ name: 'http', port: 80 }]
+          }
+        ],
+        { serviceName: 'app-service', servicePortNumber: 80 }
+      )
+    ).toBe(true);
+
+    expect(
+      hasReadyEndpointForBackend(
+        [
+          {
+            addresses: [],
+            ports: [{ name: 'http', port: 80 }]
+          }
+        ],
+        { serviceName: 'app-service', servicePortNumber: 80 }
+      )
+    ).toBe(false);
+
+    expect(
+      hasReadyEndpointForBackend(
+        [
+          {
+            addresses: [{ ip: '10.0.0.1' }],
+            ports: [{ name: 'grpc', port: 50051 }]
+          }
+        ],
+        { serviceName: 'app-service', servicePortNumber: 80 }
+      )
+    ).toBe(false);
   });
 });

--- a/frontend/providers/applaunchpad/src/components/app/detail/index/AppMainInfo.tsx
+++ b/frontend/providers/applaunchpad/src/components/app/detail/index/AppMainInfo.tsx
@@ -30,6 +30,7 @@ import { useQuery } from '@tanstack/react-query';
 import { checkReady } from '@/api/platform';
 import { useGuideStore } from '@/store/guide';
 import { startDriver, detailDriverObj } from '@/hooks/driver';
+import { isPublicAddressAccessible, type PublicAddressStatus } from '@/utils/publicAccess';
 
 const AppMainInfo = ({ app = MOCK_APP_DETAIL }: { app: AppDetailType }) => {
   const { t } = useTranslation();
@@ -163,7 +164,7 @@ const AppMainInfo = ({ app = MOCK_APP_DETAIL }: { app: AppDetailType }) => {
               }
               return acc;
             },
-            {} as Record<string, { ready: boolean; url: string }>
+            {} as Record<string, PublicAddressStatus>
           )
         : {},
     [networkStatus]
@@ -229,6 +230,10 @@ const AppMainInfo = ({ app = MOCK_APP_DETAIL }: { app: AppDetailType }) => {
               </thead>
               <tbody>
                 {networks.map((network, index) => {
+                  const publicAddressAccessible = isPublicAddressAccessible({
+                    app,
+                    status: statusMap[network.public]
+                  });
                   return (
                     <tr key={network.inline + index}>
                       <th>
@@ -249,7 +254,7 @@ const AppMainInfo = ({ app = MOCK_APP_DETAIL }: { app: AppDetailType }) => {
                         <Flex alignItems={'center'} gap={'2px'}>
                           {network.public && network.showReadyStatus && (
                             <>
-                              {statusMap[network.public]?.ready ? (
+                              {publicAddressAccessible ? (
                                 <Center
                                   fontSize={'12px'}
                                   fontWeight={400}

--- a/frontend/providers/applaunchpad/src/pages/api/checkReady.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/checkReady.ts
@@ -3,9 +3,14 @@ import { authSession } from '@/services/backend/auth';
 import { getK8s } from '@/services/backend/kubernetes';
 import { jsonRes } from '@/services/backend/response';
 import { ApplicationProtocolType } from '@/types/app';
-import { normalizeCustomDomainMode } from '@/utils/custom-domain';
 import { getPublicAddressReadyResult } from '@/utils/publicAccess';
-import { getReadyCheckTarget, ReadyCheckTarget } from '@/utils/ready-check';
+import {
+  getIngressServiceBackends,
+  getReadyCheckTarget,
+  hasReadyEndpointForBackend,
+  ReadyCheckBackend,
+  ReadyCheckTarget
+} from '@/utils/ready-check';
 import http from 'http';
 import https from 'https';
 import { NextApiRequest, NextApiResponse } from 'next';
@@ -60,6 +65,23 @@ const requestReadyCheckTarget = (target: ReadyCheckTarget) => {
   });
 };
 
+const hasReadyServiceBackend = async ({
+  k8sCore,
+  namespace,
+  backend
+}: {
+  k8sCore: Awaited<ReturnType<typeof getK8s>>['k8sCore'];
+  namespace: string;
+  backend: ReadyCheckBackend;
+}) => {
+  try {
+    const endpoints = await k8sCore.readNamespacedEndpoints(backend.serviceName, namespace);
+    return hasReadyEndpointForBackend(endpoints.body.subsets, backend);
+  } catch (error) {
+    return false;
+  }
+};
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
     const { appName } = req.query as { appName: string };
@@ -68,14 +90,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       cloudPort: global.AppConfig.cloud.port,
       httpPort: global.AppConfig.cloud.httpPort
     };
-    const customDomainMode = normalizeCustomDomainMode(
-      global.AppConfig.launchpad.customDomain?.mode
-    );
     if (!appName) {
       throw new Error('appName is empty');
     }
 
-    const { k8sNetworkingApp, namespace } = await getK8s({
+    const { k8sCore, k8sNetworkingApp, namespace } = await getK8s({
       kubeconfig: await authSession(req.headers)
     });
 
@@ -110,9 +129,28 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           host,
           backendProtocol,
           config: accessConfig,
-          customDomainMode,
           gatewayHost: process.env.CUSTOM_DOMAIN_READY_CHECK_GATEWAY_HOST
         });
+        const serviceBackends = getIngressServiceBackends(item);
+        if (!serviceBackends.length) {
+          return { ready: false, url: target.url, error: 'Invalid ingress backend' };
+        }
+
+        const hasReadyBackend = (
+          await Promise.all(
+            serviceBackends.map((backend) =>
+              hasReadyServiceBackend({
+                k8sCore,
+                namespace,
+                backend
+              })
+            )
+          )
+        ).every(Boolean);
+
+        if (!hasReadyBackend) {
+          return { ready: false, url: target.url, error: 'No ready endpoints' };
+        }
 
         try {
           const response = await requestReadyCheckTarget(target);

--- a/frontend/providers/applaunchpad/src/pages/api/checkReady.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/checkReady.ts
@@ -4,6 +4,7 @@ import { getK8s } from '@/services/backend/kubernetes';
 import { jsonRes } from '@/services/backend/response';
 import { ApplicationProtocolType } from '@/types/app';
 import { normalizeCustomDomainMode } from '@/utils/custom-domain';
+import { getPublicAddressReadyResult } from '@/utils/publicAccess';
 import { getReadyCheckTarget, ReadyCheckTarget } from '@/utils/ready-check';
 import http from 'http';
 import https from 'https';
@@ -115,21 +116,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
         try {
           const response = await requestReadyCheckTarget(target);
-
-          if (response.status === 404 && response.headers.get('content-length') === '0') {
-            return { ready: false, url: target.url, error: '404' };
-          }
-
-          const text = await response.text();
-
-          if (
-            response.status === 503 &&
-            (text.includes('upstream connect error') || text.includes('upstream not health'))
-          ) {
-            return { ready: false, url: target.url, error: 'Upstream not healthy' };
-          }
-
-          return { ready: true, url: target.url };
+          return getPublicAddressReadyResult(response as Response, target.url);
         } catch (error) {
           return { ready: false, url: target.url, error: 'fetch error' };
         }

--- a/frontend/providers/applaunchpad/src/utils/publicAccess.ts
+++ b/frontend/providers/applaunchpad/src/utils/publicAccess.ts
@@ -1,0 +1,51 @@
+import { AppStatusEnum } from '@/constants/app';
+import type { AppDetailType } from '@/types/app';
+
+type AppAccessStatus = Pick<AppDetailType, 'status' | 'openapi'>;
+
+export type PublicAddressStatus = {
+  ready: boolean;
+  url: string;
+  error?: string;
+};
+
+const unhealthyUpstreamText = [
+  'upstream connect error',
+  'upstream not health',
+  'no healthy upstream'
+];
+
+export const hasAvailableBackend = (app: AppAccessStatus) => {
+  return (
+    app.status.value === AppStatusEnum.running || (app.openapi?.status.availableReplicas || 0) > 0
+  );
+};
+
+export const isPublicAddressAccessible = ({
+  app,
+  status
+}: {
+  app: AppAccessStatus;
+  status?: PublicAddressStatus;
+}) => {
+  return !!status?.ready && hasAvailableBackend(app);
+};
+
+export const getPublicAddressReadyResult = async (response: Response, url: string) => {
+  const text = await response.text();
+
+  if (response.status === 404 && response.headers.get('content-length') === '0') {
+    return { ready: false, url, error: '404' };
+  }
+
+  if (response.status < 200 || response.status >= 400) {
+    const isUnhealthyUpstream = unhealthyUpstreamText.some((message) => text.includes(message));
+    return {
+      ready: false,
+      url,
+      error: isUnhealthyUpstream ? 'Upstream not healthy' : `HTTP ${response.status}`
+    };
+  }
+
+  return { ready: true, url };
+};

--- a/frontend/providers/applaunchpad/src/utils/ready-check.ts
+++ b/frontend/providers/applaunchpad/src/utils/ready-check.ts
@@ -1,5 +1,4 @@
 import type { ApplicationProtocolType } from '@/types/app';
-import type { CustomDomainMode } from '@/types';
 import { buildExternalUrl, ExternalAccessConfig } from './network-url';
 
 export const DEFAULT_READY_CHECK_GATEWAY_HOST = 'higress-gateway.higress-system.svc.cluster.local';
@@ -11,23 +10,120 @@ export type ReadyCheckTarget = {
   servername?: string;
 };
 
+export type ReadyCheckBackend = {
+  serviceName: string;
+  servicePortName?: string;
+  servicePortNumber?: number;
+};
+
+type IngressLike = {
+  spec?: {
+    defaultBackend?: {
+      service?: {
+        name?: string;
+        port?: {
+          name?: string;
+          number?: number;
+        };
+      };
+    };
+    rules?: Array<{
+      http?: {
+        paths?: Array<{
+          backend?: {
+            service?: {
+              name?: string;
+              port?: {
+                name?: string;
+                number?: number;
+              };
+            };
+          };
+        }>;
+      };
+    }>;
+  };
+};
+
+type EndpointSubsetLike = {
+  addresses?: unknown[];
+  ports?: Array<{
+    name?: string;
+    port?: number;
+  }>;
+};
+
 const getInternalGatewayAccessConfig = (config: ExternalAccessConfig): ExternalAccessConfig => ({
   ...config,
+  disableHttps: true,
   cloudPort: '',
   httpPort: ''
 });
+
+const getServiceBackend = (service?: {
+  name?: string;
+  port?: {
+    name?: string;
+    number?: number;
+  };
+}): ReadyCheckBackend | null => {
+  if (!service?.name) return null;
+
+  return {
+    serviceName: service.name,
+    servicePortName: service.port?.name,
+    servicePortNumber: service.port?.number
+  };
+};
+
+export const getIngressServiceBackends = (ingress: IngressLike): ReadyCheckBackend[] => {
+  const backendMap = new Map<string, ReadyCheckBackend>();
+  const addBackend = (backend: ReadyCheckBackend | null) => {
+    if (!backend) return;
+    const port = backend.servicePortName || backend.servicePortNumber || '';
+    backendMap.set(`${backend.serviceName}:${port}`, backend);
+  };
+
+  addBackend(getServiceBackend(ingress.spec?.defaultBackend?.service));
+
+  ingress.spec?.rules?.forEach((rule) => {
+    rule.http?.paths?.forEach((path) => {
+      addBackend(getServiceBackend(path.backend?.service));
+    });
+  });
+
+  return Array.from(backendMap.values());
+};
+
+export const hasReadyEndpointForBackend = (
+  subsets: EndpointSubsetLike[] | undefined,
+  backend: ReadyCheckBackend
+) => {
+  return !!subsets?.some((subset) => {
+    if (!subset.addresses?.length) return false;
+    const ports = subset.ports || [];
+    if (!backend.servicePortName && !backend.servicePortNumber) return true;
+    if (!ports.length) return true;
+
+    return ports.some((port) => {
+      if (backend.servicePortName) {
+        return port.name === backend.servicePortName;
+      }
+
+      return port.port === backend.servicePortNumber;
+    });
+  });
+};
 
 export const getReadyCheckTarget = ({
   host,
   backendProtocol,
   config,
-  customDomainMode,
   gatewayHost = DEFAULT_READY_CHECK_GATEWAY_HOST
 }: {
   host: string;
   backendProtocol?: ApplicationProtocolType;
   config: ExternalAccessConfig;
-  customDomainMode: CustomDomainMode;
   gatewayHost?: string;
 }): ReadyCheckTarget => {
   const url = buildExternalUrl({
@@ -36,25 +132,14 @@ export const getReadyCheckTarget = ({
     config
   });
 
-  if (customDomainMode === 'certificate') {
-    return {
-      fetchUrl: buildExternalUrl({
-        protocol: 'HTTP',
-        host: gatewayHost,
-        config: getInternalGatewayAccessConfig(config)
-      }),
-      url,
-      hostHeader: host,
-      servername: host
-    };
-  }
-
   return {
     fetchUrl: buildExternalUrl({
       protocol: 'HTTP',
-      host,
-      config
+      host: gatewayHost,
+      config: getInternalGatewayAccessConfig(config)
     }),
-    url
+    url,
+    hostHeader: host,
+    servername: host
   };
 };


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->

## Summary
- Gate the App Launchpad Accessible badge on both public address readiness and backend availability.
- Share public address readiness parsing between the detail UI and the checkReady API so non-success responses stay not ready.
- Add unit coverage for backend readiness gating and unhealthy upstream responses.

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant Detail as App Detail
    participant API as checkReady API
    participant Gateway as Public Address
    participant Workload as Workload Status

    User->>Detail: Open app detail
    Detail->>API: Check public address
    API->>Gateway: Request public URL
    Gateway-->>API: Return HTTP status and body
    API-->>Detail: Return address readiness
    Detail->>Workload: Read app status and available replicas
    Detail-->>User: Show Accessible only when address and backend are ready
```

## Verification
- `pnpm --dir frontend --filter applaunchpad lint --file src/utils/publicAccess.ts --file src/pages/api/checkReady.ts --file src/components/app/detail/index/AppMainInfo.tsx`
- `git diff --check upstream/release-v5.1...HEAD`
- `pnpm --dir frontend exec vitest run providers/applaunchpad/__tests__/unit/utils/publicAccess.test.ts --config providers/applaunchpad/vitest.config.ts` could not run because Vitest is not installed for the frontend workspace/package.
