### PR TITLE
feat(desktop): route Stripe returns to declared app

### DIFF
--- a/controllers/pkg/database/cockroach/accountv2.go
+++ b/controllers/pkg/database/cockroach/accountv2.go
@@ -2455,6 +2455,16 @@ func (c *Cockroach) migrateColumns() error {
 			return fmt.Errorf("failed to add column ai_quota to WorkspaceSubscriptionPlan: %w", err)
 		}
 	}
+	if !c.DB.Migrator().HasColumn(&types.WorkspaceSubscriptionTransaction{}, "pay_app") {
+		fmt.Println("add column pay_app to WorkspaceSubscriptionTransaction")
+		tableName := types.WorkspaceSubscriptionTransaction{}.TableName()
+		err := c.DB.Exec(
+			alterTableAddColumnSQL(tableName, `"pay_app" TEXT NOT NULL DEFAULT ''`),
+		).Error
+		if err != nil {
+			return fmt.Errorf("failed to add column pay_app to WorkspaceSubscriptionTransaction: %w", err)
+		}
+	}
 	if !c.Localdb.Migrator().HasColumn(&types.WorkspaceSubscriptionPlan{}, "ai_quota") {
 		fmt.Println("add column ai_quota to WorkspaceSubscriptionPlan")
 		tableName := types.WorkspaceSubscriptionPlan{}.TableName()

--- a/controllers/pkg/types/enum.go
+++ b/controllers/pkg/types/enum.go
@@ -82,6 +82,22 @@ const (
 	PaymentMethodStripe           PaymentMethod = "stripe"              // Stripe 支付
 )
 
+type PayApp string
+
+const (
+	PayAppCostcenter PayApp = "system-costcenter"
+	PayAppBrain      PayApp = "system-brain"
+)
+
+func (p PayApp) IsValid() bool {
+	switch p {
+	case PayAppCostcenter, PayAppBrain:
+		return true
+	default:
+		return false
+	}
+}
+
 type SubscriptionPayStatus string
 
 const (

--- a/controllers/pkg/types/workspace_subscription.go
+++ b/controllers/pkg/types/workspace_subscription.go
@@ -52,6 +52,7 @@ type WorkspaceSubscriptionTransaction struct {
 	StatusDesc    string                        `gorm:"type:varchar(255);column:status_desc"`                                             // 状态描述
 	PayStatus     SubscriptionPayStatus         `gorm:"type:subscription_pay_status;column:pay_status"`                                   // 支付状态
 	PayID         string                        `gorm:"type:text;column:pay_id"`                                                          // 支付订单号
+	PayApp        PayApp                        `gorm:"type:text;column:pay_app"`                                                         // Stripe 回跳后打开的应用
 	Period        SubscriptionPeriod            `gorm:"type:text;column:period"`                                                          // 周期, 默认1一个月，年或者月
 	Amount        int64                         `gorm:"type:bigint;column:amount"`                                                        // 金额
 }

--- a/frontend/desktop/src/__tests__/unit/utils/stripeCallback.test.ts
+++ b/frontend/desktop/src/__tests__/unit/utils/stripeCallback.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveStripeCallbackTarget } from '@/utils/stripeCallback';
+
+describe('resolveStripeCallbackTarget', () => {
+  it('opens Brain billing when the checkout declares system-brain', () => {
+    expect(resolveStripeCallbackTarget('system-brain')).toEqual({
+      appKey: 'system-brain',
+      pathname: '/billing'
+    });
+  });
+
+  it.each([undefined, 'system-costcenter', 'untrusted-app'])(
+    'keeps the existing costcenter callback for %s',
+    (payApp) => {
+      expect(resolveStripeCallbackTarget(payApp)).toEqual({
+        appKey: 'system-costcenter',
+        pathname: '/'
+      });
+    }
+  );
+});

--- a/frontend/desktop/src/__tests__/unit/utils/stripeCallback.test.ts
+++ b/frontend/desktop/src/__tests__/unit/utils/stripeCallback.test.ts
@@ -10,6 +10,13 @@ describe('resolveStripeCallbackTarget', () => {
     });
   });
 
