### PR TITLE
fix(template): gate template repo auto injection

### DIFF
--- a/frontend/providers/template/.env.template
+++ b/frontend/providers/template/.env.template
@@ -3,6 +3,9 @@ SEALOS_CLOUD_DOMAIN=
 SEALOS_CERT_SECRET_NAME=
 TEMPLATE_REPO_URL="https://github.com/labring-actions/templates"
 TEMPLATE_REPO_BRANCH="main"
+TEMPLATE_REPO_PROVIDER="github"
+TEMPLATE_REPO_FOLDER="templates"
+TEMPLATE_REPO_AUTO_INJECT="true"
 # The CDN_URL environment variable is used to specify a CDN address; when set, it replaces raw.githubusercontent.com in the resource loading URL. If not set, the default address is used.
 CDN_URL=
 TEMPLATE_CATEGORIES='[{"slug":"ai","i18n":{"en":"AI","zh":"AI"}},{"slug":"backend","i18n":{"en":"Backend","zh":"后端"}},{"slug":"blog","i18n":{"en":"Blog","zh":"博客"}},{"slug":"database","i18n":{"en":"Database","zh":"数据库"}},{"slug":"dev-ops","i18n":{"en":"DevOps","zh":"运维"}},{"slug":"frontend","i18n":{"en":"Frontend","zh":"前端"}},{"slug":"game","i18n":{"en":"Games","zh":"游戏"}},{"slug":"low-code","i18n":{"en":"Low-Code","zh":"低代码"}},{"slug":"monitor","i18n":{"en":"Monitoring","zh":"监控"}},{"slug":"storage","i18n":{"en":"Storage","zh":"存储"}},{"slug":"tool","i18n":{"en":"Tools","zh":"工具"}}]'
@@ -12,4 +15,5 @@ GUIDE_ENABLED="false"
 BILLING_URL=""
 
 NEXT_PUBLIC_BRAND_NAME="sealos"
-ENABLE_README_FETCH=true
+TEMPLATE_REPO_ENABLE_README_FETCH=true
+TEMPLATE_REPO_GIT_SSL_NO_VERIFY=false

--- a/frontend/providers/template/deploy/Kubefile
+++ b/frontend/providers/template/deploy/Kubefile
@@ -6,4 +6,12 @@ COPY registry registry
 COPY charts charts
 COPY template-frontend-entrypoint.sh template-frontend-entrypoint.sh
 
+ENV templateRepoAutoInject="true"
+ENV templateRepoUrl="https://github.com/labring-actions/templates"
+ENV templateRepoBranch="main"
+ENV templateRepoPath="templates"
+ENV templateRepoProvider="github"
+ENV templateRepoEnableReadmeFetch="true"
+ENV templateRepoGitSslNoVerify="false"
+
 CMD ["bash template-frontend-entrypoint.sh"]

--- a/frontend/providers/template/deploy/charts/template-frontend/template-frontend-values.yaml
+++ b/frontend/providers/template/deploy/charts/template-frontend/template-frontend-values.yaml
@@ -36,6 +36,7 @@ resources:
 # Keep release-v5.1 env defaults and names. Entrypoint auto-fills cloud values from sealos-config when available.
 templateConfig:
   userDomain: ""
+  templateRepoAutoInject: "true"
   templateRepoUrl: "https://github.com/labring-actions/templates"
   templateRepoBranch: "main"
   templateRepoProvider: "github"
@@ -44,8 +45,8 @@ templateConfig:
   accountUrl: "http://account-service.account-system.svc:2333"
   guideEnabled: "true"
   billingUrl: "http://account-service.account-system.svc:2333"
-  enableReadmeFetch: "true"
-  gitSslNoVerify: "false"
+  templateRepoEnableReadmeFetch: "true"
+  templateRepoGitSslNoVerify: "false"
   templateCategories: '[{"slug":"ai","i18n":{"en":"AI","zh":"AI"}},{"slug":"backend","i18n":{"en":"Backend","zh":"后端"}},{"slug":"blog","i18n":{"en":"Blog","zh":"博客"}},{"slug":"database","i18n":{"en":"Database","zh":"数据库"}},{"slug":"dev-ops","i18n":{"en":"DevOps","zh":"运维"}},{"slug":"frontend","i18n":{"en":"Frontend","zh":"前端"}},{"slug":"game","i18n":{"en":"Games","zh":"游戏"}},{"slug":"low-code","i18n":{"en":"Low-Code","zh":"低代码"}},{"slug":"monitor","i18n":{"en":"Monitoring","zh":"监控"}},{"slug":"storage","i18n":{"en":"Storage","zh":"存储"}},{"slug":"tool","i18n":{"en":"Tools","zh":"工具"}}]'
 
 affinity:

