### PR TITLE
fix(applaunchpad): prevent app name hover flicker

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/components/apps/appList.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/components/apps/appList.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'fs';
+import { describe, expect, it } from 'vitest';
+
+describe('AppList name hover layout', () => {
+  it('keeps the hover area and remarked app name width stable', () => {
+    const source = readFileSync(
+      new URL('../../../../src/components/apps/appList.tsx', import.meta.url),
+      'utf8'
+    );
+
+    expect(source).toContain('width="100%"');
+    expect(source).toContain('minWidth={0}');
+    expect(source).toContain("'& .remark-button-sibling': {");
+    expect(source).toContain(
+      "className={item.remark ? undefined : 'remark-button-sibling'}"
+    );
+    expect(source).not.toContain("'& .app-name': {");
+  });
+});

--- a/frontend/providers/applaunchpad/src/components/apps/appList.tsx
+++ b/frontend/providers/applaunchpad/src/components/apps/appList.tsx
@@ -205,13 +205,15 @@ const AppList = ({
               pl={4}
               fontSize={'14px'}
               fontWeight={'500'}
+              width="100%"
+              minWidth={0}
               alignItems={item?.remark ? 'flex-start' : 'center'}
               _hover={{
                 '& .remark-button': {
                   opacity: 1,
                   visibility: 'visible'
                 },
-                '& .app-name': {
+                '& .remark-button-sibling': {
                   maxWidth: '100px'
                 }
               }}
@@ -221,7 +223,7 @@ const AppList = ({
               <Flex alignItems="center" width="100%">
                 <MyTooltip label={item.name}>
                   <Text
-                    className="app-name"
+                    className={item.remark ? undefined : 'remark-button-sibling'}
                     overflow="hidden"
                     textOverflow="ellipsis"
                     whiteSpace="nowrap"
@@ -255,7 +257,7 @@ const AppList = ({
               {item.remark && (
                 <Flex alignItems="center" width="100%">
                   <Text
-                    className="app-name"
+                    className="remark-button-sibling"
                     fontSize={'12px'}
                     color={'#737373'}
                     flex={1}


### PR DESCRIPTION
## Summary

- Keep the application list hover hit area stable when an app has a remark.
- Scope the width transition to the text beside the remark action so the application-name tooltip anchor does not resize.
- Add a regression assertion for the layout contract.

## Sequence Diagram

```mermaid
sequenceDiagram
    participant User
    participant AppList
    participant Tooltip
    participant RemarkAction

    User->>AppList: Hover an application name
    AppList->>Tooltip: Keep the application-name anchor width stable
    AppList->>RemarkAction: Reveal the edit action
    RemarkAction-->>AppList: Resize only the sibling remark text
    AppList-->>User: Show a stable, non-flickering row
```

## Verification

- `pnpm --filter applaunchpad build`
- `pnpm exec tsc --noEmit -p providers/applaunchpad/tsconfig.json`
- Cluster 62 rollout verified with the new AMD64 image, `/healthz` 200, and `/apps` 200.