### PR TITLE
feat(service): add health endpoints and Kubernetes probes

### DIFF
--- a/service/database/deploy/charts/database-monitor/database-monitor-values.yaml
+++ b/service/database/deploy/charts/database-monitor/database-monitor-values.yaml
@@ -10,5 +10,20 @@ resources:
     cpu: 5m
     memory: 64Mi
 
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 9090
+  initialDelaySeconds: 3
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 9090
+  initialDelaySeconds: 3
+  periodSeconds: 5
+  failureThreshold: 6
+
 databaseMonitorConfig:
   prometheusServiceHost: "http://vmselect-vm-stack-victoria-metrics-k8s-stack.vm.svc:8481/select/0/prometheus/"

--- a/service/database/deploy/charts/database-monitor/database-monitor-values.yaml
+++ b/service/database/deploy/charts/database-monitor/database-monitor-values.yaml
@@ -10,6 +10,14 @@ resources:
     cpu: 5m
     memory: 64Mi
 
+startupProbe:
+  httpGet:
+    path: /health
+    port: 9090
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 30
+
 livenessProbe:
   httpGet:
     path: /health

--- a/service/database/deploy/charts/database-monitor/templates/deployment.yaml
+++ b/service/database/deploy/charts/database-monitor/templates/deployment.yaml
@@ -34,6 +34,8 @@ spec:
           ports:
             - containerPort: {{ .Values.service.port }}
               protocol: TCP
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/service/database/deploy/charts/database-monitor/templates/deployment.yaml
+++ b/service/database/deploy/charts/database-monitor/templates/deployment.yaml
@@ -34,6 +34,19 @@ spec:
           ports:
             - containerPort: {{ .Values.service.port }}
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.service.port }}
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.service.port }}
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            failureThreshold: 6
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/service/database/deploy/charts/database-monitor/templates/deployment.yaml
+++ b/service/database/deploy/charts/database-monitor/templates/deployment.yaml
@@ -35,18 +35,9 @@ spec:
             - containerPort: {{ .Values.service.port }}
               protocol: TCP
           livenessProbe:
-            httpGet:
-              path: /health
-              port: {{ .Values.service.port }}
-            initialDelaySeconds: 3
-            periodSeconds: 10
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /health
-              port: {{ .Values.service.port }}
-            initialDelaySeconds: 3
-            periodSeconds: 5
-            failureThreshold: 6
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/service/database/deploy/charts/database-monitor/values.yaml
+++ b/service/database/deploy/charts/database-monitor/values.yaml
@@ -14,6 +14,14 @@ resources:
 service:
   port: 9090
 
+startupProbe:
+  httpGet:
+    path: /health
+    port: 9090
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 30
+
 livenessProbe:
   httpGet:
     path: /health

--- a/service/database/deploy/charts/database-monitor/values.yaml
+++ b/service/database/deploy/charts/database-monitor/values.yaml
@@ -14,5 +14,20 @@ resources:
 service:
   port: 9090
 
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 9090
+  initialDelaySeconds: 3
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 9090
+  initialDelaySeconds: 3
+  periodSeconds: 5
+  failureThreshold: 6
+
 databaseMonitorConfig:
   prometheusServiceHost: "http://vmselect-vm-stack-victoria-metrics-k8s-stack.vm.svc:8481/select/0/prometheus/"

--- a/service/launchpad/deploy/charts/launchpad-monitor/launchpad-monitor-values.yaml
+++ b/service/launchpad/deploy/charts/launchpad-monitor/launchpad-monitor-values.yaml
@@ -10,5 +10,20 @@ resources:
     cpu: 5m
     memory: 64Mi
 
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8428
+  initialDelaySeconds: 3
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 8428
+  initialDelaySeconds: 3
+  periodSeconds: 5
+  failureThreshold: 6
+
 launchpadMonitorConfig:
   vmServiceHost: "http://vmselect-vm-stack-victoria-metrics-k8s-stack.vm.svc:8481/select/0/prometheus/"

--- a/service/launchpad/deploy/charts/launchpad-monitor/launchpad-monitor-values.yaml
+++ b/service/launchpad/deploy/charts/launchpad-monitor/launchpad-monitor-values.yaml
@@ -10,6 +10,14 @@ resources:
     cpu: 5m
     memory: 64Mi
 