--- a/frontend/providers/template/deploy/charts/template-frontend/templates/configmap.yaml
+++ b/frontend/providers/template/deploy/charts/template-frontend/templates/configmap.yaml
@@ -11,17 +11,20 @@ data:
     SEALOS_CLOUD_PORT={{ .Values.templateConfig.cloudPort }}
     SEALOS_USER_DOMAIN={{ .Values.templateConfig.userDomain }}
     SEALOS_CERT_SECRET_NAME={{ .Values.templateConfig.certSecretName }}
+    TEMPLATE_REPO_AUTO_INJECT={{ .Values.templateConfig.templateRepoAutoInject }}
     TEMPLATE_REPO_URL={{ .Values.templateConfig.templateRepoUrl }}
     TEMPLATE_REPO_BRANCH={{ .Values.templateConfig.templateRepoBranch }}
     TEMPLATE_REPO_PROVIDER={{ .Values.templateConfig.templateRepoProvider }}
+    TEMPLATE_REPO_FOLDER={{ .Values.templateConfig.templateRepoPath }}
     SHOW_AUTHOR={{ .Values.templateConfig.showAuthor }}
     ACCOUNT_URL={{ .Values.templateConfig.accountUrl }}
     GUIDE_ENABLED={{ .Values.templateConfig.guideEnabled }}
     BILLING_URL={{ .Values.templateConfig.billingUrl }}
     DESKTOP_DOMAIN={{ .Values.templateConfig.cloudDomain }}
-    ENABLE_README_FETCH={{ .Values.templateConfig.enableReadmeFetch }}
+    TEMPLATE_REPO_ENABLE_README_FETCH={{ .Values.templateConfig.templateRepoEnableReadmeFetch }}
     TEMPLATE_CATEGORIES={{ .Values.templateConfig.templateCategories }}
-    GIT_SSL_NO_VERIFY={{ .Values.templateConfig.gitSslNoVerify }}
+    TEMPLATE_REPO_GIT_SSL_NO_VERIFY={{ .Values.templateConfig.templateRepoGitSslNoVerify }}
+    GIT_SSL_NO_VERIFY={{ .Values.templateConfig.templateRepoGitSslNoVerify }}
   config.yaml: |-
     addr: :3000
   config.json: |-

--- a/frontend/providers/template/deploy/charts/template-frontend/values.yaml
+++ b/frontend/providers/template/deploy/charts/template-frontend/values.yaml
@@ -71,6 +71,7 @@ templateConfig:
   userDomain: ""
   certSecretName: "wildcard-cert"
   tlsRejectUnauthorized: "1"
+  templateRepoAutoInject: "true"
   templateRepoUrl: "https://github.com/labring-actions/templates"
   templateRepoBranch: "main"
   templateRepoProvider: "github"
@@ -79,8 +80,8 @@ templateConfig:
   accountUrl: "http://account-service.account-system.svc:2333"
   guideEnabled: "true"
   billingUrl: "http://account-service.account-system.svc:2333"
-  enableReadmeFetch: "true"
-  gitSslNoVerify: "false"
+  templateRepoEnableReadmeFetch: "true"
+  templateRepoGitSslNoVerify: "false"
   templateCategories: '[{"slug":"ai","i18n":{"en":"AI","zh":"AI"}},{"slug":"backend","i18n":{"en":"Backend","zh":"后端"}},{"slug":"blog","i18n":{"en":"Blog","zh":"博客"}},{"slug":"database","i18n":{"en":"Database","zh":"数据库"}},{"slug":"dev-ops","i18n":{"en":"DevOps","zh":"运维"}},{"slug":"frontend","i18n":{"en":"Frontend","zh":"前端"}},{"slug":"game","i18n":{"en":"Games","zh":"游戏"}},{"slug":"low-code","i18n":{"en":"Low-Code","zh":"低代码"}},{"slug":"monitor","i18n":{"en":"Monitoring","zh":"监控"}},{"slug":"storage","i18n":{"en":"Storage","zh":"存储"}},{"slug":"tool","i18n":{"en":"Tools","zh":"工具"}}]'
 
 affinity:

