### PR TITLE
fix(desktop): expose pod workspace quota

### DIFF
--- a/frontend/desktop/src/__tests__/unit/backend/workspace/getQuota.api.test.ts
+++ b/frontend/desktop/src/__tests__/unit/backend/workspace/getQuota.api.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { verifyAccessToken, generateBillingToken, fetchQuota } = vi.hoisted(() => ({
+  verifyAccessToken: vi.fn(),
+  generateBillingToken: vi.fn(() => 'billing-token'),
+  fetchQuota: vi.fn()
+}));
+
+vi.mock('@/services/backend/auth', () => ({
+  generateBillingToken,
+  verifyAccessToken
+}));
+
+import handler from '@/pages/api/workspace/getQuota';
+
+const createMockRes = () => {
+  const res: any = {
+    body: undefined,
+    json: vi.fn((payload: unknown) => {
+      res.body = payload;
+      return res;
+    })
+  };
+  return res;
+};
+
+describe('workspace quota api', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (global as any).AppConfig = {
+      desktop: {
+        auth: {
+          billingUrl: 'https://billing.example.com'
+        }
+      }
+    };
+    vi.stubGlobal('fetch', fetchQuota);
+    verifyAccessToken.mockResolvedValue({
+      userId: 'user-id',
+      userUid: 'user-uid',
+      workspaceId: 'workspace-id'
+    });
+  });
+
+  it('maps the ResourceQuota pods entry to a pod quota item', async () => {
+    fetchQuota.mockResolvedValue({
+      clone: () => ({
+        json: async () => ({
+          quota: {
+            hard: { pods: '20' },
+            used: { pods: '3' }
+          }
+        })
+      })
+    });
+
+    const res = createMockRes();
+    await handler({ headers: {}, method: 'GET' } as any, res);
+
+    expect(res.body).toEqual({
+      code: 200,
+      data: {
+        quota: [{ limit: 20, type: 'pod', used: 3 }]
+      },
+      message: ''
+    });
+  });
+
+  it('keeps an empty quota response compatible when pods is absent', async () => {
+    fetchQuota.mockResolvedValue({
+      clone: () => ({
+        json: async () => ({ quota: { hard: {}, used: {} } })
+      })
+    });
+
+    const res = createMockRes();
+    await handler({ headers: {}, method: 'GET' } as any, res);
+
+    expect(res.body).toEqual({ code: 200, data: { quota: [] }, message: '' });
+  });
+});

--- a/frontend/desktop/src/pages/api/workspace/getQuota.ts
+++ b/frontend/desktop/src/pages/api/workspace/getQuota.ts
@@ -79,6 +79,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       });
     }
 