+startupProbe:
+  httpGet:
+    path: /health
+    port: 8428
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 30
+
 livenessProbe:
   httpGet:
     path: /health

--- a/service/launchpad/deploy/charts/launchpad-monitor/templates/deployment.yaml
+++ b/service/launchpad/deploy/charts/launchpad-monitor/templates/deployment.yaml
@@ -34,6 +34,8 @@ spec:
           ports:
             - containerPort: {{ .Values.service.port }}
               protocol: TCP
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/service/launchpad/deploy/charts/launchpad-monitor/templates/deployment.yaml
+++ b/service/launchpad/deploy/charts/launchpad-monitor/templates/deployment.yaml
@@ -34,6 +34,19 @@ spec:
           ports:
             - containerPort: {{ .Values.service.port }}
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.service.port }}
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.service.port }}
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            failureThreshold: 6
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/service/launchpad/deploy/charts/launchpad-monitor/templates/deployment.yaml
+++ b/service/launchpad/deploy/charts/launchpad-monitor/templates/deployment.yaml
@@ -35,18 +35,9 @@ spec:
             - containerPort: {{ .Values.service.port }}
               protocol: TCP
           livenessProbe:
-            httpGet:
-              path: /health
-              port: {{ .Values.service.port }}
-            initialDelaySeconds: 3
-            periodSeconds: 10
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /health
-              port: {{ .Values.service.port }}
-            initialDelaySeconds: 3
-            periodSeconds: 5
-            failureThreshold: 6
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/service/launchpad/deploy/charts/launchpad-monitor/values.yaml
+++ b/service/launchpad/deploy/charts/launchpad-monitor/values.yaml
@@ -14,5 +14,20 @@ resources:
 service:
   port: 8428
 
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8428
+  initialDelaySeconds: 3
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 8428
+  initialDelaySeconds: 3
+  periodSeconds: 5
+  failureThreshold: 6
+
 launchpadMonitorConfig:
   vmServiceHost: "http://vmselect-vm-stack-victoria-metrics-k8s-stack.vm.svc:8481/select/0/prometheus/"

--- a/service/launchpad/deploy/charts/launchpad-monitor/values.yaml
+++ b/service/launchpad/deploy/charts/launchpad-monitor/values.yaml
@@ -14,6 +14,14 @@ resources:
 service:
   port: 8428
 
+startupProbe:
+  httpGet:
+    path: /health
+    port: 8428
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 30
+
 livenessProbe:
   httpGet:
     path: /health

--- a/service/launchpad/server/server.go
+++ b/service/launchpad/server/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labring/sealos/service/launchpad/request"
 	"github.com/labring/sealos/service/pkg/api"
 	"github.com/labring/sealos/service/pkg/auth"