--- a/frontend/providers/template/deploy/manifests/deploy.yaml.tmpl
+++ b/frontend/providers/template/deploy/manifests/deploy.yaml.tmpl
@@ -63,12 +63,16 @@ spec:
               value: {{ .userDomain }}
             - name: SEALOS_CERT_SECRET_NAME
               value: {{ .certSecretName }}
+            - name: TEMPLATE_REPO_AUTO_INJECT
+              value: "{{ .templateRepoAutoInject }}"
             - name: TEMPLATE_REPO_URL
               value: {{ .templateRepoUrl }}
             - name: TEMPLATE_REPO_BRANCH
               value: {{ .templateRepoBranch }}
             - name: TEMPLATE_REPO_PROVIDER
               value: {{ .templateRepoProvider }}
+            - name: TEMPLATE_REPO_FOLDER
+              value: {{ .templateRepoPath }}
             - name: SHOW_AUTHOR
               value: "false"
             - name: ACCOUNT_URL
@@ -79,8 +83,12 @@ spec:
               value: {{ .billingUrl }}
             - name: DESKTOP_DOMAIN
               value: {{ .cloudDomain }}
-            - name: ENABLE_README_FETCH
-              value: "{{ .enableReadmeFetch }}"
+            - name: TEMPLATE_REPO_ENABLE_README_FETCH
+              value: "{{ .templateRepoEnableReadmeFetch }}"
+            - name: TEMPLATE_REPO_GIT_SSL_NO_VERIFY
+              value: "{{ .templateRepoGitSslNoVerify }}"
+            - name: GIT_SSL_NO_VERIFY
+              value: "{{ .templateRepoGitSslNoVerify }}"
             - name: TEMPLATE_CATEGORIES
               value: '[{"slug":"ai","i18n":{"en":"AI","zh":"AI"}},{"slug":"backend","i18n":{"en":"Backend","zh":"后端"}},{"slug":"blog","i18n":{"en":"Blog","zh":"博客"}},{"slug":"database","i18n":{"en":"Database","zh":"数据库"}},{"slug":"dev-ops","i18n":{"en":"DevOps","zh":"运维"}},{"slug":"frontend","i18n":{"en":"Frontend","zh":"前端"}},{"slug":"game","i18n":{"en":"Games","zh":"游戏"}},{"slug":"low-code","i18n":{"en":"Low-Code","zh":"低代码"}},{"slug":"monitor","i18n":{"en":"Monitoring","zh":"监控"}},{"slug":"storage","i18n":{"en":"Storage","zh":"存储"}},{"slug":"tool","i18n":{"en":"Tools","zh":"工具"}}]'
           image: ghcr.io/labring/sealos-template-frontend:latest

--- a/frontend/providers/template/deploy/template-frontend-entrypoint.sh
+++ b/frontend/providers/template/deploy/template-frontend-entrypoint.sh
@@ -94,6 +94,19 @@ add_enforced_set_string() {
   fi
 }
 
+read_template_repo_auto_inject() {
+  local configured="${TEMPLATE_REPO_AUTO_INJECT:-${templateRepoAutoInject:-}}"
+  if [ -z "${configured}" ] && [ -f "${USER_VALUES_PATH}" ]; then
+    configured="$(
+      sed -n '/^[[:space:]]*templateConfig:[[:space:]]*$/,/^[^[:space:]][^:]*:/s/^[[:space:]]*templateRepoAutoInject:[[:space:]]*//p' "${USER_VALUES_PATH}" |
+        head -n 1
+    )"
+  fi
+  configured="$(printf '%s' "${configured:-true}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]"' | tr -d "'")"
+  [ "${configured}" != "false" ]
+}
+
+USER_VALUES_PATH="/root/.sealos/cloud/values/apps/template/template-values.yaml"
 load_cloud_tools_or_exit
 tls_reject_unauthorized="$(read_cert_tls_reject_unauthorized)"
 if [ "${tls_reject_unauthorized}" = "1" ]; then
@@ -102,7 +115,6 @@ else
   git_ssl_no_verify="true"
 fi
 add_enforced_set_string templateConfig.tlsRejectUnauthorized "${tls_reject_unauthorized}"
