### PR TITLE
feat(marketing): propagate attribution through desktop auth

### DIFF
--- a/frontend/desktop/data/config.yaml
+++ b/frontend/desktop/data/config.yaml
@@ -95,6 +95,7 @@ desktop:
       internal: "thisisinternaljwt"
       regional: "thisisregionaljwt"
       global: "thisisglobaljwt"
+      marketingConsent: ""
     billingUrl: "http://account-service.account-system.svc:2333"
     workorderUrl: ""
     cloudVitrualMachineUrl: ""

--- a/frontend/desktop/deploy/HELM_VALUES_GUIDE.md
+++ b/frontend/desktop/deploy/HELM_VALUES_GUIDE.md
@@ -58,6 +58,7 @@ desktopConfig:
   jwtInternal: 'your-jwt-internal-key' # 内部 JWT 密钥
   jwtRegional: 'your-jwt-regional-key' # 区域 JWT 密钥
   jwtGlobal: 'your-jwt-global-key' # 全局 JWT 密钥
+  jwtMarketingConsent: 'your-marketing-consent-key' # Marketing consent JWT secret shared with Brain
 ```
 
 ### 4. 计费配置

--- a/frontend/desktop/deploy/HELM_VALUES_GUIDE_CN.md
+++ b/frontend/desktop/deploy/HELM_VALUES_GUIDE_CN.md
@@ -58,6 +58,7 @@ desktopConfig:
   jwtInternal: 'your-jwt-internal-key' # 内部 JWT 密钥
   jwtRegional: 'your-jwt-regional-key' # 区域 JWT 密钥
   jwtGlobal: 'your-jwt-global-key' # 全局 JWT 密钥
+  jwtMarketingConsent: 'your-marketing-consent-key' # 与 Brain 共享的营销 consent JWT 密钥
 ```
 
 ### 4. 计费配置