+  it('normalizes a repeated app query param to its first value', () => {
+    expect(resolveStripeCallbackTarget(['system-brain', 'system-costcenter'])).toEqual({
+      appKey: 'system-brain',
+      pathname: '/billing'
+    });
+  });
+
   it.each([undefined, 'system-costcenter', 'untrusted-app'])(
     'keeps the existing costcenter callback for %s',
     (payApp) => {

--- a/frontend/desktop/src/constants/app.ts
+++ b/frontend/desktop/src/constants/app.ts
@@ -1,0 +1,2 @@
+export const BRAIN_APP_KEY = 'system-brain';
+export const COSTCENTER_APP_KEY = 'system-costcenter';

--- a/frontend/desktop/src/pages/index.tsx
+++ b/frontend/desktop/src/pages/index.tsx
@@ -18,6 +18,7 @@ import { parseOpenappQuery } from '@/utils/format';
 import { resolveInitialAppTarget } from '@/utils/initialAppTarget';
 import type { InitialAppLaunchState } from '@/utils/initialAppTarget';
 import { sessionConfig, setAdClickData, setUserSemData } from '@/utils/sessionConfig';
+import { resolveStripeCallbackTarget } from '@/utils/stripeCallback';
 import { switchKubeconfigNamespace } from '@/utils/switchKubeconfigNamespace';
 import { ensureLocaleCookie } from '@/utils/ssrLocale';
 import { Box, useColorMode, useDisclosure } from '@chakra-ui/react';
@@ -391,9 +392,11 @@ export default function Home({ sealos_cloud_domain }: { sealos_cloud_domain: str
             callbackParams.set('workspaceId', query.workspaceId as string);
           }
 
+          const callbackTarget = resolveStripeCallbackTarget(query.app);
+
           await openInitialApp({
             state,
-            appKey: 'system-costcenter',
+            ...callbackTarget,
             raw: callbackParams.toString()
           });
           void router.replace(router.pathname, undefined, { shallow: true });

--- a/frontend/desktop/src/stores/app.ts
+++ b/frontend/desktop/src/stores/app.ts
@@ -1,3 +1,4 @@
+import { BRAIN_APP_KEY } from '@/constants/app';
 import request from '@/services/request';
 import { APPTYPE, TApp, TAppMenuData, TOSState, WindowSize, displayType } from '@/types';
 import { formatUrl } from '@/utils/format';
@@ -10,7 +11,7 @@ import { useDesktopConfigStore } from './desktopConfig';
 import { track } from '@sealos/gtm';
 import useSessionStore from './session';
 
-export const BRAIN_APP_KEY = 'system-brain';
+export { BRAIN_APP_KEY };
 export const SESSION_RESTORE_APP_KEY = 'sealos_desktop_restore_app_key';
 
 const buildAppUrl = ({

--- a/frontend/desktop/src/utils/stripeCallback.ts
+++ b/frontend/desktop/src/utils/stripeCallback.ts
@@ -1,5 +1,4 @@
-const COSTCENTER_APP_KEY = 'system-costcenter';
-const BRAIN_APP_KEY = 'system-brain';
+import { BRAIN_APP_KEY, COSTCENTER_APP_KEY } from '@/constants/app';
 
 export const resolveStripeCallbackTarget = (payApp: string | string[] | undefined) => {
   if (payApp === BRAIN_APP_KEY) {

--- a/frontend/desktop/src/utils/stripeCallback.ts
+++ b/frontend/desktop/src/utils/stripeCallback.ts
@@ -1,0 +1,16 @@
+const COSTCENTER_APP_KEY = 'system-costcenter';
+const BRAIN_APP_KEY = 'system-brain';
+
+export const resolveStripeCallbackTarget = (payApp: string | string[] | undefined) => {
+  if (payApp === BRAIN_APP_KEY) {
+    return {
+      appKey: BRAIN_APP_KEY,
+      pathname: '/billing'
+    } as const;
+  }
+
+  return {
+    appKey: COSTCENTER_APP_KEY,
+    pathname: '/'
+  } as const;
+};

--- a/frontend/desktop/src/utils/stripeCallback.ts
+++ b/frontend/desktop/src/utils/stripeCallback.ts
@@ -1,7 +1,8 @@
 import { BRAIN_APP_KEY, COSTCENTER_APP_KEY } from '@/constants/app';
 
 export const resolveStripeCallbackTarget = (payApp: string | string[] | undefined) => {
-  if (payApp === BRAIN_APP_KEY) {
+  const normalizedPayApp = Array.isArray(payApp) ? payApp[0] : payApp;
+  if (normalizedPayApp === BRAIN_APP_KEY) {
     return {
       appKey: BRAIN_APP_KEY,
       pathname: '/billing'

--- a/service/account/api/workspace_subscription.go
+++ b/service/account/api/workspace_subscription.go
@@ -1389,7 +1389,6 @@ func CreateWorkspaceSubscriptionPay(c *gin.Context) {
 			if req.PromotionCode != "" {
 				transaction.StatusDesc = legacyPromotionCodeStatusPrefix + req.PromotionCode
 			}
-
 		}
 
 	case types.SubscriptionTransactionTypeDowngraded:
@@ -1486,11 +1485,7 @@ var ErrSamePendingOperation = errors.New("same pending operation exists")
 const legacyPromotionCodeStatusPrefix = "Promotion code: "
 
 func pendingTransactionPromotionCode(description string) string {
-	if !strings.Contains(description, legacyPromotionCodeStatusPrefix) {
-		return ""
-	}
-
-	parts := strings.Split(description, legacyPromotionCodeStatusPrefix)
+	parts := strings.SplitN(description, legacyPromotionCodeStatusPrefix, 2)
 	if len(parts) < 2 {
 		return ""
 	}

--- a/service/account/api/workspace_subscription.go
+++ b/service/account/api/workspace_subscription.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -1162,8 +1163,21 @@ func handleCalculatedUpgrade(
 // @Param req body WorkspaceSubscriptionOperatorReq true "WorkspaceSubscriptionOperatorReq"
 // @Success 200 {object} WorkspaceSubscriptionPayResp
 // @Router /payment/v1alpha1/workspace-subscription/pay [post]
-func CreateWorkspaceSubscriptionPay(c *gin.Context) {
+func parseWorkspaceSubscriptionPayReq(
+	c *gin.Context,
+) (*helper.WorkspaceSubscriptionOperatorReq, error) {
 	req, err := helper.ParseWorkspaceSubscriptionOperatorReq(c)
+	if err != nil {
+		return nil, err
+	}
+	if req.PayApp != "" && !req.PayApp.IsValid() {
+		return nil, fmt.Errorf("invalid payApp: %s", req.PayApp)
+	}
+	return req, nil
+}
+
+func CreateWorkspaceSubscriptionPay(c *gin.Context) {
+	req, err := parseWorkspaceSubscriptionPayReq(c)
 	if err != nil {
 		SetErrorResp(
 			c,
@@ -1263,6 +1277,16 @@ func CreateWorkspaceSubscriptionPay(c *gin.Context) {
 	//	req.Operator = types.SubscriptionTransactionTypeCreated
 	//}
 
+	requestStatusDescription, err := encodePendingWorkspaceSubscriptionRequestIdentity(req, false)
+	if err != nil {
+		SetErrorResp(
+			c,
+			http.StatusInternalServerError,
+			gin.H{"error": fmt.Sprintf("failed to encode payment request identity: %v", err)},
+		)
+		return
+	}
+
 	// Create subscription transaction with direct operator usage
 	transaction := types.WorkspaceSubscriptionTransaction{
 		ID:           uuid.New(),
@@ -1275,6 +1299,7 @@ func CreateWorkspaceSubscriptionPay(c *gin.Context) {
 		StartAt:      time.Now().UTC(),
 		CreatedAt:    time.Now().UTC(),
 		Status:       types.SubscriptionTransactionStatusProcessing,
+		StatusDesc:   requestStatusDescription,
 		Period:       req.Period,
 		Amount:       planPrice.Price,
 	}
@@ -1372,10 +1397,20 @@ func CreateWorkspaceSubscriptionPay(c *gin.Context) {
 				transaction.Amount = 0
 			}
 
-			// Store promotion code for later use in Stripe session creation
-			if req.PromotionCode != "" {
-				transaction.StatusDesc = "Promotion code: " + req.PromotionCode
+			requestStatusDescription, err := encodePendingWorkspaceSubscriptionRequestIdentity(
+				req,
+				true,
+			)
+			if err != nil {
+				SetErrorResp(
+					c,
+					http.StatusInternalServerError,
+					gin.H{"error": fmt.Sprintf("failed to encode payment request identity: %v", err)},
+				)
+				return
 			}
+			transaction.StatusDesc = requestStatusDescription
+
 		}
 
 	case types.SubscriptionTransactionTypeDowngraded:
@@ -1469,6 +1504,71 @@ func CreateWorkspaceSubscriptionPay(c *gin.Context) {
 
 var ErrSamePendingOperation = errors.New("same pending operation exists")
 
+const legacyPromotionCodeStatusPrefix = "Promotion code: "
+
+type pendingWorkspaceSubscriptionRequestIdentity struct {
+	PromotionCode string       `json:"promotionCode,omitempty"`
+	PayApp        types.PayApp `json:"payApp"`
+}
+
+func encodePendingWorkspaceSubscriptionRequestIdentity(
+	req *helper.WorkspaceSubscriptionOperatorReq,
+	includePromotionCode bool,
+) (string, error) {
+	if req.PayApp == "" {
+		if includePromotionCode && req.PromotionCode != "" {
+			return legacyPromotionCodeStatusPrefix + req.PromotionCode, nil
+		}
+		return "", nil
+	}
+	if !req.PayApp.IsValid() {
+		return "", fmt.Errorf("invalid payApp: %s", req.PayApp)
+	}
+
+	identity := pendingWorkspaceSubscriptionRequestIdentity{PayApp: req.PayApp}
+	if includePromotionCode {
+		identity.PromotionCode = req.PromotionCode
+	}
+	data, err := json.Marshal(identity)
+	if err != nil {
+		return "", fmt.Errorf("marshal pending request identity: %w", err)
+	}
+	return string(data), nil
+}
+
+func decodePendingWorkspaceSubscriptionRequestIdentity(
+	description string,
+) pendingWorkspaceSubscriptionRequestIdentity {
+	var identity pendingWorkspaceSubscriptionRequestIdentity
+	if err := json.Unmarshal([]byte(description), &identity); err == nil && identity.PayApp.IsValid() {
+		return identity
+	}
+
+	if strings.Contains(description, legacyPromotionCodeStatusPrefix) {
+		parts := strings.Split(description, legacyPromotionCodeStatusPrefix)
+		if len(parts) > 1 {
+			identity.PromotionCode = strings.TrimSpace(parts[1])
+		}
+	}
+	identity.PayApp = ""
+	return identity
+}
+
+func samePendingWorkspaceSubscriptionRequest(
+	lastTransaction *types.WorkspaceSubscriptionTransaction,
+	req *helper.WorkspaceSubscriptionOperatorReq,
+) bool {
+	lastRequestIdentity := decodePendingWorkspaceSubscriptionRequestIdentity(
+		lastTransaction.StatusDesc,
+	)
+
+	return lastTransaction.NewPlanName == req.PlanName &&
+		lastTransaction.Operator == req.Operator &&
+		lastTransaction.Period == req.Period &&
+		lastRequestIdentity.PromotionCode == req.PromotionCode &&
+		lastRequestIdentity.PayApp == req.PayApp
+}
+
 // handleWorkspaceSubscriptionTransactionWithConcurrencyControl provides unified transaction handling with concurrency control
 func handleWorkspaceSubscriptionTransactionWithConcurrencyControl(
 	c *gin.Context,
@@ -1497,20 +1597,7 @@ func handleWorkspaceSubscriptionTransactionWithConcurrencyControl(
 		// Handle existing pending/processing transactions
 		if lastTransaction != nil &&
 			(lastTransaction.Status == types.SubscriptionTransactionStatusProcessing || lastTransaction.Status == types.SubscriptionTransactionStatusPending) {
-			// 判断是否为相同请求（包括优惠码）
-			// 提取上次交易的优惠码
-			lastPromotionCode := ""
-			if strings.Contains(lastTransaction.StatusDesc, "Promotion code: ") {
-				parts := strings.Split(lastTransaction.StatusDesc, "Promotion code: ")
-				if len(parts) > 1 {
-					lastPromotionCode = strings.TrimSpace(parts[1])
-				}
-			}
-
-			isSameRequest := lastTransaction.NewPlanName == req.PlanName &&
-				lastTransaction.Operator == req.Operator &&
-				lastTransaction.Period == req.Period &&
-				lastPromotionCode == req.PromotionCode
+			isSameRequest := samePendingWorkspaceSubscriptionRequest(lastTransaction, req)
 
 			switch {
 			case isSameRequest:
@@ -2166,6 +2253,7 @@ func createStripeSessionAndPaymentOrder(
 		UserAgent:     c.GetHeader("User-Agent"),
 		ClientIP:      c.ClientIP(),
 		DeviceTokenID: c.GetHeader("Device-Token-ID"),
+		PayApp:        req.PayApp,
 	}
 	// Get or create Stripe customer ID
 	// customer, err := services.StripeServiceInstance.GetCustomerByUID(req.UserUID.String())

--- a/service/account/api/workspace_subscription.go
+++ b/service/account/api/workspace_subscription.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -1277,16 +1276,6 @@ func CreateWorkspaceSubscriptionPay(c *gin.Context) {
 	//	req.Operator = types.SubscriptionTransactionTypeCreated
 	//}
 
-	requestStatusDescription, err := encodePendingWorkspaceSubscriptionRequestIdentity(req, false)
-	if err != nil {
-		SetErrorResp(
-			c,
-			http.StatusInternalServerError,
-			gin.H{"error": fmt.Sprintf("failed to encode payment request identity: %v", err)},
-		)
-		return
-	}
-
 	// Create subscription transaction with direct operator usage
 	transaction := types.WorkspaceSubscriptionTransaction{
 		ID:           uuid.New(),
@@ -1299,7 +1288,7 @@ func CreateWorkspaceSubscriptionPay(c *gin.Context) {
 		StartAt:      time.Now().UTC(),
 		CreatedAt:    time.Now().UTC(),
 		Status:       types.SubscriptionTransactionStatusProcessing,
-		StatusDesc:   requestStatusDescription,
+		PayApp:       req.PayApp,
 		Period:       req.Period,
 		Amount:       planPrice.Price,
 	}
@@ -1397,19 +1386,9 @@ func CreateWorkspaceSubscriptionPay(c *gin.Context) {
 				transaction.Amount = 0
 			}
 
-			requestStatusDescription, err := encodePendingWorkspaceSubscriptionRequestIdentity(
-				req,
-				true,
-			)
-			if err != nil {
-				SetErrorResp(
-					c,
-					http.StatusInternalServerError,
-					gin.H{"error": fmt.Sprintf("failed to encode payment request identity: %v", err)},
-				)
-				return
+			if req.PromotionCode != "" {
+				transaction.StatusDesc = legacyPromotionCodeStatusPrefix + req.PromotionCode
 			}
-			transaction.StatusDesc = requestStatusDescription
 
 		}
 
@@ -1506,67 +1485,27 @@ var ErrSamePendingOperation = errors.New("same pending operation exists")
 
 const legacyPromotionCodeStatusPrefix = "Promotion code: "
 
-type pendingWorkspaceSubscriptionRequestIdentity struct {
-	PromotionCode string       `json:"promotionCode,omitempty"`
-	PayApp        types.PayApp `json:"payApp"`
-}
-
-func encodePendingWorkspaceSubscriptionRequestIdentity(
-	req *helper.WorkspaceSubscriptionOperatorReq,
-	includePromotionCode bool,
-) (string, error) {
-	if req.PayApp == "" {
-		if includePromotionCode && req.PromotionCode != "" {
-			return legacyPromotionCodeStatusPrefix + req.PromotionCode, nil
-		}
-		return "", nil
-	}
-	if !req.PayApp.IsValid() {
-		return "", fmt.Errorf("invalid payApp: %s", req.PayApp)
+func pendingTransactionPromotionCode(description string) string {
+	if !strings.Contains(description, legacyPromotionCodeStatusPrefix) {
+		return ""
 	}
 
-	identity := pendingWorkspaceSubscriptionRequestIdentity{PayApp: req.PayApp}
-	if includePromotionCode {
-		identity.PromotionCode = req.PromotionCode
+	parts := strings.Split(description, legacyPromotionCodeStatusPrefix)
+	if len(parts) < 2 {
+		return ""
 	}
-	data, err := json.Marshal(identity)
-	if err != nil {
-		return "", fmt.Errorf("marshal pending request identity: %w", err)
-	}
-	return string(data), nil
-}
-
-func decodePendingWorkspaceSubscriptionRequestIdentity(
-	description string,
-) pendingWorkspaceSubscriptionRequestIdentity {
-	var identity pendingWorkspaceSubscriptionRequestIdentity
-	if err := json.Unmarshal([]byte(description), &identity); err == nil && identity.PayApp.IsValid() {
-		return identity
-	}
-
-	if strings.Contains(description, legacyPromotionCodeStatusPrefix) {
-		parts := strings.Split(description, legacyPromotionCodeStatusPrefix)
-		if len(parts) > 1 {
-			identity.PromotionCode = strings.TrimSpace(parts[1])
-		}
-	}
-	identity.PayApp = ""
-	return identity
+	return strings.TrimSpace(parts[1])
 }
 
 func samePendingWorkspaceSubscriptionRequest(
 	lastTransaction *types.WorkspaceSubscriptionTransaction,
 	req *helper.WorkspaceSubscriptionOperatorReq,
 ) bool {
-	lastRequestIdentity := decodePendingWorkspaceSubscriptionRequestIdentity(
-		lastTransaction.StatusDesc,
-	)
-
 	return lastTransaction.NewPlanName == req.PlanName &&
 		lastTransaction.Operator == req.Operator &&
 		lastTransaction.Period == req.Period &&
-		lastRequestIdentity.PromotionCode == req.PromotionCode &&
-		lastRequestIdentity.PayApp == req.PayApp
+		pendingTransactionPromotionCode(lastTransaction.StatusDesc) == req.PromotionCode &&
+		lastTransaction.PayApp == req.PayApp
 }
 
 // handleWorkspaceSubscriptionTransactionWithConcurrencyControl provides unified transaction handling with concurrency control

--- a/service/account/api/workspace_subscription_pay_test.go
+++ b/service/account/api/workspace_subscription_pay_test.go
@@ -44,12 +44,9 @@ func TestSamePendingWorkspaceSubscriptionRequestIncludesPayApp(t *testing.T) {
 		NewPlanName: brainReq.PlanName,
 		Operator:    brainReq.Operator,
 		Period:      brainReq.Period,
+		PayApp:      brainReq.PayApp,
+		StatusDesc:  "Promotion code: SAVE20",
 	}
-	statusDescription, err := encodePendingWorkspaceSubscriptionRequestIdentity(brainReq, true)
-	if err != nil {
-		t.Fatalf("encode request identity: %v", err)
-	}
-	lastTransaction.StatusDesc = statusDescription
 
 	if !samePendingWorkspaceSubscriptionRequest(lastTransaction, brainReq) {
 		t.Fatal("expected the same declared payApp to reuse the pending request")
@@ -63,30 +60,8 @@ func TestSamePendingWorkspaceSubscriptionRequestIncludesPayApp(t *testing.T) {
 
 	omittedReq := *brainReq
 	omittedReq.PayApp = ""
-	lastTransaction.StatusDesc = "Promotion code: SAVE20"
+	lastTransaction.PayApp = ""
 	if !samePendingWorkspaceSubscriptionRequest(lastTransaction, &omittedReq) {
 		t.Fatal("expected an omitted payApp to match a legacy pending request")
-	}
-}
-
-func TestEncodePendingWorkspaceSubscriptionRequestIdentityPreservesLegacyOmission(t *testing.T) {
-	req := &helper.WorkspaceSubscriptionOperatorReq{
-		PromotionCode: "SAVE20",
-	}
-
-	statusDescription, err := encodePendingWorkspaceSubscriptionRequestIdentity(req, false)
-	if err != nil {
-		t.Fatalf("encode request identity: %v", err)
-	}
-	if statusDescription != "" {
-		t.Fatalf("status description = %q, want legacy empty value", statusDescription)
-	}
-
-	statusDescription, err = encodePendingWorkspaceSubscriptionRequestIdentity(req, true)
-	if err != nil {
-		t.Fatalf("encode upgrade request identity: %v", err)
-	}
-	if statusDescription != "Promotion code: SAVE20" {
-		t.Fatalf("status description = %q, want legacy promotion value", statusDescription)
 	}
 }

--- a/service/account/api/workspace_subscription_pay_test.go
+++ b/service/account/api/workspace_subscription_pay_test.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/labring/sealos/controllers/pkg/types"
+	"github.com/labring/sealos/service/account/helper"
+)
+
+func TestParseWorkspaceSubscriptionPayReqRejectsInvalidPayApp(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(
+		"POST",
+		"/workspace-subscription/pay",
+		strings.NewReader(`{
+			"regionDomain":"example.com",
+			"planName":"pro",
+			"payMethod":"stripe",
+			"operator":"created",
+			"payApp":"untrusted-app"
+		}`),
+	)
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	if _, err := parseWorkspaceSubscriptionPayReq(ctx); err == nil {
+		t.Fatal("expected an invalid payApp to be rejected by the pay endpoint")
+	}
+}
+
+func TestSamePendingWorkspaceSubscriptionRequestIncludesPayApp(t *testing.T) {
+	brainReq := &helper.WorkspaceSubscriptionOperatorReq{
+		PlanName:      "pro",
+		Operator:      types.SubscriptionTransactionTypeCreated,
+		Period:        types.SubscriptionPeriodMonthly,
+		PromotionCode: "SAVE20",
+		PayApp:        types.PayAppBrain,
+	}
+	lastTransaction := &types.WorkspaceSubscriptionTransaction{
+		NewPlanName: brainReq.PlanName,
+		Operator:    brainReq.Operator,
+		Period:      brainReq.Period,
+	}
+	statusDescription, err := encodePendingWorkspaceSubscriptionRequestIdentity(brainReq, true)
+	if err != nil {
+		t.Fatalf("encode request identity: %v", err)
+	}
+	lastTransaction.StatusDesc = statusDescription
+
+	if !samePendingWorkspaceSubscriptionRequest(lastTransaction, brainReq) {
+		t.Fatal("expected the same declared payApp to reuse the pending request")
+	}
+
+	costcenterReq := *brainReq
+	costcenterReq.PayApp = types.PayAppCostcenter
+	if samePendingWorkspaceSubscriptionRequest(lastTransaction, &costcenterReq) {
+		t.Fatal("expected a different declared payApp not to reuse the pending request")
+	}
+
+	omittedReq := *brainReq
+	omittedReq.PayApp = ""
+	lastTransaction.StatusDesc = "Promotion code: SAVE20"
+	if !samePendingWorkspaceSubscriptionRequest(lastTransaction, &omittedReq) {
+		t.Fatal("expected an omitted payApp to match a legacy pending request")
+	}
+}
+
+func TestEncodePendingWorkspaceSubscriptionRequestIdentityPreservesLegacyOmission(t *testing.T) {
+	req := &helper.WorkspaceSubscriptionOperatorReq{
+		PromotionCode: "SAVE20",
+	}
+
+	statusDescription, err := encodePendingWorkspaceSubscriptionRequestIdentity(req, false)
+	if err != nil {
+		t.Fatalf("encode request identity: %v", err)
+	}
+	if statusDescription != "" {
+		t.Fatalf("status description = %q, want legacy empty value", statusDescription)
+	}
+
+	statusDescription, err = encodePendingWorkspaceSubscriptionRequestIdentity(req, true)
+	if err != nil {
+		t.Fatalf("encode upgrade request identity: %v", err)
+	}
+	if statusDescription != "Promotion code: SAVE20" {
+		t.Fatalf("status description = %q, want legacy promotion value", statusDescription)
+	}
+}

--- a/service/account/api/workspace_subscription_pay_test.go
+++ b/service/account/api/workspace_subscription_pay_test.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"context"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -14,8 +16,9 @@ func TestParseWorkspaceSubscriptionPayReqRejectsInvalidPayApp(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(recorder)
-	ctx.Request = httptest.NewRequest(
-		"POST",
+	ctx.Request = httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
 		"/workspace-subscription/pay",
 		strings.NewReader(`{
 			"regionDomain":"example.com",

--- a/service/account/helper/request.go
+++ b/service/account/helper/request.go
@@ -740,6 +740,11 @@ type WorkspaceSubscriptionOperatorReq struct {
 	// @Summary Card ID (optional for stripe payments)
 	// @Description Card ID for stripe payments
 	CardID *uuid.UUID `json:"cardId,omitempty" bson:"cardId,omitempty"`
+
+	// @Summary Stripe return app
+	// @Description Desktop app opened after returning from Stripe Checkout
+	// @JSONSchema optional
+	PayApp types.PayApp `json:"payApp,omitempty" bson:"payApp,omitempty" example:"system-costcenter"`
 }
 
 type WorkspaceSubscriptionInfoReq struct {

--- a/service/account/helper/request_test.go
+++ b/service/account/helper/request_test.go
@@ -1,0 +1,66 @@
+package helper
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestParseWorkspaceSubscriptionOperatorReqAcceptsAllowedPayApps(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, payApp := range []string{"system-costcenter", "system-brain"} {
+		t.Run(payApp, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(recorder)
+			ctx.Request = httptest.NewRequest(
+				"POST",
+				"/workspace-subscription/pay",
+				strings.NewReader(fmt.Sprintf(`{
+					"regionDomain":"example.com",
+					"planName":"pro",
+					"payMethod":"stripe",
+					"operator":"created",
+					"payApp":%q
+				}`, payApp)),
+			)
+			ctx.Request.Header.Set("Content-Type", "application/json")
+
+			req, err := ParseWorkspaceSubscriptionOperatorReq(ctx)
+			if err != nil {
+				t.Fatalf("expected payApp %q to be accepted: %v", payApp, err)
+			}
+			if string(req.PayApp) != payApp {
+				t.Fatalf("payApp = %q, want %q", req.PayApp, payApp)
+			}
+		})
+	}
+}
+
+func TestParseWorkspaceSubscriptionOperatorReqLeavesPayAppValidationToPayEndpoint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(
+		"POST",
+		"/workspace-subscription/upgrade-amount",
+		strings.NewReader(`{
+			"regionDomain":"example.com",
+			"planName":"pro",
+			"payMethod":"stripe",
+			"operator":"upgraded",
+			"payApp":"ignored-by-preview"
+		}`),
+	)
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	req, err := ParseWorkspaceSubscriptionOperatorReq(ctx)
+	if err != nil {
+		t.Fatalf("expected the shared parser not to validate payApp: %v", err)
+	}
+	if req.PayApp != "ignored-by-preview" {
+		t.Fatalf("payApp = %q, want %q", req.PayApp, "ignored-by-preview")
+	}
+}

--- a/service/account/helper/request_test.go
+++ b/service/account/helper/request_test.go
@@ -1,7 +1,9 @@
 package helper
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -9,14 +11,15 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func TestParseWorkspaceSubscriptionOperatorReqAcceptsAllowedPayApps(t *testing.T) {
+func TestParseWorkspaceSubscriptionOperatorReqBindsPayApp(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	for _, payApp := range []string{"system-costcenter", "system-brain"} {
 		t.Run(payApp, func(t *testing.T) {
 			recorder := httptest.NewRecorder()
 			ctx, _ := gin.CreateTestContext(recorder)
-			ctx.Request = httptest.NewRequest(
-				"POST",
+			ctx.Request = httptest.NewRequestWithContext(
+				context.Background(),
+				http.MethodPost,
 				"/workspace-subscription/pay",
 				strings.NewReader(fmt.Sprintf(`{
 					"regionDomain":"example.com",
@@ -43,8 +46,9 @@ func TestParseWorkspaceSubscriptionOperatorReqLeavesPayAppValidationToPayEndpoin
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(recorder)
-	ctx.Request = httptest.NewRequest(
-		"POST",
+	ctx.Request = httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
 		"/workspace-subscription/upgrade-amount",
 		strings.NewReader(`{
 			"regionDomain":"example.com",

--- a/service/pkg/pay/atom.go
+++ b/service/pkg/pay/atom.go
@@ -42,6 +42,7 @@ type PaymentRequest struct {
 	ClientIP      string
 	DeviceTokenID string
 	CustomerID    *string
+	PayApp        types.PayApp
 }
 
 // StripeResponse Stripe 支付响应

--- a/service/pkg/pay/stripe.go
+++ b/service/pkg/pay/stripe.go
@@ -62,11 +62,17 @@ func getBaseURL() string {
 func buildURLs(
 	s *StripeService,
 	transaction *types.WorkspaceSubscriptionTransaction,
+	payApp types.PayApp,
 ) (string, string) {
 	// https://192.168.10.35.nip.io/?openapp=system-costcenter?payId%3D4W86BOp70ltT%26stripeState%3Dsuccess%26transactionId%3D3d09bc07-976c-44bc-8b52-05619693056e%26workspaceId%3Dns-47f3dbxj
 	baseURL := s.Domain + "/?payId=" + transaction.PayID + "&workspaceId=" + transaction.Workspace + "&transactionId=" + transaction.ID.String() + "&stripeState="
 	successURL := baseURL + "success"
 	cancelURL := baseURL + "cancel"
+	if payApp != "" {
+		appParam := "&app=" + string(payApp)
+		successURL += appParam
+		cancelURL += appParam
+	}
 
 	return successURL, cancelURL
 }
@@ -89,7 +95,7 @@ func (s *StripeService) CreateWorkspaceSubscriptionSessionWithPromotion(
 ) (*StripeResponse, error) {
 	// 构造成功与取消回调URL，避免硬编码斜杠问题
 	// Assuming workspaceID and transaction.PayID are your custom variables
-	successURL, cancelURL := buildURLs(s, transaction)
+	successURL, cancelURL := buildURLs(s, transaction, paymentReq.PayApp)
 	// Create checkout session following official example pattern
 	// var anchorTime int64
 

--- a/service/pkg/pay/stripe.go
+++ b/service/pkg/pay/stripe.go
@@ -64,7 +64,7 @@ func buildURLs(
 	transaction *types.WorkspaceSubscriptionTransaction,
 	payApp types.PayApp,
 ) (string, string) {
-	// Example: https://cloud.sealos.io/?payId=4W86BOp70ltT&workspaceId=ns-47f3dbxj&transactionId=3d09bc07-976c-44bc-8b52-05619693056e&stripeState=success&app=system-brain
+	// Example: https://cloud.sealos.io/?payId=examplePayId&workspaceId=ns-example&transactionId=00000000-0000-0000-0000-000000000000&stripeState=success&app=system-brain
 	baseURL := s.Domain + "/?payId=" + transaction.PayID + "&workspaceId=" + transaction.Workspace + "&transactionId=" + transaction.ID.String() + "&stripeState="
 	successURL := baseURL + "success"
 	cancelURL := baseURL + "cancel"

--- a/service/pkg/pay/stripe.go
+++ b/service/pkg/pay/stripe.go
@@ -64,7 +64,7 @@ func buildURLs(
 	transaction *types.WorkspaceSubscriptionTransaction,
 	payApp types.PayApp,
 ) (string, string) {
-	// https://192.168.10.35.nip.io/?openapp=system-costcenter?payId%3D4W86BOp70ltT%26stripeState%3Dsuccess%26transactionId%3D3d09bc07-976c-44bc-8b52-05619693056e%26workspaceId%3Dns-47f3dbxj
+	// Example: https://cloud.sealos.io/?payId=4W86BOp70ltT&workspaceId=ns-47f3dbxj&transactionId=3d09bc07-976c-44bc-8b52-05619693056e&stripeState=success&app=system-brain
 	baseURL := s.Domain + "/?payId=" + transaction.PayID + "&workspaceId=" + transaction.Workspace + "&transactionId=" + transaction.ID.String() + "&stripeState="
 	successURL := baseURL + "success"
 	cancelURL := baseURL + "cancel"

--- a/service/pkg/pay/stripe_test.go
+++ b/service/pkg/pay/stripe_test.go
@@ -1,0 +1,44 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/labring/sealos/controllers/pkg/types"
+)
+
+func TestBuildURLsAppendsDeclaredPayApp(t *testing.T) {
+	service := &StripeService{Domain: "https://example.com"}
+	transaction := &types.WorkspaceSubscriptionTransaction{
+		ID:        uuid.MustParse("11111111-2222-3333-4444-555555555555"),
+		PayID:     "pay-123",
+		Workspace: "ns-demo",
+	}
+
+	successURL, cancelURL := buildURLs(service, transaction, types.PayAppBrain)
+
+	if want := "https://example.com/?payId=pay-123&workspaceId=ns-demo&transactionId=11111111-2222-3333-4444-555555555555&stripeState=success&app=system-brain"; successURL != want {
+		t.Fatalf("success URL = %q, want %q", successURL, want)
+	}
+	if want := "https://example.com/?payId=pay-123&workspaceId=ns-demo&transactionId=11111111-2222-3333-4444-555555555555&stripeState=cancel&app=system-brain"; cancelURL != want {
+		t.Fatalf("cancel URL = %q, want %q", cancelURL, want)
+	}
+}
+
+func TestBuildURLsPreservesExistingURLsWithoutPayApp(t *testing.T) {
+	service := &StripeService{Domain: "https://example.com"}
+	transaction := &types.WorkspaceSubscriptionTransaction{
+		ID:        uuid.MustParse("11111111-2222-3333-4444-555555555555"),
+		PayID:     "pay-123",
+		Workspace: "ns-demo",
+	}
+
+	successURL, cancelURL := buildURLs(service, transaction, "")
+
+	if want := "https://example.com/?payId=pay-123&workspaceId=ns-demo&transactionId=11111111-2222-3333-4444-555555555555&stripeState=success"; successURL != want {
+		t.Fatalf("success URL = %q, want %q", successURL, want)
+	}
+	if want := "https://example.com/?payId=pay-123&workspaceId=ns-demo&transactionId=11111111-2222-3333-4444-555555555555&stripeState=cancel"; cancelURL != want {
+		t.Fatalf("cancel URL = %q, want %q", cancelURL, want)
+	}
+}


### PR DESCRIPTION
Extends the workspace subscription Stripe payment flow so the client can declare which desktop app initiated the payment (`payApp`), and routes the Stripe success return back to that app (costcenter by default, Brain billing for `system-brain`).

- Add a `PayApp` enum, validate it on the pay endpoint, persist it on workspace subscription transactions (with a Cockroach migration for the global DB).
- Propagate `payApp` into the Stripe Checkout success/cancel URLs and include it in the same-pending-request check.
- Desktop resolves the `app` callback param and opens the declared app after a successful Stripe return.

**Known limitation:** the redirect only exists on the Checkout Session paths (new subscription / upgrade from Free). Upgrades between paid plans go through a Stripe hosted invoice (`HostedInvoiceURL`), which never redirects back to the desktop, so `payApp` has no effect on that path even though it is persisted.

The Brain frontend change that sends `payApp: "system-brain"` lives outside this repo and will follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)