-add_enforced_set_string templateConfig.gitSslNoVerify "${git_ssl_no_verify}"
 
 CONFIG_CLOUD_DOMAIN=$(get_cm_value sealos-system sealos-config cloudDomain)
 CONFIG_CLOUD_PORT=$(get_cm_value sealos-system sealos-config cloudPort)
@@ -120,12 +132,17 @@ add_set_string templateConfig.cloudDomain "${SEALOS_CLOUD_DOMAIN}"
 add_set_string templateConfig.cloudPort "${SEALOS_CLOUD_PORT}"
 add_set_string templateConfig.certSecretName "${SEALOS_CERT_SECRET_NAME}"
 
-if [ "${SEALOS_CERT_MODE}" = "https" ] || [ "${SEALOS_CERT_MODE}" = "acme" ] || [ "${SEALOS_CERT_MODE}" = "acmedns" ]; then
-  add_set_string templateConfig.templateRepoUrl "https://github.com/labring-actions/templates"
-  add_set_string templateConfig.templateRepoProvider "github"
-else
-  add_set_string templateConfig.templateRepoUrl "https://gogs.${SEALOS_CLOUD_DOMAIN}/sealos-admin/templates"
-  add_set_string templateConfig.templateRepoProvider "gogs"
+if read_template_repo_auto_inject; then
+  add_set_string templateConfig.templateRepoAutoInject "true"
+  add_set_string templateConfig.templateRepoEnableReadmeFetch "true"
+  add_enforced_set_string templateConfig.templateRepoGitSslNoVerify "${git_ssl_no_verify}"
+  if [ "${SEALOS_CERT_MODE}" = "https" ] || [ "${SEALOS_CERT_MODE}" = "acme" ] || [ "${SEALOS_CERT_MODE}" = "acmedns" ]; then
+    add_set_string templateConfig.templateRepoUrl "https://github.com/labring-actions/templates"
+    add_set_string templateConfig.templateRepoProvider "github"
+  else
+    add_set_string templateConfig.templateRepoUrl "https://gogs.${SEALOS_CLOUD_DOMAIN}/sealos-admin/templates"
+    add_set_string templateConfig.templateRepoProvider "gogs"
+  fi
 fi
 
 adopt_namespaced_resource() {
@@ -187,7 +204,6 @@ adopt_cluster_resource clusterrole template-frontend-static-role
 adopt_cluster_resource clusterrolebinding template-frontend-static-role-binding
 
 SERVICE_NAME="template-frontend"
-USER_VALUES_PATH="/root/.sealos/cloud/values/apps/template/template-values.yaml"
 if [ ! -f "${USER_VALUES_PATH}" ]; then
   mkdir -p "$(dirname "${USER_VALUES_PATH}")"
   cp "./charts/${SERVICE_NAME}/${SERVICE_NAME}-values.yaml" "${USER_VALUES_PATH}"

--- a/frontend/providers/template/deploy/verify-template-repo-config.sh
+++ b/frontend/providers/template/deploy/verify-template-repo-config.sh
@@ -4,8 +4,12 @@ set -euo pipefail
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 entrypoint="${script_dir}/template-frontend-entrypoint.sh"
 chart="${script_dir}/charts/template-frontend"
+env_template="${script_dir}/../.env.template"
+auto_inject_key="templateConfig.templateRepoAutoInject"
 repo_key="templateConfig.templateRepoUrl"
 repo_url="https://gogs.example.test/sealos-admin/templates"
+readme_key="templateConfig.templateRepoEnableReadmeFetch"
+ssl_key="templateConfig.templateRepoGitSslNoVerify"
 
 key_count="$(grep -Fc "add_set_string ${repo_key} " "${entrypoint}" || true)"
 if [[ "${key_count}" -ne 2 ]]; then
@@ -13,19 +17,40 @@ if [[ "${key_count}" -ne 2 ]]; then
   exit 1
 fi
 
-if grep -Eq 'add_set_string templateConfig\.templateUrl ' "${entrypoint}"; then
-  echo "entrypoint still sets unused templateConfig.templateUrl" >&2
+if ! grep -Fq "if read_template_repo_auto_inject; then" "${entrypoint}"; then
+  echo "entrypoint does not guard repository auto-injection" >&2
+  exit 1
+fi
+
+if grep -Eq 'templateConfig\.(enableReadmeFetch|gitSslNoVerify|templateUrl)\b|^ENABLE_README_FETCH=' "${entrypoint}" "${chart}/values.yaml" "${chart}/template-frontend-values.yaml" "${env_template}"; then
+  echo "template repository settings still use old or unused templateConfig keys" >&2
   exit 1
 fi
 
 rendered="$(
   helm template template-frontend "${chart}" \
     --namespace template-frontend \
+    --set-string "${auto_inject_key}=false" \
     --set-string "${repo_key}=${repo_url}"
 )"
 
