### PR TITLE
fix(applaunchpad): preserve instance ownership for recreated resources

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/pages/api/updateApp.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/pages/api/updateApp.test.ts
@@ -1,0 +1,228 @@
+// @vitest-environment node
+import type { NextApiRequest, NextApiResponse } from 'next';
+import yaml from 'js-yaml';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import handler from '@/pages/api/updateApp';
+import { initK8s } from 'sealos-desktop-sdk/service';
+
+vi.mock('sealos-desktop-sdk/service', () => ({
+  initK8s: vi.fn()
+}));
+
+vi.mock('sealos-desktop-sdk', () => ({
+  errLog: vi.fn(),
+  infoLog: vi.fn(),
+  warnLog: vi.fn()
+}));
+
+vi.mock('@/config', () => ({
+  Config: () => ({
+    cloud: {
+      disableHttps: false,
+      httpPort: undefined,
+      port: undefined
+    }
+  })
+}));
+
+const mockedInitK8s = vi.mocked(initK8s);
+
+const createResponse = () =>
+  ({
+    json: vi.fn((payload) => payload)
+  } as unknown as NextApiResponse & { json: ReturnType<typeof vi.fn> });
+
+const createResourceYaml = (kind: 'Service' | 'Ingress', name: string, type?: string) =>
+  yaml.dump({
+    apiVersion: kind === 'Ingress' ? 'networking.k8s.io/v1' : 'v1',
+    kind,
+    metadata: {
+      name,
+      labels: {
+        'cloud.sealos.io/app-deploy-manager': 'demo'
+      }
+    },
+    ...(kind === 'Service'
+      ? {
+          spec: {
+            ...(type ? { type } : {}),
+            selector: { app: 'demo' },
+            ports: [{ name: 'web', port: 80, targetPort: 80, protocol: 'TCP' }]
+          }
+        }
+      : {
+          spec: {
+            rules: [
+              {
+                host: 'demo.example.com',
+                http: {
+                  paths: [
+                    {
+                      path: '/',
+                      pathType: 'Prefix',
+                      backend: { service: { name: 'demo-cluster', port: { number: 80 } } }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        })
+  });
+
+const setupK8s = ({
+  deploymentMetadata,
+  statefulSetMetadata,
+  deleteService = vi.fn().mockResolvedValue({})
+}: {
+  deploymentMetadata?: Record<string, any>;
+  statefulSetMetadata?: Record<string, any>;
+  deleteService?: ReturnType<typeof vi.fn>;
+}) => {
+  const applyYamlList = vi.fn().mockResolvedValue([]);
+  const readNamespacedDeployment = deploymentMetadata
+    ? vi.fn().mockResolvedValue({ body: { metadata: deploymentMetadata } })
+    : vi.fn().mockRejectedValue({ body: { code: 404 } });
+  const readNamespacedStatefulSet = statefulSetMetadata
+    ? vi.fn().mockResolvedValue({ body: { metadata: statefulSetMetadata } })
+    : vi.fn().mockRejectedValue({ body: { code: 404 } });
+
+  mockedInitK8s.mockResolvedValue({
+    namespace: 'ns-test',
+    applyYamlList,
+    k8sApp: {
+      readNamespacedDeployment,
+      readNamespacedStatefulSet
+    },
+    k8sCore: {
+      listNamespacedPersistentVolumeClaim: vi.fn().mockResolvedValue({ body: { items: [] } }),
+      deleteNamespacedService: deleteService
+    },
+    k8sNetworkingApp: {},
+    k8sAutoscaling: {},
+    k8sCustomObjects: {
+      getNamespacedCustomObject: vi.fn().mockResolvedValue(null)
+    }
+  } as any);
+
+  return { applyYamlList, readNamespacedDeployment, readNamespacedStatefulSet, deleteService };
+};
+
+const callHandler = async (resources: string[]) => {
+  const req = {
+    body: {
+      appName: 'demo',
+      patch: resources.map((value) => ({
+        type: 'create',
+        kind: (yaml.load(value) as { kind: string }).kind,
+        value
+      }))
+    }
+  } as unknown as NextApiRequest;
+  const res = createResponse();
+
+  await handler(req, res);
+
+  return res;
+};
+
+const getAppliedResources = (applyYamlList: ReturnType<typeof vi.fn>) => {
+  expect(applyYamlList).toHaveBeenCalledTimes(1);
+  expect(applyYamlList.mock.calls[0][1]).toBe('create');
+  return (applyYamlList.mock.calls[0][0] as string[]).map((item) => yaml.load(item) as any);
+};
+
+describe('/api/updateApp recreated resource ownership', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('inherits the template Instance ownership of a Deployment', async () => {
+    const instanceOwnerReference = {
+      apiVersion: 'app.sealos.io/v1',
+      kind: 'Instance',
+      name: 'template-instance',
+      uid: 'instance-uid',
+      controller: false,
+      blockOwnerDeletion: false
+    };
+    const { applyYamlList, readNamespacedDeployment, readNamespacedStatefulSet } = setupK8s({
+      deploymentMetadata: {
+        labels: { 'cloud.sealos.io/deploy-on-sealos': 'template-instance' },
+        ownerReferences: [instanceOwnerReference]
+      }
+    });
+
+    const res = await callHandler([
+      createResourceYaml('Service', 'demo-cluster'),
+      createResourceYaml('Ingress', 'demo-ingress'),
+      createResourceYaml('Service', 'demo-nodeport', 'NodePort')
+    ]);
+
+    const resources = getAppliedResources(applyYamlList);
+    expect(resources).toHaveLength(3);
+    resources.forEach((resource) => {
+      expect(resource.metadata.ownerReferences).toEqual([instanceOwnerReference]);
+      expect(resource.metadata.labels['cloud.sealos.io/deploy-on-sealos']).toBe(
+        'template-instance'
+      );
+    });
+    expect(readNamespacedDeployment).toHaveBeenCalledWith('demo', 'ns-test');
+    expect(readNamespacedStatefulSet).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 200 }));
+  });
+
+  it('falls back to the StatefulSet for template ownership metadata', async () => {
+    const instanceOwnerReference = {
+      apiVersion: 'app.sealos.io/v1',
+      kind: 'Instance',
+      name: 'template-instance',
+      uid: 'instance-uid',
+      controller: false,
+      blockOwnerDeletion: false
+    };
+    const { applyYamlList, readNamespacedStatefulSet } = setupK8s({
+      statefulSetMetadata: {
+        labels: { 'cloud.sealos.io/deploy-on-sealos': 'template-instance' },
+        ownerReferences: [instanceOwnerReference]
+      }
+    });
+
+    await callHandler([createResourceYaml('Service', 'demo-nodeport', 'NodePort')]);
+
+    const [service] = getAppliedResources(applyYamlList);
+    expect(service.metadata.ownerReferences).toEqual([instanceOwnerReference]);
+    expect(service.metadata.labels['cloud.sealos.io/deploy-on-sealos']).toBe('template-instance');
+    expect(readNamespacedStatefulSet).toHaveBeenCalledWith('demo', 'ns-test');
+  });
+
+  it('does not attach a recreated resource to a replaceable standalone workload', async () => {
+    const { applyYamlList } = setupK8s({
+      deploymentMetadata: { uid: 'deployment-uid', labels: {} }
+    });
+
+    await callHandler([createResourceYaml('Service', 'demo-nodeport', 'NodePort')]);
+
+    const [service] = getAppliedResources(applyYamlList);
+    expect(service.metadata.ownerReferences).toBeUndefined();
+    expect(service.metadata.labels['cloud.sealos.io/deploy-on-sealos']).toBeUndefined();
+  });
+
+  it('treats deleting an already garbage-collected resource as success', async () => {
+    const deleteService = vi.fn().mockRejectedValue({ body: { code: 404 } });
+    setupK8s({ deleteService });
+    const req = {
+      body: {
+        appName: 'demo',
+        patch: [{ type: 'delete', kind: 'Service', name: 'demo-nodeport' }]
+      }
+    } as unknown as NextApiRequest;
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(deleteService).toHaveBeenCalledWith('demo-nodeport', 'ns-test');
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 200 }));
+  });
+});

