### PR TITLE
fix(dbprovider): align disk unit labels

### DIFF
--- a/frontend/providers/dbprovider/src/components/QuotaBox/index.tsx
+++ b/frontend/providers/dbprovider/src/components/QuotaBox/index.tsx
@@ -16,7 +16,7 @@ const sourceMap = {
   },
   storage: {
     color: '#8172D8',
-    unit: 'GB'
+    unit: 'Gi'
   },
   gpu: {
     color: '#89CD11',

--- a/frontend/providers/dbprovider/src/pages/db/edit/components/Form.tsx
+++ b/frontend/providers/dbprovider/src/pages/db/edit/components/Form.tsx
@@ -171,7 +171,7 @@ function ResourcesDistributeTable({ data }: { data: Parameters<typeof distribute
                         <Td w="190px">{keyName}</Td>
                         <Td>{value.cpuMemory.limits.cpu}</Td>
                         <Td>{value.cpuMemory.limits.memory}</Td>
-                        <Td>{value.storage} G</Td>
+                        <Td>{value.storage} Gi</Td>
                         <Td>{value.other?.replicas ?? data.replicas}</Td>
                       </Tr>
                     );


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->

## Summary
This fixes DBProvider disk quota display labels so the edit and migrate quota panels, plus the edit resource distribution table, use `Gi` consistently with the detail/list experience.

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant DBProviderUI
    participant QuotaBox
    participant EditForm

    User->>DBProviderUI: Open database edit or migrate flow
    DBProviderUI->>QuotaBox: Render storage quota label
    QuotaBox-->>DBProviderUI: Show storage unit as Gi
    DBProviderUI->>EditForm: Render distributed resources
    EditForm-->>User: Show storage allocation as Gi
```

## Verification
`git diff --check origin/release-v5.1...HEAD` passed, and `pnpm --dir frontend/providers/dbprovider lint` passed with existing React hook warnings.
`pnpm --dir frontend/providers/dbprovider typecheck` is blocked by the existing SVG import declaration issue at `src/components/ErrorLog/LogCounts.tsx`, where TypeScript cannot resolve `@/components/Icon/icons/emptyChart.svg`.