+if ! grep -Fq "TEMPLATE_REPO_AUTO_INJECT=false" <<<"${rendered}"; then
+  echo "chart did not render ${auto_inject_key} into TEMPLATE_REPO_AUTO_INJECT" >&2
+  exit 1
+fi
+
 if ! grep -Fq "TEMPLATE_REPO_URL=${repo_url}" <<<"${rendered}"; then
   echo "chart did not render ${repo_key} into TEMPLATE_REPO_URL" >&2
+  exit 1
+fi
+
+if ! grep -Fq "TEMPLATE_REPO_ENABLE_README_FETCH=true" <<<"${rendered}"; then
+  echo "chart did not render ${readme_key} into TEMPLATE_REPO_ENABLE_README_FETCH" >&2
+  exit 1
+fi
+
+if ! grep -Fq "TEMPLATE_REPO_GIT_SSL_NO_VERIFY=false" <<<"${rendered}"; then
+  echo "chart did not render ${ssl_key} into TEMPLATE_REPO_GIT_SSL_NO_VERIFY" >&2
   exit 1
 fi
 

--- a/frontend/providers/template/src/pages/api/getTemplateSource.ts
+++ b/frontend/providers/template/src/pages/api/getTemplateSource.ts
@@ -21,7 +21,8 @@ import { proxyTemplateIconUrls, resolveTemplateAssetUrls } from '@/utils/templat
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
-    const envEnableReadme = process.env.ENABLE_README_FETCH;
+    const envEnableReadme =
+      process.env.TEMPLATE_REPO_ENABLE_README_FETCH || process.env.ENABLE_README_FETCH;
     const queryIncludeReadme = req.query.includeReadme !== 'false';
     const includeRequirements = req.query.includeRequirements !== 'false';
 
@@ -185,7 +186,9 @@ export async function GetTemplateReadmeByName({
   templateName: string;
   locale?: string;
 }) {
-  if (process.env.ENABLE_README_FETCH === 'false') {
+  const envEnableReadme =
+    process.env.TEMPLATE_REPO_ENABLE_README_FETCH || process.env.ENABLE_README_FETCH;
+  if (envEnableReadme === 'false') {
     return {
       code: 20000,
       message: 'success',


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->

### What this PR does

- Adds `templateRepoAutoInject` to template frontend chart values so release scripts can choose whether to auto-fill the template repository settings.
- Keeps fallback repository settings available when auto-injection is disabled: `templateRepoUrl`, `templateRepoBranch`, `templateRepoPath`, and `templateRepoProvider`.
- Renames repo-related deployment options to `templateRepoEnableReadmeFetch` and `templateRepoGitSslNoVerify`, while rendering the standard `GIT_SSL_NO_VERIFY` env for git compatibility.
- Updates template frontend runtime README-fetch checks to prefer `TEMPLATE_REPO_ENABLE_README_FETCH` with the old env as a fallback.

### Verification

- `bash frontend/providers/template/deploy/verify-template-repo-config.sh`
- `helm lint frontend/providers/template/deploy/charts/template-frontend`
- `bash -n frontend/providers/template/deploy/template-frontend-entrypoint.sh`
- `bash -n frontend/providers/template/deploy/verify-template-repo-config.sh`
- `git diff --check`
- `helm template template-frontend frontend/providers/template/deploy/charts/template-frontend --namespace template-frontend --set-string templateConfig.templateRepoAutoInject=false --set-string templateConfig.templateRepoUrl=https://example.test/templates --set-string templateConfig.templateRepoBranch=dev --set-string templateConfig.templateRepoProvider=gogs --set-string templateConfig.templateRepoPath=custom --set-string templateConfig.templateRepoEnableReadmeFetch=false --set-string templateConfig.templateRepoGitSslNoVerify=true`

### Notes

- `pnpm --dir frontend --filter template exec tsc --noEmit` could not run in this workspace because `tsc` was not installed in local node_modules and the local Node version is v26.1.0 while the workspace expects Node 20.4.0.
