### PR TITLE
fix(costcenter): remove total amount time unit

### DIFF
--- a/frontend/providers/costcenter/src/components/valuation/CalculatorPanel/index.tsx
+++ b/frontend/providers/costcenter/src/components/valuation/CalculatorPanel/index.tsx
@@ -9,7 +9,6 @@ import { PortIcon } from '@/components/icons/PortIcon';
 import { StorageIcon } from '@/components/icons/StorageIcon';
 import BaseMenu from '@/components/menu/BaseMenu';
 import { PricePayload } from '@/components/table/PriceTable';
-import { CYCLE } from '@/constants/valuation';
 import { PRICE_CYCLE_SCALE } from '@/pages/valuation';
 import useEnvStore from '@/stores/env';
 import { formatMoney } from '@/utils/format';
@@ -478,9 +477,6 @@ export default function CalculatorPanel({
             {totalAmount}
           </Text>
           <CurrencySymbol type={currencyType} boxSize={'20px'}></CurrencySymbol>
-          <Text color={'grayModern.900'} fontSize={'16px'} fontWeight={'500'}>
-            /{t(CYCLE[config.usage.timeUnit])}
-          </Text>
         </HStack>
       </Center>
     </TabPanel>


### PR DESCRIPTION
## Summary
Remove the time-unit suffix from the cost center price calculator total amount so the total reads as a currency value only.

Related issue: none provided.

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant CalculatorPanel
    participant CurrencySymbol

    User->>CalculatorPanel: Change resources or usage values
    CalculatorPanel->>CalculatorPanel: Recompute total amount
    CalculatorPanel->>CurrencySymbol: Render the currency symbol only
    CalculatorPanel-->>User: Show total amount without a time-unit suffix
```

## Verification
- `pnpm --filter costcenter lint`
- `pnpm --filter costcenter build`
