### PR TITLE
fix(user): make kube API client rate limit configurable

### DIFF
--- a/controllers/user/config/default/manager_auth_proxy_patch.yaml
+++ b/controllers/user/config/default/manager_auth_proxy_patch.yaml
@@ -53,18 +53,11 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
-        - "--config-file-path=/config.yaml"
-        volumeMounts:
-          - name: user-manager-volume
-            mountPath: /config.yaml
-            subPath: config.yaml
+        - "--kube-api-qps=5"
+        - "--kube-api-burst=10"
         env:
           - name: NAMESPACE_NAME
             valueFrom:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.namespace
-      volumes:
-      - name: user-manager-volume
-        configMap:
-          name: user-manager-config

--- a/controllers/user/deploy/README.md
+++ b/controllers/user/deploy/README.md
@@ -8,7 +8,7 @@ sealos build -t docker.io/labring/sealos-user-controller:latest -f Kubefile .
 
 ```shell
 # 可选：使用 HELM_OPTS 传递 Helm 参数，例如覆盖云 API Server 域名/端口
-# export HELM_OPTS="--set cloudAPIServerDomain=my.domain --set cloudAPIServerPort=6443"
+# export HELM_OPTS="--set cloudAPIServerDomain=my.domain --set cloudAPIServerPort=6443 --set kubeAPI.qps=50 --set kubeAPI.burst=100"
 
 sealos run docker.io/labring/sealos-user-controller:latest
 ```

--- a/controllers/user/deploy/charts/user-controller/templates/deployment.yaml
+++ b/controllers/user/deploy/charts/user-controller/templates/deployment.yaml
@@ -39,6 +39,8 @@ spec:
           args:
             - --health-probe-bind-address=:8081
             - --leader-elect
+            - --kube-api-qps={{ .Values.kubeAPI.qps }}
+            - --kube-api-burst={{ .Values.kubeAPI.burst }}
             {{- if .Values.metrics.enabled }}
             - --metrics-secure=true
             - --metrics-bind-address=:8443

--- a/controllers/user/deploy/charts/user-controller/user-controller-values.yaml
+++ b/controllers/user/deploy/charts/user-controller/user-controller-values.yaml
@@ -10,3 +10,7 @@ resources:
   requests:
     cpu: 10m
     memory: 64Mi
+
+kubeAPI:
+  qps: 5
+  burst: 10

--- a/controllers/user/deploy/charts/user-controller/user-controller-values.yaml
+++ b/controllers/user/deploy/charts/user-controller/user-controller-values.yaml
@@ -12,5 +12,5 @@ resources:
     memory: 64Mi
 
 kubeAPI:
-  qps: 5
-  burst: 10
+  qps: 50
+  burst: 100

--- a/controllers/user/deploy/charts/user-controller/values.yaml
+++ b/controllers/user/deploy/charts/user-controller/values.yaml
@@ -46,8 +46,8 @@ readinessProbe:
 
 kubeAPI:
   # Kubernetes API client-side rate limit used by the controller manager.
-  qps: 5
-  burst: 10
+  qps: 50
+  burst: 100
 
 # Cloud API server configuration
 # cloudAPIServerDomain is auto-configured by entrypoint.sh from sealos-config ConfigMap

--- a/controllers/user/deploy/charts/user-controller/values.yaml
+++ b/controllers/user/deploy/charts/user-controller/values.yaml
@@ -44,6 +44,11 @@ readinessProbe:
   initialDelaySeconds: 5
   periodSeconds: 10
 
+kubeAPI:
+  # Kubernetes API client-side rate limit used by the controller manager.
+  qps: 5
+  burst: 10
+
 # Cloud API server configuration
 # cloudAPIServerDomain is auto-configured by entrypoint.sh from sealos-config ConfigMap
 cloudAPIServerDomain: 127.0.0.1.nip.io

--- a/controllers/user/deploy/drop/deploy.yaml
+++ b/controllers/user/deploy/drop/deploy.yaml
@@ -199,10 +199,6 @@ data:
     # if you are doing or is intended to do any operation such as perform cleanups
     # after the manager stops then its usage might be unsafe.
     # leaderElectionReleaseOnCancel: true