--- a/frontend/desktop/deploy/README.md
+++ b/frontend/desktop/deploy/README.md
@@ -150,6 +150,7 @@ The following values are **automatically retrieved** from the `sealos-system/sea
 | `jwtInternal`                  | `desktopConfig.jwtInternal`                  | Internal JWT secret    |
 | `jwtRegional`                  | `desktopConfig.jwtRegional`                  | Regional JWT secret    |
 | `jwtGlobal`                    | `desktopConfig.jwtGlobal`                    | Global JWT secret      |
+| `jwtMarketingConsent`          | `desktopConfig.jwtMarketingConsent`          | Marketing consent JWT secret |
 | `regionUID`                    | `desktopConfig.regionUID`                    | Region UID             |
 | `databaseMongodbURI`           | `desktopConfig.databaseMongodbURI`           | MongoDB connection URI |
 | `databaseGlobalCockroachdbURI` | `desktopConfig.databaseGlobalCockroachdbURI` | Global CockroachDB URI |

--- a/frontend/desktop/deploy/README_CN.md
+++ b/frontend/desktop/deploy/README_CN.md
@@ -150,6 +150,7 @@ Helm Chart 使用两个 values 文件来管理配置：
 | `jwtInternal`                  | `desktopConfig.jwtInternal`                  | 内部 JWT 密钥        |
 | `jwtRegional`                  | `desktopConfig.jwtRegional`                  | 区域 JWT 密钥        |
 | `jwtGlobal`                    | `desktopConfig.jwtGlobal`                    | 全局 JWT 密钥        |
+| `jwtMarketingConsent`          | `desktopConfig.jwtMarketingConsent`          | 营销 consent JWT 密钥 |
 | `regionUID`                    | `desktopConfig.regionUID`                    | 区域 UID             |
 | `databaseMongodbURI`           | `desktopConfig.databaseMongodbURI`           | MongoDB 连接 URI     |
 | `databaseGlobalCockroachdbURI` | `desktopConfig.databaseGlobalCockroachdbURI` | 全局 CockroachDB URI |

--- a/frontend/desktop/deploy/charts/desktop-frontend/desktop-frontend-values.yaml
+++ b/frontend/desktop/deploy/charts/desktop-frontend/desktop-frontend-values.yaml
@@ -4,7 +4,7 @@
 # Note: The following configurations are automatically fetched from sealos-system/sealos-config ConfigMap
 # and do NOT need to be manually configured:
 #   - cloudDomain, cloudPort, regionUID
-#   - jwtInternal, jwtRegional, jwtGlobal
+#   - jwtInternal, jwtRegional, jwtGlobal, jwtMarketingConsent
 #   - passwordSalt
 #   - databaseMongodbURI, databaseGlobalCockroachdbURI, databaseLocalCockroachdbURI
 #

--- a/frontend/desktop/deploy/charts/desktop-frontend/templates/configmap.yaml
+++ b/frontend/desktop/deploy/charts/desktop-frontend/templates/configmap.yaml
@@ -111,6 +111,7 @@ data:
           internal: "{{ .Values.desktopConfig.jwtInternal }}"
           regional: "{{ .Values.desktopConfig.jwtRegional }}"
           global: "{{ .Values.desktopConfig.jwtGlobal }}"
+          marketingConsent: "{{ .Values.desktopConfig.jwtMarketingConsent }}"
         invite:
           enabled: {{ .Values.desktopConfig.inviteEnabled }}
           lafSecretKey: "{{ .Values.desktopConfig.inviteLafSecretKey }}"

--- a/frontend/desktop/deploy/charts/desktop-frontend/values.yaml
+++ b/frontend/desktop/deploy/charts/desktop-frontend/values.yaml
@@ -80,6 +80,7 @@ desktopConfig:
   jwtInternal: ""                  # Auto-fetched from sealos-config.jwtInternal
   jwtRegional: ""                  # Auto-fetched from sealos-config.jwtRegional
   jwtGlobal: ""                    # Auto-fetched from sealos-config.jwtGlobal
+  jwtMarketingConsent: ""           # Auto-fetched from sealos-config.jwtMarketingConsent
 
   # Render-safe defaults for nested layout fields. CI/sealos build may render
   # the chart with only this base values file loaded.

--- a/frontend/desktop/deploy/desktop-frontend-entrypoint.sh
+++ b/frontend/desktop/deploy/desktop-frontend-entrypoint.sh
@@ -63,6 +63,7 @@ if [ "$AUTO_CONFIG_ENABLED" = "true" ]; then
   SEALOS_JWT_INTERNAL=$(get_cm_value sealos-system sealos-config jwtInternal)
   SEALOS_JWT_REGIONAL=$(get_cm_value sealos-system sealos-config jwtRegional)
   SEALOS_JWT_GLOBAL=$(get_cm_value sealos-system sealos-config jwtGlobal)
+  SEALOS_JWT_MARKETING_CONSENT=$(get_cm_value sealos-system sealos-config jwtMarketingConsent)
   SEALOS_REGION_UID=$(get_cm_value sealos-system sealos-config regionUID)
   SEALOS_DATABASE_MONGODB_URI=$(get_cm_value sealos-system sealos-config databaseMongodbURI)
   SEALOS_DATABASE_GLOBAL_COCKROACHDB_URI=$(get_cm_value sealos-system sealos-config databaseGlobalCockroachdbURI)
@@ -83,6 +84,7 @@ if [ "$AUTO_CONFIG_ENABLED" = "true" ]; then
   [ -n "$SEALOS_JWT_INTERNAL" ] && HELM_ARGS="$HELM_ARGS --set-string desktopConfig.jwtInternal=$SEALOS_JWT_INTERNAL"
   [ -n "$SEALOS_JWT_REGIONAL" ] && HELM_ARGS="$HELM_ARGS --set-string desktopConfig.jwtRegional=$SEALOS_JWT_REGIONAL"
   [ -n "$SEALOS_JWT_GLOBAL" ] && HELM_ARGS="$HELM_ARGS --set-string desktopConfig.jwtGlobal=$SEALOS_JWT_GLOBAL"
+  [ -n "$SEALOS_JWT_MARKETING_CONSENT" ] && HELM_ARGS="$HELM_ARGS --set-string desktopConfig.jwtMarketingConsent=$SEALOS_JWT_MARKETING_CONSENT"
   [ -n "$SEALOS_REGION_UID" ] && HELM_ARGS="$HELM_ARGS --set-string desktopConfig.regionUID=$SEALOS_REGION_UID"
   [ -n "$SEALOS_DATABASE_MONGODB_URI" ] && HELM_ARGS="$HELM_ARGS --set-string desktopConfig.databaseMongodbURI=$SEALOS_DATABASE_MONGODB_URI"
   [ -n "$SEALOS_DATABASE_GLOBAL_COCKROACHDB_URI" ] && HELM_ARGS="$HELM_ARGS --set-string desktopConfig.databaseGlobalCockroachdbURI=$SEALOS_DATABASE_GLOBAL_COCKROACHDB_URI"

--- a/frontend/desktop/src/__tests__/unit/backend/auth/marketing-consent.test.ts
+++ b/frontend/desktop/src/__tests__/unit/backend/auth/marketing-consent.test.ts
@@ -1,0 +1,44 @@
+import { verify } from 'jsonwebtoken';
+
+import { generateMarketingConsentToken, marketingConsentJwtSecret } from '@/services/backend/auth';
+
+describe('marketing consent token', () => {
+  const previousConfig = global.AppConfig;
+
+  beforeEach(() => {
+    global.AppConfig = {
+      cloud: { regionUID: 'region-test' },
+      desktop: { auth: { jwt: { marketingConsent: 'marketing-secret-test' } } }
+    } as typeof global.AppConfig;
+  });
+
+  afterEach(() => {
+    global.AppConfig = previousConfig;
+  });
+
+  it('issues a short-lived token with the Brain contract claims', () => {
+    const token = generateMarketingConsentToken({
+      ad_personalization: 'granted',
+      ad_user_data_consent: 'granted',
+      attribution_hash: 'hash-test',
+      region: 'region-test',
+      sub: 'user-test'
+    });
+    const payload = verify(token, marketingConsentJwtSecret(), {
+      audience: 'brain-marketing-attribution',
+      issuer: 'sealos-desktop'
+    });
+
+    expect(payload).toMatchObject({
+      ad_personalization: 'granted',
+      ad_user_data_consent: 'granted',
+      attribution_hash: 'hash-test',
+      consent_source: 'desktop_oauth',
+      region: 'region-test',
+      sub: 'user-test'
+    });
+    expect(payload).toHaveProperty('jti');
+    expect(payload).toHaveProperty('iat');
+    expect(payload).toHaveProperty('exp');
+  });
+});

--- a/frontend/desktop/src/__tests__/unit/utils/marketing-attribution.test.ts
+++ b/frontend/desktop/src/__tests__/unit/utils/marketing-attribution.test.ts
@@ -1,0 +1,55 @@
+import {
+  appendMarketingQuery,
+  marketingQueryFromRecord,
+  mergeMarketingQuery,
+  marketingQueryFromSearch,
+  resolveMarketingQuery
+} from '@/utils/marketing-attribution';
+
+describe('marketing attribution query propagation', () => {
+  it('keeps only the signed attribution parameters from router input', () => {
+    expect(
+      marketingQueryFromRecord({
+        consent_token: 'token-1',
+        sea_attr: ['state-1', 'state-2'],
+        openapp: 'system-brain'
+      })
+    ).toEqual({ consent_token: 'token-1', sea_attr: 'state-1' });
+  });
+
+  it('merges attribution into an app query without changing app parameters', () => {
+    expect(
+      mergeMarketingQuery('templateName=n8n', {
+        consent_token: 'token-1',
+        sea_attr: 'state-1'
+      })
+    ).toBe('templateName=n8n&sea_attr=state-1&consent_token=token-1');
+  });
+
+  it('appends attribution to redirects and parses encoded search strings', () => {
+    const query = marketingQueryFromSearch('?sea_attr=state-1&ignored=value');
+    expect(appendMarketingQuery('/?openapp=system-brain', query)).toBe(
+      '/?openapp=system-brain&sea_attr=state-1'
+    );
+  });
+
+  it('drops a persisted consent token when a new attribution payload arrives', () => {
+    const storage = new Map<string, string>([
+      [
+        'sealos_marketing_query_v1',
+        JSON.stringify({ consent_token: 'old-token', sea_attr: 'old-state' })
+      ]
+    ]);
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('sessionStorage', {
+      getItem: (key: string) => storage.get(key) || null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+      removeItem: (key: string) => storage.delete(key)
+    });
+
+    expect(resolveMarketingQuery({ sea_attr: 'new-state' })).toEqual({
+      sea_attr: 'new-state'
+    });
+    vi.unstubAllGlobals();
+  });
+});

--- a/frontend/desktop/src/api/auth.ts
+++ b/frontend/desktop/src/api/auth.ts
@@ -23,6 +23,11 @@ import { type AxiosInstance } from 'axios';
 import { ProviderType } from 'prisma/global/generated/client';
 import { SubscriptionInfoResponse, WorkspacesPlansResponse } from '@/types/plan';
 
+export const issueMarketingConsentToken = (seaAttr?: string) =>
+  request.post<any, ApiResp<{ token: string }>>('/api/marketing/consent-token', {
+    ...(seaAttr ? { sea_attr: seaAttr } : {})
+  });
+
 export const _getRegionToken = (request: AxiosInstance) => () =>
   request.post<any, ApiResp<{ token: string; kubeconfig: string; appToken: string }>>(
     '/api/auth/regionToken'

--- a/frontend/desktop/src/pages/api/marketing/consent-token.ts
+++ b/frontend/desktop/src/pages/api/marketing/consent-token.ts
@@ -1,0 +1,100 @@
+import { createHash } from 'node:crypto';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { z } from 'zod';
+
+import {
+  ensureGlobalTokenClaims,
+  generateMarketingConsentToken,
+  verifyGlobalJwt
+} from '@/services/backend/auth';
+import { jsonRes } from '@/services/backend/response';
+import type { OAuth2AccessTokenPayload, OAuth2RefreshTokenPayload } from '@/types/token';
+import { SHARED_AUTH_COOKIE_NAME } from '@/utils/cookieUtils';
+
+const requestSchema = z
+  .object({
+    sea_attr: z.string().trim().max(16384).optional()
+  })
+  .strict();
+
+type RawAttribution = {
+  ad_personalization?: unknown;
+  ad_user_data_consent?: unknown;
+};
+
+function decodeAttribution(value: string | undefined): RawAttribution {
+  if (!value) {
+    return {};
+  }
+  try {
+    const decoded = JSON.parse(Buffer.from(value, 'base64url').toString('utf8'));
+    return decoded && typeof decoded === 'object' && !Array.isArray(decoded) ? decoded : {};
+  } catch {
+    return {};
+  }
+}
+
+function consentState(value: unknown): 'granted' | 'denied' | 'unspecified' {
+  if (value === true || value === 'granted') {
+    return 'granted';
+  }
+  if (value === false || value === 'denied') {
+    return 'denied';
+  }
+  return 'unspecified';
+}
+
+function requestToken(req: NextApiRequest): string | undefined {
+  const cookieToken = req.cookies[SHARED_AUTH_COOKIE_NAME];
+  if (cookieToken) {
+    return cookieToken;
+  }
+  const headerToken = req.headers.authorization;
+  if (!headerToken) {
+    return undefined;
+  }
+  try {
+    return decodeURIComponent(headerToken);
+  } catch {
+    return headerToken;
+  }
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return jsonRes(res, { code: 405, message: 'Method not allowed' });
+  }
+
+  try {
+    const payload = await verifyGlobalJwt<OAuth2AccessTokenPayload | OAuth2RefreshTokenPayload>(
+      requestToken(req)
+    );
+    const claims = ensureGlobalTokenClaims(payload);
+    if (!claims) {
+      return jsonRes(res, { code: 401, message: 'Unauthorized' });
+    }
+
+    const parsed = requestSchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return jsonRes(res, { code: 400, message: 'Invalid marketing consent payload' });
+    }
+
+    const attribution = decodeAttribution(parsed.data.sea_attr);
+    const token = generateMarketingConsentToken({
+      ad_personalization: consentState(attribution.ad_personalization),
+      ad_user_data_consent: consentState(attribution.ad_user_data_consent),
+      ...(parsed.data.sea_attr
+        ? {
+            attribution_hash: createHash('sha256').update(parsed.data.sea_attr).digest('hex')
+          }
+        : {}),
+      region: global.AppConfig?.cloud.regionUID || 'unknown',
+      sub: claims.sub
+    });
+
+    return jsonRes(res, { code: 200, data: { token } });
+  } catch (error) {
+    console.error('Marketing consent token error:', error);
+    return jsonRes(res, { code: 503, message: 'Marketing consent signing is unavailable' });
+  }
+}

--- a/frontend/desktop/src/pages/callback.tsx
+++ b/frontend/desktop/src/pages/callback.tsx
@@ -8,6 +8,7 @@ import { isString } from 'lodash';
 import {
   bindRequest,
   getRegionToken,
+  issueMarketingConsentToken,
   signInRequest,
   unBindRequest,
   autoInitRegionToken
@@ -24,6 +25,12 @@ import { useGuideModalStore } from '@/stores/guideModal';
 import { ensureLocaleCookie } from '@/utils/ssrLocale';
 import useAppStore from '@/stores/app';
 import { consumePendingOauth2RedirectPath } from '@/utils/oauth2';
+import {
+  appendMarketingQuery,
+  persistMarketingQuery,
+  resolveMarketingQuery,
+  type MarketingQuery
+} from '@/utils/marketing-attribution';
 
 export default function Callback() {
   const router = useRouter();
@@ -36,6 +43,10 @@ export default function Callback() {
   useEffect(() => {
     if (!router.isReady) return;
     let isProxy: boolean = false;
+    const marketingQuery: MarketingQuery = {
+      ...resolveMarketingQuery(router.query)
+    };
+    persistMarketingQuery(marketingQuery);
     (async () => {
       try {
         if (!provider || !['GITHUB', 'WECHAT', 'GOOGLE', 'OAUTH2'].includes(provider))
@@ -102,22 +113,31 @@ export default function Callback() {
               data.data.error === 'OAUTH_PROVIDER_CONFLICT'
             ) {
               setSigninPageAction('PROMPT_REAUTH_GITHUB');
-              await router.push({
-                pathname: '/signin'
-              });
+              await router.push(appendMarketingQuery('/signin', marketingQuery));
               return;
             }
 
             if (data.data && data.code === 200 && !('error' in data.data)) {
               const globalToken = data.data?.token; // This is the global token from OAuth
               setGlobalToken(globalToken); // Sets global token and cookie
+              if (marketingQuery.sea_attr && !marketingQuery.consent_token) {
+                try {
+                  const consentResult = await issueMarketingConsentToken(marketingQuery.sea_attr);
+                  if (consentResult.data?.token) {
+                    marketingQuery.consent_token = consentResult.data.token;
+                    persistMarketingQuery(marketingQuery);
+                  }
+                } catch (error) {
+                  console.warn('[Callback] Marketing consent token unavailable:', error);
+                }
+              }
               const needInit = data.data.needInit;
 
               // Helper function to handle redirect after login
               const handleLoginRedirect = async () => {
                 const oauth2RedirectPath = consumePendingOauth2RedirectPath();
                 if (oauth2RedirectPath) {
-                  await router.replace(oauth2RedirectPath);
+                  await router.replace(appendMarketingQuery(oauth2RedirectPath, marketingQuery));
                   return;
                 }
                 const appState = useAppStore.getState();
@@ -129,9 +149,11 @@ export default function Callback() {
                   if (appState.autolaunch) {
                     params.append('openapp', appState.autolaunch);
                   }
-                  await router.replace(`/oauth?${params.toString()}`);
+                  await router.replace(
+                    appendMarketingQuery(`/oauth?${params.toString()}`, marketingQuery)
+                  );
                 } else {
-                  await router.replace('/');
+                  await router.replace(appendMarketingQuery('/', marketingQuery));
                 }
               };
 
@@ -181,7 +203,7 @@ export default function Callback() {
               const response = await bindRequest(provider)({ code });
               if (response.message === BIND_STATUS.RESULT_SUCCESS) {
                 setProvider();
-                await router.replace('/');
+                await router.replace(appendMarketingQuery('/', marketingQuery));
               } else if (response.message === MERGE_USER_READY.MERGE_USER_CONTINUE) {
                 const code = response.data?.code;
                 if (!code) return;
@@ -191,19 +213,19 @@ export default function Callback() {
                 });
                 setMergeUserStatus(MergeUserStatus.CANMERGE);
                 setProvider();
-                await router.replace('/');
+                await router.replace(appendMarketingQuery('/', marketingQuery));
               } else if (response.message === MERGE_USER_READY.MERGE_USER_PROVIDER_CONFLICT) {
                 setMergeUserData();
                 setMergeUserStatus(MergeUserStatus.CONFLICT);
                 setProvider();
-                await router.replace('/');
+                await router.replace(appendMarketingQuery('/', marketingQuery));
               }
             } catch (bindError) {
               if ((bindError as any)?.message === MERGE_USER_READY.MERGE_USER_PROVIDER_CONFLICT) {
                 setMergeUserData();
                 setMergeUserStatus(MergeUserStatus.CONFLICT);
                 setProvider();
-                await router.replace('/');
+                await router.replace(appendMarketingQuery('/', marketingQuery));
               } else {
                 console.log('unkownerror', bindError);
                 throw Error();
@@ -212,12 +234,12 @@ export default function Callback() {
           } else if (action === 'UNBIND') {
             await unBindRequest(provider)({ code });
             setProvider();
-            await router.replace('/');
+            await router.replace(appendMarketingQuery('/', marketingQuery));
           }
         }
       } catch (error) {
         console.error(error);
-        await router.replace('/signin');
+        await router.replace(appendMarketingQuery('/signin', marketingQuery));
       }
     })();
   }, [router]);

--- a/frontend/desktop/src/pages/index.tsx
+++ b/frontend/desktop/src/pages/index.tsx
@@ -20,6 +20,13 @@ import type { InitialAppLaunchState } from '@/utils/initialAppTarget';
 import { sessionConfig, setAdClickData, setUserSemData } from '@/utils/sessionConfig';
 import { switchKubeconfigNamespace } from '@/utils/switchKubeconfigNamespace';
 import { ensureLocaleCookie } from '@/utils/ssrLocale';
+import {
+  appendMarketingQuery,
+  mergeMarketingQuery,
+  persistMarketingQuery,
+  resolveMarketingQuery,
+  type MarketingQuery
+} from '@/utils/marketing-attribution';
 import { Box, useColorMode, useDisclosure } from '@chakra-ui/react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import dayjs from 'dayjs';
@@ -176,6 +183,11 @@ export default function Home({ sealos_cloud_domain }: { sealos_cloud_domain: str
       };
     }
 
+    const marketingQuery: MarketingQuery = {
+      ...resolveMarketingQuery(router.query)
+    };
+    persistMarketingQuery(marketingQuery);
+
     const handleInit = async () => {
       initialLaunchInFlightRef.current = true;
       const { query } = router;
@@ -207,7 +219,7 @@ export default function Home({ sealos_cloud_domain }: { sealos_cloud_domain: str
           return;
         }
 
-        let appQuery = raw;
+        let appQuery = appKey === BRAIN_APP_KEY ? mergeMarketingQuery(raw, marketingQuery) : raw;
         let appRoute = pathname;
         if (appKey === BRAIN_APP_KEY && appRoute === '/trial') {
           appRoute = '/';
@@ -309,7 +321,10 @@ export default function Home({ sealos_cloud_domain }: { sealos_cloud_domain: str
           if (parsedOpenApp.appkey && (parsedOpenApp.appQuery || parsedOpenApp.appPath)) {
             setAutoLaunch(
               parsedOpenApp.appkey,
-              { raw: parsedOpenApp.appQuery, pathname: parsedOpenApp.appPath },
+              {
+                raw: mergeMarketingQuery(parsedOpenApp.appQuery, marketingQuery),
+                pathname: parsedOpenApp.appPath
+              },
               workspaceUid
             );
           }
@@ -317,7 +332,7 @@ export default function Home({ sealos_cloud_domain }: { sealos_cloud_domain: str
           if (hasLoggedInBefore) {
             // logged in user (logged out) → redirect to login page
             initialLaunchResolvedRef.current = true;
-            await router.replace('/signin');
+            await router.replace(appendMarketingQuery('/signin', marketingQuery));
             return;
           }
 
@@ -334,7 +349,7 @@ export default function Home({ sealos_cloud_domain }: { sealos_cloud_domain: str
             // Clear guest session
             useSessionStore.getState().delSession();
             initialLaunchResolvedRef.current = true;
-            await router.replace('/signin');
+            await router.replace(appendMarketingQuery('/signin', marketingQuery));
             return;
           }
 

--- a/frontend/desktop/src/pages/oauth.tsx
+++ b/frontend/desktop/src/pages/oauth.tsx
@@ -9,7 +9,7 @@ import { parseOpenappQuery } from '@/utils/format';
 import { gtmLoginStart } from '@/utils/gtm';
 import { ensureLocaleCookie } from '@/utils/ssrLocale';
 import { createTemplateInstance } from '@/api/platform';
-import { getRegionToken, initRegionToken } from '@/api/auth';
+import { getRegionToken, initRegionToken, issueMarketingConsentToken } from '@/api/auth';
 import { nsListRequest, switchRequest } from '@/api/namespace';
 import { SwitchRegionType } from '@/constants/account';
 import { sessionConfig } from '@/utils/sessionConfig';
@@ -19,6 +19,13 @@ import { jwtDecode } from 'jwt-decode';
 import { isString } from 'lodash';
 import { useMutation } from '@tanstack/react-query';
 import { useCustomToast } from '@/hooks/useCustomToast';
+import {
+  appendMarketingQuery,
+  mergeMarketingQuery,
+  persistMarketingQuery,
+  resolveMarketingQuery,
+  type MarketingQuery
+} from '@/utils/marketing-attribution';
 
 export default function OAuth() {
   const router = useRouter();
@@ -74,7 +81,29 @@ export default function OAuth() {
       workspaceName
     } = router.query;
 
-    const openBrainTemplateDeploy = async () => {
+    const marketingQuery: MarketingQuery = {
+      ...resolveMarketingQuery(router.query)
+    };
+    persistMarketingQuery(marketingQuery);
+
+    const ensureMarketingConsentToken = async (): Promise<MarketingQuery> => {
+      if (!marketingQuery.sea_attr || marketingQuery.consent_token) {
+        return marketingQuery;
+      }
+      try {
+        const result = await issueMarketingConsentToken(marketingQuery.sea_attr);
+        const token = result.data?.token;
+        if (token) {
+          marketingQuery.consent_token = token;
+          persistMarketingQuery(marketingQuery);
+        }
+      } catch (error) {
+        console.warn('[OAuth] Marketing consent token unavailable:', error);
+      }
+      return marketingQuery;
+    };
+
+    const openBrainTemplateDeploy = async (activeMarketingQuery = marketingQuery) => {
       if (
         openapp !== 'system-brain' ||
         typeof templateName !== 'string' ||
@@ -87,13 +116,14 @@ export default function OAuth() {
         templateName,
         templateForm
       });
+      const rawQuery = mergeMarketingQuery(brainDeployQuery.toString(), activeMarketingQuery);
 
       setAutoLaunch('system-brain', {
         pathname: '/deploy',
-        raw: brainDeployQuery.toString()
+        raw: rawQuery
       });
       cancelAutoDeployTemplate();
-      await router.replace('/');
+      await router.replace(appendMarketingQuery('/', activeMarketingQuery));
 
       return true;
     };
@@ -150,7 +180,9 @@ export default function OAuth() {
           }
         }
 
-        if (await openBrainTemplateDeploy()) {
+        const activeMarketingQuery = await ensureMarketingConsentToken();
+
+        if (await openBrainTemplateDeploy(activeMarketingQuery)) {
           return;
         }
 
@@ -170,10 +202,16 @@ export default function OAuth() {
 
           const { appkey, appQuery, appPath } = parseOpenappQuery(finalOpenapp);
           if (appkey) {
-            setAutoLaunch(appkey, { raw: appQuery, pathname: appPath });
+            setAutoLaunch(appkey, {
+              raw: mergeMarketingQuery(appQuery, activeMarketingQuery),
+              pathname: appPath
+            });
           }
 
-          const redirectUrl = `/?openapp=${encodeURIComponent(finalOpenapp)}`;
+          const redirectUrl = appendMarketingQuery(
+            `/?openapp=${encodeURIComponent(finalOpenapp)}`,
+            activeMarketingQuery
+          );
           await router.replace(redirectUrl);
           if (deploymentError) {
             setTimeout(() => {
@@ -187,7 +225,7 @@ export default function OAuth() {
             }, 500);
           }
         } else {
-          await router.replace('/');
+          await router.replace(appendMarketingQuery('/', activeMarketingQuery));
           if (deploymentError) {
             setTimeout(() => {
               toast({
@@ -202,7 +240,7 @@ export default function OAuth() {
         }
       } catch (error) {
         setGlobalToken('');
-        await router.replace('/signin');
+        await router.replace(appendMarketingQuery('/signin', marketingQuery));
       }
     };
 
@@ -292,13 +330,17 @@ export default function OAuth() {
         try {
           const { appkey, appQuery, appPath } = parseOpenappQuery(openapp);
           if (appkey) {
-            setAutoLaunch(appkey, { raw: appQuery, pathname: appPath });
+            setAutoLaunch(appkey, {
+              raw: mergeMarketingQuery(appQuery, marketingQuery),
+              pathname: appPath
+            });
           }
         } catch (error) {}
       }
     };
 
     const handleOAuthLogin = async (provider: OauthProvider) => {
+      persistMarketingQuery(marketingQuery);
       gtmLoginStart();
       const state = generateState();
       setProvider(provider);
@@ -371,12 +413,12 @@ export default function OAuth() {
             break;
           }
           default: {
-            router.replace('/signin');
+            router.replace(appendMarketingQuery('/signin', marketingQuery));
             return;
           }
         }
       } catch (error) {
-        router.replace('/signin');
+        router.replace(appendMarketingQuery('/signin', marketingQuery));
       }
     };
 
@@ -389,7 +431,8 @@ export default function OAuth() {
       hasProcessedRef.current = true;
 
       (async () => {
-        if (await openBrainTemplateDeploy()) {
+        const activeMarketingQuery = await ensureMarketingConsentToken();
+        if (await openBrainTemplateDeploy(activeMarketingQuery)) {
           return;
         }
 
@@ -420,7 +463,7 @@ export default function OAuth() {
             }
 
             const redirectUrl = `/?openapp=${encodeURIComponent(finalOpenapp)}`;
-            router.replace(redirectUrl);
+            router.replace(appendMarketingQuery(redirectUrl, activeMarketingQuery));
 
             if (deploymentError) {
               setTimeout(() => {
@@ -434,7 +477,7 @@ export default function OAuth() {
               }, 500);
             }
           } else {
-            router.replace('/');
+            router.replace(appendMarketingQuery('/', activeMarketingQuery));
 
             if (deploymentError) {
               setTimeout(() => {
@@ -457,7 +500,7 @@ export default function OAuth() {
     handleSaveParams();
 
     if (!login || typeof login !== 'string') {
-      router.replace('/signin');
+      router.replace(appendMarketingQuery('/signin', marketingQuery));
       return;
     }
 
@@ -466,7 +509,7 @@ export default function OAuth() {
     } else if (login === 'google' && authConfig.idp.google?.enabled) {
       handleOAuthLogin('GOOGLE');
     } else {
-      router.replace('/signin');
+      router.replace(appendMarketingQuery('/signin', marketingQuery));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router.isReady, router.query, authConfig]);

--- a/frontend/desktop/src/services/backend/auth.ts
+++ b/frontend/desktop/src/services/backend/auth.ts
@@ -9,6 +9,7 @@ import {
   OAuth2RefreshTokenPayload,
   OnceTokenPayload
 } from '@/types/token';
+import { randomUUID } from 'node:crypto';
 import { IncomingHttpHeaders } from 'http';
 import { sign, verify } from 'jsonwebtoken';
 
@@ -16,6 +17,8 @@ const regionUID = () => global.AppConfig?.cloud.regionUID || '123456789';
 export const globalJwtSecret = () => global.AppConfig?.desktop.auth.jwt.global || '123456789';
 const regionalJwtSecret = () => global.AppConfig?.desktop.auth.jwt.regional || '123456789';
 const internalJwtSecret = () => global.AppConfig?.desktop.auth.jwt.internal || '123456789';
+export const marketingConsentJwtSecret = () =>
+  global.AppConfig?.desktop.auth.jwt.marketingConsent || '';
 
 const ACCESS_TOKEN_TYPE = 'access_token' as const;
 const REFRESH_TOKEN_TYPE = 'refresh_token' as const;
@@ -240,6 +243,38 @@ export const generateGlobalAccessToken = (
     },
     expiresIn
   );
+
+export type MarketingConsentState = 'granted' | 'denied' | 'unspecified';
+
+export type MarketingConsentTokenInput = {
+  ad_personalization: MarketingConsentState;
+  ad_user_data_consent: MarketingConsentState;
+  attribution_hash?: string;
+  region: string;
+  sub: string;
+};
+
+/** Issues the short-lived, server-authenticated consent receipt consumed by Brain. */
+export const generateMarketingConsentToken = (props: MarketingConsentTokenInput) => {
+  const secret = marketingConsentJwtSecret();
+  if (!secret) {
+    throw new Error('Marketing consent signing secret is not configured');
+  }
+  return sign(
+    {
+      ...props,
+      consent_source: 'desktop_oauth'
+    },
+    secret,
+    {
+      algorithm: 'HS256',
+      audience: 'brain-marketing-attribution',
+      expiresIn: '15m',
+      issuer: 'sealos-desktop',
+      jwtid: randomUUID()
+    }
+  );
+};
 
 const verifyOAuth2TokenByType = async (
   token: string | undefined,

--- a/frontend/desktop/src/stores/app.ts
+++ b/frontend/desktop/src/stores/app.ts
@@ -310,7 +310,8 @@ const useAppStore = create<TOSState>()(
 
           const iframe = document.getElementById(`app-window-${appKey}`) as HTMLIFrameElement;
           if (!iframe) return;
-          iframe.contentWindow?.postMessage(messageData, app.data.url);
+          const targetOrigin = new URL(app.data.url, window.location.origin).origin;
+          iframe.contentWindow?.postMessage(messageData, targetOrigin);
         },
         // maximize app
         switchAppById: (pid: number) => {

--- a/frontend/desktop/src/types/system.ts
+++ b/frontend/desktop/src/types/system.ts
@@ -242,6 +242,7 @@ export type JwtConfigType = {
   internal?: string;
   regional?: string;
   global?: string;
+  marketingConsent?: string;
 };
 
 export type DesktopConfigType<T = AuthConfigType> = {

--- a/frontend/desktop/src/utils/marketing-attribution.ts
+++ b/frontend/desktop/src/utils/marketing-attribution.ts
@@ -1,0 +1,104 @@
+const MARKETING_QUERY_KEYS = ['sea_attr', 'consent_token'] as const;
+const MARKETING_QUERY_STORAGE_KEY = 'sealos_marketing_query_v1';
+
+export type MarketingQuery = Partial<Record<(typeof MARKETING_QUERY_KEYS)[number], string>>;
+
+function firstQueryValue(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim()) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    const first = value.find((item) => typeof item === 'string' && item.trim());
+    return typeof first === 'string' ? first : undefined;
+  }
+  return undefined;
+}
+
+export function marketingQueryFromRecord(record: Record<string, unknown>): MarketingQuery {
+  const result: MarketingQuery = {};
+  for (const key of MARKETING_QUERY_KEYS) {
+    const value = firstQueryValue(record[key]);
+    if (value) {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+export function marketingQueryFromSearch(search: string): MarketingQuery {
+  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+  return marketingQueryFromRecord(Object.fromEntries(params.entries()));
+}
+
+export function resolveMarketingQuery(record: Record<string, unknown>): MarketingQuery {
+  const persisted = readPersistedMarketingQuery();
+  const current = marketingQueryFromRecord(record);
+  const query = { ...persisted, ...current };
+  if (current.sea_attr && current.sea_attr !== persisted.sea_attr && !current.consent_token) {
+    delete query.consent_token;
+  }
+  return query;
+}
+
+export function hasMarketingQuery(query: MarketingQuery): boolean {
+  return MARKETING_QUERY_KEYS.some((key) => !!query[key]);
+}
+
+export function mergeMarketingQuery(raw: string | undefined, query: MarketingQuery): string {
+  const params = new URLSearchParams(raw || '');
+  for (const key of MARKETING_QUERY_KEYS) {
+    const value = query[key];
+    if (value && !params.has(key)) {
+      params.set(key, value);
+    }
+  }
+  return params.toString();
+}
+
+export function appendMarketingQuery(path: string, query: MarketingQuery): string {
+  if (!hasMarketingQuery(query)) {
+    return path;
+  }
+  const url = new URL(path, 'https://desktop.sealos.local');
+  for (const key of MARKETING_QUERY_KEYS) {
+    const value = query[key];
+    if (value) {
+      url.searchParams.set(key, value);
+    }
+  }
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+export function persistMarketingQuery(query: MarketingQuery): void {
+  if (!hasMarketingQuery(query) || typeof window === 'undefined') {
+    return;
+  }
+  try {
+    sessionStorage.setItem(MARKETING_QUERY_STORAGE_KEY, JSON.stringify(query));
+  } catch {
+    // Session storage is optional in private browsing contexts.
+  }
+}
+
+export function readPersistedMarketingQuery(): MarketingQuery {
+  if (typeof window === 'undefined') {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(sessionStorage.getItem(MARKETING_QUERY_STORAGE_KEY) || '{}');
+    return marketingQueryFromRecord(parsed && typeof parsed === 'object' ? parsed : {});
+  } catch {
+    return {};
+  }
+}
+
+export function clearPersistedMarketingQuery(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    sessionStorage.removeItem(MARKETING_QUERY_STORAGE_KEY);
+  } catch {
+    // Session storage is optional in private browsing contexts.
+  }
+}


### PR DESCRIPTION
## Summary

Adds the Desktop side of the consent-safe Google Ads attribution contract used by Brain #259.

## Changes

- Preserve the allowlisted `sea_attr` and `consent_token` parameters through OAuth, callback, sign-in redirects, openapp, autolaunch, and Brain iframe URLs.
- Store the marketing query in session storage and drop a stale consent token when a new attribution payload arrives.
- Issue a short-lived HS256 consent token from an authenticated Desktop OAuth backend endpoint.
- Bind token claims to the authenticated subject, region, issuer, audience, consent state, and attribution hash.
- Add the shared `jwtMarketingConsent` Helm/ConfigMap configuration path.
- Restrict iframe postMessage delivery to the app origin.
- Add unit coverage for token claims and query propagation.

## Dependency

The Brain consumer and migration live in [labring/brain#259](https://github.com/labring/brain/pull/259). Production rollout requires the same signing secret in Desktop and Brain plus the platform ConfigMap entry.

## Verification

- [x] Desktop TypeScript check from `frontend/desktop`
- [x] Desktop unit tests: 113 passed, 2 todo
- [x] Focused attribution and consent tests pass
- [x] Prettier check for changed files
- [ ] Helm rendering: local `helm` binary unavailable

