### PR TITLE
feat(user): issue kubeconfigs with token requests

### DIFF
--- a/controllers/user/api/v1/user_types.go
+++ b/controllers/user/api/v1/user_types.go
@@ -23,20 +23,22 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const DefaultCSRExpirationSeconds int32 = 1_000_000_000
+
 // UserSpec defines the desired state of User
 type UserSpec struct {
 	// expirationSeconds is the requested duration of validity of the issued
-	// certificate. The certificate signer may issue a certificate with a different
-	// validity duration so a client must check the delta between the notBefore and
-	// notAfter fields in the issued certificate to determine the actual duration.
+	// kubeconfig credential. The issuer may issue a credential with a different
+	// validity duration so a client must check the issued credential to determine
+	// the actual duration.
 	//
 	// The minimum valid value for expirationSeconds is 600, i.e. 10 minutes.
 	//
 	// +optional
-	//+kubebuilder:default:=7200
+	//+kubebuilder:default:=1000000000
 	CSRExpirationSeconds int32 `json:"csrExpirationSeconds,omitempty"`
 	// kubeConfigRotateAt 用于手动触发 kubeconfig 轮转。
-	// 当字段被设置或更新时，controller 会重建 token Secret 与 kubeconfig。
+	// 当字段被设置或更新时，controller 会重新请求 token 并重建 kubeconfig。
 	// +optional
 	KubeConfigRotateAt *metav1.Time `json:"kubeConfigRotateAt,omitempty"`
 }