-  config.yaml: |
-    global:
-      cloudAPIServerDomain: {{ .cloudDomain }}
-      cloudAPIServerPort: "{{ .apiServerPort }}"
 
 kind: ConfigMap
 metadata:
@@ -262,7 +258,8 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
-        - --config-file-path=/config.yaml
+        - --kube-api-qps=5
+        - --kube-api-burst=10
         command:
         - /manager
         env:
@@ -307,9 +304,6 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
-        - name: user-manager-volume
-          mountPath: /config.yaml
-          subPath: config.yaml
       - args:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8080/
@@ -355,9 +349,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: webhook-server-cert
-      - name: user-manager-volume
-        configMap:
-          name: user-manager-config
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/controllers/user/deploy/user-controller-entrypoint.sh
+++ b/controllers/user/deploy/user-controller-entrypoint.sh
@@ -1,16 +1,42 @@
 #!/bin/bash
-set -euo pipefail
+set -eo pipefail
 
 HELM_OPTS=${HELM_OPTS:-""}
+HELM_OPTIONS=${HELM_OPTIONS:-""}
 RELEASE_NAME=${RELEASE_NAME:-"user-controller"}
 RELEASE_NAMESPACE=${RELEASE_NAMESPACE:-"user-system"}
 CHART_PATH=${CHART_PATH:-"./charts/user-controller"}
