### PR TITLE
fix(template): hide recharge action when payment is unavailable

### DIFF
--- a/frontend/providers/template/src/api/platform.ts
+++ b/frontend/providers/template/src/api/platform.ts
@@ -2,6 +2,7 @@ import { EnvResponse } from '@/types/index';
 import { GET } from '@/services/request';
 import { SystemConfigType, TemplateType } from '@/types/app';
 import type { UserTask, userPriceType } from '@/types/user';
+import type { PaymentConfigResponse } from '@/pages/api/platform/paymentConfig';
 import useSessionStore from '@/store/session';
 
 export const updateRepo = () => GET('/api/updateRepo');
@@ -20,6 +21,8 @@ export const getSystemConfig = () => {
 };
 
 export const getResourcePrice = () => GET<userPriceType>('/api/platform/resourcePrice');
+
+export const getPaymentConfig = () => GET<PaymentConfigResponse>('/api/platform/paymentConfig');
 
 export const getUserTasks = () =>
   GET<{ needGuide: boolean; task: UserTask }>('/api/guide/getTasks', undefined, {

--- a/frontend/providers/template/src/instrumentation.ts
+++ b/frontend/providers/template/src/instrumentation.ts
@@ -1,6 +1,9 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const applyRuntimeAppConfigEnv = (await import('./utils/appConfig')).applyRuntimeAppConfigEnv;
     const updateRepo = (await import('./services/backend/template-repo')).updateRepo;
+
+    applyRuntimeAppConfigEnv();
 
     console.log('[Instrumentation Hook] Trying to update templates repository.');
     await updateRepo()

--- a/frontend/providers/template/src/pages/api/platform/getClientAppConfig.ts
+++ b/frontend/providers/template/src/pages/api/platform/getClientAppConfig.ts
@@ -1,0 +1,51 @@
+import { jsonRes } from '@/services/backend/response';
+import {
+  getRuntimeCategories,
+  getRuntimeCurrencySymbol,
+  getRuntimeDesktopDomain,
+  readRuntimeAppConfig,
+  type TemplateCategory
+} from '@/utils/appConfig';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+type ClientAppConfig = {
+  brandName: string;
+  carousel: {
+    enabled: boolean;
+    slides: unknown[];
+  };
+  categories: TemplateCategory[];
+  showAuthor: boolean;
+  currencySymbol: 'shellCoin' | 'cny' | 'usd';
+  desktopDomain: string;
+};
+
+export function getClientAppConfigServer(): ClientAppConfig {
+  const config = readRuntimeAppConfig();
+  const templateConfig = config.template;
+  const uiConfig = templateConfig?.ui;
+  const carousel = uiConfig?.carousel;
+  const slides = carousel?.slides;
+  const carouselSlides = Array.isArray(slides) ? slides : [];
+
+  return {
+    brandName: uiConfig?.brandName || process.env.NEXT_PUBLIC_BRAND_NAME || 'Sealos',
+    carousel: {
+      enabled: carousel?.enabled === true,
+      slides: carouselSlides
+    },
+    categories: getRuntimeCategories(templateConfig?.categories),
+    showAuthor: templateConfig?.features?.showAuthor ?? process.env.SHOW_AUTHOR === 'true',
+    currencySymbol: getRuntimeCurrencySymbol(
+      uiConfig?.currencySymbol || uiConfig?.currencySymbolType || process.env.CURRENCY_SYMBOL
+    ),
+    desktopDomain: getRuntimeDesktopDomain(config)
+  };
+}
+
+export default async function handler(_req: NextApiRequest, res: NextApiResponse) {
+  jsonRes<ClientAppConfig>(res, {
+    code: 200,
+    data: getClientAppConfigServer()
+  });
+}

--- a/frontend/providers/template/src/pages/api/platform/getSystemConfig.ts
+++ b/frontend/providers/template/src/pages/api/platform/getSystemConfig.ts
@@ -1,5 +1,6 @@
 import { jsonRes } from '@/services/backend/response';
 import { ApplicationType, SystemConfigType } from '@/types/app';
+import { readRuntimeAppConfig } from '@/utils/appConfig';
 import { readFileSync } from 'fs';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
@@ -23,6 +24,16 @@ export async function getSystemConfig(): Promise<SystemConfigType> {
     const res = JSON.parse(readFileSync(filename, 'utf-8')) as SystemConfigType;
     return res;
   } catch (error) {
+    const carousel = readRuntimeAppConfig().template?.ui?.carousel;
+    if (carousel) {
+      return {
+        showCarousel: carousel.enabled === true,
+        slideData: Array.isArray(carousel.slides)
+          ? (carousel.slides as SystemConfigType['slideData'])
+          : []
+      };
+    }
+
     console.log('-getSystemConfig-\n', error);
     return defaultConfig;
   }

--- a/frontend/providers/template/src/pages/api/platform/paymentConfig.ts
+++ b/frontend/providers/template/src/pages/api/platform/paymentConfig.ts
@@ -1,5 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { jsonRes } from '@/services/backend/response';
+import {
+  getRuntimeCloudPort,
+  getRuntimeDesktopDomain,
+  readRuntimeAppConfig
+} from '@/utils/appConfig';
 
 type CostCenterConfigResponse = {
   code: number;
@@ -16,8 +21,9 @@ export type PaymentConfigResponse = {
 };
 
 const getCostCenterConfigUrl = () => {
-  const domain = process.env.DESKTOP_DOMAIN || process.env.SEALOS_CLOUD_DOMAIN || 'cloud.sealos.io';
-  const port = process.env.SEALOS_CLOUD_PORT;
+  const config = readRuntimeAppConfig();
+  const domain = getRuntimeDesktopDomain(config);
+  const port = getRuntimeCloudPort(config);
   const portSuffix = port && port !== '443' && port !== '80' ? `:${port}` : '';
 
   return `https://costcenter.${domain}${portSuffix}/api/platform/getAppConfig`;

--- a/frontend/providers/template/src/pages/api/platform/paymentConfig.ts
+++ b/frontend/providers/template/src/pages/api/platform/paymentConfig.ts
@@ -1,0 +1,52 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { jsonRes } from '@/services/backend/response';
+
+type CostCenterConfigResponse = {
+  code: number;
+  data?: {
+    RECHARGE_ENABLED?: boolean;
+    STRIPE_ENABLED?: boolean;
+    WECHAT_ENABLED?: boolean;
+    ALIPAY_ENABLED?: boolean;
+  };
+};
+
+export type PaymentConfigResponse = {
+  paymentEnabled: boolean;
+};
+
+const getCostCenterConfigUrl = () => {
+  const domain = process.env.DESKTOP_DOMAIN || process.env.SEALOS_CLOUD_DOMAIN || 'cloud.sealos.io';
+  const port = process.env.SEALOS_CLOUD_PORT;
+  const portSuffix = port && port !== '443' && port !== '80' ? `:${port}` : '';
+
+  return `https://costcenter.${domain}${portSuffix}/api/platform/getAppConfig`;
+};
+
+export default async function handler(_req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const response = await fetch(getCostCenterConfigUrl());
+
+    if (!response.ok) {
+      throw new Error(`CostCenter config request failed with status ${response.status}`);
+    }
+
+    const result = (await response.json()) as CostCenterConfigResponse;
+    const config = result.data;
+    const hasPaymentMethod =
+      !!config?.STRIPE_ENABLED || !!config?.WECHAT_ENABLED || !!config?.ALIPAY_ENABLED;
+
+    jsonRes<PaymentConfigResponse>(res, {
+      data: {
+        paymentEnabled: !!config?.RECHARGE_ENABLED && hasPaymentMethod
+      }
+    });
+  } catch (error) {
+    console.log('error: /api/platform/paymentConfig', error);
+    jsonRes<PaymentConfigResponse>(res, {
+      data: {
+        paymentEnabled: false
+      }
+    });
+  }
+}

--- a/frontend/providers/template/src/pages/deploy/components/ErrorModal.tsx
+++ b/frontend/providers/template/src/pages/deploy/components/ErrorModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Modal,
   ModalOverlay,
@@ -14,6 +14,7 @@ import MyIcon from '@/components/Icon';
 import { useTranslation } from 'next-i18next';
 import { ResponseCode } from '@/types/response';
 import { sealosApp } from 'sealos-desktop-sdk/app';
+import { getPaymentConfig } from '@/api/platform';
 
 const ErrorModal = ({
   title,
@@ -27,6 +28,37 @@ const ErrorModal = ({
   errorCode?: ResponseCode;
 }) => {
   const { t } = useTranslation();
+  const [paymentEnabled, setPaymentEnabled] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let ignore = false;
+
+    if (errorCode !== ResponseCode.BALANCE_NOT_ENOUGH) {
+      setPaymentEnabled(null);
+      return;
+    }
+
+    setPaymentEnabled(null);
+    getPaymentConfig()
+      .then((config) => {
+        if (!ignore) {
+          setPaymentEnabled(config.paymentEnabled);
+        }
+      })
+      .catch(() => {
+        if (!ignore) {
+          setPaymentEnabled(false);
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [errorCode]);
+
+  const shouldRecharge = errorCode === ResponseCode.BALANCE_NOT_ENOUGH && paymentEnabled === true;
+  const isCheckingPayment =
+    errorCode === ResponseCode.BALANCE_NOT_ENOUGH && paymentEnabled === null;
 
   const openCostCenterApp = () => {
     sealosApp.runEvents('openDesktopApp', {
@@ -52,24 +84,27 @@ const ErrorModal = ({
           {content}
         </ModalBody>
         <ModalFooter>
+          {(errorCode !== ResponseCode.BALANCE_NOT_ENOUGH || shouldRecharge) && (
+            <Button
+              onClick={() => {
+                onClose();
+              }}
+              variant={'outline'}
+            >
+              {t('Cancel')}
+            </Button>
+          )}
           <Button
+            ml={errorCode !== ResponseCode.BALANCE_NOT_ENOUGH || shouldRecharge ? '12px' : 0}
+            isDisabled={isCheckingPayment}
             onClick={() => {
-              onClose();
-            }}
-            variant={'outline'}
-          >
-            {t('Cancel')}
-          </Button>
-          <Button
-            ml={'12px'}
-            onClick={() => {
-              if (errorCode === ResponseCode.BALANCE_NOT_ENOUGH) {
+              if (shouldRecharge) {
                 openCostCenterApp();
               }
               onClose();
             }}
           >
-            {errorCode === ResponseCode.BALANCE_NOT_ENOUGH ? t('add_credit') : t('Confirm')}
+            {shouldRecharge ? t('add_credit') : t('Confirm')}
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/frontend/providers/template/src/utils/appConfig.ts
+++ b/frontend/providers/template/src/utils/appConfig.ts
@@ -1,0 +1,135 @@
+import { existsSync, readFileSync } from 'fs';
+import JsYaml from 'js-yaml';
+
+export type TemplateCategory = {
+  slug: string;
+  i18n: Record<string, string>;
+};
+
+export type RuntimeAppConfig = {
+  cloud?: {
+    domain?: string;
+    port?: number;
+    certSecretName?: string;
+  };
+  template?: {
+    ui?: {
+      brandName?: string;
+      forcedLanguage?: string;
+      currencySymbol?: string;
+      currencySymbolType?: string;
+      carousel?: {
+        enabled?: boolean;
+        slides?: unknown[];
+      };
+    };
+    repo?: {
+      url?: string;
+      branch?: string;
+      localDir?: string;
+    };
+    features?: {
+      showAuthor?: boolean;
+      fetchReadme?: boolean;
+      guide?: boolean;
+    };
+    categories?: TemplateCategory[];
+    desktopDomain?: string;
+    userDomain?: string;
+    billingUrl?: string;
+  };
+};
+
+export const DEFAULT_TEMPLATE_CATEGORIES: TemplateCategory[] = [
+  { slug: 'ai', i18n: { en: 'AI', zh: 'AI' } },
+  { slug: 'backend', i18n: { en: 'Backend', zh: '后端' } },
+  { slug: 'blog', i18n: { en: 'Blog', zh: '博客' } },
+  { slug: 'database', i18n: { en: 'Database', zh: '数据库' } },
+  { slug: 'dev-ops', i18n: { en: 'DevOps', zh: '运维' } },
+  { slug: 'frontend', i18n: { en: 'Frontend', zh: '前端' } },
+  { slug: 'game', i18n: { en: 'Games', zh: '游戏' } },
+  { slug: 'low-code', i18n: { en: 'Low-Code', zh: '低代码' } },
+  { slug: 'monitor', i18n: { en: 'Monitoring', zh: '监控' } }
+];
+
+const CONFIG_PATH = '/app/data/config.yaml';
+
+export function readRuntimeAppConfig(): RuntimeAppConfig {
+  try {
+    if (!existsSync(CONFIG_PATH)) return {};
+    return (JsYaml.load(readFileSync(CONFIG_PATH, 'utf-8')) || {}) as RuntimeAppConfig;
+  } catch (error) {
+    console.log('[App Config] Failed to read runtime config:', error);
+    return {};
+  }
+}
+
+export function getRuntimeCurrencySymbol(value?: string): 'shellCoin' | 'cny' | 'usd' {
+  if (value === 'cny' || value === 'usd') return value;
+  return 'shellCoin';
+}
+
+export function getRuntimeCategories(value?: TemplateCategory[]): TemplateCategory[] {
+  if (!Array.isArray(value)) return DEFAULT_TEMPLATE_CATEGORIES;
+
+  const categories = value.filter(
+    (category): category is TemplateCategory =>
+      typeof category?.slug === 'string' &&
+      !!category.slug &&
+      typeof category?.i18n === 'object' &&
+      category.i18n !== null
+  );
+
+  return categories.length > 0 ? categories : DEFAULT_TEMPLATE_CATEGORIES;
+}
+
+export function getRuntimeCloudDomain(config: RuntimeAppConfig = readRuntimeAppConfig()) {
+  return (
+    process.env.SEALOS_USER_DOMAIN ||
+    config.template?.userDomain ||
+    config.cloud?.domain ||
+    process.env.SEALOS_CLOUD_DOMAIN ||
+    'cloud.sealos.io'
+  );
+}
+
+export function getRuntimeDesktopDomain(config: RuntimeAppConfig = readRuntimeAppConfig()) {
+  return (
+    config.template?.desktopDomain || process.env.DESKTOP_DOMAIN || getRuntimeCloudDomain(config)
+  );
+}
+
+export function getRuntimeCloudPort(config: RuntimeAppConfig = readRuntimeAppConfig()) {
+  return process.env.SEALOS_CLOUD_PORT || String(config.cloud?.port || '');
+}
+
+function setRuntimeEnv(name: string, value: boolean | number | string | undefined) {
+  if (value === undefined || value === '') return;
+  if (process.env[name] !== undefined && process.env[name] !== '') return;
+
+  process.env[name] = String(value);
+}
+
+export function applyRuntimeAppConfigEnv() {
+  const config = readRuntimeAppConfig();
+  const cloud = config.cloud;
+  const template = config.template;
+
+  setRuntimeEnv('SEALOS_CLOUD_DOMAIN', cloud?.domain);
+  setRuntimeEnv('SEALOS_CLOUD_PORT', cloud?.port);
+  setRuntimeEnv('SEALOS_CERT_SECRET_NAME', cloud?.certSecretName);
+  setRuntimeEnv('SEALOS_USER_DOMAIN', template?.userDomain);
+  setRuntimeEnv('TEMPLATE_REPO_URL', template?.repo?.url);
+  setRuntimeEnv('TEMPLATE_REPO_BRANCH', template?.repo?.branch);
+  setRuntimeEnv('TEMPLATE_REPO_FOLDER', template?.repo?.localDir);
+  setRuntimeEnv('SHOW_AUTHOR', template?.features?.showAuthor);
+  setRuntimeEnv('DESKTOP_DOMAIN', template?.desktopDomain);
+  setRuntimeEnv(
+    'CURRENCY_SYMBOL',
+    template?.ui?.currencySymbol || template?.ui?.currencySymbolType
+  );
+  setRuntimeEnv('FORCED_LANGUAGE', template?.ui?.forcedLanguage);
+  setRuntimeEnv('ENABLE_README_FETCH', template?.features?.fetchReadme);
+  setRuntimeEnv('GUIDE_ENABLED', template?.features?.guide);
+  setRuntimeEnv('BILLING_URL', template?.billingUrl);
+}


### PR DESCRIPTION
## Summary

Hide the template deploy recharge action when the platform has recharge disabled or no active payment method.
Add a template API route that reads CostCenter payment flags and fails closed when the config request cannot be completed.
Keep the normal confirm path for non-balance errors and while payment availability is unavailable.

## Sequence Diagram

```mermaid
sequenceDiagram
    participant User
    participant TemplateDeploy as Template Deploy Error Modal
    participant TemplateAPI as Template paymentConfig API
    participant CostCenter as CostCenter getAppConfig

    User->>TemplateDeploy: Trigger a balance-not-enough deploy error
    TemplateDeploy->>TemplateAPI: Request payment availability
    TemplateAPI->>CostCenter: Read recharge and payment method flags
    CostCenter-->>TemplateAPI: Return payment configuration
    alt Recharge and a payment method are enabled
        TemplateAPI-->>TemplateDeploy: paymentEnabled=true
        TemplateDeploy-->>User: Show recharge action
    else Payment is unavailable or config lookup fails
        TemplateAPI-->>TemplateDeploy: paymentEnabled=false
        TemplateDeploy-->>User: Show confirm-only action
    end
```

## Tests

- `git diff --check origin/main...HEAD`
- `pnpm --filter template build`
