### PR TITLE
fix(applaunchpad): avoid duplicate private registry prefixes

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/services/backend/appService.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/services/backend/appService.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from 'vitest';
+import { updateAppResources } from '@/services/backend/appService';
+
+vi.mock('@/pages/app/edit', () => ({
+  formData2Yamls: vi.fn()
+}));
+
+const createK8sContext = (currentImage: string, hasImagePullSecret = true) => {
+  const patchNamespacedDeployment = vi.fn().mockResolvedValue({});
+  const replaceNamespacedSecret = vi.fn().mockResolvedValue({});
+  const replaceApp = vi.fn().mockResolvedValue({});
+
+  return {
+    context: {
+      namespace: 'ns-demo',
+      apiClient: { replace: replaceApp },
+      getDeployApp: vi.fn().mockResolvedValue({
+        apiVersion: 'apps/v1',
+        kind: 'Deployment',
+        metadata: {
+          name: 'demo',
+          annotations: { originImageName: currentImage }
+        },
+        spec: {
+          template: {
+            spec: {
+              containers: [{ name: 'demo', image: currentImage }],
+              ...(hasImagePullSecret ? { imagePullSecrets: [{ name: 'demo' }] } : {})
+            }
+          }
+        }
+      }),
+      k8sApp: {
+        patchNamespacedDeployment
+      },
+      k8sCore: {
+        readNamespacedSecret: vi.fn().mockResolvedValue({}),
+        replaceNamespacedSecret
+      }
+    } as any,
+    patchNamespacedDeployment,
+    replaceNamespacedSecret,
+    replaceApp
+  };
+};
+
+describe('updateAppResources image registry binding', () => {
+  it('uses a separate private registry for a short image update', async () => {
+    const { context, patchNamespacedDeployment, replaceNamespacedSecret } = createK8sContext(
+      'registry.example.com/team/app:v1'
+    );
+
+    await updateAppResources(
+      'demo',
+      {
+        imageName: 'team/app:v2',
+        imageRegistry: {
+          username: 'demo-user',
+          password: 'real-password',
+          serverAddress: 'registry.example.com'
+        }
+      },
+      context
+    );
+
+    const patch = patchNamespacedDeployment.mock.calls[0][2];
+    expect(patch).toContainEqual({
+      op: 'replace',
+      path: '/spec/template/spec/containers/0/image',
+      value: 'registry.example.com/team/app:v2'
+    });
+
+    const secret = replaceNamespacedSecret.mock.calls[0][2];
+    const dockerconfigjson = JSON.parse(
+      Buffer.from(secret.data['.dockerconfigjson'], 'base64').toString()
+    );
+    expect(Object.keys(dockerconfigjson.auths)).toEqual(['registry.example.com']);
+  });
+
+  it('preserves the existing private registry when only a short image is updated', async () => {
+    const { context, patchNamespacedDeployment } = createK8sContext(
+      'registry.example.com/team/app:v1'
+    );
+
+    await updateAppResources('demo', { imageName: 'team/app:v2' }, context);
+
+    const patch = patchNamespacedDeployment.mock.calls[0][2];
+    expect(patch).toContainEqual({
+      op: 'replace',
+      path: '/spec/template/spec/containers/0/image',
+      value: 'registry.example.com/team/app:v2'
+    });
+  });
+
+  it('rejects mismatched registry credentials before Kubernetes writes', async () => {
+    const { context, patchNamespacedDeployment, replaceNamespacedSecret, replaceApp } =
+      createK8sContext('old-registry.example.com/team/app:v1');
+
+    await expect(
+      updateAppResources(
+        'demo',
+        {
+          resource: { replicas: 2 },
+          imageName: 'new-registry.example.com/team/app:v2',
+          imageRegistry: {
+            username: 'demo-user',
+            password: 'real-password',
+            serverAddress: 'old-registry.example.com'
+          }
+        },
+        context
+      )
+    ).rejects.toThrow('registry credentials');
+
+    expect(patchNamespacedDeployment).not.toHaveBeenCalled();
+    expect(replaceNamespacedSecret).not.toHaveBeenCalled();
+    expect(replaceApp).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/providers/applaunchpad/__tests__/unit/utils/deployYaml2Json.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/deployYaml2Json.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { compare } from 'fast-json-patch';
 import {
+  alignImageRegistrySecret,
+  getBoundImageRegistryCredentials,
   getImageRegistryAddress,
   json2DeployCr,
   json2Ingress,
   json2Secret,
+  resolveImageRegistryBinding,
   json2Service,
   yamlString2Objects
 } from '@/utils/deployYaml2Json';
@@ -554,6 +557,196 @@ describe('json2Secret', () => {
     );
 
     expect(dockerconfigjson.auths).toHaveProperty('docker.io');
+  });
+
+  it('keeps the API contract for a short image and a separate private registry', () => {
+    const app = createApp();
+    app.imageName = 'team/app:v1';
+    app.secret = {
+      use: true,
+      username: 'demo-user',
+      password: 'real-password',
+      serverAddress: 'registry.example.com'
+    };
+
+    const deployment = yamlString2Objects(json2DeployCr(app, 'deployment'))[0] as any;
+    const secret = yamlString2Objects(json2Secret(app))[0] as any;
+    const dockerconfigjson = JSON.parse(
+      Buffer.from(secret.data['.dockerconfigjson'], 'base64').toString()
+    );
+
+    expect(deployment.spec.template.spec.containers[0].image).toBe(
+      'registry.example.com/team/app:v1'
+    );
+    expect(Object.keys(dockerconfigjson.auths)).toEqual(['registry.example.com']);
+  });
+
+  it('rejects credentials that belong to a different explicit registry', () => {
+    const app = createApp();
+    app.imageName = 'new-registry.example.com/team/app:v1';
+    app.secret = {
+      use: true,
+      username: 'demo-user',
+      password: 'real-password',
+      serverAddress: 'old-registry.example.com'
+    };
+
+    const deployment = yamlString2Objects(json2DeployCr(app, 'deployment'))[0] as any;
+    expect(deployment.spec.template.spec.containers[0].image).toBe(
+      'new-registry.example.com/team/app:v1'
+    );
+    expect(() => json2Secret(app)).toThrow('registry credentials');
+  });
+
+  it('resolves API image updates using a separate private registry', () => {
+    expect(
+      resolveImageRegistryBinding({
+        imageName: 'team/app:v2',
+        credentialRegistry: 'registry.example.com',
+        useCredentials: true,
+        requireCredentialMatch: true
+      })
+    ).toEqual({
+      imageName: 'registry.example.com/team/app:v2',
+      registry: 'registry.example.com'
+    });
+  });
+
+  it('ignores stale registry fields when private credentials are disabled', () => {
+    const app = createApp();
+    app.imageName = 'new-registry.example.com/team/app:v1';
+    app.secret = {
+      use: false,
+      username: 'old-user',
+      password: 'old-password',
+      serverAddress: 'old-registry.example.com'
+    };
+
+    const deployment = yamlString2Objects(json2DeployCr(app, 'deployment'))[0] as any;
+    expect(deployment.spec.template.spec.containers[0].image).toBe(
+      'new-registry.example.com/team/app:v1'
+    );
+  });
+
+  it('clears credentials when the image registry changes', () => {
+    expect(
+      alignImageRegistrySecret('new-registry.example.com/team/app:v1', {
+        use: true,
+        username: 'demo-user',
+        password: 'real-password',
+        serverAddress: 'old-registry.example.com'
+      })
+    ).toEqual({
+      use: true,
+      username: '',
+      password: '',
+      serverAddress: 'new-registry.example.com'
+    });
+  });
+
+  it('keeps Docker Hub credentials stored under the legacy auth key', () => {
+    const secret = {
+      use: true,
+      username: 'demo-user',
+      password: 'real-password',
+      serverAddress: 'https://index.docker.io/v1/'
+    };
+
+    expect(alignImageRegistrySecret('team/app:v1', secret)).toBe(secret);
+    expect(getBoundImageRegistryCredentials('team/app:v1', secret)).toEqual({
+      username: 'demo-user',
+      password: 'real-password',
+      serverAddress: 'docker.io'
+    });
+  });
+
+  it('accepts Docker Hub aliases in explicit image and credential registries', () => {
+    const app = createApp();
+    app.imageName = 'index.docker.io/team/app:v1';
+    app.secret = {
+      use: true,
+      username: 'demo-user',
+      password: 'real-password',
+      serverAddress: 'https://index.docker.io/v1/'
+    };
+
+    const deployment = yamlString2Objects(json2DeployCr(app, 'deployment'))[0] as any;
+    const secret = yamlString2Objects(json2Secret(app))[0] as any;
+    const dockerconfigjson = JSON.parse(
+      Buffer.from(secret.data['.dockerconfigjson'], 'base64').toString()
+    );
+
+    expect(deployment.spec.template.spec.containers[0].image).toBe('index.docker.io/team/app:v1');
+    expect(Object.keys(dockerconfigjson.auths)).toEqual(['docker.io']);
+  });
+
+  it.each(['registry-1.docker.io', 'registry.hub.docker.com'])(
+    'preserves the explicit Docker registry hostname %s',
+    (registry) => {
+      const app = createApp();
+      app.imageName = `${registry}/team/app:v1`;
+      app.secret = {
+        use: true,
+        username: 'demo-user',
+        password: 'real-password',
+        serverAddress: registry
+      };
+
+      const secret = yamlString2Objects(json2Secret(app))[0] as any;
+      const dockerconfigjson = JSON.parse(
+        Buffer.from(secret.data['.dockerconfigjson'], 'base64').toString()
+      );
+
+      expect(Object.keys(dockerconfigjson.auths)).toEqual([registry]);
+    }
+  );
+
+  it('preserves credentials scoped to the image repository path', () => {
+    const app = createApp();
+    app.imageName = 'registry.example.com/team/app:v1';
+    app.secret = {
+      use: true,
+      username: 'demo-user',
+      password: 'real-password',
+      serverAddress: 'registry.example.com/team'
+    };
+
+    expect(alignImageRegistrySecret(app.imageName, app.secret)).toBe(app.secret);
+    expect(getBoundImageRegistryCredentials(app.imageName, app.secret)).toEqual({
+      username: 'demo-user',
+      password: 'real-password',
+      serverAddress: 'registry.example.com'
+    });
+
+    const secret = yamlString2Objects(json2Secret(app))[0] as any;
+    const dockerconfigjson = JSON.parse(
+      Buffer.from(secret.data['.dockerconfigjson'], 'base64').toString()
+    );
+    expect(Object.keys(dockerconfigjson.auths)).toEqual(['registry.example.com/team']);
+  });
+
+  it('rejects credentials scoped to a sibling image repository path', () => {
+    const app = createApp();
+    app.imageName = 'registry.example.com/team/app:v1';
+    app.secret = {
+      use: true,
+      username: 'demo-user',
+      password: 'real-password',
+      serverAddress: 'registry.example.com/other-team'
+    };
+
+    expect(() => json2Secret(app)).toThrow('registry credentials');
+  });
+
+  it('does not expose credentials to an image registry they are not bound to', () => {
+    expect(
+      getBoundImageRegistryCredentials('new-registry.example.com/team/app:v1', {
+        use: true,
+        username: 'demo-user',
+        password: 'real-password',
+        serverAddress: 'old-registry.example.com'
+      })
+    ).toBeUndefined();
   });
 
   it('uses the deployed image when editing a legacy private registry app', () => {

--- a/frontend/providers/applaunchpad/__tests__/unit/utils/deployYaml2Json.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/deployYaml2Json.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { compare } from 'fast-json-patch';
 import {
+  getImageRegistryAddress,
   json2DeployCr,
   json2Ingress,
   json2Secret,
@@ -8,6 +9,7 @@ import {
   yamlString2Objects
 } from '@/utils/deployYaml2Json';
 import type { AppEditType } from '@/types/app';
+import { resolveAppImageName } from '@/utils/adapt';
 
 const createApp = (customDomain = ''): AppEditType =>
   ({
@@ -512,5 +514,55 @@ describe('json2Secret', () => {
 
     expect(secretYaml).toContain('.dockerconfigjson: ********');
     expect(secretYaml).not.toContain(".dockerconfigjson: '********'");
+  });
+
+  it.each([
+    ['hub.example.com/team/app:v1', 'hub.example.com'],
+    ['192.168.1.10:5000/team/app:v1', '192.168.1.10:5000'],
+    ['team/app:v1', 'docker.io'],
+    ['app:v1', 'docker.io']
+  ])('resolves the registry for %s as %s', (imageName, registry) => {
+    expect(getImageRegistryAddress(imageName)).toBe(registry);
+  });
+
+  it('uses the complete image as-is and derives the pull secret registry', () => {
+    const app = createApp();
+    app.imageName = 'hub.example.com/team/app:v1';
+    app.secret = {
+      use: true,
+      username: 'demo-user',
+      password: 'real-password',
+      serverAddress: ''
+    };
+
+    const deployment = yamlString2Objects(json2DeployCr(app, 'deployment'))[0] as any;
+    const secret = yamlString2Objects(json2Secret(app))[0] as any;
+    const dockerconfigjson = JSON.parse(
+      Buffer.from(secret.data['.dockerconfigjson'], 'base64').toString()
+    );
+
+    expect(deployment.spec.template.spec.containers[0].image).toBe('hub.example.com/team/app:v1');
+    expect(Object.keys(dockerconfigjson.auths)).toEqual(['hub.example.com']);
+  });
+
+  it('uses docker.io for the pull secret of a short image reference', () => {
+    const app = createApp();
+    app.imageName = 'team/app:v1';
+    const secret = yamlString2Objects(json2Secret(app))[0] as any;
+    const dockerconfigjson = JSON.parse(
+      Buffer.from(secret.data['.dockerconfigjson'], 'base64').toString()
+    );
+
+    expect(dockerconfigjson.auths).toHaveProperty('docker.io');
+  });
+
+  it('uses the deployed image when editing a legacy private registry app', () => {
+    expect(
+      resolveAppImageName({
+        deployedImage: 'hub.example.com/team/app:v1',
+        originImageName: 'team/app:v1',
+        usesPrivateRegistry: true
+      })
+    ).toBe('hub.example.com/team/app:v1');
   });
 });

--- a/frontend/providers/applaunchpad/public/locales/en/common.json
+++ b/frontend/providers/applaunchpad/public/locales/en/common.json
@@ -103,6 +103,7 @@
   "Image Name": "Image Name",
   "Image Name (Private)": "Image Name (Private)",
   "Image name cannot be empty": "Image name is required.",
+  "private_image_registry_tip": "Include the registry address in the image name. If omitted, docker.io is used by default.",
   "image_ports_detection_failed": "Port detection failed",
   "no_image_ports_detected": "No exposed ports detected",
   "recognized_image_ports": "{{count}} ports detected",

--- a/frontend/providers/applaunchpad/public/locales/zh/common.json
+++ b/frontend/providers/applaunchpad/public/locales/zh/common.json
@@ -103,6 +103,7 @@
   "Image Name": "镜像名",
   "Image Name (Private)": "镜像名称（私有）",
   "Image name cannot be empty": "镜像名称不能为空。",
+  "private_image_registry_tip": "请在镜像名中填写镜像仓库地址；未填写时默认使用 docker.io。",
   "image_ports_detection_failed": "端口识别失败",
   "no_image_ports_detected": "未识别到暴露端口",
   "recognized_image_ports": "已识别 {{count}} 个端口",

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
@@ -220,6 +220,13 @@ const Form = ({
   const watchedSecretUse = watch('secret.use');
   const watchedSecretUsername = watch('secret.username');
   const watchedSecretPassword = watch('secret.password');
+  const [isImageNameFocused, setIsImageNameFocused] = useState(false);
+  const imageNameField = register('imageName', {
+    required: 'Image name cannot be empty',
+    setValueAs(e) {
+      return e.replace(/\s*/g, '');
+    }
+  });
 
   useEffect(() => {
     secretPasswordVersion.current += 1;
@@ -816,12 +823,12 @@ const Form = ({
                         value={getValues('imageName')}
                         backgroundColor={getValues('imageName') ? 'myWhite.500' : 'grayModern.100'}
                         placeholder={`${t('Image Name')}`}
-                        {...register('imageName', {
-                          required: 'Image name cannot be empty',
-                          setValueAs(e) {
-                            return e.replace(/\s*/g, '');
-                          }
-                        })}
+                        {...imageNameField}
+                        onFocus={() => setIsImageNameFocused(true)}
+                        onBlur={(event) => {
+                          setIsImageNameFocused(false);
+                          imageNameField.onBlur(event);
+                        }}
                       />
                       <Flex
                         alignItems={'center'}
@@ -841,7 +848,7 @@ const Form = ({
                         </Box>
                       </Flex>
                     </Flex>
-                    {watchedImageName ? (
+                    {isImageNameFocused ? (
                       <Box mt={2} fontSize={'12px'} color={'brightBlue.600'}>
                         {t('private_image_registry_tip')}
                       </Box>

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
@@ -841,9 +841,11 @@ const Form = ({
                         </Box>
                       </Flex>
                     </Flex>
-                    <Box mt={2} fontSize={'12px'} color={'brightBlue.600'}>
-                      {t('private_image_registry_tip')}
-                    </Box>
+                    {watchedImageName ? (
+                      <Box mt={2} fontSize={'12px'} color={'brightBlue.600'}>
+                        {t('private_image_registry_tip')}
+                      </Box>
+                    ) : null}
                   </FormControl>
                   {getValues('secret.use') ? (
                     <>

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
@@ -59,7 +59,10 @@ import {
   APP_NAME_BASE_PATTERN,
   isValidAppNameBase
 } from '@/utils/appNameValidation';
-import { getImageRegistryAddress } from '@/utils/deployYaml2Json';
+import {
+  alignImageRegistrySecret,
+  getBoundImageRegistryCredentials
+} from '@/utils/deployYaml2Json';
 
 const ConfigmapModal = dynamic(() => import('./ConfigmapModal'));
 const StoreModal = dynamic(() => import('./StoreModal'));
@@ -325,12 +328,12 @@ const Form = ({
       return;
     }
     const secret = getValues('secret');
-    const serverAddress = getImageRegistryAddress(imageName);
+    const imageRegistry = getBoundImageRegistryCredentials(imageName, secret);
     const autoPortKey = [
       imageName,
-      secret.use ? secret.username : '',
-      secret.use ? serverAddress : '',
-      secret.use && secret.password ? `password-v${secretPasswordVersion.current}` : ''
+      imageRegistry?.username || '',
+      imageRegistry?.serverAddress || '',
+      imageRegistry?.password ? `password-v${secretPasswordVersion.current}` : ''
     ].join('|');
     if (lastAutoPortKey.current === autoPortKey) return;
 
@@ -345,13 +348,7 @@ const Form = ({
       try {
         const res = await getImagePorts({
           imageName,
-          imageRegistry: secret.use
-            ? {
-                username: secret.username,
-                password: secret.password,
-                serverAddress
-              }
-            : undefined
+          imageRegistry
         });
 
         if (requestId !== imagePortRequestId.current) {
@@ -805,7 +802,13 @@ const Form = ({
                       if (val === 'public') {
                         setValue('secret.use', false);
                       } else {
-                        setValue('secret.use', true);
+                        setValue(
+                          'secret',
+                          alignImageRegistrySecret(getValues('imageName'), {
+                            ...getValues('secret'),
+                            use: true
+                          })
+                        );
                       }
                     }}
                   />
@@ -824,6 +827,20 @@ const Form = ({
                         backgroundColor={getValues('imageName') ? 'myWhite.500' : 'grayModern.100'}
                         placeholder={`${t('Image Name')}`}
                         {...imageNameField}
+                        onChange={(event) => {
+                          imageNameField.onChange(event);
+                          const secret = getValues('secret');
+                          if (!secret.use) return;
+
+                          const imageName = event.target.value.replace(/\s*/g, '');
+                          const nextSecret = alignImageRegistrySecret(imageName, secret);
+                          if (nextSecret !== secret) {
+                            setValue('secret', nextSecret, {
+                              shouldDirty: true,
+                              shouldValidate: true
+                            });
+                          }
+                        }}
                         onFocus={() => setIsImageNameFocused(true)}
                         onBlur={(event) => {
                           setIsImageNameFocused(false);

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
@@ -866,6 +866,8 @@ const Form = ({
                           {t('Username')}
                         </Box>
                         <Input
+                          w={'350px'}
+                          maxW={'100%'}
                           backgroundColor={
                             getValues('imageName') ? 'myWhite.500' : 'grayModern.100'
                           }
@@ -885,6 +887,8 @@ const Form = ({
                           {t('Password')}
                         </Box>
                         <Input
+                          w={'350px'}
+                          maxW={'100%'}
                           type={'password'}
                           placeholder={`${t('Password for the image registry')}`}
                           backgroundColor={

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
@@ -556,14 +556,14 @@ const Form = ({
     const sortedCpuList = !!gpuType
       ? cpuList
       : cpu !== undefined
-      ? [...new Set([...cpuList, cpu])].sort((a, b) => a - b)
-      : cpuList;
+        ? [...new Set([...cpuList, cpu])].sort((a, b) => a - b)
+        : cpuList;
 
     const sortedMemoryList = !!gpuType
       ? memoryList
       : memory !== undefined
-      ? [...new Set([...memoryList, memory])].sort((a, b) => a - b)
-      : memoryList;
+        ? [...new Set([...memoryList, memory])].sort((a, b) => a - b)
+        : memoryList;
 
     const sortedEphemeralStorageList =
       ephemeralStorage !== undefined
@@ -810,7 +810,8 @@ const Form = ({
                     </Box>
                     <Flex alignItems={'center'} gap={3}>
                       <Input
-                        width={'350px'}
+                        w={'350px'}
+                        maxW={'100%'}
                         flexShrink={0}
                         value={getValues('imageName')}
                         backgroundColor={getValues('imageName') ? 'myWhite.500' : 'grayModern.100'}
@@ -840,10 +841,18 @@ const Form = ({
                         </Box>
                       </Flex>
                     </Flex>
+                    <Box mt={2} fontSize={'12px'} color={'brightBlue.600'}>
+                      {t('private_image_registry_tip')}
+                    </Box>
                   </FormControl>
                   {getValues('secret.use') ? (
                     <>
-                      <FormControl mt={4} isInvalid={!!errors.secret?.username} w={'420px'}>
+                      <FormControl
+                        mt={4}
+                        isInvalid={!!errors.secret?.username}
+                        w={'350px'}
+                        maxW={'100%'}
+                      >
                         <Box mb={1} fontSize={'sm'}>
                           {t('Username')}
                         </Box>
@@ -857,7 +866,12 @@ const Form = ({
                           })}
                         />
                       </FormControl>
-                      <FormControl mt={4} isInvalid={!!errors.secret?.password} w={'420px'}>
+                      <FormControl
+                        mt={4}
+                        isInvalid={!!errors.secret?.password}
+                        w={'350px'}
+                        maxW={'100%'}
+                      >
                         <Box mb={1} fontSize={'sm'}>
                           {t('Password')}
                         </Box>
@@ -1292,8 +1306,8 @@ const Form = ({
                             const valText = env.value
                               ? env.value
                               : env.valueFrom
-                              ? 'value from | ***'
-                              : '';
+                                ? 'value from | ***'
+                                : '';
                             return (
                               <tr key={env.id}>
                                 <th>{env.key}</th>

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/Form.tsx
@@ -59,6 +59,7 @@ import {
   APP_NAME_BASE_PATTERN,
   isValidAppNameBase
 } from '@/utils/appNameValidation';
+import { getImageRegistryAddress } from '@/utils/deployYaml2Json';
 
 const ConfigmapModal = dynamic(() => import('./ConfigmapModal'));
 const StoreModal = dynamic(() => import('./StoreModal'));
@@ -178,9 +179,7 @@ const Form = ({
           getValues('appName') &&
           getValues('imageName') &&
           (getValues('secret.use')
-            ? getValues('secret.username') &&
-              getValues('secret.password') &&
-              getValues('secret.serverAddress')
+            ? getValues('secret.username') && getValues('secret.password')
             : true)
       },
       {
@@ -221,7 +220,6 @@ const Form = ({
   const watchedSecretUse = watch('secret.use');
   const watchedSecretUsername = watch('secret.username');
   const watchedSecretPassword = watch('secret.password');
-  const watchedSecretServerAddress = watch('secret.serverAddress');
 
   useEffect(() => {
     secretPasswordVersion.current += 1;
@@ -320,10 +318,11 @@ const Form = ({
       return;
     }
     const secret = getValues('secret');
+    const serverAddress = getImageRegistryAddress(imageName);
     const autoPortKey = [
       imageName,
       secret.use ? secret.username : '',
-      secret.use ? secret.serverAddress : '',
+      secret.use ? serverAddress : '',
       secret.use && secret.password ? `password-v${secretPasswordVersion.current}` : ''
     ].join('|');
     if (lastAutoPortKey.current === autoPortKey) return;
@@ -343,7 +342,7 @@ const Form = ({
             ? {
                 username: secret.username,
                 password: secret.password,
-                serverAddress: secret.serverAddress
+                serverAddress
               }
             : undefined
         });
@@ -395,7 +394,6 @@ const Form = ({
     setValue,
     watchedImageName,
     watchedSecretPassword,
-    watchedSecretServerAddress,
     watchedSecretUse,
     watchedSecretUsername
   ]);
@@ -871,20 +869,6 @@ const Form = ({
                           }
                           {...register('secret.password', {
                             required: t('The password cannot be empty') || ''
-                          })}
-                        />
-                      </FormControl>
-                      <FormControl mt={4} isInvalid={!!errors.secret?.serverAddress} w={'420px'}>
-                        <Box mb={1} fontSize={'sm'}>
-                          {t('Image Address')}
-                        </Box>
-                        <Input
-                          backgroundColor={
-                            getValues('imageName') ? 'myWhite.500' : 'grayModern.100'
-                          }
-                          placeholder={`${t('Image Address')}`}
-                          {...register('secret.serverAddress', {
-                            required: t('The image cannot be empty') || ''
                           })}
                         />
                       </FormControl>
@@ -1467,7 +1451,9 @@ const Form = ({
                                 bg: 'rgba(17, 24, 36, 0.05)'
                               }}
                               onClick={() => {
-                                const isApplied = existingStores.some((store) => store.path === item.path);
+                                const isApplied = existingStores.some(
+                                  (store) => store.path === item.path
+                                );
                                 if (isApplied) {
                                   const appliedCount = localStores.filter((store) =>
                                     existingStores.some((e) => e.path === store.path)

--- a/frontend/providers/applaunchpad/src/services/backend/appService.ts
+++ b/frontend/providers/applaunchpad/src/services/backend/appService.ts
@@ -3,7 +3,11 @@ import { formData2Yamls } from '@/pages/app/edit';
 import { serverLoadInitData } from '@/store/static';
 import { AppEditType } from '@/types/app';
 import { UserQuotaItemType } from '@/types/user';
-import { json2HPA } from '@/utils/deployYaml2Json';
+import {
+  getImageRegistryAddress,
+  json2HPA,
+  resolveImageRegistryBinding
+} from '@/utils/deployYaml2Json';
 import { str2Num } from '@/utils/tools';
 import { adaptAppDetail } from '@/utils/adapt';
 import { DeployKindsType, AppDetailType } from '@/types/app';
@@ -480,6 +484,36 @@ export async function updateAppResources(
     throw new Error('app data error');
   }
 
+  const imageNameToUpdate =
+    updateData.image !== undefined ? updateData.image : updateData.imageName;
+  const currentImageName = app.spec.template.spec?.containers?.[0]?.image || '';
+  const hasExistingCredentials = !!app.spec.template.spec?.imagePullSecrets?.length;
+  const registryUpdate = updateData.imageRegistry;
+  const credentialRegistry =
+    registryUpdate && registryUpdate !== null
+      ? registryUpdate.serverAddress
+      : registryUpdate === undefined && hasExistingCredentials
+        ? getImageRegistryAddress(currentImageName)
+        : undefined;
+  const imageBinding =
+    imageNameToUpdate !== undefined
+      ? resolveImageRegistryBinding({
+          imageName: imageNameToUpdate || '',
+          credentialRegistry,
+          useCredentials: !!credentialRegistry,
+          requireCredentialMatch: !!registryUpdate
+        })
+      : undefined;
+  let registryBinding: ReturnType<typeof resolveImageRegistryBinding> | undefined;
+  if (registryUpdate && registryUpdate !== null) {
+    registryBinding = resolveImageRegistryBinding({
+      imageName: imageNameToUpdate ?? currentImageName,
+      credentialRegistry: registryUpdate.serverAddress,
+      useCredentials: true,
+      requireCredentialMatch: true
+    });
+  }
+
   if (updateData.resource?.replicas !== undefined) {
     if (updateData.resource.replicas === 0) {
       const restartAnnotations: Record<string, string> = {
@@ -659,34 +693,33 @@ export async function updateAppResources(
     }
 
     // Handle image name update (either from image or imageName field)
-    const imageNameToUpdate =
-      updateData.image !== undefined ? updateData.image : updateData.imageName;
-    if (imageNameToUpdate !== undefined) {
-      // Allow empty string for image name
-      const finalImageName = imageNameToUpdate || '';
+    if (imageBinding) {
       jsonPatch.push({
         op: 'replace',
         path: '/spec/template/spec/containers/0/image',
-        value: finalImageName
+        value: imageBinding.imageName
       });
 
       jsonPatch.push({
         op: 'replace',
         path: '/metadata/annotations/originImageName',
-        value: finalImageName
+        value: imageBinding.imageName
       });
     }
 
     if (updateData.imageRegistry !== undefined) {
       if (updateData.imageRegistry !== null) {
         const { k8sCore } = k8s;
+        if (!registryBinding) {
+          throw new Error('Image registry binding is required');
+        }
         const auth = Buffer.from(
           `${updateData.imageRegistry.username}:${updateData.imageRegistry.password}`
         ).toString('base64');
         const dockerconfigjson = Buffer.from(
           JSON.stringify({
             auths: {
-              [updateData.imageRegistry.serverAddress]: {
+              [registryBinding.registry]: {
                 username: updateData.imageRegistry.username,
                 password: updateData.imageRegistry.password,
                 auth

--- a/frontend/providers/applaunchpad/src/utils/adapt.ts
+++ b/frontend/providers/applaunchpad/src/utils/adapt.ts
@@ -55,6 +55,16 @@ import { getInitData } from '@/api/platform';
 
 const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz', 12);
 
+export const resolveAppImageName = ({
+  deployedImage,
+  originImageName,
+  usesPrivateRegistry
+}: {
+  deployedImage: string;
+  originImageName: string;
+  usesPrivateRegistry: boolean;
+}) => (usesPrivateRegistry ? deployedImage || originImageName : originImageName || deployedImage);
+
 export const getAppSource = (
   app: V1Deployment | V1StatefulSet
 ): {
@@ -476,6 +486,10 @@ export const adaptAppDetail = async (
     return map;
   }, new Map<number, V1Ingress>());
 
+  const secret = atobSecretYaml(deployKindsMap?.Secret?.data?.['.dockerconfigjson']);
+  const deployedImage = appDeploy.spec?.template?.spec?.containers?.[0]?.image || '';
+  const originImageName = appDeploy?.metadata?.annotations?.originImageName || '';
+
   return {
     labels: appDeploy?.metadata?.labels || {},
     crYamlList: configs,
@@ -484,10 +498,11 @@ export const adaptAppDetail = async (
     createTime: dayjs(appDeploy.metadata?.creationTimestamp).format('YYYY-MM-DD HH:mm'),
     status: appStatusMap.waiting,
     isPause: !!appDeploy?.metadata?.annotations?.[pauseKey],
-    imageName:
-      appDeploy?.metadata?.annotations?.originImageName ||
-      appDeploy.spec?.template?.spec?.containers?.[0]?.image ||
-      '',
+    imageName: resolveAppImageName({
+      deployedImage,
+      originImageName,
+      usesPrivateRegistry: secret.use
+    }),
     runCMD: appDeploy.spec?.template?.spec?.containers?.[0]?.command?.join(' ') || '',
     cmdParam:
       (appDeploy.spec?.template?.spec?.containers?.[0]?.args?.length === 1
@@ -562,7 +577,7 @@ export const adaptAppDetail = async (
         // and only fall back to HTTP when an Ingress proves this TCP port is application traffic.
         const appProtocol = APPLICATION_PROTOCOLS.includes(serviceAppProtocol)
           ? (serviceAppProtocol as ApplicationProtocolType)
-          : (ingressAppProtocol ?? (ingress && protocol === 'TCP' ? 'HTTP' : undefined));
+          : ingressAppProtocol ?? (ingress && protocol === 'TCP' ? 'HTTP' : undefined);
 
         const isCustomDomain =
           !domain.endsWith(SEALOS_DOMAIN) &&
@@ -585,8 +600,8 @@ export const adaptAppDetail = async (
           domain: isCustomDomain
             ? SEALOS_DOMAIN
             : item?.nodePort
-              ? domain
-              : domain.split('.').slice(1).join('.') || SEALOS_DOMAIN,
+            ? domain
+            : domain.split('.').slice(1).join('.') || SEALOS_DOMAIN,
           routes: ingressPaths.length
             ? ingressPaths.map((path) => ({
                 path: path.path || '/',
@@ -628,7 +643,7 @@ export const adaptAppDetail = async (
         }
       : defaultEditVal.hpa,
     configMapList: getConfigMapList(),
-    secret: atobSecretYaml(deployKindsMap?.Secret?.data?.['.dockerconfigjson']),
+    secret,
     storeList: (() => {
       // Local stores from volumeClaimTemplates
       const localStores = deployKindsMap.StatefulSet?.spec?.volumeClaimTemplates
@@ -721,8 +736,8 @@ export const sliderNumber2MarkList = ({
           ? `${item / 1024} G`
           : `${item} M`
         : type === 'ephemeralStorage'
-          ? `${item}`
-          : `${item / 1000}`,
+        ? `${item}`
+        : `${item / 1000}`,
     value: item
   }));
 };

--- a/frontend/providers/applaunchpad/src/utils/deployYaml2Json.ts
+++ b/frontend/providers/applaunchpad/src/utils/deployYaml2Json.ts
@@ -115,7 +115,7 @@ export const yamlString2Objects = (yamlString: string): object[] => {
 
 const normalizeIngressHost = (host: string) => host.trim().toLowerCase().replace(/\.+$/g, '');
 
-export const getImageRegistryAddress = (imageName: string): string => {
+const getExplicitImageRegistryAddress = (imageName: string): string | undefined => {
   const components = imageName.trim().split('/');
   const firstComponent = components[0];
   if (
@@ -125,10 +125,125 @@ export const getImageRegistryAddress = (imageName: string): string => {
   ) {
     return firstComponent;
   }
-  return 'docker.io';
+  return undefined;
+};
+
+const dockerHubRegistryAliases = new Set(['docker.io', 'index.docker.io', 'index.docker.io/v1']);
+
+const normalizeRegistryAddress = (serverAddress: string) => {
+  const normalized = serverAddress
+    .trim()
+    .replace(/^https?:\/\//i, '')
+    .replace(/\/+$/g, '')
+    .toLowerCase();
+
+  return dockerHubRegistryAliases.has(normalized) ? 'docker.io' : normalized;
+};
+
+export const getImageRegistryAddress = (imageName: string): string =>
+  normalizeRegistryAddress(getExplicitImageRegistryAddress(imageName) || 'docker.io');
+
+const registryCredentialsCoverImage = (imageName: string, credentialRegistry: string) => {
+  const explicitRegistry = getExplicitImageRegistryAddress(imageName);
+  if (!explicitRegistry) {
+    return normalizeRegistryAddress(credentialRegistry) === 'docker.io';
+  }
+
+  const normalizedImageRegistry = normalizeRegistryAddress(explicitRegistry);
+  const normalizedCredentialRegistry = normalizeRegistryAddress(credentialRegistry);
+  if (normalizedCredentialRegistry === normalizedImageRegistry) {
+    return true;
+  }
+
+  const normalizedImageName = `${normalizedImageRegistry}${imageName
+    .trim()
+    .slice(explicitRegistry.length)
+    .toLowerCase()}`;
+  return normalizedImageName.startsWith(`${normalizedCredentialRegistry}/`);
+};
+
+export const alignImageRegistrySecret = (
+  imageName: string,
+  secret: AppEditType['secret']
+): AppEditType['secret'] => {
+  const imageRegistry = getImageRegistryAddress(imageName);
+  const credentialRegistry = normalizeRegistryAddress(secret.serverAddress);
+
+  if (
+    credentialRegistry === imageRegistry ||
+    registryCredentialsCoverImage(imageName, secret.serverAddress)
+  ) {
+    return secret;
+  }
+
+  return {
+    ...secret,
+    username: '',
+    password: '',
+    serverAddress: imageRegistry
+  };
+};
+
+export const getBoundImageRegistryCredentials = (
+  imageName: string,
+  secret: AppEditType['secret']
+) => {
+  const imageRegistry = getImageRegistryAddress(imageName);
+  if (!secret.use || !registryCredentialsCoverImage(imageName, secret.serverAddress)) {
+    return undefined;
+  }
+
+  return {
+    username: secret.username,
+    password: secret.password,
+    serverAddress: imageRegistry
+  };
+};
+
+export const resolveImageRegistryBinding = ({
+  imageName: rawImageName,
+  credentialRegistry: rawCredentialRegistry,
+  useCredentials,
+  requireCredentialMatch = false
+}: {
+  imageName: string;
+  credentialRegistry?: string;
+  useCredentials: boolean;
+  requireCredentialMatch?: boolean;
+}) => {
+  const imageName = rawImageName.trim();
+  const explicitRegistry = getExplicitImageRegistryAddress(imageName);
+  const normalizedExplicitRegistry = explicitRegistry
+    ? normalizeRegistryAddress(explicitRegistry)
+    : undefined;
+  const credentialRegistry = useCredentials
+    ? normalizeRegistryAddress(rawCredentialRegistry || '')
+    : '';
+
+  if (
+    requireCredentialMatch &&
+    normalizedExplicitRegistry &&
+    credentialRegistry &&
+    !registryCredentialsCoverImage(imageName, credentialRegistry)
+  ) {
+    throw new Error('Image registry credentials do not match the image registry');
+  }
+
+  const registry = credentialRegistry || normalizedExplicitRegistry || 'docker.io';
+  const resolvedImageName =
+    useCredentials && !explicitRegistry && registry !== 'docker.io' && imageName
+      ? `${registry}/${imageName}`
+      : imageName;
+
+  return { imageName: resolvedImageName, registry };
 };
 
 export const json2DeployCr = (data: AppEditType, type: 'deployment' | 'statefulset') => {
+  const privateImage = resolveImageRegistryBinding({
+    imageName: data.imageName,
+    credentialRegistry: data.secret.serverAddress,
+    useCredentials: data.secret.use
+  });
   const totalStorage = data.storeList.reduce((acc, item) => acc + item.value, 0);
 
   // Separate local and remote stores
@@ -142,10 +257,13 @@ export const json2DeployCr = (data: AppEditType, type: 'deployment' | 'statefuls
       ? {
           [`${data.gpu.manufacturers}.com/use-gputype`]: data.gpu.type
         }
-      : supportedGpuManufacturers.reduce((acc, manufacturer) => {
-          acc[`${manufacturer}.com/use-gputype`] = null;
-          return acc;
-        }, {} as Record<string, null>);
+      : supportedGpuManufacturers.reduce(
+          (acc, manufacturer) => {
+            acc[`${manufacturer}.com/use-gputype`] = null;
+            return acc;
+          },
+          {} as Record<string, null>
+        );
 
   const metadata = {
     name: data.appName,
@@ -192,7 +310,7 @@ export const json2DeployCr = (data: AppEditType, type: 'deployment' | 'statefuls
 
   const commonContainer = {
     name: data.appName,
-    image: data.imageName,
+    image: privateImage.imageName,
     env:
       data.envs.length > 0
         ? data.envs.map((env) => ({
@@ -784,11 +902,17 @@ export const json2Secret = (
   ownerReferences?: V1OwnerReference[],
   options?: { maskPassword?: boolean }
 ) => {
+  const privateImage = resolveImageRegistryBinding({
+    imageName: data.imageName,
+    credentialRegistry: data.secret.serverAddress,
+    useCredentials: data.secret.use,
+    requireCredentialMatch: true
+  });
   const auth = strToBase64(`${data.secret.username}:${data.secret.password}`);
   const dockerconfigjson = strToBase64(
     JSON.stringify({
       auths: {
-        [getImageRegistryAddress(data.imageName)]: {
+        [privateImage.registry]: {
           username: data.secret.username,
           password: data.secret.password,
           auth

--- a/frontend/providers/applaunchpad/src/utils/deployYaml2Json.ts
+++ b/frontend/providers/applaunchpad/src/utils/deployYaml2Json.ts
@@ -115,6 +115,19 @@ export const yamlString2Objects = (yamlString: string): object[] => {
 
 const normalizeIngressHost = (host: string) => host.trim().toLowerCase().replace(/\.+$/g, '');
 
+export const getImageRegistryAddress = (imageName: string): string => {
+  const components = imageName.trim().split('/');
+  const firstComponent = components[0];
+  if (
+    components.length > 1 &&
+    firstComponent &&
+    (firstComponent === 'localhost' || firstComponent.includes('.') || firstComponent.includes(':'))
+  ) {
+    return firstComponent;
+  }
+  return 'docker.io';
+};
+
 export const json2DeployCr = (data: AppEditType, type: 'deployment' | 'statefulset') => {
   const totalStorage = data.storeList.reduce((acc, item) => acc + item.value, 0);
 
@@ -129,13 +142,10 @@ export const json2DeployCr = (data: AppEditType, type: 'deployment' | 'statefuls
       ? {
           [`${data.gpu.manufacturers}.com/use-gputype`]: data.gpu.type
         }
-      : supportedGpuManufacturers.reduce(
-          (acc, manufacturer) => {
-            acc[`${manufacturer}.com/use-gputype`] = null;
-            return acc;
-          },
-          {} as Record<string, null>
-        );
+      : supportedGpuManufacturers.reduce((acc, manufacturer) => {
+          acc[`${manufacturer}.com/use-gputype`] = null;
+          return acc;
+        }, {} as Record<string, null>);
 
   const metadata = {
     name: data.appName,
@@ -182,7 +192,7 @@ export const json2DeployCr = (data: AppEditType, type: 'deployment' | 'statefuls
 
   const commonContainer = {
     name: data.appName,
-    image: `${data.secret.use ? `${data.secret.serverAddress}/` : ''}${data.imageName}`,
+    image: data.imageName,
     env:
       data.envs.length > 0
         ? data.envs.map((env) => ({
@@ -778,7 +788,7 @@ export const json2Secret = (
   const dockerconfigjson = strToBase64(
     JSON.stringify({
       auths: {
-        [data.secret.serverAddress || '']: {
+        [getImageRegistryAddress(data.imageName)]: {
           username: data.secret.username,
           password: data.secret.password,
           auth


### PR DESCRIPTION
<!--
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR,
because it will be placed in the release note.
-->

## Summary

Use the image name as the complete container image reference, derive private-registry credentials from its registry component, and default short references to `docker.io` while preserving legacy application edits. Remove the redundant registry field, show a focused input hint, align credential input widths, and cover image and pull-secret generation with unit tests.

## Verification

`pnpm exec vitest run __tests__/unit/utils/deployYaml2Json.test.ts __tests__/unit/utils/adapt.test.ts` (34 tests passed) and `pnpm exec tsc --noEmit --pretty false`.

## Sequence Diagram

```mermaid
sequenceDiagram
    participant User
    participant Launchpad
    participant Kubernetes
    User->>Launchpad: Enter full image reference and registry credentials
    Launchpad->>Launchpad: Derive registry from image reference
    Launchpad->>Kubernetes: Apply workload with unchanged image reference
    Launchpad->>Kubernetes: Apply pull secret for derived registry
    Kubernetes-->>User: Pull image without duplicated registry prefix
```