+    if (hard.pods !== undefined || used.pods !== undefined) {
+      quota.push({
+        type: 'pod',
+        limit: Number(hard.pods) || 0,
+        used: Number(used.pods) || 0
+      });
+    }
+
     if (hard['services.nodeports'] !== undefined || used['services.nodeports'] !== undefined) {
       quota.push({
         type: 'nodeport',

--- a/frontend/desktop/src/types/workspace.ts
+++ b/frontend/desktop/src/types/workspace.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 export const WorkspaceQuotaItemSchema = z.object({
-  type: z.enum(['cpu', 'memory', 'storage', 'gpu', 'traffic', 'nodeport']),
+  type: z.enum(['cpu', 'memory', 'storage', 'pod', 'gpu', 'traffic', 'nodeport']),
   used: z.number(),
   limit: z.number()
 });

--- a/frontend/packages/client-sdk/src/types/user.d.ts
+++ b/frontend/packages/client-sdk/src/types/user.d.ts
@@ -61,7 +61,7 @@ export type SessionV1 = {
 };
 
 export type WorkspaceQuotaItem = {
-  type: 'cpu' | 'memory' | 'storage' | 'gpu' | 'traffic' | 'nodeport';
+  type: 'cpu' | 'memory' | 'storage' | 'pod' | 'gpu' | 'traffic' | 'nodeport';
   used: number;
   limit: number;
 };

--- a/frontend/packages/shared/src/constants/resource.tsx
+++ b/frontend/packages/shared/src/constants/resource.tsx
@@ -3,6 +3,7 @@ import {
   CircuitBoardIcon,
   HardDriveIcon,
   HdmiPortIcon,
+  LayersIcon,
   MemoryStickIcon,
   NetworkIcon
 } from 'lucide-react';
@@ -34,6 +35,13 @@ export const resourcePropertyMap: Record<
       <MemoryStickIcon className={className} size={size} />
     ),
     scale: 1024
+  },
+  pod: {
+    unit: '',
+    icon: ({ className, size = 20 }: ResourceIconProps) => (
+      <LayersIcon className={className} size={size} />
+    ),
+    scale: 1
   },
   nodeport: {
     unit: '',

--- a/frontend/packages/shared/src/hooks/useQuotaGuarded.ts
+++ b/frontend/packages/shared/src/hooks/useQuotaGuarded.ts
@@ -7,7 +7,9 @@ import { useQuotaGuardConfig, type UseQuotaGuardedConfig } from './QuotaGuardPro
 
 export type QuotaGuardedOptions = {
   /** Resource requirements to check */
-  requirements: Partial<Record<'cpu' | 'memory' | 'gpu' | 'nodeport' | 'storage', number>> & {
+  requirements: Partial<
+    Record<'cpu' | 'memory' | 'gpu' | 'nodeport' | 'pod' | 'storage', number>
+  > & {
     traffic?: boolean | number;
   };
   /** Whether to check immediately */

--- a/frontend/packages/shared/src/hooks/useUserQuota.ts
+++ b/frontend/packages/shared/src/hooks/useUserQuota.ts
@@ -11,7 +11,9 @@ import { useQuotaGuardConfig } from './QuotaGuardProvider';
 
 export interface UseUserQuotaOptions {
   /** Resource requirements to check against */
-  requirements?: Partial<Record<'cpu' | 'memory' | 'gpu' | 'nodeport' | 'storage', number>> & {
+  requirements?: Partial<
+    Record<'cpu' | 'memory' | 'gpu' | 'nodeport' | 'pod' | 'storage', number>
+  > & {
     traffic?: boolean | number;
   };
   /** Types to show in requirements dialog */

--- a/frontend/packages/shared/src/i18n/quota-dialog.ts
+++ b/frontend/packages/shared/src/i18n/quota-dialog.ts
@@ -48,6 +48,7 @@ export const quotaDialogI18n: Record<SupportedLang, QuotaDialogI18nConfig> = {
       cpu: 'CPU',
       memory: '内存',
       storage: '存储卷',
+      pod: 'Pod',
       gpu: 'GPU',
       traffic: '流量',
       nodeport: '端口'
@@ -76,6 +77,7 @@ export const quotaDialogI18n: Record<SupportedLang, QuotaDialogI18nConfig> = {
       cpu: 'CPU',
       memory: 'Memory',
       storage: 'Storage',
+      pod: 'Pods',
       gpu: 'GPU',
       traffic: 'Traffic',
       nodeport: 'Port'

--- a/frontend/packages/shared/src/store/quota.ts
+++ b/frontend/packages/shared/src/store/quota.ts
@@ -26,7 +26,7 @@ type State = {
   exceededQuotas: ExceededWorkspaceQuotaItem[];
   setExceededQuotas: (quotas: ExceededWorkspaceQuotaItem[]) => void;
   checkExceededQuotas: (
-    request: Partial<Record<'cpu' | 'memory' | 'gpu' | 'nodeport' | 'storage', number>> & {
+    request: Partial<Record<'cpu' | 'memory' | 'gpu' | 'nodeport' | 'pod' | 'storage', number>> & {
       traffic?: number | boolean;
     }
   ) => ExceededWorkspaceQuotaItem[];

--- a/frontend/packages/shared/src/types/workspace.ts
+++ b/frontend/packages/shared/src/types/workspace.ts
@@ -4,6 +4,7 @@ export const WorkspaceQuotaItemTypeSchema = z.enum([
   'cpu',
   'memory',
   'storage',
+  'pod',
   'gpu',
   'traffic',
   'nodeport'

--- a/frontend/providers/applaunchpad/public/locales/en/common.json
+++ b/frontend/providers/applaunchpad/public/locales/en/common.json
@@ -288,6 +288,7 @@
   "confirm_to_go": "Confirm",
   "contains": "contains",
   "cpu": "CPU",
+  "pod": "Pod",
   "cpu_exceeds_quota": "CPU Insufficient Resources: Your setting of {{requested}} cores exceeds the available {{limit}} cores ({{used}} cores used).",
   "custom_domain_input_title": "Your Domain",
   "day": "days",

--- a/frontend/providers/applaunchpad/public/locales/zh/common.json
+++ b/frontend/providers/applaunchpad/public/locales/zh/common.json
@@ -287,6 +287,7 @@
   "confirm_to_go": "确认前往",
   "contains": "包含",
   "cpu": "CPU",
+  "pod": "Pod",
   "cpu_exceeds_quota": "CPU 资源不足：你设置的 {{requested}} 核心超出工作空间可用 {{limit}} 核限制（已使用 {{used}} 核）。",
   "custom_domain_input_title": "您的域名",
   "day": "天",

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/QuotaBox.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/QuotaBox.tsx
@@ -8,7 +8,7 @@ import {
 } from '@sealos/shadcn-ui/tooltip';
 import { Progress } from '@sealos/shadcn-ui/progress';
 import { Card, CardContent, CardHeader, CardTitle } from '@sealos/shadcn-ui/card';
-import { Cpu, MemoryStick, HardDrive, CircuitBoard, HdmiPort, ArrowUpDown } from 'lucide-react';
+import { Cpu, MemoryStick, HardDrive, CircuitBoard, HdmiPort, ArrowUpDown, Layers } from 'lucide-react';
 
 import { useUserQuota, resourcePropertyMap, formatResourceQuotaValue } from '@sealos/shared';
 
@@ -18,6 +18,7 @@ const iconMap: Record<string, React.ReactNode> = {
   storage: <HardDrive className="h-5 w-5" />,
   gpu: <CircuitBoard className="h-5 w-5" />,
   nodeport: <HdmiPort className="h-5 w-5" />,
+  pod: <Layers className="h-5 w-5" />,
   traffic: <ArrowUpDown className="h-5 w-5" />
 };
 

--- a/frontend/providers/dbprovider/public/locales/zh/common.json
+++ b/frontend/providers/dbprovider/public/locales/zh/common.json
@@ -378,7 +378,7 @@
     "2": " 或调整设置"
   },
   "pls_create": "无结果，请自行创建",
-  "pod": "实例",
+  "pod": "Pod",
   "pod_completed": "Pod已经结束，无法查看日志",
   "prompt": "提示",
   "query_operations": "查询操作数",

--- a/frontend/providers/dbprovider/src/components/QuotaBox/index.tsx
+++ b/frontend/providers/dbprovider/src/components/QuotaBox/index.tsx
@@ -21,6 +21,9 @@ const sourceMap = {
   nodeport: {
     color: '#FFA500'
   },
+  pod: {
+    color: '#EC4899'
+  },
   traffic: {
     color: '#FF6B6B'
   }

--- a/frontend/providers/template/public/locales/en/common.json
+++ b/frontend/providers/template/public/locales/en/common.json
@@ -196,6 +196,7 @@
     "Used": "Used"
   },
   "cpu": "CPU",
+  "pod": "Pod",
   "cronjob": "CronJob",
   "database": "DataBase",
   "delete message": "Are you sure you want to delete this app? If you proceed, all project data will be permanently deleted.",

--- a/frontend/providers/template/public/locales/zh/common.json
+++ b/frontend/providers/template/public/locales/zh/common.json
@@ -196,6 +196,7 @@
     "Used": "已用"
   },
   "cpu": "CPU",
+  "pod": "Pod",
   "cronjob": "定时任务",
   "database": "数据库",
   "delete message": "您确定要删除此应用程序吗？\n如果继续，该项目的所有数据都将被删除。",

--- a/frontend/providers/template/src/pages/deploy/components/QuotaBox.tsx
+++ b/frontend/providers/template/src/pages/deploy/components/QuotaBox.tsx
@@ -26,6 +26,9 @@ const sourceMap = {
   nodeport: {
     color: '#FFA500'
   },
+  pod: {
+    color: '#EC4899'
+  },
   traffic: {
     color: '#FF6B6B'
   }


### PR DESCRIPTION
## Summary

- map ResourceQuota `hard.pods` and `used.pods` to a public quota item with `type: "pod"`
- add pod quota support to Desktop, client SDK, shared types, formatting, icons, i18n, and quota guards
- cover the workspace quota API mapping with focused unit tests

## Why

User quota CRDs already contain pod limits, but the Desktop workspace quota API omitted them, so downstream consumers could not display or guard against pod limits.

## Validation

- Desktop workspace quota API tests: 2/2
- shared package TypeScript check
- targeted Prettier and ESLint
- `git diff --check`

Full workspace TypeScript compilation is unavailable in the sparse checkout because unrelated generated Prisma clients and package outputs are absent.

## Related change

The corresponding brain PR consumes and displays this new quota item. Its link will be added here after both PRs are created.