--- a/frontend/providers/applaunchpad/src/pages/api/updateApp.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/updateApp.ts
@@ -1,9 +1,15 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { templateDeployKey } from '@/constants/app';
 import { ApiResp } from '@/services/kubernet';
 import { jsonRes } from '@/services/backend/response';
 import { YamlKindEnum } from '@/utils/adapt';
 import yaml from 'js-yaml';
-import type { CustomObjectsApi, V1StatefulSet } from '@kubernetes/client-node';
+import type {
+  CustomObjectsApi,
+  V1ObjectMeta,
+  V1OwnerReference,
+  V1StatefulSet
+} from '@kubernetes/client-node';
 import { PatchUtils } from '@kubernetes/client-node';
 import type { AppPatchPropsType } from '@/types/app';
 import { initK8s } from 'sealos-desktop-sdk/service';
@@ -17,6 +23,51 @@ export type Props = {
   patch: AppPatchPropsType;
   stateFulSetYaml?: string;
   appName: string;
+};
+
+const isKubernetesNotFound = (error: any): boolean =>
+  +error?.body?.code === 404 || +error?.response?.statusCode === 404 || +error?.statusCode === 404;
+
+const ownershipInheritingKinds = new Set([
+  'Service',
+  'Ingress',
+  'ConfigMap',
+  'Secret',
+  'HorizontalPodAutoscaler',
+  'Certificate',
+  'Issuer',
+  'PersistentVolumeClaim'
+]);
+
+const getTemplateInstanceOwnerReferences = (
+  ownerReferences: V1OwnerReference[] | undefined
+): V1OwnerReference[] =>
+  (ownerReferences ?? []).filter(
+    (reference) =>
+      reference.kind === 'Instance' && reference.apiVersion?.startsWith('app.sealos.io/')
+  );
+
+const addOrReplaceOwnerReferences = (
+  existing: V1OwnerReference[] | undefined,
+  inherited: V1OwnerReference[]
+): V1OwnerReference[] => {
+  const result = [...(existing ?? [])];
+
+  for (const ownerReference of inherited) {
+    const index = result.findIndex(
+      (item) =>
+        item.apiVersion === ownerReference.apiVersion &&
+        item.kind === ownerReference.kind &&
+        item.name === ownerReference.name
+    );
+    if (index >= 0) {
+      result[index] = ownerReference;
+    } else {
+      result.push(ownerReference);
+    }
+  }
+
+  return result;
 };
 
 async function updateAppCRUrl(
@@ -387,11 +438,66 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
         }
         return item.value;
       })