+	commonserver "github.com/labring/sealos/service/pkg/server"
 )
 
 type VMServer struct {
@@ -102,6 +103,8 @@ func isNetworkServiceRequest(queryType string) bool {
 func (vs *VMServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	pathPrefix := ""
 	switch req.URL.Path {
+	case commonserver.HealthPath:
+		commonserver.ServeHealth(rw, req)
 	case pathPrefix + "/query":
 		vs.doReqNew(rw, req)
 	default:

--- a/service/launchpad/server/server_test.go
+++ b/service/launchpad/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,7 +12,15 @@ import (
 func TestVMServerHealth(t *testing.T) {
 	t.Parallel()
 
-	req := httptest.NewRequest(http.MethodGet, commonserver.HealthPath, nil)
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		commonserver.HealthPath,
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rw := httptest.NewRecorder()
 
 	(&VMServer{}).ServeHTTP(rw, req)

--- a/service/launchpad/server/server_test.go
+++ b/service/launchpad/server/server_test.go
@@ -1,0 +1,22 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	commonserver "github.com/labring/sealos/service/pkg/server"
+)
+
+func TestVMServerHealth(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, commonserver.HealthPath, nil)
+	rw := httptest.NewRecorder()
+
+	(&VMServer{}).ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rw.Code)
+	}
+}

--- a/service/minio/deploy/manifests/deploy.yaml.tmpl
+++ b/service/minio/deploy/manifests/deploy.yaml.tmpl
@@ -100,19 +100,6 @@ spec:
         ports:
         - containerPort: 9090
           protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 9090
-          initialDelaySeconds: 3
-          periodSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /health
-            port: 9090
-          initialDelaySeconds: 3
-          periodSeconds: 5
-          failureThreshold: 6
         resources:
           limits:
             cpu: 50m

--- a/service/minio/deploy/manifests/deploy.yaml.tmpl
+++ b/service/minio/deploy/manifests/deploy.yaml.tmpl
@@ -100,6 +100,19 @@ spec:
         ports:
         - containerPort: 9090
           protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 9090
+          initialDelaySeconds: 3
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 9090
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          failureThreshold: 6
         resources:
           limits:
             cpu: 50m

--- a/service/pkg/server/health.go
+++ b/service/pkg/server/health.go
@@ -1,0 +1,26 @@
+package server
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+const HealthPath = "/health"
+
+type healthResponse struct {
+	Status string `json:"status"`
+}
+
+func ServeHealth(rw http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet {
+		rw.Header().Set("Allow", http.MethodGet)
+		http.Error(rw, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	rw.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(rw).Encode(healthResponse{Status: "healthy"}); err != nil {
+		log.Printf("Failed to write health response: %s", err)
+	}
+}

--- a/service/pkg/server/health_test.go
+++ b/service/pkg/server/health_test.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPromServerHealth(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, HealthPath, nil)
+	rw := httptest.NewRecorder()
+
+	(&PromServer{}).ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rw.Code)
+	}
+	if got := rw.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("expected JSON content type, got %q", got)
+	}
+
+	var response healthResponse
+	if err := json.NewDecoder(rw.Body).Decode(&response); err != nil {
+		t.Fatalf("decode health response: %v", err)
+	}
+	if response.Status != "healthy" {
+		t.Fatalf("expected healthy status, got %q", response.Status)
+	}
+}
+
+func TestServeHealthRejectsNonGET(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodPost, HealthPath, nil)
+	rw := httptest.NewRecorder()
+
+	ServeHealth(rw, req)
+
+	if rw.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected status %d, got %d", http.StatusMethodNotAllowed, rw.Code)
+	}
+	if got := rw.Header().Get("Allow"); got != http.MethodGet {
+		t.Fatalf("expected Allow header %q, got %q", http.MethodGet, got)
+	}
+}