+HELM_SET_ARGS=()
+
+get_cm_value() {
+  local namespace="$1"
+  local name="$2"
+  local key="$3"
+  kubectl get configmap "${name}" -n "${namespace}" -o "jsonpath={.data.${key}}" 2>/dev/null || true
+}
+
+add_set_string() {
+  local key="$1"
+  local value="$2"
+  value=${value//\\/\\\\}
+  value=${value//,/\\,}
+  HELM_SET_ARGS+=(--set-string "${key}=${value}")
+}
 
 # Clean up old resources
 kubectl delete -f ./drop/ --ignore-not-found
 
-# Get cloud domain from configmap
-SEALOS_CLOUD_DOMAIN=$(kubectl get configmap sealos-config -n sealos-system -o jsonpath='{.data.cloudDomain}')
+# Auto configure from sealos-config
+SEALOS_CLOUD_DOMAIN=${SEALOS_CLOUD_DOMAIN:-"$(get_cm_value sealos-system sealos-config cloudDomain)"}
+SEALOS_CLOUD_PORT=${SEALOS_CLOUD_PORT:-"$(get_cm_value sealos-system sealos-config cloudPort)"}
+
+if [ -n "${SEALOS_CLOUD_DOMAIN}" ]; then
+  add_set_string cloudAPIServerDomain "${SEALOS_CLOUD_DOMAIN}"
+fi
+
+if [ -n "${SEALOS_CLOUD_PORT}" ]; then
+  add_set_string cloudAPIServerPort "${SEALOS_CLOUD_PORT}"
+fi
 
 # Prepare values files
 SERVICE_NAME="user-controller"
@@ -26,7 +52,8 @@ fi
 helm upgrade -i "${RELEASE_NAME}" -n "${RELEASE_NAMESPACE}" --create-namespace "${CHART_PATH}" \
   -f "./charts/${SERVICE_NAME}/values.yaml" \
   -f "${USER_VALUES_PATH}" \
-  --set cloudAPIServerDomain=${SEALOS_CLOUD_DOMAIN} \
+  "${HELM_SET_ARGS[@]}" \
+  ${HELM_OPTIONS} \
   ${HELM_OPTS}
 
 # Apply CRDs

--- a/controllers/user/deploy/user-controller-entrypoint.sh
+++ b/controllers/user/deploy/user-controller-entrypoint.sh
@@ -26,17 +26,17 @@ add_set_string() {
 # Clean up old resources
 kubectl delete -f ./drop/ --ignore-not-found
 
-# Auto configure from sealos-config
-SEALOS_CLOUD_DOMAIN=${SEALOS_CLOUD_DOMAIN:-"$(get_cm_value sealos-system sealos-config cloudDomain)"}
-SEALOS_CLOUD_PORT=${SEALOS_CLOUD_PORT:-"$(get_cm_value sealos-system sealos-config cloudPort)"}
+# Auto configure from sealos-config, then fall back to chart defaults.
+DEFAULT_SEALOS_CLOUD_DOMAIN="127.0.0.1.nip.io"
+DEFAULT_SEALOS_CLOUD_APISERVER_PORT="6443"
 
-if [ -n "${SEALOS_CLOUD_DOMAIN}" ]; then
-  add_set_string cloudAPIServerDomain "${SEALOS_CLOUD_DOMAIN}"
-fi
+SEALOS_CLOUD_DOMAIN=${SEALOS_CLOUD_DOMAIN:-"${cloudDomain:-$(get_cm_value sealos-system sealos-config cloudDomain)}"}
+SEALOS_CLOUD_DOMAIN=${SEALOS_CLOUD_DOMAIN:-"${DEFAULT_SEALOS_CLOUD_DOMAIN}"}
+SEALOS_CLOUD_APISERVER_PORT=${SEALOS_CLOUD_APISERVER_PORT:-"${apiserverPort:-$(get_cm_value sealos-system sealos-config apiserverPort)}"}
+SEALOS_CLOUD_APISERVER_PORT=${SEALOS_CLOUD_APISERVER_PORT:-"${DEFAULT_SEALOS_CLOUD_APISERVER_PORT}"}
 
-if [ -n "${SEALOS_CLOUD_PORT}" ]; then
-  add_set_string cloudAPIServerPort "${SEALOS_CLOUD_PORT}"
-fi
+add_set_string cloudAPIServerDomain "${SEALOS_CLOUD_DOMAIN}"
+add_set_string cloudAPIServerPort "${SEALOS_CLOUD_APISERVER_PORT}"
 
 # Prepare values files
 SERVICE_NAME="user-controller"

--- a/controllers/user/main.go
+++ b/controllers/user/main.go
@@ -33,6 +33,7 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -69,6 +70,8 @@ func main() {
 		operationReqExpirationTime time.Duration
 		restartPredicateDuration   time.Duration
 		operationReqRetentionTime  time.Duration
+		kubeAPIQPS                 float64
+		kubeAPIBurst               int
 		secureMetrics              bool
 		enableHTTP2                bool
 		tlsOpts                    []func(*tls.Config)
@@ -124,6 +127,18 @@ func main() {
 		time.Hour*2,
 		"Sets the restrat predicate time duration for user controller restart. By default, the duration is set to 2 hours.",
 	)
+	flag.Float64Var(
+		&kubeAPIQPS,
+		"kube-api-qps",
+		float64(rest.DefaultQPS),
+		"Sets the Kubernetes API client QPS used by the manager and reconciler clients.",
+	)
+	flag.IntVar(
+		&kubeAPIBurst,
+		"kube-api-burst",
+		rest.DefaultBurst,
+		"Sets the Kubernetes API client burst used by the manager and reconciler clients.",
+	)
 	flag.BoolVar(
 		&secureMetrics,
 		"metrics-secure",
@@ -177,7 +192,12 @@ func main() {
 		// this setup is not recommended for production.
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	cfg := ctrl.GetConfigOrDie()
+	cfg.QPS = float32(kubeAPIQPS)
+	cfg.Burst = kubeAPIBurst
+	setupLog.Info("configured Kubernetes API client rate limit", "qps", cfg.QPS, "burst", cfg.Burst)
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:  scheme,
 		Metrics: metricsServerOptions,
 		// WebhookServer: webhook.NewServer(webhook.Options{


### PR DESCRIPTION
## Background

User controller reconciles were hitting client-side throttling when listing and updating many users, which slows kubeconfig rotation and related reconciliation work.

## Changes

- Add `--kube-api-qps` and `--kube-api-burst` flags to the user controller.
- Thread those settings through the chart, generated deploy manifest, and entrypoint script.
- Expose `kubeAPI.qps` and `kubeAPI.burst` in the user controller values files.
- Update the default user controller deployment patch and README examples to match the new flags.
- Remove the old `config-file-path` wiring from the user controller deployment path.

## Risks / Notes

- Default client-side limits are now explicit and can be tuned per deployment.
- Deployments that relied on the mounted config file need the updated chart/entrypoint path.