-      .filter((item) => item);
-    await applyYamlList(createYamlList as string[], 'create');
+      .filter((item): item is string => !!item);
+
+    if (createYamlList.length > 0) {
+      let workloadMetadata: V1ObjectMeta | undefined;
+
+      try {
+        const deployment = await k8sApp.readNamespacedDeployment(appName, namespace);
+        workloadMetadata = deployment.body.metadata;
+      } catch (error: any) {
+        if (isKubernetesNotFound(error)) {
+          try {
+            const statefulSet = await k8sApp.readNamespacedStatefulSet(appName, namespace);
+            workloadMetadata = statefulSet.body.metadata;
+          } catch (statefulSetError) {
+            if (!isKubernetesNotFound(statefulSetError)) {
+              throw statefulSetError;
+            }
+          }
+        } else {
+          throw error;
+        }
+      }
+
+      const instanceOwnerReferences = getTemplateInstanceOwnerReferences(
+        workloadMetadata?.ownerReferences
+      );
+      const templateInstanceName = workloadMetadata?.labels?.[templateDeployKey];
+      const ownedCreateYamlList = createYamlList.map((yamlString) => {
+        const resource = yaml.load(yamlString) as Record<string, any>;
+
+        if (ownershipInheritingKinds.has(resource.kind)) {
+          resource.metadata ??= {};
+
+          if (templateInstanceName) {
+            resource.metadata.labels ??= {};
+            resource.metadata.labels[templateDeployKey] = templateInstanceName;
+          }
+
+          if (instanceOwnerReferences.length > 0) {
+            resource.metadata.ownerReferences = addOrReplaceOwnerReferences(
+              resource.metadata.ownerReferences,
+              instanceOwnerReferences
+            );
+          }
+
+          infoLog('Inherited application ownership for new resource', {
+            kind: resource.kind,
+            name: resource.metadata.name,
+            templateInstanceName,
+            inheritedOwnerReferences: instanceOwnerReferences.length
+          });
+        }
+
+        return yaml.dump(resource);
+      });
+      await applyYamlList(ownedCreateYamlList, 'create');
+    }
 
     // delete
-    await Promise.all(
+    const deleteResults = await Promise.allSettled(
       patch.map((item) => {
         const cr = crMap[item.kind];
         if (!cr || item.type !== 'delete' || !item?.name) {
@@ -401,6 +507,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
         return cr.delete(item.name);
       })
     );
+    deleteResults.forEach((result) => {
+      if (result.status === 'rejected' && !isKubernetesNotFound(result.reason)) {
+        throw result.reason;
+      }
+    });
 
     // Update AppCR URL in background (non-blocking)
     updateAppCRUrl(k8sCustomObjects, namespace, appName, patch).catch((error) => {


### PR DESCRIPTION
## What does this PR do?

- Preserves App Store Instance ownership when App Launchpad recreates Services, Ingresses, and other dependent resources.
- Inherits the `cloud.sealos.io/deploy-on-sealos` label from the existing Deployment or StatefulSet.
- Treats Kubernetes `404 NotFound` responses during deletion as success, making resource deletion idempotent.
- Adds regression tests for Deployment- and StatefulSet-backed applications, standalone Launchpad applications, and already garbage-collected resources.

## Why is this needed?

When an App Store application port is removed and recreated through App Launchpad, the newly created Service or Ingress loses the ownership metadata established by the App Store Instance.

Deleting the Instance then removes the original workload resources, but the recreated network resources can remain in the namespace.

During validation, attaching recreated resources directly to the Deployment or StatefulSet exposed another lifecycle issue: StatefulSets can be deleted and recreated during updates, causing Kubernetes to garbage-collect the Service before the explicit delete operation runs. This produced a false `500` response even though the Service had already been deleted.

This PR therefore inherits the stable App Store `Instance` ownerReference instead of making the replaceable workload the ownership root.

Fixes #7187

## How was this tested?

### Automated tests

- App Launchpad unit tests: 171 passed
- TypeScript type check: passed
- ESLint: passed with existing React Hook warnings only
- Prettier and pre-commit checks: passed

### Manual verification

1. Installed an application from the Sealos App Store.
2. Recreated a public port through the locally running App Launchpad.
3. Deleted the application from the App Store.
4. Confirmed that the recreated network Service was garbage-collected.
5. Removed a recreated port through App Launchpad and saved the application.
6. Confirmed that the update returned successfully and the Service was removed.