### PR TITLE
fix(desktop): Fix desktop identity propagation after workspace init

### DIFF
--- a/frontend/desktop/src/components/v2/Workspace.tsx
+++ b/frontend/desktop/src/components/v2/Workspace.tsx
@@ -31,6 +31,7 @@ import { SwitchRegionType } from '@/constants/account';
 import { I18nCloudProvidersKey } from '@/types/i18next';
 import { ChevronDownIcon } from '@chakra-ui/icons';
 import { useGuideModalStore } from '@/stores/guideModal';
+import { track } from '@sealos/gtm';
 
 export default function Workspace() {
   const { t } = useTranslation();
@@ -92,6 +93,9 @@ export default function Workspace() {
       }
       // globalToken is already set in session store, no need to pass it
       await sessionConfig(initRegionTokenResult.data);
+      track('workspace_switch', {
+        module: 'workspace'
+      });
       await router.replace('/');
     } catch (error) {
       console.error(error);

--- a/frontend/desktop/src/pages/callback.tsx
+++ b/frontend/desktop/src/pages/callback.tsx
@@ -153,11 +153,6 @@ export default function Callback() {
                   }
                 } catch (error) {
                   console.error('Auto init failed, fallback to manual:', error);
-                  gtmLoginSuccess({
-                    user_type: 'new',
-                    method: 'oauth2',
-                    oauth2Provider: provider
-                  });
                   await router.push('/workspace');
                 }
                 return;


### PR DESCRIPTION
## Summary
- Emit workspace identity after successful manual workspace initialization
- Remove the early fallback login_success event from the OAuth callback manual path

## Verification
- git diff --check
- prettier --check desktop/src/pages/callback.tsx desktop/src/components/v2/Workspace.tsx