@@ -63,7 +65,7 @@ type UserStatus struct {
 	//+kubebuilder:default:=Unknown
 	Phase      UserPhase `json:"phase,omitempty"`
 	KubeConfig string    `json:"kubeConfig"`
-	//+kubebuilder:default:=7200
+	//+kubebuilder:default:=1000000000
 	ObservedCSRExpirationSeconds int32 `json:"observedCSRExpirationSeconds,omitempty"`
 	// ObservedKubeConfigRotateAt 记录已处理的轮转请求时间戳。
 	// +optional

--- a/controllers/user/api/v1/user_webhook.go
+++ b/controllers/user/api/v1/user_webhook.go
@@ -80,7 +80,7 @@ func (r *User) Default(ctx context.Context, obj runtime.Object) error {
 	userlog.Info("default", "name", user.Name)
 	user.ObjectMeta = initAnnotationAndLabels(user.ObjectMeta)
 	if user.Spec.CSRExpirationSeconds == 0 {
-		user.Spec.CSRExpirationSeconds = 7200
+		user.Spec.CSRExpirationSeconds = DefaultCSRExpirationSeconds
 	}
 	if user.Annotations[UserAnnotationDisplayKey] == "" {
 		user.Annotations[UserAnnotationDisplayKey] = user.Name

--- a/controllers/user/config/crd/bases/user.sealos.io_users.yaml
+++ b/controllers/user/config/crd/bases/user.sealos.io_users.yaml
@@ -64,12 +64,12 @@ spec:
             description: UserSpec defines the desired state of User
             properties:
               csrExpirationSeconds:
-                default: 7200
+                default: 1000000000
                 description: |-
                   expirationSeconds is the requested duration of validity of the issued
-                  certificate. The certificate signer may issue a certificate with a different
-                  validity duration so a client must check the delta between the notBefore and
-                  notAfter fields in the issued certificate to determine the actual duration.
+                  kubeconfig credential. The issuer may issue a credential with a different
+                  validity duration so a client must check the issued credential to determine
+                  the actual duration.
 
 
                   The minimum valid value for expirationSeconds is 600, i.e. 10 minutes.
@@ -77,8 +77,8 @@ spec:
                 type: integer
               kubeConfigRotateAt:
                 description: kubeConfigRotateAt is a manual trigger for kubeconfig
-                  rotation. When set/updated, controller will recreate token secret
-                  and kubeconfig.
+                  rotation. When set/updated, controller will request a new token
+                  and recreate kubeconfig.
                 format: date-time
                 type: string
             type: object
@@ -122,7 +122,7 @@ spec:
               kubeConfig:
                 type: string
               observedCSRExpirationSeconds:
-                default: 7200
+                default: 1000000000
                 format: int32
                 type: integer
               observedKubeConfigRotateAt:

--- a/controllers/user/controllers/helper/kubeconfig/interface.go
+++ b/controllers/user/controllers/helper/kubeconfig/interface.go
@@ -17,12 +17,14 @@ limitations under the License.
 package kubeconfig
 
 import (
+	"context"
 	"net"
 	"os"
-	"time"
 
+	userv1 "github.com/labring/sealos/controllers/user/api/v1"
 	csrv1 "k8s.io/api/certificates/v1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd/api"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -33,6 +35,11 @@ var defaultLog = ctrl.Log.WithName("kubeconfig")
 
 type Interface interface {
 	Apply(config *rest.Config, client client.Client) (*api.Config, error)
+}
+
+type TokenRequestInterface interface {
+	Interface
+	ApplyWithTokenRequest(ctx context.Context, config *rest.Config, client client.Client) (*api.Config, metav1.Time, error)
 }
 
 type CertConfig struct {
@@ -56,9 +63,8 @@ type CsrConfig struct {
 }
 type ServiceAccountConfig struct {
 	*DefaultConfig
-	namespace  string
-	sa         *v1.ServiceAccount
-	secretName string
+	namespace string
+	sa        *v1.ServiceAccount
 }
 
 type WebhookConfig struct {
@@ -89,7 +95,7 @@ func NewConfig(user, clusterName string, expirationSeconds int32) *DefaultConfig
 		clusterName = "sealos"
 	}
 	if expirationSeconds == 0 {
-		expirationSeconds = int32(2 * time.Hour.Seconds())
+		expirationSeconds = userv1.DefaultCSRExpirationSeconds
 	}
 	return &DefaultConfig{
 		user:              user,

--- a/controllers/user/controllers/helper/kubeconfig/interface.go
+++ b/controllers/user/controllers/helper/kubeconfig/interface.go
@@ -63,8 +63,9 @@ type CsrConfig struct {
 }
 type ServiceAccountConfig struct {
 	*DefaultConfig
-	namespace string
-	sa        *v1.ServiceAccount
+	namespace  string
+	secretName string
+	sa         *v1.ServiceAccount
 }
 
 type WebhookConfig struct {

--- a/controllers/user/controllers/helper/kubeconfig/interface.go
+++ b/controllers/user/controllers/helper/kubeconfig/interface.go
@@ -39,7 +39,11 @@ type Interface interface {
 
 type TokenRequestInterface interface {
 	Interface
-	ApplyWithTokenRequest(ctx context.Context, config *rest.Config, client client.Client) (*api.Config, metav1.Time, error)
+	ApplyWithTokenRequest(
+		ctx context.Context,
+		config *rest.Config,
+		client client.Client,
+	) (*api.Config, metav1.Time, error)
 }
 
 type CertConfig struct {

--- a/controllers/user/controllers/helper/kubeconfig/interface.go
+++ b/controllers/user/controllers/helper/kubeconfig/interface.go
@@ -68,9 +68,10 @@ type CsrConfig struct {
 }
 type ServiceAccountConfig struct {
 	*DefaultConfig
-	namespace  string
-	secretName string
-	sa         *v1.ServiceAccount
+	namespace      string
+	secretName     string
+	forceNewSecret bool
+	sa             *v1.ServiceAccount
 }
 
 type WebhookConfig struct {
@@ -141,7 +142,7 @@ func (d *DefaultConfig) WithCsrConfig(
 func (d *DefaultConfig) WithServiceAccountConfig(
 	namespace string,
 	sa *v1.ServiceAccount,
-) Interface {
+) *ServiceAccountConfig {
 	if namespace == "" {
 		namespace = "default"
 	}
@@ -150,6 +151,11 @@ func (d *DefaultConfig) WithServiceAccountConfig(
 		namespace:     namespace,
 		sa:            sa,
 	}
+}
+
+func (sac *ServiceAccountConfig) WithForceNewSecret() *ServiceAccountConfig {
+	sac.forceNewSecret = true
+	return sac
 }
 
 func (d *DefaultConfig) WithWebhookConfigConfig(webhookURL string) Interface {

--- a/controllers/user/controllers/helper/kubeconfig/interface.go
+++ b/controllers/user/controllers/helper/kubeconfig/interface.go
@@ -21,7 +21,6 @@ import (
 	"net"
 	"os"
 
-	userv1 "github.com/labring/sealos/controllers/user/api/v1"
 	csrv1 "k8s.io/api/certificates/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +31,8 @@ import (
 )
 
 var defaultLog = ctrl.Log.WithName("kubeconfig")
+
+const defaultCSRExpirationSeconds int32 = 1_000_000_000
 
 type Interface interface {
 	Apply(config *rest.Config, client client.Client) (*api.Config, error)
@@ -100,7 +101,7 @@ func NewConfig(user, clusterName string, expirationSeconds int32) *DefaultConfig
 		clusterName = "sealos"
 	}
 	if expirationSeconds == 0 {
-		expirationSeconds = userv1.DefaultCSRExpirationSeconds
+		expirationSeconds = defaultCSRExpirationSeconds
 	}
 	return &DefaultConfig{
 		user:              user,

--- a/controllers/user/controllers/helper/kubeconfig/sa.go
+++ b/controllers/user/controllers/helper/kubeconfig/sa.go
@@ -131,7 +131,11 @@ func (sac *ServiceAccountConfig) applyBoundTokenSecret(
 		return nil, err
 	}
 	if secret.UID == "" {
-		return nil, fmt.Errorf("bound token secret %s/%s has empty uid", secret.Namespace, secret.Name)
+		return nil, fmt.Errorf(
+			"bound token secret %s/%s has empty uid",
+			secret.Namespace,
+			secret.Name,
+		)
 	}
 	return secret, nil
 }

--- a/controllers/user/controllers/helper/kubeconfig/sa.go
+++ b/controllers/user/controllers/helper/kubeconfig/sa.go
@@ -224,7 +224,10 @@ func (sac *ServiceAccountConfig) generateSecretName() string {
 	if sac.secretName != "" {
 		return sac.secretName
 	}
-	if !sac.forceNewSecret && sac.sa != nil && len(sac.sa.Secrets) > 0 && sac.sa.Secrets[0].Name != "" {
+	if !sac.forceNewSecret &&
+		sac.sa != nil &&
+		len(sac.sa.Secrets) > 0 &&
+		sac.sa.Secrets[0].Name != "" {
 		return sac.sa.Secrets[0].Name
 	}
 	return "sealos-token-" + sac.user + "-" + GetRandomString(5)

--- a/controllers/user/controllers/helper/kubeconfig/sa.go
+++ b/controllers/user/controllers/helper/kubeconfig/sa.go
@@ -163,7 +163,11 @@ func CleanupLegacyBoundTokenSecrets(ctx context.Context, cli client.Client, user
 	return nil
 }
 
-func (sac *ServiceAccountConfig) requestToken(ctx context.Context, config *rest.Config, boundSecret *v1.Secret) (*authenticationv1.TokenRequest, error) {
+func (sac *ServiceAccountConfig) requestToken(
+	ctx context.Context,
+	config *rest.Config,
+	boundSecret *v1.Secret,
+) (*authenticationv1.TokenRequest, error) {
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err

--- a/controllers/user/controllers/helper/kubeconfig/sa.go
+++ b/controllers/user/controllers/helper/kubeconfig/sa.go
@@ -22,10 +22,10 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	userv1 "github.com/labring/sealos/controllers/user/api/v1"
 	config2 "github.com/labring/sealos/controllers/user/controllers/helper/config"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -140,6 +140,29 @@ func (sac *ServiceAccountConfig) applyBoundTokenSecret(
 	return secret, nil
 }
 
+// CleanupLegacyBoundTokenSecrets removes legacy ServiceAccountToken secrets for a user.
+func CleanupLegacyBoundTokenSecrets(ctx context.Context, cli client.Client, userName string) error {
+	secrets := &v1.SecretList{}
+	if err := cli.List(
+		ctx,
+		secrets,
+		client.InNamespace(config2.GetUserSystemNamespace()),
+		client.MatchingFields{v1.ServiceAccountNameKey: userName},
+	); err != nil {
+		return fmt.Errorf("failed to list legacy bound token secrets: %w", err)
+	}
+	for i := range secrets.Items {
+		secret := &secrets.Items[i]
+		if secret.Type != v1.SecretTypeServiceAccountToken {
+			continue
+		}
+		if err := cli.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete legacy bound token secret %s: %w", secret.Name, err)
+		}
+	}
+	return nil
+}
+
 func (sac *ServiceAccountConfig) requestToken(ctx context.Context, config *rest.Config, boundSecret *v1.Secret) (*authenticationv1.TokenRequest, error) {
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
@@ -168,8 +191,8 @@ func (sac *ServiceAccountConfig) requestToken(ctx context.Context, config *rest.
 }
 
 func (sac *ServiceAccountConfig) tokenRequestExpirationSeconds() int32 {
-	if sac.expirationSeconds < userv1.DefaultCSRExpirationSeconds {
-		return userv1.DefaultCSRExpirationSeconds
+	if sac.expirationSeconds < defaultCSRExpirationSeconds {
+		return defaultCSRExpirationSeconds
 	}
 	return sac.expirationSeconds
 }

--- a/controllers/user/controllers/helper/kubeconfig/sa.go
+++ b/controllers/user/controllers/helper/kubeconfig/sa.go
@@ -49,7 +49,11 @@ func (sac *ServiceAccountConfig) ApplyWithTokenRequest(
 	if err := sac.applyServiceAccount(config, client); err != nil {
 		return nil, metav1.Time{}, fmt.Errorf("failed to apply service account error: %w", err)
 	}
-	tokenRequest, err := sac.requestToken(ctx, config)
+	boundSecret, err := sac.applyBoundTokenSecret(ctx, client)
+	if err != nil {
+		return nil, metav1.Time{}, fmt.Errorf("failed to apply bound token secret: %w", err)
+	}
+	tokenRequest, err := sac.requestToken(ctx, config, boundSecret)
 	if err != nil {
 		return nil, metav1.Time{}, fmt.Errorf("failed to fetch token: %w", err)
 	}
@@ -77,7 +81,34 @@ func (sac *ServiceAccountConfig) applyServiceAccount(_ *rest.Config, client clie
 	return err
 }
 
-func (sac *ServiceAccountConfig) requestToken(ctx context.Context, config *rest.Config) (*authenticationv1.TokenRequest, error) {
+func (sac *ServiceAccountConfig) applyBoundTokenSecret(ctx context.Context, cli client.Client) (*v1.Secret, error) {
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      TokenSecretName(sac.user),
+			Namespace: sac.namespace,
+		},
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, cli, secret, func() error {
+		secret.Type = v1.SecretTypeOpaque
+		if secret.Annotations == nil {
+			secret.Annotations = map[string]string{}
+		}
+		secret.Annotations[v1.ServiceAccountNameKey] = sac.user
+		if sac.sa != nil {
+			secret.OwnerReferences = append([]metav1.OwnerReference(nil), sac.sa.OwnerReferences...)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if secret.UID == "" {
+		return nil, fmt.Errorf("bound token secret %s/%s has empty uid", secret.Namespace, secret.Name)
+	}
+	return secret, nil
+}
+
+func (sac *ServiceAccountConfig) requestToken(ctx context.Context, config *rest.Config, boundSecret *v1.Secret) (*authenticationv1.TokenRequest, error) {
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err
@@ -87,6 +118,12 @@ func (sac *ServiceAccountConfig) requestToken(ctx context.Context, config *rest.
 		CreateToken(ctx, sac.user, &authenticationv1.TokenRequest{
 			Spec: authenticationv1.TokenRequestSpec{
 				ExpirationSeconds: ptr.To(int64(sac.tokenRequestExpirationSeconds())),
+				BoundObjectRef: &authenticationv1.BoundObjectReference{
+					Kind:       "Secret",
+					APIVersion: "v1",
+					Name:       boundSecret.Name,
+					UID:        boundSecret.UID,
+				},
 			},
 		}, metav1.CreateOptions{})
 	if err != nil {
@@ -103,6 +140,10 @@ func (sac *ServiceAccountConfig) tokenRequestExpirationSeconds() int32 {
 		return userv1.DefaultCSRExpirationSeconds
 	}
 	return sac.expirationSeconds
+}
+
+func TokenSecretName(name string) string {
+	return fmt.Sprintf("sealos-token-%s", name)
 }
 
 func (sac *ServiceAccountConfig) generatorKubeConfig(

--- a/controllers/user/controllers/helper/kubeconfig/sa.go
+++ b/controllers/user/controllers/helper/kubeconfig/sa.go
@@ -83,7 +83,7 @@ func (sac *ServiceAccountConfig) applyServiceAccount(_ *rest.Config, client clie
 		sa.Namespace = sac.namespace
 	}
 	_, err := controllerutil.CreateOrUpdate(context.TODO(), client, sa, func() error {
-		if len(sa.Secrets) == 0 {
+		if sac.forceNewSecret || len(sa.Secrets) == 0 {
 			sa.Secrets = []v1.ObjectReference{
 				{
 					Name: sac.generateSecretName(),
@@ -140,8 +140,12 @@ func (sac *ServiceAccountConfig) applyBoundTokenSecret(
 	return secret, nil
 }
 
-// CleanupLegacyBoundTokenSecrets removes legacy ServiceAccountToken secrets for a user.
-func CleanupLegacyBoundTokenSecrets(ctx context.Context, cli client.Client, userName string) error {
+// CleanupLegacyBoundTokenSecrets removes stale bound token secrets for a user.
+func CleanupLegacyBoundTokenSecrets(
+	ctx context.Context,
+	cli client.Client,
+	userName, keepSecretName string,
+) error {
 	secrets := &v1.SecretList{}
 	if err := cli.List(
 		ctx,
@@ -151,9 +155,15 @@ func CleanupLegacyBoundTokenSecrets(ctx context.Context, cli client.Client, user
 	); err != nil {
 		return fmt.Errorf("failed to list legacy bound token secrets: %w", err)
 	}
+	if keepSecretName == "" {
+		return fmt.Errorf("keep secret name is empty")
+	}
 	for i := range secrets.Items {
 		secret := &secrets.Items[i]
-		if secret.Type != v1.SecretTypeServiceAccountToken {
+		if secret.Name == "" || secret.Name == keepSecretName {
+			continue
+		}
+		if secret.Annotations == nil || secret.Annotations[v1.ServiceAccountNameKey] != userName {
 			continue
 		}
 		if err := cli.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
@@ -209,7 +219,7 @@ func (sac *ServiceAccountConfig) generateSecretName() string {
 	if sac.secretName != "" {
 		return sac.secretName
 	}
-	if sac.sa != nil && len(sac.sa.Secrets) > 0 && sac.sa.Secrets[0].Name != "" {
+	if !sac.forceNewSecret && sac.sa != nil && len(sac.sa.Secrets) > 0 && sac.sa.Secrets[0].Name != "" {
 		return sac.sa.Secrets[0].Name
 	}
 	return "sealos-token-" + sac.user + "-" + GetRandomString(5)

--- a/controllers/user/controllers/helper/kubeconfig/sa.go
+++ b/controllers/user/controllers/helper/kubeconfig/sa.go
@@ -18,6 +18,8 @@ package kubeconfig
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 
 	userv1 "github.com/labring/sealos/controllers/user/api/v1"
@@ -65,26 +67,49 @@ func (sac *ServiceAccountConfig) ApplyWithTokenRequest(
 }
 
 func (sac *ServiceAccountConfig) applyServiceAccount(_ *rest.Config, client client.Client) error {
-	if sac.sa != nil {
-		return nil
+	sa := sac.sa
+	if sa == nil {
+		sa = &v1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      sac.user,
+				Namespace: sac.namespace,
+			},
+		}
 	}
-	sa := &v1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      sac.user,
-			Namespace: sac.namespace,
-		},
+	if sa.Name == "" {
+		sa.Name = sac.user
+	}
+	if sa.Namespace == "" {
+		sa.Namespace = sac.namespace
 	}
 	_, err := controllerutil.CreateOrUpdate(context.TODO(), client, sa, func() error {
+		if len(sa.Secrets) == 0 {
+			sa.Secrets = []v1.ObjectReference{
+				{
+					Name: sac.generateSecretName(),
+				},
+			}
+		}
 		return nil
 	})
+	if err != nil {
+		return err
+	}
 	sac.sa = sa
-	return err
+	if len(sa.Secrets) > 0 {
+		sac.secretName = sa.Secrets[0].Name
+	}
+	return nil
 }
 
 func (sac *ServiceAccountConfig) applyBoundTokenSecret(ctx context.Context, cli client.Client) (*v1.Secret, error) {
+	secretName := sac.secretName
+	if secretName == "" {
+		secretName = sac.generateSecretName()
+	}
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      TokenSecretName(sac.user),
+			Name:      secretName,
 			Namespace: sac.namespace,
 		},
 	}
@@ -144,6 +169,24 @@ func (sac *ServiceAccountConfig) tokenRequestExpirationSeconds() int32 {
 
 func TokenSecretName(name string) string {
 	return fmt.Sprintf("sealos-token-%s", name)
+}
+
+func (sac *ServiceAccountConfig) generateSecretName() string {
+	if sac.secretName != "" {
+		return sac.secretName
+	}
+	if sac.sa != nil && len(sac.sa.Secrets) > 0 && sac.sa.Secrets[0].Name != "" {
+		return sac.sa.Secrets[0].Name
+	}
+	return fmt.Sprintf("sealos-token-%s-%s", sac.user, GetRandomString(5))
+}
+
+func GetRandomString(n int) string {
+	randBytes := make([]byte, n/2)
+	if _, err := rand.Read(randBytes); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(randBytes)
 }
 
 func (sac *ServiceAccountConfig) generatorKubeConfig(

--- a/controllers/user/controllers/helper/kubeconfig/sa.go
+++ b/controllers/user/controllers/helper/kubeconfig/sa.go
@@ -102,7 +102,10 @@ func (sac *ServiceAccountConfig) applyServiceAccount(_ *rest.Config, client clie
 	return nil
 }
 
-func (sac *ServiceAccountConfig) applyBoundTokenSecret(ctx context.Context, cli client.Client) (*v1.Secret, error) {
+func (sac *ServiceAccountConfig) applyBoundTokenSecret(
+	ctx context.Context,
+	cli client.Client,
+) (*v1.Secret, error) {
 	secretName := sac.secretName
 	if secretName == "" {
 		secretName = sac.generateSecretName()
@@ -168,7 +171,7 @@ func (sac *ServiceAccountConfig) tokenRequestExpirationSeconds() int32 {
 }
 
 func TokenSecretName(name string) string {
-	return fmt.Sprintf("sealos-token-%s", name)
+	return "sealos-token-" + name
 }
 
 func (sac *ServiceAccountConfig) generateSecretName() string {
@@ -178,7 +181,7 @@ func (sac *ServiceAccountConfig) generateSecretName() string {
 	if sac.sa != nil && len(sac.sa.Secrets) > 0 && sac.sa.Secrets[0].Name != "" {
 		return sac.sa.Secrets[0].Name
 	}
-	return fmt.Sprintf("sealos-token-%s-%s", sac.user, GetRandomString(5))
+	return "sealos-token-" + sac.user + "-" + GetRandomString(5)
 }
 
 func GetRandomString(n int) string {

--- a/controllers/user/controllers/helper/kubeconfig/sa.go
+++ b/controllers/user/controllers/helper/kubeconfig/sa.go
@@ -19,14 +19,16 @@ package kubeconfig
 import (
 	"context"
 	"fmt"
-	"strconv"
-	"time"
 
+	userv1 "github.com/labring/sealos/controllers/user/api/v1"
 	config2 "github.com/labring/sealos/controllers/user/controllers/helper/config"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -35,19 +37,27 @@ func (sac *ServiceAccountConfig) Apply(
 	config *rest.Config,
 	client client.Client,
 ) (*api.Config, error) {
+	cfg, _, err := sac.ApplyWithTokenRequest(context.Background(), config, client)
+	return cfg, err
+}
+
+func (sac *ServiceAccountConfig) ApplyWithTokenRequest(
+	ctx context.Context,
+	config *rest.Config,
+	client client.Client,
+) (*api.Config, metav1.Time, error) {
 	if err := sac.applyServiceAccount(config, client); err != nil {
-		return nil, fmt.Errorf("failed to apply service account error: %w", err)
+		return nil, metav1.Time{}, fmt.Errorf("failed to apply service account error: %w", err)
 	}
-	if err := sac.applySecret(config, client); err != nil {
-		return nil, fmt.Errorf("failed to apply secret: %w", err)
+	tokenRequest, err := sac.requestToken(ctx, config)
+	if err != nil {
+		return nil, metav1.Time{}, fmt.Errorf("failed to fetch token: %w", err)
 	}
-	token, err := sac.fetchToken(client)
-	if err == nil {
-		if cfg, err := sac.generatorKubeConfig(config, token); err == nil {
-			return cfg, nil
-		}
+	cfg, err := sac.generatorKubeConfig(config, tokenRequest.Status.Token)
+	if err != nil {
+		return nil, metav1.Time{}, fmt.Errorf("failed to generate kube config: %w", err)
 	}
-	return nil, fmt.Errorf("failed to fetch token: %w", err)
+	return cfg, tokenRequest.Status.ExpirationTimestamp, nil
 }
 
 func (sac *ServiceAccountConfig) applyServiceAccount(_ *rest.Config, client client.Client) error {
@@ -61,93 +71,38 @@ func (sac *ServiceAccountConfig) applyServiceAccount(_ *rest.Config, client clie
 		},
 	}
 	_, err := controllerutil.CreateOrUpdate(context.TODO(), client, sa, func() error {
-		if len(sa.Secrets) == 0 {
-			sa.Secrets = []v1.ObjectReference{
-				{
-					Name: sac.getSecretName(),
-				},
-			}
-		}
 		return nil
 	})
-	sac.secretName = sa.Secrets[0].Name
+	sac.sa = sa
 	return err
 }
 
-func (sac *ServiceAccountConfig) applySecret(_ *rest.Config, client client.Client) error {
-	if sac.sa != nil {
-		return nil
+func (sac *ServiceAccountConfig) requestToken(ctx context.Context, config *rest.Config) (*authenticationv1.TokenRequest, error) {
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
 	}
-	secret := &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      sac.secretName,
-			Namespace: sac.namespace,
-		},
+	tokenRequest, err := clientset.CoreV1().
+		ServiceAccounts(sac.namespace).
+		CreateToken(ctx, sac.user, &authenticationv1.TokenRequest{
+			Spec: authenticationv1.TokenRequestSpec{
+				ExpirationSeconds: ptr.To(int64(sac.tokenRequestExpirationSeconds())),
+			},
+		}, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
 	}
-	_, err := controllerutil.CreateOrUpdate(context.TODO(), client, secret, func() error {
-		if secret.Annotations == nil {
-			secret.Annotations = make(map[string]string, 0)
-		}
-		secret.Type = v1.SecretTypeServiceAccountToken
-		secret.Annotations[v1.ServiceAccountNameKey] = sac.user
-		secret.Annotations["sealos.io/user.expirationSeconds"] = strconv.Itoa(
-			int(sac.expirationSeconds),
-		)
-		return nil
-	})
-	sac.sa = &v1.ServiceAccount{}
-	sac.sa.Name = sac.user
-	sac.sa.Namespace = sac.namespace
-	return err
+	if tokenRequest.Status.Token == "" {
+		return nil, fmt.Errorf("token request returned empty token for serviceaccount %s/%s", sac.namespace, sac.user)
+	}
+	return tokenRequest, nil
 }
 
-func (sac *ServiceAccountConfig) getSecretName() string {
-	if sac.sa != nil {
-		return sac.sa.Secrets[0].Name
+func (sac *ServiceAccountConfig) tokenRequestExpirationSeconds() int32 {
+	if sac.expirationSeconds < userv1.DefaultCSRExpirationSeconds {
+		return userv1.DefaultCSRExpirationSeconds
 	}
-	return SecretName(sac.user)
-}
-
-func (sac *ServiceAccountConfig) fetchToken(cli client.Client) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-	defer cancel()
-	start := time.Now()
-	for {
-		select {
-		case <-time.After(5 * time.Millisecond):
-			sa := sac.sa
-			if err := cli.Get(ctx, client.ObjectKeyFromObject(sa), sa); err != nil {
-				return "", err
-			}
-			if len(sa.Secrets) == 0 {
-				continue
-			}
-			secret := &v1.Secret{}
-			secret.Name = sa.Secrets[0].Name
-			secret.Namespace = sac.sa.Namespace
-			if err := cli.Get(ctx, client.ObjectKeyFromObject(secret), secret); err != nil {
-				continue
-			}
-			if secret.Data != nil && secret.Data[v1.ServiceAccountTokenKey] != nil {
-				dis := time.Since(start).Milliseconds()
-				defaultLog.Info(
-					"The serviceAccount secret is ready.",
-					"secretName",
-					secret.Name,
-					"using Milliseconds",
-					dis,
-				)
-				return string(secret.Data[v1.ServiceAccountTokenKey]), nil
-			}
-		case <-ctx.Done():
-			// A negligible error: The first 10-second wait to obtain the token failed. Subsequent reconcile will continue to obtain
-			defaultLog.Error(
-				ctx.Err(),
-				"context get secrets time out, wait until next time reconcile to get it done",
-			)
-			return "", ctx.Err()
-		}
-	}
+	return sac.expirationSeconds
 }
 
 func (sac *ServiceAccountConfig) generatorKubeConfig(

--- a/controllers/user/controllers/helper/kubeconfig/sa.go
+++ b/controllers/user/controllers/helper/kubeconfig/sa.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	config2 "github.com/labring/sealos/controllers/user/controllers/helper/config"
@@ -156,7 +157,7 @@ func CleanupLegacyBoundTokenSecrets(
 		return fmt.Errorf("failed to list legacy bound token secrets: %w", err)
 	}
 	if keepSecretName == "" {
-		return fmt.Errorf("keep secret name is empty")
+		return errors.New("keep secret name is empty")
 	}
 	for i := range secrets.Items {
 		secret := &secrets.Items[i]
@@ -199,7 +200,11 @@ func (sac *ServiceAccountConfig) requestToken(
 		return nil, err
 	}
 	if tokenRequest.Status.Token == "" {
-		return nil, fmt.Errorf("token request returned empty token for serviceaccount %s/%s", sac.namespace, sac.user)
+		return nil, fmt.Errorf(
+			"token request returned empty token for serviceaccount %s/%s",
+			sac.namespace,
+			sac.user,
+		)
 	}
 	return tokenRequest, nil
 }

--- a/controllers/user/controllers/helper/kubeconfig/sa_legacy_secret_test.go
+++ b/controllers/user/controllers/helper/kubeconfig/sa_legacy_secret_test.go
@@ -181,6 +181,10 @@ func TestServiceAccountConfigWithForceNewSecret(t *testing.T) {
 		t.Fatalf("secret name reused old secret %q", oldSecret)
 	}
 	if cfg.secretName != cfg.sa.Secrets[0].Name {
-		t.Fatalf("cached secret name %q != current secret name %q", cfg.secretName, cfg.sa.Secrets[0].Name)
+		t.Fatalf(
+			"cached secret name %q != current secret name %q",
+			cfg.secretName,
+			cfg.sa.Secrets[0].Name,
+		)
 	}
 }

--- a/controllers/user/controllers/helper/kubeconfig/sa_legacy_secret_test.go
+++ b/controllers/user/controllers/helper/kubeconfig/sa_legacy_secret_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2022 labring.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeconfig
+
+import (
+	"context"
+	"testing"
+
+	config2 "github.com/labring/sealos/controllers/user/controllers/helper/config"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCleanupLegacyBoundTokenSecrets(t *testing.T) {
+	t.Parallel()
+
+	const (
+		userName      = "alice"
+		currentSecret = "sealos-token-alice-new"
+		legacySecret  = "sealos-token-alice-old"
+		otherSecret   = "sealos-token-bob-old"
+	)
+
+	current := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      currentSecret,
+			Namespace: config2.GetUserSystemNamespace(),
+			Annotations: map[string]string{
+				corev1.ServiceAccountNameKey: userName,
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+	legacy := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      legacySecret,
+			Namespace: config2.GetUserSystemNamespace(),
+			Annotations: map[string]string{
+				corev1.ServiceAccountNameKey: userName,
+			},
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+	}
+	other := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      otherSecret,
+			Namespace: config2.GetUserSystemNamespace(),
+			Annotations: map[string]string{
+				corev1.ServiceAccountNameKey: "bob",
+			},
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(current, legacy, other).
+		WithIndex(&corev1.Secret{}, corev1.ServiceAccountNameKey, func(obj client.Object) []string {
+			secret, ok := obj.(*corev1.Secret)
+			if !ok || secret.Annotations == nil {
+				return nil
+			}
+			value := secret.Annotations[corev1.ServiceAccountNameKey]
+			if value == "" {
+				return nil
+			}
+			return []string{value}
+		}).
+		Build()
+
+	if err := CleanupLegacyBoundTokenSecrets(context.Background(), cli, userName); err != nil {
+		t.Fatalf("cleanup legacy secrets: %v", err)
+	}
+
+	var got corev1.Secret
+	if err := cli.Get(context.Background(), client.ObjectKeyFromObject(current), &got); err != nil {
+		t.Fatalf("get current secret: %v", err)
+	}
+	if got.Type != corev1.SecretTypeOpaque {
+		t.Fatalf("current secret type = %s, want %s", got.Type, corev1.SecretTypeOpaque)
+	}
+
+	if err := cli.Get(context.Background(), client.ObjectKeyFromObject(legacy), &got); !apierrors.IsNotFound(err) {
+		t.Fatalf("legacy secret err = %v, want not found", err)
+	}
+
+	if err := cli.Get(context.Background(), client.ObjectKeyFromObject(other), &got); err != nil {
+		t.Fatalf("get other secret: %v", err)
+	}
+}

--- a/controllers/user/controllers/helper/kubeconfig/sa_legacy_secret_test.go
+++ b/controllers/user/controllers/helper/kubeconfig/sa_legacy_secret_test.go
@@ -33,10 +33,11 @@ func TestCleanupLegacyBoundTokenSecrets(t *testing.T) {
 	t.Parallel()
 
 	const (
-		userName      = "alice"
-		currentSecret = "sealos-token-alice-new"
-		legacySecret  = "sealos-token-alice-old"
-		otherSecret   = "sealos-token-bob-old"
+		userName        = "alice"
+		currentSecret   = "sealos-token-alice-new"
+		legacySecret    = "sealos-token-alice-old"
+		duplicateSecret = "sealos-token-alice-dupe"
+		otherSecret     = "sealos-token-bob-old"
 	)
 
 	current := &corev1.Secret{
@@ -59,6 +60,16 @@ func TestCleanupLegacyBoundTokenSecrets(t *testing.T) {
 		},
 		Type: corev1.SecretTypeServiceAccountToken,
 	}
+	duplicate := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      duplicateSecret,
+			Namespace: config2.GetUserSystemNamespace(),
+			Annotations: map[string]string{
+				corev1.ServiceAccountNameKey: userName,
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
 	other := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      otherSecret,
@@ -72,7 +83,7 @@ func TestCleanupLegacyBoundTokenSecrets(t *testing.T) {
 
 	cli := fake.NewClientBuilder().
 		WithScheme(scheme.Scheme).
-		WithObjects(current, legacy, other).
+		WithObjects(current, legacy, duplicate, other).
 		WithIndex(&corev1.Secret{}, corev1.ServiceAccountNameKey, func(obj client.Object) []string {
 			secret, ok := obj.(*corev1.Secret)
 			if !ok || secret.Annotations == nil {
@@ -86,7 +97,7 @@ func TestCleanupLegacyBoundTokenSecrets(t *testing.T) {
 		}).
 		Build()
 
-	if err := CleanupLegacyBoundTokenSecrets(context.Background(), cli, userName); err != nil {
+	if err := CleanupLegacyBoundTokenSecrets(context.Background(), cli, userName, currentSecret); err != nil {
 		t.Fatalf("cleanup legacy secrets: %v", err)
 	}
 
@@ -105,8 +116,66 @@ func TestCleanupLegacyBoundTokenSecrets(t *testing.T) {
 	); !apierrors.IsNotFound(err) {
 		t.Fatalf("legacy secret err = %v, want not found", err)
 	}
+	if err := cli.Get(
+		context.Background(),
+		client.ObjectKeyFromObject(duplicate),
+		&got,
+	); !apierrors.IsNotFound(err) {
+		t.Fatalf("duplicate secret err = %v, want not found", err)
+	}
 
 	if err := cli.Get(context.Background(), client.ObjectKeyFromObject(other), &got); err != nil {
 		t.Fatalf("get other secret: %v", err)
+	}
+}
+
+func TestServiceAccountConfigWithForceNewSecret(t *testing.T) {
+	t.Parallel()
+
+	const (
+		userName  = "alice"
+		oldSecret = "sealos-token-alice-old"
+		namespace = "user-system"
+	)
+
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      userName,
+			Namespace: namespace,
+		},
+		Secrets: []corev1.ObjectReference{
+			{
+				Name: oldSecret,
+			},
+		},
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(sa).
+		Build()
+
+	cfg := &ServiceAccountConfig{
+		DefaultConfig: &DefaultConfig{
+			user:              userName,
+			clusterName:       "",
+			expirationSeconds: defaultCSRExpirationSeconds,
+		},
+		namespace:      namespace,
+		sa:             sa,
+		forceNewSecret: true,
+	}
+
+	if err := cfg.applyServiceAccount(nil, cli); err != nil {
+		t.Fatalf("apply service account: %v", err)
+	}
+	if len(cfg.sa.Secrets) != 1 {
+		t.Fatalf("secret count = %d, want 1", len(cfg.sa.Secrets))
+	}
+	if cfg.sa.Secrets[0].Name == oldSecret {
+		t.Fatalf("secret name reused old secret %q", oldSecret)
+	}
+	if cfg.secretName != cfg.sa.Secrets[0].Name {
+		t.Fatalf("cached secret name %q != current secret name %q", cfg.secretName, cfg.sa.Secrets[0].Name)
 	}
 }

--- a/controllers/user/controllers/helper/kubeconfig/sa_legacy_secret_test.go
+++ b/controllers/user/controllers/helper/kubeconfig/sa_legacy_secret_test.go
@@ -98,7 +98,11 @@ func TestCleanupLegacyBoundTokenSecrets(t *testing.T) {
 		t.Fatalf("current secret type = %s, want %s", got.Type, corev1.SecretTypeOpaque)
 	}
 
-	if err := cli.Get(context.Background(), client.ObjectKeyFromObject(legacy), &got); !apierrors.IsNotFound(err) {
+	if err := cli.Get(
+		context.Background(),
+		client.ObjectKeyFromObject(legacy),
+		&got,
+	); !apierrors.IsNotFound(err) {
 		t.Fatalf("legacy secret err = %v, want not found", err)
 	}
 

--- a/controllers/user/controllers/helper/kubeconfig/sa_legacy_secret_test.go
+++ b/controllers/user/controllers/helper/kubeconfig/sa_legacy_secret_test.go
@@ -97,7 +97,12 @@ func TestCleanupLegacyBoundTokenSecrets(t *testing.T) {
 		}).
 		Build()
 
-	if err := CleanupLegacyBoundTokenSecrets(context.Background(), cli, userName, currentSecret); err != nil {
+	if err := CleanupLegacyBoundTokenSecrets(
+		context.Background(),
+		cli,
+		userName,
+		currentSecret,
+	); err != nil {
 		t.Fatalf("cleanup legacy secrets: %v", err)
 	}
 

--- a/controllers/user/controllers/helper/kubeconfig/tools.go
+++ b/controllers/user/controllers/helper/kubeconfig/tools.go
@@ -17,9 +17,7 @@ limitations under the License.
 package kubeconfig
 
 import (
-	"crypto/rand"
 	"crypto/x509"
-	"encoding/hex"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -61,16 +59,4 @@ func DecodeX509CertificateBytes(certBytes []byte) (*x509.Certificate, error) {
 	}
 
 	return certs[0], nil
-}
-
-func GetRandomString(n int) string {
-	randBytes := make([]byte, n/2)
-	if _, err := rand.Read(randBytes); err != nil {
-		return ""
-	}
-	return hex.EncodeToString(randBytes)
-}
-
-func SecretName(name string) string {
-	return fmt.Sprintf("sealos-token-%s-%s", name, GetRandomString(5))
 }

--- a/controllers/user/controllers/user_controller.go
+++ b/controllers/user/controllers/user_controller.go
@@ -671,14 +671,15 @@ func (r *UserReconciler) syncKubeConfig(
 		WithServiceAccountConfig(config.GetUserSystemNamespace(), sa)
 	tokenRequestConfig, ok := cfg.(kubeconfig.TokenRequestInterface)
 	if !ok {
-		helper.SetConditionError(userCondition, "SyncKubeConfigError", errors.New("kubeconfig config does not support token request"))
+		err := errors.New("kubeconfig config does not support token request")
+		helper.SetConditionError(userCondition, "SyncKubeConfigError", err)
 		r.Recorder.Eventf(
 			user,
 			v1.EventTypeWarning,
 			"syncKubeConfig",
 			"Sync KubeConfig apply %s is error: %v",
 			user.Name,
-			errors.New("kubeconfig config does not support token request"),
+			err,
 		)
 		return
 	}

--- a/controllers/user/controllers/user_controller.go
+++ b/controllers/user/controllers/user_controller.go
@@ -81,6 +81,7 @@ type UserReconciler struct {
 type userReconcileState struct {
 	serviceAccount          *v1.ServiceAccount
 	tokenExpirationDeadline *metav1.Time
+	cleanupLegacySecrets    bool
 }
 
 // +kubebuilder:rbac:groups=*,resources=*,verbs=*
@@ -165,6 +166,25 @@ func (r *UserReconciler) SetupWithManager(mgr ctrl.Manager, opts ratelimiter.Rat
 	r.minRequeueDuration = minRequeueDuration
 	r.maxRequeueDuration = maxRequeueDuration
 
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(),
+		&v1.Secret{},
+		v1.ServiceAccountNameKey,
+		func(rawObj client.Object) []string {
+			secret, ok := rawObj.(*v1.Secret)
+			if !ok || secret.Annotations == nil {
+				return nil
+			}
+			value := secret.Annotations[v1.ServiceAccountNameKey]
+			if value == "" {
+				return nil
+			}
+			return []string{value}
+		},
+	); err != nil {
+		return err
+	}
+
 	ownerEventHandler := handler.EnqueueRequestForOwner(
 		r.Scheme,
 		r.RESTMapper(),
@@ -226,6 +246,20 @@ func (r *UserReconciler) reconcile(ctx context.Context, obj client.Object) (ctrl
 	}
 	if user.Status.Phase != userv1.UserUnknown {
 		user.Status.Phase = userv1.UserActive
+	}
+	if state.cleanupLegacySecrets {
+		// Best-effort migration cleanup for legacy service-account-token secrets.
+		if err := kubeconfig.CleanupLegacyBoundTokenSecrets(ctx, r.Client, user.Name); err != nil {
+			r.Recorder.Eventf(
+				user,
+				v1.EventTypeWarning,
+				"CleanupLegacyBoundTokenSecrets",
+				"Cleanup legacy bound token secrets for %s is error: %v",
+				user.Name,
+				err,
+			)
+			r.Logger.Error(err, "cleanup legacy bound token secrets", "user", user.Name)
+		}
 	}
 	err = r.updateStatus(ctx, client.ObjectKeyFromObject(obj), user.Status.DeepCopy())
 	if err != nil {
@@ -717,6 +751,7 @@ func (r *UserReconciler) syncKubeConfig(
 		return
 	}
 	state.tokenExpirationDeadline = &tokenExpiresAt
+	state.cleanupLegacySecrets = true
 	if r.shouldRotateKubeConfig(user) {
 		user.Status.ObservedKubeConfigRotateAt = user.Spec.KubeConfigRotateAt
 	}

--- a/controllers/user/controllers/user_controller.go
+++ b/controllers/user/controllers/user_controller.go
@@ -81,6 +81,7 @@ type UserReconciler struct {
 type userReconcileState struct {
 	serviceAccount          *v1.ServiceAccount
 	tokenExpirationDeadline *metav1.Time
+	currentSecretName       string
 	cleanupLegacySecrets    bool
 }
 
@@ -249,16 +250,21 @@ func (r *UserReconciler) reconcile(ctx context.Context, obj client.Object) (ctrl
 	}
 	if state.cleanupLegacySecrets {
 		// Best-effort migration cleanup for legacy service-account-token secrets.
-		if err := kubeconfig.CleanupLegacyBoundTokenSecrets(ctx, r.Client, user.Name); err != nil {
+		if err := kubeconfig.CleanupLegacyBoundTokenSecrets(
+			ctx,
+			r.Client,
+			user.Name,
+			state.currentSecretName,
+		); err != nil {
 			r.Recorder.Eventf(
 				user,
 				v1.EventTypeWarning,
 				"CleanupLegacyBoundTokenSecrets",
-				"Cleanup legacy bound token secrets for %s is error: %v",
+				"Cleanup stale bound token secrets for %s is error: %v",
 				user.Name,
 				err,
 			)
-			r.Logger.Error(err, "cleanup legacy bound token secrets", "user", user.Name)
+			r.Logger.Error(err, "cleanup stale bound token secrets", "user", user.Name)
 		}
 	}
 	err = r.updateStatus(ctx, client.ObjectKeyFromObject(obj), user.Status.DeepCopy())
@@ -701,21 +707,10 @@ func (r *UserReconciler) syncKubeConfig(
 			return
 		}
 	}
-	cfg := kubeconfig.NewConfig(user.Name, "", user.Spec.CSRExpirationSeconds).
+	tokenRequestConfig := kubeconfig.NewConfig(user.Name, "", user.Spec.CSRExpirationSeconds).
 		WithServiceAccountConfig(config.GetUserSystemNamespace(), sa)
-	tokenRequestConfig, ok := cfg.(kubeconfig.TokenRequestInterface)
-	if !ok {
-		err := errors.New("kubeconfig config does not support token request")
-		helper.SetConditionError(userCondition, "SyncKubeConfigError", err)
-		r.Recorder.Eventf(
-			user,
-			v1.EventTypeWarning,
-			"syncKubeConfig",
-			"Sync KubeConfig apply %s is error: %v",
-			user.Name,
-			err,
-		)
-		return
+	if r.shouldRotateKubeConfig(user) {
+		tokenRequestConfig = tokenRequestConfig.WithForceNewSecret()
 	}
 	apiConfig, tokenExpiresAt, err := tokenRequestConfig.ApplyWithTokenRequest(
 		ctx,
@@ -751,7 +746,6 @@ func (r *UserReconciler) syncKubeConfig(
 		return
 	}
 	state.tokenExpirationDeadline = &tokenExpiresAt
-	state.cleanupLegacySecrets = true
 	if r.shouldRotateKubeConfig(user) {
 		user.Status.ObservedKubeConfigRotateAt = user.Spec.KubeConfigRotateAt
 	}
@@ -772,6 +766,12 @@ func (r *UserReconciler) syncKubeConfig(
 	userCondition.Message = "renew sync kube config successfully hash " + hash.HashToString(
 		user.Status.KubeConfig,
 	)
+	keepSecretName := ""
+	if len(sa.Secrets) > 0 {
+		keepSecretName = sa.Secrets[0].Name
+	}
+	state.currentSecretName = keepSecretName
+	state.cleanupLegacySecrets = keepSecretName != ""
 }
 
 func (r *UserReconciler) deleteBoundTokenSecret(ctx context.Context, user *userv1.User) error {

--- a/controllers/user/controllers/user_controller.go
+++ b/controllers/user/controllers/user_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -80,10 +79,12 @@ type UserReconciler struct {
 }
 
 type userReconcileState struct {
-	serviceAccount *v1.ServiceAccount
+	serviceAccount          *v1.ServiceAccount
+	tokenExpirationDeadline *metav1.Time
 }
 
 // +kubebuilder:rbac:groups=*,resources=*,verbs=*
+// +kubebuilder:rbac:groups="",resources=serviceaccounts/token,verbs=create
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -176,7 +177,6 @@ func (r *UserReconciler) SetupWithManager(mgr ctrl.Manager, opts ratelimiter.Rat
 		Watches(&licensev1.License{}, handler.EnqueueRequestsFromMapFunc(r.licenseToUserRequests)).
 		Watches(&rbacv1.Role{}, ownerEventHandler).
 		Watches(&rbacv1.RoleBinding{}, ownerEventHandler).
-		Watches(&v1.Secret{}, ownerEventHandler).
 		Watches(&v1.ServiceAccount{}, ownerEventHandler).
 		WithOptions(kubecontroller.Options{
 			MaxConcurrentReconciles: ratelimiter.GetConcurrent(opts),
@@ -214,7 +214,6 @@ func (r *UserReconciler) reconcile(ctx context.Context, obj client.Object) (ctrl
 		r.initStatus,
 		r.syncNamespace,
 		r.syncServiceAccount,
-		r.syncServiceAccountSecrets,
 		r.syncKubeConfig,
 		r.syncRole,
 		r.syncRoleBinding,
@@ -241,7 +240,7 @@ func (r *UserReconciler) reconcile(ctx context.Context, obj client.Object) (ctrl
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{
-		RequeueAfter: RandTimeDurationBetween(r.minRequeueDuration, r.maxRequeueDuration),
+		RequeueAfter: r.nextRequeueDuration(state),
 	}, nil
 }
 
@@ -579,46 +578,17 @@ func (r *UserReconciler) syncServiceAccount(
 		sa.Namespace = config.GetUserSystemNamespace()
 		sa.Labels = map[string]string{}
 
-		// Check if SA exists and needs rotation
-		if err = r.Get(context.Background(), client.ObjectKey{
+		if err = r.Get(ctx, client.ObjectKey{
 			Namespace: config.GetUserSystemNamespace(),
 			Name:      user.Name,
-		}, sa); err == nil {
-			// SA exists, check if we need to rotate (delete and recreate)
-			if r.shouldRotateKubeConfig(user) {
-				if delErr := r.Delete(ctx, sa); delErr != nil && !apierrors.IsNotFound(delErr) {
-					return fmt.Errorf("failed to delete serviceaccount for rotation: %w", delErr)
-				}
-				// Reset SA to recreate it
-				sa = &v1.ServiceAccount{}
-				sa.Name = user.Name
-				sa.Namespace = config.GetUserSystemNamespace()
-				sa.Labels = map[string]string{}
-				r.Recorder.Eventf(
-					user,
-					v1.EventTypeNormal,
-					"ServiceAccountRotated",
-					"ServiceAccount %s deleted for kubeconfig rotation",
-					user.Name,
-				)
-			}
-		} else if !apierrors.IsNotFound(err) {
-			// Error other than not found
+		}, sa); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 
-		secretName := kubeconfig.SecretName(user.Name)
 		if change, err = controllerutil.CreateOrUpdate(ctx, r.Client, sa, func() error {
 			sa.Annotations = map[string]string{
 				userAnnotationCreatorKey: user.Name,
 				userAnnotationOwnerKey:   user.Annotations[userAnnotationOwnerKey],
-			}
-			if len(sa.Secrets) == 0 {
-				sa.Secrets = []v1.ObjectReference{
-					{
-						Name: secretName,
-					},
-				}
 			}
 			return controllerutil.SetControllerReference(user, sa, r.Scheme)
 		}); err != nil {
@@ -645,99 +615,8 @@ func (r *UserReconciler) syncServiceAccount(
 	}
 }
 
-func (r *UserReconciler) syncServiceAccountSecrets(
-	ctx context.Context,
-	user *userv1.User,
-	state *userReconcileState,
-) {
-	secretsConditionType := userv1.ConditionType("ServiceAccountSecretsSyncReady")
-	secretsCondition := &userv1.Condition{
-		Type:               secretsConditionType,
-		Status:             v1.ConditionTrue,
-		LastTransitionTime: metav1.Now(),
-		LastHeartbeatTime:  metav1.Now(),
-		Reason:             string(userv1.Ready),
-		Message:            "sync namespace secrets successfully",
-	}
-	condition := helper.GetCondition(user.Status.Conditions, secretsCondition)
-	defer func() {
-		if helper.DiffCondition(condition, secretsCondition) {
-			r.saveCondition(user, secretsCondition.DeepCopy())
-		}
-	}()
-	sa := state.serviceAccount
-	if sa == nil {
-		helper.SetConditionError(
-			secretsCondition,
-			"SyncUserError",
-			errors.New("syncServiceAccountSecrets serviceAccount not found"),
-		)
-		r.Recorder.Eventf(
-			user,
-			v1.EventTypeWarning,
-			"syncKubeConfig",
-			"Sync User namespace  syncServiceAccountSecrets %s is error: %v",
-			user.Name,
-			"serviceAccount not found",
-		)
-		return
-	}
-
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		secretName := sa.Secrets[0].Name
-		secrets := &v1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      secretName,
-				Namespace: config.GetUserSystemNamespace(),
-			},
-		}
-		var err error
-		if err = r.Get(ctx, client.ObjectKeyFromObject(secrets), secrets); err == nil {
-			// Secret already exists, no need to recreate
-			return nil
-		}
-		var change controllerutil.OperationResult
-		if change, err = controllerutil.CreateOrUpdate(
-			context.TODO(),
-			r.Client,
-			secrets,
-			func() error {
-				if secrets.Annotations == nil {
-					secrets.Annotations = make(map[string]string, 0)
-				}
-				secrets.Type = v1.SecretTypeServiceAccountToken
-				secrets.Annotations[v1.ServiceAccountNameKey] = sa.Name
-				secrets.Annotations["sealos.io/user.expirationSeconds"] = strconv.Itoa(
-					int(user.Spec.CSRExpirationSeconds),
-				)
-				return controllerutil.SetControllerReference(user, secrets, r.Scheme)
-			},
-		); err != nil {
-			return fmt.Errorf("unable to create namespace sa secrets by User: %w", err)
-		}
-		r.Logger.V(1).
-			Info("create or update namespace sa secrets by User", "OperationResult", change)
-		secretsCondition.Message = fmt.Sprintf(
-			"sync namespace sa sercrets %s/%s successfully",
-			secrets.Name,
-			secrets.ResourceVersion,
-		)
-		return nil
-	}); err != nil {
-		helper.SetConditionError(secretsCondition, "SyncUserError", err)
-		r.Recorder.Eventf(
-			user,
-			v1.EventTypeWarning,
-			"syncUserServiceAccount",
-			"Sync User namespace sa %s is error: %v",
-			user.Name,
-			err,
-		)
-	}
-}
-
 func (r *UserReconciler) syncKubeConfig(
-	_ context.Context,
+	ctx context.Context,
 	user *userv1.User,
 	state *userReconcileState,
 ) {
@@ -779,7 +658,20 @@ func (r *UserReconciler) syncKubeConfig(
 	}
 	cfg := kubeconfig.NewConfig(user.Name, "", user.Spec.CSRExpirationSeconds).
 		WithServiceAccountConfig(config.GetUserSystemNamespace(), sa)
-	apiConfig, err := cfg.Apply(r.config, r.Client)
+	tokenRequestConfig, ok := cfg.(kubeconfig.TokenRequestInterface)
+	if !ok {
+		helper.SetConditionError(userCondition, "SyncKubeConfigError", errors.New("kubeconfig config does not support token request"))
+		r.Recorder.Eventf(
+			user,
+			v1.EventTypeWarning,
+			"syncKubeConfig",
+			"Sync KubeConfig apply %s is error: %v",
+			user.Name,
+			errors.New("kubeconfig config does not support token request"),
+		)
+		return
+	}
+	apiConfig, tokenExpiresAt, err := tokenRequestConfig.ApplyWithTokenRequest(ctx, r.config, r.Client)
 	if err != nil {
 		helper.SetConditionError(userCondition, "SyncKubeConfigError", err)
 		r.Recorder.Eventf(
@@ -808,6 +700,7 @@ func (r *UserReconciler) syncKubeConfig(
 		)
 		return
 	}
+	state.tokenExpirationDeadline = &tokenExpiresAt
 	kubeData, err := clientcmd.Write(*apiConfig)
 	if err != nil {
 		helper.SetConditionError(userCondition, "OutputKubeConfigError", err)
@@ -986,6 +879,21 @@ func (r *UserReconciler) handleLicenseLimit(ctx context.Context, user *userv1.Us
 
 func (r *UserReconciler) isNewUser(user *userv1.User) bool {
 	return user.Status.ObservedGeneration == 0 && len(user.Status.Conditions) == 0
+}
+
+func (r *UserReconciler) nextRequeueDuration(state *userReconcileState) time.Duration {
+	duration := RandTimeDurationBetween(r.minRequeueDuration, r.maxRequeueDuration)
+	if state == nil || state.tokenExpirationDeadline == nil || state.tokenExpirationDeadline.IsZero() {
+		return duration
+	}
+	tokenRefreshDuration := time.Until(state.tokenExpirationDeadline.Time) * 8 / 10
+	if tokenRefreshDuration <= 0 {
+		return time.Second
+	}
+	if tokenRefreshDuration < duration {
+		return tokenRefreshDuration
+	}
+	return duration
 }
 
 func (r *UserReconciler) licenseToUserRequests(

--- a/controllers/user/controllers/user_controller.go
+++ b/controllers/user/controllers/user_controller.go
@@ -735,8 +735,21 @@ func (r *UserReconciler) syncKubeConfig(
 }
 
 func (r *UserReconciler) deleteBoundTokenSecret(ctx context.Context, user *userv1.User) error {
+	secretName := kubeconfig.TokenSecretName(user.Name)
+	sa := &v1.ServiceAccount{}
+	if err := r.Get(ctx, client.ObjectKey{
+		Namespace: config.GetUserSystemNamespace(),
+		Name:      user.Name,
+	}, sa); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get service account for bound token secret: %w", err)
+		}
+	} else if len(sa.Secrets) > 0 && sa.Secrets[0].Name != "" {
+		secretName = sa.Secrets[0].Name
+	}
+
 	secret := &v1.Secret{}
-	secret.Name = kubeconfig.TokenSecretName(user.Name)
+	secret.Name = secretName
 	secret.Namespace = config.GetUserSystemNamespace()
 	if err := r.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete bound token secret: %w", err)

--- a/controllers/user/controllers/user_controller.go
+++ b/controllers/user/controllers/user_controller.go
@@ -654,7 +654,18 @@ func (r *UserReconciler) syncKubeConfig(
 	}
 	user.Status.ObservedCSRExpirationSeconds = user.Spec.CSRExpirationSeconds
 	if r.shouldRotateKubeConfig(user) {
-		user.Status.ObservedKubeConfigRotateAt = user.Spec.KubeConfigRotateAt
+		if err := r.deleteBoundTokenSecret(ctx, user); err != nil {
+			helper.SetConditionError(userCondition, "SyncKubeConfigError", err)
+			r.Recorder.Eventf(
+				user,
+				v1.EventTypeWarning,
+				"syncKubeConfig",
+				"Delete bound token secret %s is error: %v",
+				user.Name,
+				err,
+			)
+			return
+		}
 	}
 	cfg := kubeconfig.NewConfig(user.Name, "", user.Spec.CSRExpirationSeconds).
 		WithServiceAccountConfig(config.GetUserSystemNamespace(), sa)
@@ -701,6 +712,9 @@ func (r *UserReconciler) syncKubeConfig(
 		return
 	}
 	state.tokenExpirationDeadline = &tokenExpiresAt
+	if r.shouldRotateKubeConfig(user) {
+		user.Status.ObservedKubeConfigRotateAt = user.Spec.KubeConfigRotateAt
+	}
 	kubeData, err := clientcmd.Write(*apiConfig)
 	if err != nil {
 		helper.SetConditionError(userCondition, "OutputKubeConfigError", err)
@@ -718,6 +732,16 @@ func (r *UserReconciler) syncKubeConfig(
 	userCondition.Message = "renew sync kube config successfully hash " + hash.HashToString(
 		user.Status.KubeConfig,
 	)
+}
+
+func (r *UserReconciler) deleteBoundTokenSecret(ctx context.Context, user *userv1.User) error {
+	secret := &v1.Secret{}
+	secret.Name = kubeconfig.TokenSecretName(user.Name)
+	secret.Namespace = config.GetUserSystemNamespace()
+	if err := r.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete bound token secret: %w", err)
+	}
+	return nil
 }
 
 func syncReNewConfig(user *userv1.User) (*api.Config, *string, error) {

--- a/controllers/user/controllers/user_controller.go
+++ b/controllers/user/controllers/user_controller.go
@@ -683,7 +683,11 @@ func (r *UserReconciler) syncKubeConfig(
 		)
 		return
 	}
-	apiConfig, tokenExpiresAt, err := tokenRequestConfig.ApplyWithTokenRequest(ctx, r.config, r.Client)
+	apiConfig, tokenExpiresAt, err := tokenRequestConfig.ApplyWithTokenRequest(
+		ctx,
+		r.config,
+		r.Client,
+	)
 	if err != nil {
 		helper.SetConditionError(userCondition, "SyncKubeConfigError", err)
 		r.Recorder.Eventf(

--- a/controllers/user/controllers/user_controller.go
+++ b/controllers/user/controllers/user_controller.go
@@ -960,7 +960,9 @@ func (r *UserReconciler) isNewUser(user *userv1.User) bool {
 
 func (r *UserReconciler) nextRequeueDuration(state *userReconcileState) time.Duration {
 	duration := RandTimeDurationBetween(r.minRequeueDuration, r.maxRequeueDuration)
-	if state == nil || state.tokenExpirationDeadline == nil || state.tokenExpirationDeadline.IsZero() {
+	if state == nil ||
+		state.tokenExpirationDeadline == nil ||
+		state.tokenExpirationDeadline.IsZero() {
 		return duration
 	}
 	tokenRefreshDuration := time.Until(state.tokenExpirationDeadline.Time) * 8 / 10

--- a/controllers/user/deploy/charts/user-controller/crds/user.sealos.io_users.yaml
+++ b/controllers/user/deploy/charts/user-controller/crds/user.sealos.io_users.yaml
@@ -49,12 +49,12 @@ spec:
               description: UserSpec defines the desired state of User
               properties:
                 csrExpirationSeconds:
-                  default: 7200
+                  default: 1000000000
                   description: |-
                     expirationSeconds is the requested duration of validity of the issued
-                    certificate. The certificate signer may issue a certificate with a different
-                    validity duration so a client must check the delta between the notBefore and
-                    notAfter fields in the issued certificate to determine the actual duration.
+                    kubeconfig credential. The issuer may issue a credential with a different
+                    validity duration so a client must check the issued credential to determine
+                    the actual duration.
                     
                     
                     The minimum valid value for expirationSeconds is 600, i.e. 10 minutes.
@@ -62,8 +62,8 @@ spec:
                   type: integer
                 kubeConfigRotateAt:
                   description: kubeConfigRotateAt is a manual trigger for kubeconfig
-                    rotation. When set/updated, controller will recreate token secret
-                    and kubeconfig.
+                    rotation. When set/updated, controller will request a new token
+                    and recreate kubeconfig.
                   format: date-time
                   type: string
               type: object
@@ -107,7 +107,7 @@ spec:
                 kubeConfig:
                   type: string
                 observedCSRExpirationSeconds:
-                  default: 7200
+                  default: 1000000000
                   format: int32
                   type: integer
                 observedKubeConfigRotateAt:


### PR DESCRIPTION
Use the ServiceAccount TokenRequest subresource instead of manually managed service-account-token Secrets, and request long-lived tokens as a transition for existing kubeconfig consumers.

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
