### PR TITLE
feat(dbprovider): add independent log analysis toggle

### DIFF
--- a/frontend/providers/dbprovider/README.md
+++ b/frontend/providers/dbprovider/README.md
@@ -20,6 +20,14 @@ dbproviderConfig:
   dataImportEnabled: 'false'
 ```
 
+`dbproviderConfig.logEnabled` controls whether the Log Analysis tab appears on supported database
+detail pages. It defaults to `"false"` and is independent of `backupEnabled`:
+
+```yaml
+dbproviderConfig:
+  logEnabled: 'true'
+```
+
 The installer seeds `/root/.sealos/cloud/values/apps/dataflow/dbprovider-values.yaml` from
 `dbprovider-frontend-values.yaml` only when the user values file does not exist. Existing
 installations must update their persisted user values explicitly. This setting does not block

--- a/frontend/providers/dbprovider/deploy/charts/dbprovider-frontend/dbprovider-frontend-values.yaml
+++ b/frontend/providers/dbprovider/deploy/charts/dbprovider-frontend/dbprovider-frontend-values.yaml
@@ -39,6 +39,7 @@ dbproviderConfig:
   monitorUrl: "http://database-monitor.sealos.svc.cluster.local:9090"
   migrateFileImage: ""
   backupEnabled: "true"
+  logEnabled: "false"
   showDocument: "true"
   dataImportEnabled: "false"
   guideEnabled: "true"

--- a/frontend/providers/dbprovider/deploy/charts/dbprovider-frontend/templates/configmap.yaml
+++ b/frontend/providers/dbprovider/deploy/charts/dbprovider-frontend/templates/configmap.yaml
@@ -13,6 +13,7 @@ data:
     MONITOR_URL={{ .Values.dbproviderConfig.monitorUrl }}
     MIGRATE_FILE_IMAGE={{ .Values.dbproviderConfig.migrateFileImage }}
     BACKUP_ENABLED={{ .Values.dbproviderConfig.backupEnabled }}
+    LOG_ENABLED={{ .Values.dbproviderConfig.logEnabled }}
     SHOW_DOCUMENT={{ .Values.dbproviderConfig.showDocument }}
     DATA_IMPORT_ENABLED={{ .Values.dbproviderConfig.dataImportEnabled }}
     GUIDE_ENABLED={{ .Values.dbproviderConfig.guideEnabled }}

--- a/frontend/providers/dbprovider/deploy/charts/dbprovider-frontend/values.yaml
+++ b/frontend/providers/dbprovider/deploy/charts/dbprovider-frontend/values.yaml
@@ -73,6 +73,7 @@ dbproviderConfig:
   monitorUrl: "http://database-monitor.sealos.svc.cluster.local:9090"
   migrateFileImage: ""
   backupEnabled: "true"
+  logEnabled: "false"
   showDocument: "true"
   dataImportEnabled: "false"
   guideEnabled: "true"

--- a/frontend/providers/dbprovider/src/pages/api/getEnv.ts
+++ b/frontend/providers/dbprovider/src/pages/api/getEnv.ts
@@ -10,6 +10,7 @@ export type SystemEnvResponse = {
   migrate_file_image: string;
   minio_url: string;
   BACKUP_ENABLED: boolean;
+  LOG_ENABLED: boolean;
   SHOW_DOCUMENT: boolean;
   DATA_IMPORT_ENABLED: boolean;
   KAFKA_ENABLED: boolean;
@@ -37,6 +38,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       migrate_file_image: process.env.MIGRATE_FILE_IMAGE || 'ghcr.io/wallyxjh/test:7.1',
       minio_url: process.env.MINIO_URL || '',
       BACKUP_ENABLED: process.env.BACKUP_ENABLED === 'true',
+      LOG_ENABLED: process.env.LOG_ENABLED === 'true',
       SHOW_DOCUMENT: process.env.SHOW_DOCUMENT === 'true',
       DATA_IMPORT_ENABLED: process.env.DATA_IMPORT_ENABLED !== 'false',
       KAFKA_ENABLED: process.env.KAFKA_ENABLED !== 'false',

--- a/frontend/providers/dbprovider/src/pages/db/detail/index.tsx
+++ b/frontend/providers/dbprovider/src/pages/db/detail/index.tsx
@@ -61,6 +61,7 @@ const AppDetail = ({
     );
     const MigrateSupported = ['postgresql', 'mongodb', 'apecloud-mysql'].includes(dbType);
     const BackupSupported = BackupSupportedDBTypeList.includes(dbType) && SystemEnv.BACKUP_ENABLED;
+    const LogSupported = BackupSupportedDBTypeList.includes(dbType) && SystemEnv.LOG_ENABLED;
     const MonitorSupported = dbType !== 'polardbx';
     const DataImportSupported = PublicNetMigration && SystemEnv.DATA_IMPORT_ENABLED;
 
@@ -111,7 +112,7 @@ const AppDetail = ({
             }
           ]
         : []),
-      ...(BackupSupported
+      ...(LogSupported
         ? [
             {
               label: 'error_log.analysis',
@@ -129,7 +130,7 @@ const AppDetail = ({
       isDataImportSupported: DataImportSupported,
       listNav: listNavValue
     };
-  }, [SystemEnv.BACKUP_ENABLED, SystemEnv.DATA_IMPORT_ENABLED, dbType, t]);
+  }, [SystemEnv.BACKUP_ENABLED, SystemEnv.DATA_IMPORT_ENABLED, SystemEnv.LOG_ENABLED, dbType, t]);
 
   const theme = useTheme();
   const { message: toast } = useMessage();

--- a/frontend/providers/dbprovider/src/store/env.ts
+++ b/frontend/providers/dbprovider/src/store/env.ts
@@ -20,6 +20,7 @@ const useEnvStore = create<EnvState>()(
       migrate_file_image: '',
       minio_url: '',
       BACKUP_ENABLED: false,
+      LOG_ENABLED: false,
       SHOW_DOCUMENT: true,
       DATA_IMPORT_ENABLED: true,
       KAFKA_ENABLED: true,

--- a/frontend/providers/dbprovider/src/utils/healthz.ts
+++ b/frontend/providers/dbprovider/src/utils/healthz.ts
@@ -5,6 +5,7 @@ export function assertReady() {
   readNonEmptyEnv('DESKTOP_DOMAIN');
   readNonEmptyEnv('BILLING_URL');
   readOptionalBooleanEnv('BACKUP_ENABLED');
+  readOptionalBooleanEnv('LOG_ENABLED');
   readOptionalBooleanEnv('DATA_IMPORT_ENABLED');
   readOptionalBooleanEnv('GUIDE_ENABLED');
   readOptionalBooleanEnv('KAFKA_ENABLED');


### PR DESCRIPTION
<!--
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR,
because it will be placed in the release note.
-->

## Summary

Add an independent `LOG_ENABLED` flag for the database detail Log Analysis tab, defaulting to disabled and leaving `BACKUP_ENABLED` responsible only for backup UI. The flag is wired through Helm values, the ConfigMap, `/api/getEnv`, health validation, and documented in the dbprovider README.

## Sequence Diagram

```mermaid
sequenceDiagram
    participant Helm as Helm values
    participant ConfigMap
    participant API as /api/getEnv
    participant UI as Database detail page
    Helm->>ConfigMap: Render dbproviderConfig.logEnabled
    ConfigMap->>API: Expose LOG_ENABLED
    API-->>UI: Return LOG_ENABLED boolean
    UI->>UI: Show Log Analysis tab only when enabled and DB type is supported
```

## Verification

- `helm lint frontend/providers/dbprovider/deploy/charts/dbprovider-frontend`
- Helm template checks confirmed default `LOG_ENABLED=false` and explicit enablement.
- Production amd64 image build and push succeeded; cluster 62 rollout reached `1/1 Running`, and ingress `/healthz` plus `/api/getEnv` returned healthy responses with `LOG_ENABLED=false`.