--- a/service/pkg/server/health_test.go
+++ b/service/pkg/server/health_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -10,7 +11,10 @@ import (
 func TestPromServerHealth(t *testing.T) {
 	t.Parallel()
 
-	req := httptest.NewRequest(http.MethodGet, HealthPath, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, HealthPath, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rw := httptest.NewRecorder()
 
 	(&PromServer{}).ServeHTTP(rw, req)
@@ -34,7 +38,10 @@ func TestPromServerHealth(t *testing.T) {
 func TestServeHealthRejectsNonGET(t *testing.T) {
 	t.Parallel()
 
-	req := httptest.NewRequest(http.MethodPost, HealthPath, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, HealthPath, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rw := httptest.NewRecorder()
 
 	ServeHealth(rw, req)

--- a/service/pkg/server/server.go
+++ b/service/pkg/server/server.go
@@ -102,6 +102,8 @@ func (ps *PromServer) ParseRequest(req *http.Request) (*api.PromRequest, error) 
 func (ps *PromServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	pathPrefix := ""
 	switch req.URL.Path {
+	case HealthPath:
+		ServeHealth(rw, req)
 	case pathPrefix + "/query": // 将废弃
 		ps.doReqPre(rw, req)
 	case pathPrefix + "/q":

--- a/service/vlogs/deploy/charts/vlogs/templates/deployment.yaml
+++ b/service/vlogs/deploy/charts/vlogs/templates/deployment.yaml
@@ -38,18 +38,9 @@ spec:
             - containerPort: {{ .Values.service.port }}
               protocol: TCP
           livenessProbe:
-            httpGet:
-              path: /health
-              port: {{ .Values.service.port }}
-            initialDelaySeconds: 3
-            periodSeconds: 10
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /health
-              port: {{ .Values.service.port }}
-            initialDelaySeconds: 3
-            periodSeconds: 5
-            failureThreshold: 6
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/service/vlogs/deploy/charts/vlogs/templates/deployment.yaml
+++ b/service/vlogs/deploy/charts/vlogs/templates/deployment.yaml
@@ -37,6 +37,19 @@ spec:
           ports:
             - containerPort: {{ .Values.service.port }}
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.service.port }}
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.service.port }}
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            failureThreshold: 6
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/service/vlogs/deploy/charts/vlogs/templates/deployment.yaml
+++ b/service/vlogs/deploy/charts/vlogs/templates/deployment.yaml
@@ -37,6 +37,8 @@ spec:
           ports:
             - containerPort: {{ .Values.service.port }}
               protocol: TCP
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/service/vlogs/deploy/charts/vlogs/values.yaml
+++ b/service/vlogs/deploy/charts/vlogs/values.yaml
@@ -14,6 +14,21 @@ resources:
 service:
   port: 8428
 
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8428
+  initialDelaySeconds: 3
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 8428
+  initialDelaySeconds: 3
+  periodSeconds: 5
+  failureThreshold: 6
+
 serviceVlogsConfig:
   path: "http://usr-vlc-victoria-logs-cluster-vmauth.vlc.svc:8427"
   username: ""

--- a/service/vlogs/deploy/charts/vlogs/values.yaml
+++ b/service/vlogs/deploy/charts/vlogs/values.yaml
@@ -14,6 +14,14 @@ resources:
 service:
   port: 8428
 
+startupProbe:
+  httpGet:
+    path: /health
+    port: 8428
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 30
+
 livenessProbe:
   httpGet:
     path: /health

--- a/service/vlogs/deploy/charts/vlogs/vlogs-monitor-values.yaml
+++ b/service/vlogs/deploy/charts/vlogs/vlogs-monitor-values.yaml
@@ -13,6 +13,14 @@ resources:
 service:
   port: 8428
 
+startupProbe:
+  httpGet:
+    path: /health
+    port: 8428
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 30
+
 livenessProbe:
   httpGet:
     path: /health

--- a/service/vlogs/deploy/charts/vlogs/vlogs-monitor-values.yaml
+++ b/service/vlogs/deploy/charts/vlogs/vlogs-monitor-values.yaml
@@ -13,6 +13,20 @@ resources:
 service:
   port: 8428
 
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8428
+  initialDelaySeconds: 3
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 8428
+  initialDelaySeconds: 3
+  periodSeconds: 5
+  failureThreshold: 6
 
 serviceVlogsConfig:
   path: "http://usr-vlc-victoria-logs-cluster-vmauth.vlc.svc:8427"

--- a/service/vlogs/server/server.go
+++ b/service/vlogs/server/server.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	commonserver "github.com/labring/sealos/service/pkg/server"
 	"github.com/labring/sealos/service/vlogs/config"
 )
 
@@ -25,6 +26,11 @@ func NewVLogsServer(config *config.Config) (*VLogsServer, error) {
 }
 
 func (vl *VLogsServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	if req.URL.Path == commonserver.HealthPath {
+		commonserver.ServeHealth(rw, req)
+		return
+	}
+
 	query, err := vl.queryConvert(req)
 	if err != nil {
 		http.Error(

--- a/service/vlogs/server/server_test.go
+++ b/service/vlogs/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,7 +12,15 @@ import (
 func TestVLogsServerHealth(t *testing.T) {
 	t.Parallel()
 
-	req := httptest.NewRequest(http.MethodGet, commonserver.HealthPath, nil)
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		commonserver.HealthPath,
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rw := httptest.NewRecorder()
 
 	(&VLogsServer{}).ServeHTTP(rw, req)

--- a/service/vlogs/server/server_test.go
+++ b/service/vlogs/server/server_test.go
@@ -1,0 +1,22 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	commonserver "github.com/labring/sealos/service/pkg/server"
+)
+
+func TestVLogsServerHealth(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, commonserver.HealthPath, nil)
+	rw := httptest.NewRecorder()
+
+	(&VLogsServer{}).ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rw.Code)
+	}
+}


### PR DESCRIPTION
Cherry-pick of the health endpoints + probes feature from PR #7175 onto release-v5.1.

- Adds `GET /health` to launchpad, vlogs, database (prom) and minio service monitors via `service/pkg/server`.
- Adds liveness/readiness probes to the Helm chart deployments (launchpad-monitor, vlogs, database-monitor) and the minio deploy manifest.
- Includes the context-aware request fix for the new health tests (satisfies noctx/govet lint).