### PR TITLE
fix(dbprovider): make parameter history reliable

### DIFF
--- a/frontend/providers/dbprovider/__tests__/unit/utils/parameterConfig.test.ts
+++ b/frontend/providers/dbprovider/__tests__/unit/utils/parameterConfig.test.ts
@@ -8,6 +8,7 @@ import {
   getParameterDifferences,
   getDefaultMaxConnections,
   mergeRedisParameterValues,
+  shouldUseRedisConfigurationFallback,
   toKubeBlocksParameterPairs
 } from '../../../src/utils/parameterChanges';
 import {
@@ -15,6 +16,23 @@ import {
   resolveParameterHistoryStatus
 } from '../../../src/utils/parameterHistory';
 import { ReconfigStatus } from '../../../src/constants/db';
+
+test('uses Redis Configuration fallback only when runtime ConfigMap values are absent', () => {
+  assert.equal(
+    shouldUseRedisConfigurationFallback({
+      includeConfigurationOverrides: false,
+      hasConfigMapValues: false
+    }),
+    true
+  );
+  assert.equal(
+    shouldUseRedisConfigurationFallback({
+      includeConfigurationOverrides: false,
+      hasConfigMapValues: true
+    }),
+    false
+  );
+});
 
 test('keeps MySQL submission and runtime paths distinct', () => {
   const differences = getParameterDifferences({

--- a/frontend/providers/dbprovider/__tests__/unit/utils/parameterConfig.test.ts
+++ b/frontend/providers/dbprovider/__tests__/unit/utils/parameterConfig.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
   areParameterValuesApplied,
+  getPostgreSQLConfigSpecMetadata,
+  getPostgreSQLConfigSpecPatch,
   getParameterConfigFromRuntimeValues,
   getParameterDifferences,
   toKubeBlocksParameterPairs
@@ -62,6 +64,59 @@ test('serializes parameter differences for a KubeBlocks reconfigure OpsRequest',
     [
     { key: 'max_connections', value: '701' }
     ]
+  );
+});
+
+test('preserves KubeBlocks PostgreSQL parameter constraints in generated configurations', () => {
+  assert.deepEqual(getPostgreSQLConfigSpecMetadata('12'), {
+    constraintRef: 'postgresql12-cc',
+    keys: ['postgresql.conf']
+  });
+  assert.deepEqual(getPostgreSQLConfigSpecMetadata('14'), {
+    constraintRef: 'postgresql14-cc',
+    keys: ['postgresql.conf']
+  });
+});
+
+test('repairs missing PostgreSQL parameter constraints for existing configurations', () => {
+  assert.deepEqual(
+    getPostgreSQLConfigSpecPatch({
+      dbVersion: 'postgresql-14.8.0',
+      configItemDetails: [
+        { name: 'metrics', configSpec: {} },
+        { name: 'postgresql-configuration', configSpec: {} }
+      ]
+    }),
+    [
+      {
+        op: 'add',
+        path: '/spec/configItemDetails/1/configSpec/constraintRef',
+        value: 'postgresql14-cc'
+      },
+      {
+        op: 'add',
+        path: '/spec/configItemDetails/1/configSpec/keys',
+        value: ['postgresql.conf']
+      }
+    ]
+  );
+});
+
+test('does not patch an existing valid PostgreSQL configuration', () => {
+  assert.deepEqual(
+    getPostgreSQLConfigSpecPatch({
+      dbVersion: 'postgresql-12.14.0',
+      configItemDetails: [
+        {
+          name: 'postgresql-configuration',
+          configSpec: {
+            constraintRef: 'postgresql12-cc',
+            keys: ['postgresql.conf']
+          }
+        }
+      ]
+    }),
+    []
   );
 });
 

--- a/frontend/providers/dbprovider/__tests__/unit/utils/parameterConfig.test.ts
+++ b/frontend/providers/dbprovider/__tests__/unit/utils/parameterConfig.test.ts
@@ -1,9 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
-  applyParameterDifferences,
   areParameterValuesApplied,
-  getParameterDifferences
+  getParameterConfigFromRuntimeValues,
+  getParameterDifferences,
+  toKubeBlocksParameterPairs
 } from '../../../src/utils/parameterChanges';
 import {
   getParameterHistoryName,
@@ -38,6 +39,32 @@ test('keeps MySQL submission and runtime paths distinct', () => {
   ]);
 });
 
+test('builds edit form parameters from runtime values', () => {
+  assert.deepEqual(
+    getParameterConfigFromRuntimeValues({
+      dbType: 'postgresql',
+      currentValues: { max_connections: '700', timezone: 'UTC' },
+      dynamicMaxConnections: 100
+    }),
+    {
+      maxConnections: '700',
+      timeZone: 'UTC',
+      isMaxConnectionsCustomized: true
+    }
+  );
+});
+
+test('serializes parameter differences for a KubeBlocks reconfigure OpsRequest', () => {
+  assert.deepEqual(
+    toKubeBlocksParameterPairs([
+      { path: 'max_connections', oldValue: '700', newValue: '701' }
+    ]),
+    [
+    { key: 'max_connections', value: '701' }
+    ]
+  );
+});
+
 test('reports success only after the runtime value matches', () => {
   const differences = [
     {
@@ -50,51 +77,6 @@ test('reports success only after the runtime value matches', () => {
 
   assert.equal(areParameterValuesApplied({ max_connections: '700' }, differences), false);
   assert.equal(areParameterValuesApplied({ max_connections: '900' }, differences), true);
-});
-
-test('updates only the requested configuration item', () => {
-  const configuration = {
-    metadata: { resourceVersion: '10' },
-    spec: {
-      configItemDetails: [
-        {
-          name: 'postgresql-configuration',
-          configFileParams: {
-            'postgresql.conf': { parameters: { max_connections: '700', timezone: 'UTC' } }
-          }
-        },
-        { name: 'pgbouncer-configuration', configSpec: { name: 'pgbouncer-configuration' } }
-      ]
-    }
-  };
-
-  const updated = applyParameterDifferences({
-    configuration,
-    configItemName: 'postgresql-configuration',
-    configMapKey: 'postgresql.conf',
-    differences: [
-      {
-        path: 'max_connections',
-        currentPath: 'max_connections',
-        oldValue: '700',
-        newValue: '900'
-      }
-    ]
-  });
-
-  assert.equal(
-    updated.spec.configItemDetails[0].configFileParams['postgresql.conf'].parameters.max_connections,
-    '900'
-  );
-  assert.equal(
-    updated.spec.configItemDetails[0].configFileParams['postgresql.conf'].parameters.timezone,
-    'UTC'
-  );
-  assert.deepEqual(updated.spec.configItemDetails[1], {
-    name: 'pgbouncer-configuration',
-    configSpec: { name: 'pgbouncer-configuration' }
-  });
-  assert.equal(updated.metadata.resourceVersion, '10');
 });
 
 test('keeps parameter history names within the Kubernetes limit', () => {

--- a/frontend/providers/dbprovider/__tests__/unit/utils/parameterConfig.test.ts
+++ b/frontend/providers/dbprovider/__tests__/unit/utils/parameterConfig.test.ts
@@ -5,7 +5,11 @@ import {
   areParameterValuesApplied,
   getParameterDifferences
 } from '../../../src/utils/parameterChanges';
-import { getParameterHistoryName } from '../../../src/utils/parameterHistory';
+import {
+  getParameterHistoryName,
+  resolveParameterHistoryStatus
+} from '../../../src/utils/parameterHistory';
+import { ReconfigStatus } from '../../../src/constants/db';
 
 test('keeps MySQL submission and runtime paths distinct', () => {
   const differences = getParameterDifferences({
@@ -98,4 +102,81 @@ test('keeps parameter history names within the Kubernetes limit', () => {
 
   assert.ok(name.length <= 63);
   assert.match(name, /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/);
+});
+
+test('keeps a submitted parameter change running until runtime values match', () => {
+  const history = {
+    dbType: 'mongodb' as const,
+    status: ReconfigStatus.Running,
+    createdAt: '2026-08-12T00:00:00.000Z',
+    differences: [
+      {
+        path: 'net.maxIncomingConnections',
+        currentPath: 'net.maxIncomingConnections',
+        oldValue: '700',
+        newValue: '900'
+      }
+    ]
+  };
+
+  assert.equal(
+    resolveParameterHistoryStatus({
+      history,
+      currentValues: { 'net.maxIncomingConnections': '700' },
+      now: Date.parse('2026-08-12T00:01:00.000Z')
+    }),
+    ReconfigStatus.Running
+  );
+  assert.equal(
+    resolveParameterHistoryStatus({
+      history,
+      currentValues: { 'net.maxIncomingConnections': '900' },
+      now: Date.parse('2026-08-12T00:01:00.000Z')
+    }),
+    ReconfigStatus.Succeed
+  );
+});
+
+test('marks a parameter change failed after the apply deadline', () => {
+  assert.equal(
+    resolveParameterHistoryStatus({
+      history: {
+        dbType: 'mongodb',
+        status: ReconfigStatus.Running,
+        createdAt: '2026-08-12T00:00:00.000Z',
+        differences: [
+          {
+            path: 'net.maxIncomingConnections',
+            oldValue: '700',
+            newValue: '900'
+          }
+        ]
+      },
+      currentValues: { 'net.maxIncomingConnections': '700' },
+      now: Date.parse('2026-08-12T00:05:00.000Z')
+    }),
+    ReconfigStatus.Failed
+  );
+});
+
+test('prefers an applied runtime value over an expired deadline', () => {
+  assert.equal(
+    resolveParameterHistoryStatus({
+      history: {
+        dbType: 'mongodb',
+        status: ReconfigStatus.Running,
+        createdAt: '2026-08-12T00:00:00.000Z',
+        differences: [
+          {
+            path: 'net.maxIncomingConnections',
+            oldValue: '700',
+            newValue: '900'
+          }
+        ]
+      },
+      currentValues: { 'net.maxIncomingConnections': '900' },
+      now: Date.parse('2026-08-12T00:10:00.000Z')
+    }),
+    ReconfigStatus.Succeed
+  );
 });

--- a/frontend/providers/dbprovider/__tests__/unit/utils/parameterConfig.test.ts
+++ b/frontend/providers/dbprovider/__tests__/unit/utils/parameterConfig.test.ts
@@ -6,6 +6,8 @@ import {
   getPostgreSQLConfigSpecPatch,
   getParameterConfigFromRuntimeValues,
   getParameterDifferences,
+  getDefaultMaxConnections,
+  mergeRedisParameterValues,
   toKubeBlocksParameterPairs
 } from '../../../src/utils/parameterChanges';
 import {
@@ -41,6 +43,22 @@ test('keeps MySQL submission and runtime paths distinct', () => {
   ]);
 });
 
+test('does not resubmit an equivalent MySQL timezone representation', () => {
+  assert.deepEqual(
+    getParameterDifferences({
+      dbType: 'apecloud-mysql',
+      current: {
+        'mysqld.max_connections': '100',
+        'mysqld.default-time-zone': '+00:00',
+        'mysqld.lower_case_table_names': '0'
+      },
+      requested: { timeZone: 'UTC' },
+      dynamicMaxConnections: 100
+    }),
+    []
+  );
+});
+
 test('builds edit form parameters from runtime values', () => {
   assert.deepEqual(
     getParameterConfigFromRuntimeValues({
@@ -53,6 +71,28 @@ test('builds edit form parameters from runtime values', () => {
       timeZone: 'UTC',
       isMaxConnectionsCustomized: true
     }
+  );
+});
+
+test('uses the backend Redis default connection formula consistently', () => {
+  assert.equal(getDefaultMaxConnections('redis', 100, 256), 225);
+  assert.deepEqual(
+    getParameterConfigFromRuntimeValues({
+      dbType: 'redis',
+      currentValues: { maxclients: '225' },
+      dynamicMaxConnections: 225
+    }),
+    {
+      maxConnections: '225',
+      isMaxConnectionsCustomized: false
+    }
+  );
+});
+
+test('lets Redis Configuration values override stale ConfigMap values', () => {
+  assert.deepEqual(
+    mergeRedisParameterValues({ maxclients: '700', maxmemory: '1gb' }, { maxclients: 900 }),
+    { maxclients: '900', maxmemory: '1gb' }
   );
 });
 

--- a/frontend/providers/dbprovider/__tests__/unit/utils/parameterConfig.test.ts
+++ b/frontend/providers/dbprovider/__tests__/unit/utils/parameterConfig.test.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  applyParameterDifferences,
+  areParameterValuesApplied,
+  getParameterDifferences
+} from '../../../src/utils/parameterChanges';
+import { getParameterHistoryName } from '../../../src/utils/parameterHistory';
+
+test('keeps MySQL submission and runtime paths distinct', () => {
+  const differences = getParameterDifferences({
+    dbType: 'apecloud-mysql',
+    current: {
+      'mysqld.max_connections': '700',
+      'mysqld.default-time-zone': 'UTC',
+      'mysqld.lower_case_table_names': '0'
+    },
+    requested: {
+      isMaxConnectionsCustomized: true,
+      maxConnections: '900',
+      timeZone: 'UTC',
+      lowerCaseTableNames: '0'
+    },
+    dynamicMaxConnections: 100
+  });
+
+  assert.deepEqual(differences, [
+    {
+      path: 'max_connections',
+      currentPath: 'mysqld.max_connections',
+      oldValue: '700',
+      newValue: '900'
+    }
+  ]);
+});
+
+test('reports success only after the runtime value matches', () => {
+  const differences = [
+    {
+      path: 'max_connections',
+      currentPath: 'max_connections',
+      oldValue: '700',
+      newValue: '900'
+    }
+  ];
+
+  assert.equal(areParameterValuesApplied({ max_connections: '700' }, differences), false);
+  assert.equal(areParameterValuesApplied({ max_connections: '900' }, differences), true);
+});
+
+test('updates only the requested configuration item', () => {
+  const configuration = {
+    metadata: { resourceVersion: '10' },
+    spec: {
+      configItemDetails: [
+        {
+          name: 'postgresql-configuration',
+          configFileParams: {
+            'postgresql.conf': { parameters: { max_connections: '700', timezone: 'UTC' } }
+          }
+        },
+        { name: 'pgbouncer-configuration', configSpec: { name: 'pgbouncer-configuration' } }
+      ]
+    }
+  };
+
+  const updated = applyParameterDifferences({
+    configuration,
+    configItemName: 'postgresql-configuration',
+    configMapKey: 'postgresql.conf',
+    differences: [
+      {
+        path: 'max_connections',
+        currentPath: 'max_connections',
+        oldValue: '700',
+        newValue: '900'
+      }
+    ]
+  });
+
+  assert.equal(
+    updated.spec.configItemDetails[0].configFileParams['postgresql.conf'].parameters.max_connections,
+    '900'
+  );
+  assert.equal(
+    updated.spec.configItemDetails[0].configFileParams['postgresql.conf'].parameters.timezone,
+    'UTC'
+  );
+  assert.deepEqual(updated.spec.configItemDetails[1], {
+    name: 'pgbouncer-configuration',
+    configSpec: { name: 'pgbouncer-configuration' }
+  });
+  assert.equal(updated.metadata.resourceVersion, '10');
+});
+
+test('keeps parameter history names within the Kubernetes limit', () => {
+  const name = getParameterHistoryName('a'.repeat(30));
+
+  assert.ok(name.length <= 63);
+  assert.match(name, /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/);
+});

--- a/frontend/providers/dbprovider/public/locales/en/common.json
+++ b/frontend/providers/dbprovider/public/locales/en/common.json
@@ -434,6 +434,7 @@
   "update": "Update",
   "update_database": "Update DataBase",
   "update_failed": "Update Failed",
+  "update_submitted": "Change submitted. Check Change History for its status.",
   "update_remark_failed": "Update remark failed",
   "update_sealaf_app_tip": "The database is deployed through cloud development. To change the database, please go to cloud development.",
   "update_successful": "Update succeeded",

--- a/frontend/providers/dbprovider/public/locales/zh/common.json
+++ b/frontend/providers/dbprovider/public/locales/zh/common.json
@@ -432,6 +432,7 @@
   "update": "变更",
   "update_database": "变更数据库",
   "update_failed": "更新失败",
+  "update_submitted": "变更已提交，请在变更历史中查看状态",
   "update_remark_failed": "更新备注失败",
   "update_sealaf_app_tip": "该数据库是通过云开发部署的，变更该数据库请到云开发中进行。",
   "update_successful": "更新成功",

--- a/frontend/providers/dbprovider/src/constants/db.ts
+++ b/frontend/providers/dbprovider/src/constants/db.ts
@@ -637,7 +637,7 @@ export const ParameterFieldMetadataMap: Partial<
   },
   mongodb: {
     default: {
-      // No params are allowed to be modified for MongoDB
+      'net.maxIncomingConnections': { editable: true }
     }
   },
   redis: {

--- a/frontend/providers/dbprovider/src/constants/db.ts
+++ b/frontend/providers/dbprovider/src/constants/db.ts
@@ -19,6 +19,8 @@ export const KBBackupNameLabel = 'dataprotection.kubeblocks.io/backup-name';
 export const SealosMigrationTaskLabel = 'datamigration.sealos.io/file-migration-task';
 export const MigrationRemark = 'migration-remark';
 export const DBPreviousConfigKey = 'cloud.sealos.io/previous-config';
+export const DBParameterHistoryLabel = 'cloud.sealos.io/parameter-history';
+export const DBParameterHistoryDataKey = 'history.json';
 export const templateDeployKey = 'cloud.sealos.io/deploy-on-sealos';
 export const sealafDeployKey = 'sealaf-app';
 export const DBReconfigureKey = 'ops.kubeblocks.io/ops-type=Reconfiguring';

--- a/frontend/providers/dbprovider/src/constants/editApp.ts
+++ b/frontend/providers/dbprovider/src/constants/editApp.ts
@@ -8,7 +8,7 @@ export const editModeMap: (isEdit: boolean) => {
       title: 'update_database',
       applyBtnText: 'update',
       applyMessage: 'confirm_update_database',
-      applySuccess: 'update_successful',
+      applySuccess: 'update_submitted',
       applyError: 'update_failed'
     };
   }

--- a/frontend/providers/dbprovider/src/pages/api/applyReconfigureOps.ts
+++ b/frontend/providers/dbprovider/src/pages/api/applyReconfigureOps.ts
@@ -7,6 +7,7 @@ import { KbPgClusterType } from '@/types/cluster';
 import { DBType, ParameterFieldMetadata } from '@/types/db';
 import { adjustDifferencesForIni } from '@/utils/tools';
 import { json2Reconfigure } from '@/utils/json2Yaml';
+import { ensurePostgreSQLConfigSpec } from '@/utils/parameterConfig';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 /**
@@ -113,6 +114,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       reconfigureType,
       dbType
     );
+    if (dbType === 'postgresql') {
+      await ensurePostgreSQLConfigSpec({
+        dbName,
+        dbVersion: dbVersion || '',
+        namespace,
+        k8sCustomObjects
+      });
+    }
     const reconfigureYaml = json2Reconfigure(dbName, dbType, dbUid, adjustedDifferences);
 
     await applyYamlList([reconfigureYaml], 'create');

--- a/frontend/providers/dbprovider/src/pages/api/applyReconfigureOps.ts
+++ b/frontend/providers/dbprovider/src/pages/api/applyReconfigureOps.ts
@@ -8,6 +8,7 @@ import { DBType, ParameterFieldMetadata } from '@/types/db';
 import { adjustDifferencesForIni } from '@/utils/tools';
 import { json2Reconfigure } from '@/utils/json2Yaml';
 import { ensurePostgreSQLConfigSpec } from '@/utils/parameterConfig';
+import { createParameterHistory } from '@/utils/parameterHistory';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 /**
@@ -57,7 +58,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       });
     }
 
-    const { k8sCustomObjects, applyYamlList, namespace } = await getK8s({
+    const { k8sCore, k8sCustomObjects, applyYamlList, namespace } = await getK8s({
       kubeconfig: await authSession(req)
     });
 
@@ -124,7 +125,20 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     }
     const reconfigureYaml = json2Reconfigure(dbName, dbType, dbUid, adjustedDifferences);
 
-    await applyYamlList([reconfigureYaml], 'create');
+    const [createdOpsRequest] = await applyYamlList([reconfigureYaml], 'create');
+    try {
+      await createParameterHistory({
+        k8sCore,
+        namespace,
+        dbName,
+        dbType,
+        dbUid,
+        opsRequestName: createdOpsRequest?.metadata?.name,
+        differences: adjustedDifferences
+      });
+    } catch (historyError) {
+      console.error('Failed to record parameter update history:', historyError);
+    }
 
     jsonRes(res, {
       data: { success: true }

--- a/frontend/providers/dbprovider/src/pages/api/createDB.ts
+++ b/frontend/providers/dbprovider/src/pages/api/createDB.ts
@@ -20,8 +20,7 @@ import { validatePolarDBXResources } from '@/utils/database';
 import {
   getCurrentParameterValues,
   getParameterDifferences,
-  updateParameterConfiguration,
-  waitForParameterValues
+  updateParameterConfiguration
 } from '@/utils/parameterConfig';
 import { completeParameterHistory, createParameterHistory } from '@/utils/parameterHistory';
 import { ReconfigStatus } from '@/constants/db';
@@ -105,14 +104,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
                 k8sCustomObjects,
                 differences: parameterDifferences
               });
-              await waitForParameterValues({
-                dbName: dbForm.dbName,
-                dbType: dbForm.dbType,
-                namespace,
-                k8sCore,
-                k8sCustomObjects,
-                differences: parameterDifferences
-              });
             } catch (error: any) {
               try {
                 await completeParameterHistory({
@@ -125,16 +116,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
                 console.error('Failed to record parameter update failure:', historyError);
               }
               throw error;
-            }
-
-            try {
-              await completeParameterHistory({
-                k8sCore,
-                configMap: history,
-                status: ReconfigStatus.Succeed
-              });
-            } catch (historyError) {
-              console.error('Failed to record parameter update success:', historyError);
             }
           }
         }

--- a/frontend/providers/dbprovider/src/pages/api/createDB.ts
+++ b/frontend/providers/dbprovider/src/pages/api/createDB.ts
@@ -15,7 +15,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { updateBackupPolicyApi } from './backup/updatePolicy';
 import { BackupSupportedDBTypeList } from '@/constants/db';
 import { adaptDBDetail, convertBackupFormToSpec } from '@/utils/adapt';
-import { CustomObjectsApi, PatchUtils } from '@kubernetes/client-node';
+import { CustomObjectsApi, KubernetesObject, PatchUtils } from '@kubernetes/client-node';
 import { getScore } from '@/utils/tools';
 import { validatePolarDBXResources } from '@/utils/database';
 import {
@@ -23,6 +23,8 @@ import {
   getCurrentParameterValues,
   getParameterDifferences
 } from '@/utils/parameterConfig';
+import { createParameterHistory } from '@/utils/parameterHistory';
+import type { ParameterDifference } from '@/utils/parameterChanges';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
   try {
@@ -68,6 +70,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       }
 
       // Record parameter changes through OpsRequest so they appear in history.
+      let parameterDifferencesForHistory: ParameterDifference[] | undefined;
       if (['postgresql', 'apecloud-mysql', 'mongodb', 'redis'].includes(dbForm.dbType)) {
         if (!(dbForm.dbType === 'apecloud-mysql' && dbForm.dbVersion === 'mysql-5.7.42')) {
           const dynamicMaxConnections = getScore(dbForm.dbType, dbForm.cpu, dbForm.memory);
@@ -75,7 +78,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
             dbName: dbForm.dbName,
             dbType: dbForm.dbType,
             namespace,
-            k8sCore
+            k8sCore,
+            k8sCustomObjects
           });
           const parameterDifferences = getParameterDifferences({
             dbType: dbForm.dbType,
@@ -101,12 +105,36 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
                 parameterDifferences
               )
             );
+            parameterDifferencesForHistory = parameterDifferences;
           }
         }
       }
 
       if (opsRequests.length > 0) {
-        await applyYamlList(opsRequests, 'create');
+        const createdOpsRequests = await applyYamlList(opsRequests, 'create');
+        if (parameterDifferencesForHistory) {
+          const parameterOpsRequest = createdOpsRequests.find(
+            (request) =>
+              request?.kind === 'OpsRequest' &&
+              Boolean(
+                (request as KubernetesObject & { spec?: { reconfigure?: unknown } }).spec
+                  ?.reconfigure
+              )
+          );
+          try {
+            await createParameterHistory({
+              k8sCore,
+              namespace,
+              dbName: dbForm.dbName,
+              dbType: dbForm.dbType,
+              dbUid: body.metadata.uid,
+              opsRequestName: parameterOpsRequest?.metadata?.name,
+              differences: parameterDifferencesForHistory
+            });
+          } catch (error) {
+            console.error('Failed to record parameter update history:', error);
+          }
+        }
       }
 
       if (

--- a/frontend/providers/dbprovider/src/pages/api/createDB.ts
+++ b/frontend/providers/dbprovider/src/pages/api/createDB.ts
@@ -73,39 +73,43 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       let parameterDifferencesForHistory: ParameterDifference[] | undefined;
       if (['postgresql', 'apecloud-mysql', 'mongodb', 'redis'].includes(dbForm.dbType)) {
         if (!(dbForm.dbType === 'apecloud-mysql' && dbForm.dbVersion === 'mysql-5.7.42')) {
-          const dynamicMaxConnections = getScore(dbForm.dbType, dbForm.cpu, dbForm.memory);
-          const currentParameterValues = await getCurrentParameterValues({
-            dbName: dbForm.dbName,
-            dbType: dbForm.dbType,
-            namespace,
-            k8sCore,
-            k8sCustomObjects
-          });
-          const parameterDifferences = getParameterDifferences({
-            dbType: dbForm.dbType,
-            current: currentParameterValues,
-            requested: dbForm.parameterConfig,
-            dynamicMaxConnections
-          });
+          try {
+            const dynamicMaxConnections = getScore(dbForm.dbType, dbForm.cpu, dbForm.memory);
+            const currentParameterValues = await getCurrentParameterValues({
+              dbName: dbForm.dbName,
+              dbType: dbForm.dbType,
+              namespace,
+              k8sCore,
+              k8sCustomObjects
+            });
+            const parameterDifferences = getParameterDifferences({
+              dbType: dbForm.dbType,
+              current: currentParameterValues,
+              requested: dbForm.parameterConfig,
+              dynamicMaxConnections
+            });
 
-          if (parameterDifferences.length > 0) {
-            if (dbForm.dbType === 'postgresql') {
-              await ensurePostgreSQLConfigSpec({
-                dbName: dbForm.dbName,
-                dbVersion: dbForm.dbVersion,
-                namespace,
-                k8sCustomObjects
-              });
+            if (parameterDifferences.length > 0) {
+              if (dbForm.dbType === 'postgresql') {
+                await ensurePostgreSQLConfigSpec({
+                  dbName: dbForm.dbName,
+                  dbVersion: dbForm.dbVersion,
+                  namespace,
+                  k8sCustomObjects
+                });
+              }
+              opsRequests.push(
+                json2Reconfigure(
+                  dbForm.dbName,
+                  dbForm.dbType,
+                  body.metadata.uid,
+                  parameterDifferences
+                )
+              );
+              parameterDifferencesForHistory = parameterDifferences;
             }
-            opsRequests.push(
-              json2Reconfigure(
-                dbForm.dbName,
-                dbForm.dbType,
-                body.metadata.uid,
-                parameterDifferences
-              )
-            );
-            parameterDifferencesForHistory = parameterDifferences;
+          } catch (error) {
+            console.warn('Failed to prepare parameter configuration update:', error);
           }
         }
       }

--- a/frontend/providers/dbprovider/src/pages/api/createDB.ts
+++ b/frontend/providers/dbprovider/src/pages/api/createDB.ts
@@ -71,6 +71,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
       // Record parameter changes through OpsRequest so they appear in history.
       let parameterDifferencesForHistory: ParameterDifference[] | undefined;
+      let parameterPreparationError: any;
       if (['postgresql', 'apecloud-mysql', 'mongodb', 'redis'].includes(dbForm.dbType)) {
         if (!(dbForm.dbType === 'apecloud-mysql' && dbForm.dbVersion === 'mysql-5.7.42')) {
           try {
@@ -109,6 +110,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
               parameterDifferencesForHistory = parameterDifferences;
             }
           } catch (error) {
+            parameterPreparationError = error;
             console.warn('Failed to prepare parameter configuration update:', error);
           }
         }
@@ -141,6 +143,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
         }
       }
 
+      if (parameterPreparationError && opsRequests.length === 0) {
+        throw parameterPreparationError;
+      }
+
       if (
         process.env.BACKUP_ENABLED === 'true' &&
         BackupSupportedDBTypeList.includes(dbForm.dbType) &&
@@ -167,6 +173,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
             namespace
           });
         }
+      }
+
+      if (parameterPreparationError) {
+        throw parameterPreparationError;
       }
 
       return jsonRes(res, {

--- a/frontend/providers/dbprovider/src/pages/api/createDB.ts
+++ b/frontend/providers/dbprovider/src/pages/api/createDB.ts
@@ -18,7 +18,11 @@ import { adaptDBDetail, convertBackupFormToSpec } from '@/utils/adapt';
 import { CustomObjectsApi, PatchUtils } from '@kubernetes/client-node';
 import { getScore } from '@/utils/tools';
 import { validatePolarDBXResources } from '@/utils/database';
-import { getCurrentParameterValues, getParameterDifferences } from '@/utils/parameterConfig';
+import {
+  ensurePostgreSQLConfigSpec,
+  getCurrentParameterValues,
+  getParameterDifferences
+} from '@/utils/parameterConfig';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
   try {
@@ -81,6 +85,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
           });
 
           if (parameterDifferences.length > 0) {
+            if (dbForm.dbType === 'postgresql') {
+              await ensurePostgreSQLConfigSpec({
+                dbName: dbForm.dbName,
+                dbVersion: dbForm.dbVersion,
+                namespace,
+                k8sCustomObjects
+              });
+            }
             opsRequests.push(
               json2Reconfigure(
                 dbForm.dbName,

--- a/frontend/providers/dbprovider/src/pages/api/createDB.ts
+++ b/frontend/providers/dbprovider/src/pages/api/createDB.ts
@@ -8,7 +8,8 @@ import {
   json2Account,
   json2ResourceOps,
   json2CreateCluster,
-  json2ParameterConfig
+  json2ParameterConfig,
+  json2Reconfigure
 } from '@/utils/json2Yaml';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { updateBackupPolicyApi } from './backup/updatePolicy';
@@ -17,13 +18,7 @@ import { adaptDBDetail, convertBackupFormToSpec } from '@/utils/adapt';
 import { CustomObjectsApi, PatchUtils } from '@kubernetes/client-node';
 import { getScore } from '@/utils/tools';
 import { validatePolarDBXResources } from '@/utils/database';
-import {
-  getCurrentParameterValues,
-  getParameterDifferences,
-  updateParameterConfiguration
-} from '@/utils/parameterConfig';
-import { completeParameterHistory, createParameterHistory } from '@/utils/parameterHistory';
-import { ReconfigStatus } from '@/constants/db';
+import { getCurrentParameterValues, getParameterDifferences } from '@/utils/parameterConfig';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
   try {
@@ -76,8 +71,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
             dbName: dbForm.dbName,
             dbType: dbForm.dbType,
             namespace,
-            k8sCore,
-            k8sCustomObjects
+            k8sCore
           });
           const parameterDifferences = getParameterDifferences({
             dbType: dbForm.dbType,
@@ -87,36 +81,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
           });
 
           if (parameterDifferences.length > 0) {
-            const history = await createParameterHistory({
-              k8sCore,
-              namespace,
-              dbName: dbForm.dbName,
-              dbType: dbForm.dbType,
-              dbUid: body.metadata.uid,
-              differences: parameterDifferences
-            });
-
-            try {
-              await updateParameterConfiguration({
-                dbName: dbForm.dbName,
-                dbType: dbForm.dbType,
-                namespace,
-                k8sCustomObjects,
-                differences: parameterDifferences
-              });
-            } catch (error: any) {
-              try {
-                await completeParameterHistory({
-                  k8sCore,
-                  configMap: history,
-                  status: ReconfigStatus.Failed,
-                  error: error?.message || String(error)
-                });
-              } catch (historyError) {
-                console.error('Failed to record parameter update failure:', historyError);
-              }
-              throw error;
-            }
+            opsRequests.push(
+              json2Reconfigure(
+                dbForm.dbName,
+                dbForm.dbType,
+                body.metadata.uid,
+                parameterDifferences
+              )
+            );
           }
         }
       }

--- a/frontend/providers/dbprovider/src/pages/api/createDB.ts
+++ b/frontend/providers/dbprovider/src/pages/api/createDB.ts
@@ -8,6 +8,7 @@ import {
   json2Account,
   json2ResourceOps,
   json2CreateCluster,
+  json2Reconfigure,
   json2ParameterConfig
 } from '@/utils/json2Yaml';
 import type { NextApiRequest, NextApiResponse } from 'next';
@@ -17,6 +18,7 @@ import { adaptDBDetail, convertBackupFormToSpec } from '@/utils/adapt';
 import { CustomObjectsApi, PatchUtils } from '@kubernetes/client-node';
 import { getScore } from '@/utils/tools';
 import { validatePolarDBXResources } from '@/utils/database';
+import { getCurrentParameterValues, getParameterDifferences } from '@/utils/parameterConfig';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
   try {
@@ -28,7 +30,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     console.log('api createDB dbForm', dbForm);
     validatePolarDBXResources(dbForm);
 
-    const { k8sCustomObjects, namespace, applyYamlList } = await getK8s({
+    const { k8sCore, k8sCustomObjects, namespace, applyYamlList } = await getK8s({
       kubeconfig: await authSession(req)
     });
 
@@ -61,22 +63,32 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
         opsRequests.push(volumeExpansionYaml);
       }
 
-      // Handle parameter configuration updates
+      // Record parameter changes through OpsRequest so they appear in history.
       if (['postgresql', 'apecloud-mysql', 'mongodb', 'redis'].includes(dbForm.dbType)) {
         if (!(dbForm.dbType === 'apecloud-mysql' && dbForm.dbVersion === 'mysql-5.7.42')) {
-          try {
-            const dynamicMaxConnections = getScore(dbForm.dbType, dbForm.cpu, dbForm.memory);
-            const configYaml = json2ParameterConfig(
+          const dynamicMaxConnections = getScore(dbForm.dbType, dbForm.cpu, dbForm.memory);
+          const currentParameterValues = await getCurrentParameterValues({
+            dbName: dbForm.dbName,
+            dbType: dbForm.dbType,
+            namespace,
+            k8sCore,
+            k8sCustomObjects
+          });
+          const parameterDifferences = getParameterDifferences({
+            dbType: dbForm.dbType,
+            current: currentParameterValues,
+            requested: dbForm.parameterConfig,
+            dynamicMaxConnections
+          });
+
+          if (parameterDifferences.length > 0) {
+            const reconfigureYaml = json2Reconfigure(
               dbForm.dbName,
               dbForm.dbType,
-              dbForm.dbVersion,
-              dbForm.parameterConfig,
-              dynamicMaxConnections
+              body.metadata.uid,
+              parameterDifferences
             );
-            console.log('api createDB configYaml', configYaml);
-            await applyYamlList([configYaml], 'replace');
-          } catch (err) {
-            console.log('Failed to update parameter configuration:', err);
+            opsRequests.push(reconfigureYaml);
           }
         }
       }

--- a/frontend/providers/dbprovider/src/pages/api/createDB.ts
+++ b/frontend/providers/dbprovider/src/pages/api/createDB.ts
@@ -8,7 +8,6 @@ import {
   json2Account,
   json2ResourceOps,
   json2CreateCluster,
-  json2Reconfigure,
   json2ParameterConfig
 } from '@/utils/json2Yaml';
 import type { NextApiRequest, NextApiResponse } from 'next';
@@ -18,7 +17,14 @@ import { adaptDBDetail, convertBackupFormToSpec } from '@/utils/adapt';
 import { CustomObjectsApi, PatchUtils } from '@kubernetes/client-node';
 import { getScore } from '@/utils/tools';
 import { validatePolarDBXResources } from '@/utils/database';
-import { getCurrentParameterValues, getParameterDifferences } from '@/utils/parameterConfig';
+import {
+  getCurrentParameterValues,
+  getParameterDifferences,
+  updateParameterConfiguration,
+  waitForParameterValues
+} from '@/utils/parameterConfig';
+import { completeParameterHistory, createParameterHistory } from '@/utils/parameterHistory';
+import { ReconfigStatus } from '@/constants/db';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
   try {
@@ -82,13 +88,54 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
           });
 
           if (parameterDifferences.length > 0) {
-            const reconfigureYaml = json2Reconfigure(
-              dbForm.dbName,
-              dbForm.dbType,
-              body.metadata.uid,
-              parameterDifferences
-            );
-            opsRequests.push(reconfigureYaml);
+            const history = await createParameterHistory({
+              k8sCore,
+              namespace,
+              dbName: dbForm.dbName,
+              dbType: dbForm.dbType,
+              dbUid: body.metadata.uid,
+              differences: parameterDifferences
+            });
+
+            try {
+              await updateParameterConfiguration({
+                dbName: dbForm.dbName,
+                dbType: dbForm.dbType,
+                namespace,
+                k8sCustomObjects,
+                differences: parameterDifferences
+              });
+              await waitForParameterValues({
+                dbName: dbForm.dbName,
+                dbType: dbForm.dbType,
+                namespace,
+                k8sCore,
+                k8sCustomObjects,
+                differences: parameterDifferences
+              });
+            } catch (error: any) {
+              try {
+                await completeParameterHistory({
+                  k8sCore,
+                  configMap: history,
+                  status: ReconfigStatus.Failed,
+                  error: error?.message || String(error)
+                });
+              } catch (historyError) {
+                console.error('Failed to record parameter update failure:', historyError);
+              }
+              throw error;
+            }
+
+            try {
+              await completeParameterHistory({
+                k8sCore,
+                configMap: history,
+                status: ReconfigStatus.Succeed
+              });
+            } catch (historyError) {
+              console.error('Failed to record parameter update success:', historyError);
+            }
           }
         }
       }

--- a/frontend/providers/dbprovider/src/pages/api/getConfigByName.ts
+++ b/frontend/providers/dbprovider/src/pages/api/getConfigByName.ts
@@ -14,7 +14,8 @@ import {
   ParameterConfigField,
   ParameterFieldMetadata
 } from '@/types/db';
-import { parseConfig, parseRedisConfig, flattenObject } from '@/utils/tools';
+import { parseConfig, flattenObject } from '@/utils/tools';
+import { getCurrentParameterValues } from '@/utils/parameterConfig';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 /**
@@ -108,19 +109,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     let parsedConfig: Record<string, any> | null = null;
 
     if (dbType === 'redis') {
-      const redisConfigMapKey = name + dbConfig.configMapName;
-      let redisConfigMapData = '';
-
-      if (redisConfigMapKey && dbConfig.configMapName) {
-        try {
-          const { body } = await k8sCore.readNamespacedConfigMap(redisConfigMapKey, namespace);
-          redisConfigMapData = body?.data?.[dbConfig.configMapKey] || '';
-        } catch (error) {
-          console.warn('Failed to get redis config map, falling back to configuration CR:', error);
-        }
+      try {
+        parsedConfig = await getCurrentParameterValues({
+          dbName: name,
+          dbType,
+          namespace,
+          k8sCore,
+          k8sCustomObjects
+        });
+      } catch (error) {
+        console.warn('Failed to get redis configuration:', error);
       }
-
-      parsedConfig = redisConfigMapData ? parseRedisConfig(redisConfigMapData) : null;
     } else {
       const key = name + dbConfig.configMapName;
       if (!key || !dbConfig.configMapName) {

--- a/frontend/providers/dbprovider/src/pages/api/getConfigByName.ts
+++ b/frontend/providers/dbprovider/src/pages/api/getConfigByName.ts
@@ -120,27 +120,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
         }
       }
 
-      try {
-        const { body: configurationBody } = (await k8sCustomObjects.getNamespacedCustomObject(
-          'apps.kubeblocks.io',
-          'v1alpha1',
-          namespace,
-          'configurations',
-          `${name}-redis`
-        )) as { body: any };
-        const redisConfigItem = configurationBody?.spec?.configItemDetails?.find(
-          (item: any) => item.name === dbConfig.reconfigureName
-        );
-        const redisConfigParams = redisConfigItem?.configFileParams?.['redis.conf']?.parameters || {};
-        const mergedRedisConfig = {
-          ...(redisConfigMapData ? parseRedisConfig(redisConfigMapData) : {}),
-          ...redisConfigParams
-        };
-        parsedConfig = Object.keys(mergedRedisConfig).length > 0 ? mergedRedisConfig : null;
-      } catch (error) {
-        console.warn('Failed to get redis configuration, using config map fallback if available:', error);
-        parsedConfig = redisConfigMapData ? parseRedisConfig(redisConfigMapData) : null;
-      }
+      parsedConfig = redisConfigMapData ? parseRedisConfig(redisConfigMapData) : null;
     } else {
       const key = name + dbConfig.configMapName;
       if (!key || !dbConfig.configMapName) {

--- a/frontend/providers/dbprovider/src/pages/api/getDBByName.ts
+++ b/frontend/providers/dbprovider/src/pages/api/getDBByName.ts
@@ -6,14 +6,13 @@ import { jsonRes } from '@/services/backend/response';
 import { KbPgClusterType } from '@/types/cluster';
 import { adaptDBDetail } from '@/utils/adapt';
 import { defaultDBDetail } from '@/constants/db';
-import {
-  extractParameterConfigFromConfiguration,
-  getDBConfigurationName
-} from '@/utils/parameterConfig';
+import { getCurrentParameterValues } from '@/utils/parameterConfig';
+import { getScore } from '@/utils/tools';
+import { getParameterConfigFromRuntimeValues } from '@/utils/parameterChanges';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
   try {
-    const { namespace } = await getK8s({
+    const { namespace, k8sCore, k8sCustomObjects } = await getK8s({
       kubeconfig: await authSession(req)
     });
 
@@ -32,14 +31,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     const dbDetail = adaptDBDetail(body);
 
     try {
-      const configurationBody = await getDBConfiguration(req, dbDetail.dbName, dbDetail.dbType);
-      if (configurationBody) {
-        const parameterConfig = extractParameterConfigFromConfiguration(
-          configurationBody,
-          dbDetail.dbType
-        );
-        dbDetail.parameterConfig = parameterConfig;
-      }
+      const currentValues = await getCurrentParameterValues({
+        dbName: dbDetail.dbName,
+        dbType: dbDetail.dbType,
+        namespace,
+        k8sCore
+      });
+      dbDetail.parameterConfig = getParameterConfigFromRuntimeValues({
+        dbType: dbDetail.dbType,
+        currentValues,
+        dynamicMaxConnections: getScore(dbDetail.dbType, dbDetail.cpu, dbDetail.memory)
+      });
     } catch (error) {
       console.log('Failed to get configuration:', error);
     }
@@ -71,28 +73,4 @@ export async function getCluster(req: NextApiRequest, name: string) {
   };
 
   return body;
-}
-
-export async function getDBConfiguration(req: NextApiRequest, dbName: string, dbType: string) {
-  const { k8sCustomObjects, namespace } = await getK8s({
-    kubeconfig: await authSession(req)
-  });
-
-  try {
-    const configurationName = getDBConfigurationName(dbName, dbType);
-
-    const { body } = (await k8sCustomObjects.getNamespacedCustomObject(
-      'apps.kubeblocks.io',
-      'v1alpha1',
-      namespace,
-      'configurations',
-      configurationName
-    )) as {
-      body: any;
-    };
-
-    return body;
-  } catch (err: any) {
-    return null;
-  }
 }

--- a/frontend/providers/dbprovider/src/pages/api/getDBByName.ts
+++ b/frontend/providers/dbprovider/src/pages/api/getDBByName.ts
@@ -35,7 +35,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
         dbName: dbDetail.dbName,
         dbType: dbDetail.dbType,
         namespace,
-        k8sCore
+        k8sCore,
+        k8sCustomObjects
       });
       dbDetail.parameterConfig = getParameterConfigFromRuntimeValues({
         dbType: dbDetail.dbType,

--- a/frontend/providers/dbprovider/src/pages/api/getDBByName.ts
+++ b/frontend/providers/dbprovider/src/pages/api/getDBByName.ts
@@ -6,6 +6,10 @@ import { jsonRes } from '@/services/backend/response';
 import { KbPgClusterType } from '@/types/cluster';
 import { adaptDBDetail } from '@/utils/adapt';
 import { defaultDBDetail } from '@/constants/db';
+import {
+  extractParameterConfigFromConfiguration,
+  getDBConfigurationName
+} from '@/utils/parameterConfig';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
   try {
@@ -75,24 +79,7 @@ export async function getDBConfiguration(req: NextApiRequest, dbName: string, db
   });
 
   try {
-    // Generate configuration name based on dbType
-    let configurationName = '';
-    switch (dbType) {
-      case 'postgresql':
-        configurationName = `${dbName}-postgresql`;
-        break;
-      case 'apecloud-mysql':
-        configurationName = `${dbName}-mysql`;
-        break;
-      case 'mongodb':
-        configurationName = `${dbName}-mongodb`;
-        break;
-      case 'redis':
-        configurationName = `${dbName}-redis`;
-        break;
-      default:
-        throw new Error(`Unsupported database type: ${dbType}`);
-    }
+    const configurationName = getDBConfigurationName(dbName, dbType);
 
     const { body } = (await k8sCustomObjects.getNamespacedCustomObject(
       'apps.kubeblocks.io',
@@ -108,97 +95,4 @@ export async function getDBConfiguration(req: NextApiRequest, dbName: string, db
   } catch (err: any) {
     return null;
   }
-}
-
-function extractParameterConfigFromConfiguration(configuration: any, dbType: string) {
-  if (!configuration?.spec?.configItemDetails) {
-    return undefined;
-  }
-
-  const parameterConfig: {
-    maxConnections?: string;
-    timeZone?: string;
-    lowerCaseTableNames?: string;
-    isMaxConnectionsCustomized?: boolean;
-    maxmemory?: string;
-  } = {};
-
-  let hasParams = false;
-
-  for (const configItem of configuration.spec.configItemDetails) {
-    if (configItem.configFileParams) {
-      // Extract parameters from different config files based on database type
-      switch (dbType) {
-        case 'postgresql':
-          if (configItem.configFileParams['postgresql.conf']) {
-            const pgParams = configItem.configFileParams['postgresql.conf'].parameters || {};
-            if (pgParams['max_connections']) {
-              parameterConfig.maxConnections = String(pgParams['max_connections']);
-              parameterConfig.isMaxConnectionsCustomized = true;
-              hasParams = true;
-            }
-            if (pgParams['timezone']) {
-              parameterConfig.timeZone = String(pgParams['timezone']);
-              hasParams = true;
-            }
-          }
-          break;
-
-        case 'apecloud-mysql':
-          if (configItem.configFileParams['my.cnf']) {
-            const mysqlParams = configItem.configFileParams['my.cnf'].parameters || {};
-            if (mysqlParams['max_connections']) {
-              parameterConfig.maxConnections = String(mysqlParams['max_connections']);
-              parameterConfig.isMaxConnectionsCustomized = true;
-              hasParams = true;
-            }
-            if (mysqlParams['default-time-zone']) {
-              const timezone = String(mysqlParams['default-time-zone']);
-              // Convert back from offset to timezone name
-              if (timezone === '+00:00') {
-                parameterConfig.timeZone = 'UTC';
-              } else if (timezone === '+08:00') {
-                parameterConfig.timeZone = 'Asia/Shanghai';
-              } else {
-                parameterConfig.timeZone = timezone;
-              }
-              hasParams = true;
-            }
-            if (mysqlParams['lower_case_table_names'] !== undefined) {
-              parameterConfig.lowerCaseTableNames = String(mysqlParams['lower_case_table_names']);
-              hasParams = true;
-            }
-          }
-          break;
-
-        case 'mongodb':
-          if (configItem.configFileParams['mongodb.conf']) {
-            const mongoParams = configItem.configFileParams['mongodb.conf'].parameters || {};
-            if (mongoParams['net.maxIncomingConnections']) {
-              parameterConfig.maxConnections = String(mongoParams['net.maxIncomingConnections']);
-              parameterConfig.isMaxConnectionsCustomized = true;
-              hasParams = true;
-            }
-          }
-          break;
-
-        case 'redis':
-          if (configItem.configFileParams['redis.conf']) {
-            const redisParams = configItem.configFileParams['redis.conf'].parameters || {};
-            if (redisParams['maxclients']) {
-              parameterConfig.maxConnections = String(redisParams['maxclients']);
-              parameterConfig.isMaxConnectionsCustomized = true;
-              hasParams = true;
-            }
-            if (redisParams['maxmemory']) {
-              parameterConfig.maxmemory = String(redisParams['maxmemory']);
-              hasParams = true;
-            }
-          }
-          break;
-      }
-    }
-  }
-
-  return hasParams ? parameterConfig : undefined;
 }

--- a/frontend/providers/dbprovider/src/pages/api/opsrequest/list.ts
+++ b/frontend/providers/dbprovider/src/pages/api/opsrequest/list.ts
@@ -78,8 +78,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
           dbName: name,
           dbType,
           namespace,
-          k8sCore,
-          k8sCustomObjects
+          k8sCore
         });
 
         await Promise.all(

--- a/frontend/providers/dbprovider/src/pages/api/opsrequest/list.ts
+++ b/frontend/providers/dbprovider/src/pages/api/opsrequest/list.ts
@@ -141,42 +141,44 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       const proxiedOpsRequestNames = new Set(
         historyItems.map(({ opsRequestName }) => opsRequestName).filter(Boolean)
       );
-      const parameterHistorySignatureCounts = new Map<string, number>();
-      historyItems
-        .filter(({ opsRequestName }) => !opsRequestName)
-        .forEach(({ item }) => {
-          const signature = item?.configurations
-            ?.map(
-              ({ parameterName, oldValue, newValue }) =>
-                `${parameterName}\u0000${oldValue}\u0000${newValue}`
-            )
-            .sort()
-            .join('\u0001');
-          if (signature) {
-            parameterHistorySignatureCounts.set(
-              signature,
-              (parameterHistorySignatureCounts.get(signature) || 0) + 1
-            );
-          }
-        });
-      data = data.filter((item) => {
-        if (proxiedOpsRequestNames.has(item.name)) return false;
-        const signature = item.configurations
+      const getParameterSignature = (item: OpsRequestItemType) =>
+        item.configurations
           ?.map(
             ({ parameterName, oldValue, newValue }) =>
               `${parameterName}\u0000${oldValue}\u0000${newValue}`
           )
           .sort()
           .join('\u0001');
-        const matchingHistoryCount = signature
-          ? parameterHistorySignatureCounts.get(signature) || 0
-          : 0;
-        if (signature && matchingHistoryCount > 0) {
-          parameterHistorySignatureCounts.set(signature, matchingHistoryCount - 1);
-          return false;
-        }
-        return true;
-      });
+
+      // Histories created before opsRequestName was persisted need a
+      // compatibility match. Pair each one with the closest OpsRequest of
+      // the same signature, so repeated identical edits remain visible.
+      const legacyHistoryItems = historyItems.filter(({ opsRequestName }) => !opsRequestName);
+      const matchedLegacyOps = new Set<number>();
+      for (const { item: historyItem } of legacyHistoryItems) {
+        if (!historyItem) continue;
+        const historySignature = getParameterSignature(historyItem);
+        if (!historySignature) continue;
+
+        let closestIndex = -1;
+        let closestDistance = Number.POSITIVE_INFINITY;
+        data.forEach((opsItem, index) => {
+          if (matchedLegacyOps.has(index) || proxiedOpsRequestNames.has(opsItem.name)) return;
+          if (getParameterSignature(opsItem) !== historySignature) return;
+          const distance = Math.abs(
+            new Date(opsItem.startTime).getTime() - new Date(historyItem.startTime).getTime()
+          );
+          if (distance < closestDistance) {
+            closestDistance = distance;
+            closestIndex = index;
+          }
+        });
+        if (closestIndex >= 0) matchedLegacyOps.add(closestIndex);
+      }
+
+      data = data.filter(
+        (item, index) => !proxiedOpsRequestNames.has(item.name) && !matchedLegacyOps.has(index)
+      );
       parameterHistory = historyItems
         .map(({ item }) => item)
         .filter((item): item is OpsRequestItemType => Boolean(item));

--- a/frontend/providers/dbprovider/src/pages/api/opsrequest/list.ts
+++ b/frontend/providers/dbprovider/src/pages/api/opsrequest/list.ts
@@ -5,8 +5,19 @@ import { ApiResp } from '@/services/kubernet';
 import { KubeBlockOpsRequestType } from '@/types/cluster';
 import { DBType, OpsRequestItemType } from '@/types/db';
 import { adaptOpsRequest } from '@/utils/adapt';
-import { DBNameLabel, DBParameterHistoryLabel } from '@/constants/db';
-import { adaptParameterHistory } from '@/utils/parameterHistory';
+import {
+  DBNameLabel,
+  DBParameterHistoryDataKey,
+  DBParameterHistoryLabel,
+  ReconfigStatus
+} from '@/constants/db';
+import {
+  adaptParameterHistory,
+  completeParameterHistory,
+  readParameterHistory,
+  resolveParameterHistoryStatus
+} from '@/utils/parameterHistory';
+import { getCurrentParameterValues } from '@/utils/parameterConfig';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
@@ -57,6 +68,65 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       undefined,
       `${DBNameLabel}=${name},${DBParameterHistoryLabel}=true`
     );
+
+    const runningHistory = historyList.items.filter(
+      (configMap) => readParameterHistory(configMap)?.status === ReconfigStatus.Running
+    );
+    if (runningHistory.length > 0) {
+      try {
+        const currentValues = await getCurrentParameterValues({
+          dbName: name,
+          dbType,
+          namespace,
+          k8sCore,
+          k8sCustomObjects
+        });
+
+        await Promise.all(
+          runningHistory.map(async (configMap) => {
+            const history = readParameterHistory(configMap);
+            if (!history) return;
+            const status = resolveParameterHistoryStatus({ history, currentValues });
+            if (status !== ReconfigStatus.Succeed && status !== ReconfigStatus.Failed) return;
+
+            await completeParameterHistory({
+              k8sCore,
+              configMap,
+              status,
+              ...(status === ReconfigStatus.Failed
+                ? { error: 'Timed out waiting for database parameters to take effect' }
+                : {})
+            });
+            history.status = status;
+            history.completedAt = new Date().toISOString();
+            configMap.data ||= {};
+            configMap.data[DBParameterHistoryDataKey] = JSON.stringify(history);
+          })
+        );
+      } catch (error) {
+        console.warn('Failed to read current parameter values:', error);
+        await Promise.all(
+          runningHistory.map(async (configMap) => {
+            const history = readParameterHistory(configMap);
+            if (!history) return;
+            const status = resolveParameterHistoryStatus({ history });
+            if (status !== ReconfigStatus.Failed) return;
+
+            await completeParameterHistory({
+              k8sCore,
+              configMap,
+              status,
+              error: 'Timed out waiting for database parameters to take effect'
+            });
+            history.status = status;
+            history.completedAt = new Date().toISOString();
+            configMap.data ||= {};
+            configMap.data[DBParameterHistoryDataKey] = JSON.stringify(history);
+          })
+        );
+      }
+    }
+
     const parameterHistory = historyList.items
       .map(adaptParameterHistory)
       .filter((item): item is OpsRequestItemType => Boolean(item));

--- a/frontend/providers/dbprovider/src/pages/api/opsrequest/list.ts
+++ b/frontend/providers/dbprovider/src/pages/api/opsrequest/list.ts
@@ -7,6 +7,7 @@ import { DBType, OpsRequestItemType } from '@/types/db';
 import { adaptOpsRequest } from '@/utils/adapt';
 import {
   DBNameLabel,
+  DBReconfigureKey,
   DBParameterHistoryDataKey,
   DBParameterHistoryLabel,
   ReconfigStatus
@@ -60,75 +61,126 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       data = opsrequestsList.body.items.map((res) => adaptOpsRequest(res, 'Switchover'));
     }
 
-    const { body: historyList } = await k8sCore.listNamespacedConfigMap(
-      namespace,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      `${DBNameLabel}=${name},${DBParameterHistoryLabel}=true`
-    );
+    let parameterHistory: OpsRequestItemType[] = [];
+    if (label === DBReconfigureKey) {
+      const { body: historyList } = await k8sCore.listNamespacedConfigMap(
+        namespace,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        `${DBNameLabel}=${name},${DBParameterHistoryLabel}=true`
+      );
 
-    const runningHistory = historyList.items.filter(
-      (configMap) => readParameterHistory(configMap)?.status === ReconfigStatus.Running
-    );
-    if (runningHistory.length > 0) {
-      try {
-        const currentValues = await getCurrentParameterValues({
-          dbName: name,
-          dbType,
-          namespace,
-          k8sCore
-        });
+      const runningHistory = historyList.items.filter(
+        (configMap) => readParameterHistory(configMap)?.status === ReconfigStatus.Running
+      );
+      if (runningHistory.length > 0) {
+        try {
+          const currentValues = await getCurrentParameterValues({
+            dbName: name,
+            dbType,
+            namespace,
+            k8sCore,
+            k8sCustomObjects,
+            includeConfigurationOverrides: false
+          });
 
-        await Promise.all(
-          runningHistory.map(async (configMap) => {
-            const history = readParameterHistory(configMap);
-            if (!history) return;
-            const status = resolveParameterHistoryStatus({ history, currentValues });
-            if (status !== ReconfigStatus.Succeed && status !== ReconfigStatus.Failed) return;
+          await Promise.all(
+            runningHistory.map(async (configMap) => {
+              const history = readParameterHistory(configMap);
+              if (!history) return;
+              const status = resolveParameterHistoryStatus({ history, currentValues });
+              if (status !== ReconfigStatus.Succeed && status !== ReconfigStatus.Failed) return;
 
-            await completeParameterHistory({
-              k8sCore,
-              configMap,
-              status,
-              ...(status === ReconfigStatus.Failed
-                ? { error: 'Timed out waiting for database parameters to take effect' }
-                : {})
-            });
-            history.status = status;
-            history.completedAt = new Date().toISOString();
-            configMap.data ||= {};
-            configMap.data[DBParameterHistoryDataKey] = JSON.stringify(history);
-          })
-        );
-      } catch (error) {
-        console.warn('Failed to read current parameter values:', error);
-        await Promise.all(
-          runningHistory.map(async (configMap) => {
-            const history = readParameterHistory(configMap);
-            if (!history) return;
-            const status = resolveParameterHistoryStatus({ history });
-            if (status !== ReconfigStatus.Failed) return;
+              await completeParameterHistory({
+                k8sCore,
+                configMap,
+                status,
+                ...(status === ReconfigStatus.Failed
+                  ? { error: 'Timed out waiting for database parameters to take effect' }
+                  : {})
+              });
+              history.status = status;
+              history.completedAt = new Date().toISOString();
+              configMap.data ||= {};
+              configMap.data[DBParameterHistoryDataKey] = JSON.stringify(history);
+            })
+          );
+        } catch (error) {
+          console.warn('Failed to read current parameter values:', error);
+          await Promise.all(
+            runningHistory.map(async (configMap) => {
+              const history = readParameterHistory(configMap);
+              if (!history) return;
+              const status = resolveParameterHistoryStatus({ history });
+              if (status !== ReconfigStatus.Failed) return;
 
-            await completeParameterHistory({
-              k8sCore,
-              configMap,
-              status,
-              error: 'Timed out waiting for database parameters to take effect'
-            });
-            history.status = status;
-            history.completedAt = new Date().toISOString();
-            configMap.data ||= {};
-            configMap.data[DBParameterHistoryDataKey] = JSON.stringify(history);
-          })
-        );
+              await completeParameterHistory({
+                k8sCore,
+                configMap,
+                status,
+                error: 'Timed out waiting for database parameters to take effect'
+              });
+              history.status = status;
+              history.completedAt = new Date().toISOString();
+              configMap.data ||= {};
+              configMap.data[DBParameterHistoryDataKey] = JSON.stringify(history);
+            })
+          );
+        }
       }
-    }
 
-    const parameterHistory = historyList.items
-      .map(adaptParameterHistory)
-      .filter((item): item is OpsRequestItemType => Boolean(item));
+      const historyItems = historyList.items
+        .map((configMap) => ({ configMap, history: readParameterHistory(configMap) }))
+        .filter(({ configMap, history }) => Boolean(history && configMap.metadata?.name))
+        .map(({ configMap, history }) => ({
+          item: adaptParameterHistory(configMap),
+          opsRequestName: history?.opsRequestName
+        }));
+      const proxiedOpsRequestNames = new Set(
+        historyItems.map(({ opsRequestName }) => opsRequestName).filter(Boolean)
+      );
+      const parameterHistorySignatureCounts = new Map<string, number>();
+      historyItems
+        .filter(({ opsRequestName }) => !opsRequestName)
+        .forEach(({ item }) => {
+          const signature = item?.configurations
+            ?.map(
+              ({ parameterName, oldValue, newValue }) =>
+                `${parameterName}\u0000${oldValue}\u0000${newValue}`
+            )
+            .sort()
+            .join('\u0001');
+          if (signature) {
+            parameterHistorySignatureCounts.set(
+              signature,
+              (parameterHistorySignatureCounts.get(signature) || 0) + 1
+            );
+          }
+        });
+      data = data.filter((item) => {
+        if (proxiedOpsRequestNames.has(item.name)) return false;
+        const signature = item.configurations
+          ?.map(
+            ({ parameterName, oldValue, newValue }) =>
+              `${parameterName}\u0000${oldValue}\u0000${newValue}`
+          )
+          .sort()
+          .join('\u0001');
+        const matchingHistoryCount = signature
+          ? parameterHistorySignatureCounts.get(signature) || 0
+          : 0;
+        if (signature && matchingHistoryCount > 0) {
+          parameterHistorySignatureCounts.set(signature, matchingHistoryCount - 1);
+          return false;
+        }
+        return true;
+      });
+      parameterHistory = historyItems
+        .map(({ item }) => item)
+        .filter((item): item is OpsRequestItemType => Boolean(item));
+    }
 
     jsonRes(res, {
       data: [...data, ...parameterHistory].sort(

--- a/frontend/providers/dbprovider/src/pages/api/opsrequest/list.ts
+++ b/frontend/providers/dbprovider/src/pages/api/opsrequest/list.ts
@@ -5,6 +5,8 @@ import { ApiResp } from '@/services/kubernet';
 import { KubeBlockOpsRequestType } from '@/types/cluster';
 import { DBType, OpsRequestItemType } from '@/types/db';
 import { adaptOpsRequest } from '@/utils/adapt';
+import { DBNameLabel, DBParameterHistoryLabel } from '@/constants/db';
+import { adaptParameterHistory } from '@/utils/parameterHistory';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
@@ -15,7 +17,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       dbType: DBType;
     };
 
-    const { k8sCustomObjects, namespace } = await getK8s({
+    const { k8sCore, k8sCustomObjects, namespace } = await getK8s({
       kubeconfig: await authSession(req)
     });
 
@@ -47,8 +49,22 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       data = opsrequestsList.body.items.map((res) => adaptOpsRequest(res, 'Switchover'));
     }
 
+    const { body: historyList } = await k8sCore.listNamespacedConfigMap(
+      namespace,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      `${DBNameLabel}=${name},${DBParameterHistoryLabel}=true`
+    );
+    const parameterHistory = historyList.items
+      .map(adaptParameterHistory)
+      .filter((item): item is OpsRequestItemType => Boolean(item));
+
     jsonRes(res, {
-      data: data
+      data: [...data, ...parameterHistory].sort(
+        (left, right) => new Date(right.startTime).getTime() - new Date(left.startTime).getTime()
+      )
     });
   } catch (err: any) {
     jsonRes(res, {

--- a/frontend/providers/dbprovider/src/pages/db/detail/components/Reconfigure/index.tsx
+++ b/frontend/providers/dbprovider/src/pages/db/detail/components/Reconfigure/index.tsx
@@ -111,7 +111,7 @@ const ReconfigureTable = ({ db }: { db?: DBDetailType }, ref: ForwardedRef<Compo
           subMenu: SubMenuEnum.History
         }
       });
-      toast({ title: t('Success'), status: 'success' });
+      toast({ title: t('update_submitted'), status: 'success' });
     } catch (error) {
       toast({ title: t('have_error'), status: 'error' });
     }

--- a/frontend/providers/dbprovider/src/pages/db/edit/components/Form.tsx
+++ b/frontend/providers/dbprovider/src/pages/db/edit/components/Form.tsx
@@ -18,6 +18,7 @@ import type { QueryType } from '@/types';
 import { AutoBackupType } from '@/types/backup';
 import type { DBEditType, DBType } from '@/types/db';
 import { I18nCommonKey } from '@/types/i18next';
+import { getDefaultMaxConnections } from '@/utils/parameterChanges';
 import {
   distributeResources,
   POLARDBX_MIN_COMPONENT_CPU,
@@ -452,20 +453,7 @@ const Form = ({
   }, [backupSettingsRef, parameterConfigRef, supportBackup, supportParameterConfig]);
 
   const getScore = (dbType: DBType) => {
-    const cpuCores = (getValues('cpu') || 0) / 1000; // cpu in cores
-    const memoryGB = (getValues('memory') || 0) / 1024; // memory in GB
-
-    let score = 0;
-    if (
-      dbType === DBTypeEnum.postgresql ||
-      dbType === DBTypeEnum.mongodb ||
-      dbType === DBTypeEnum.mysql
-    ) {
-      score = Math.min(cpuCores * 400 + memoryGB * 300, 100000);
-    } else if (dbType === DBTypeEnum.redis) {
-      score = Math.min(cpuCores * 500 + memoryGB * 400, 100000);
-    }
-    return Math.floor(score);
+    return getDefaultMaxConnections(dbType, getValues('cpu') || 0, getValues('memory') || 0);
   };
 
   const getParaName = (dbType: DBType) => {

--- a/frontend/providers/dbprovider/src/pages/db/edit/index.tsx
+++ b/frontend/providers/dbprovider/src/pages/db/edit/index.tsx
@@ -202,6 +202,7 @@ const EditApp = ({ dbName, tabType }: { dbName?: string; tabType?: 'form' | 'yam
       });
       router.replace(`/db/detail?name=${formData.dbName}&dbType=${formData.dbType}`);
     } catch (error: any) {
+      toast({ title: t(applyError), status: 'error' });
       if (error?.code === ResponseCode.BALANCE_NOT_ENOUGH) {
         setErrorMessage(t('user_balance_not_enough'));
         setErrorCode(ResponseCode.BALANCE_NOT_ENOUGH);

--- a/frontend/providers/dbprovider/src/utils/json2Yaml.ts
+++ b/frontend/providers/dbprovider/src/utils/json2Yaml.ts
@@ -21,6 +21,7 @@ import { V1StatefulSet } from '@kubernetes/client-node';
 import { customAlphabet } from 'nanoid';
 import { SwitchMsData } from '@/pages/api/pod/switchPodMs';
 import { distributeResources } from './database';
+import { toKubeBlocksParameterPairs } from './parameterChanges';
 import z from 'zod';
 import { backupBaseSchema } from '@/types/schemas/backup';
 
@@ -836,7 +837,7 @@ export const json2Reconfigure = (
             keys: [
               {
                 key: reconfigureConfig.reconfigureKey,
-                parameters: configParams.map((item) => ({ key: item.path, value: item.newValue }))
+                parameters: toKubeBlocksParameterPairs(configParams)
               }
             ],
             name: reconfigureConfig.reconfigureName

--- a/frontend/providers/dbprovider/src/utils/json2Yaml.ts
+++ b/frontend/providers/dbprovider/src/utils/json2Yaml.ts
@@ -21,7 +21,7 @@ import { V1StatefulSet } from '@kubernetes/client-node';
 import { customAlphabet } from 'nanoid';
 import { SwitchMsData } from '@/pages/api/pod/switchPodMs';
 import { distributeResources } from './database';
-import { toKubeBlocksParameterPairs } from './parameterChanges';
+import { getPostgreSQLConfigSpecMetadata, toKubeBlocksParameterPairs } from './parameterChanges';
 import z from 'zod';
 import { backupBaseSchema } from '@/types/schemas/backup';
 
@@ -1094,6 +1094,7 @@ export const json2ParameterConfig = (
                 }
               },
               configSpec: {
+                ...getPostgreSQLConfigSpecMetadata(majorVersion),
                 templateRef: 'postgresql-configuration',
                 volumeName: 'postgresql-config',
                 namespace: 'kb-system',
@@ -1159,6 +1160,7 @@ export const json2ParameterConfig = (
                 }
               },
               configSpec: {
+                ...getPostgreSQLConfigSpecMetadata(majorVersion),
                 templateRef: 'postgresql-configuration',
                 volumeName: 'postgresql-config',
                 namespace: 'kb-system',

--- a/frontend/providers/dbprovider/src/utils/json2Yaml.ts
+++ b/frontend/providers/dbprovider/src/utils/json2Yaml.ts
@@ -808,8 +808,7 @@ export const json2Reconfigure = (
       labels: {
         'app.kubernetes.io/instance': dbName,
         'app.kubernetes.io/managed-by': 'kubeblocks',
-        'ops.kubeblocks.io/ops-type': 'Reconfiguring',
-        ...configParams.reduce((acc, param) => ({ ...acc, [param.path]: param.newValue }), {})
+        'ops.kubeblocks.io/ops-type': 'Reconfiguring'
       },
       annotations: {
         // For displaying previous value.

--- a/frontend/providers/dbprovider/src/utils/parameterChanges.ts
+++ b/frontend/providers/dbprovider/src/utils/parameterChanges.ts
@@ -13,6 +13,60 @@ export const toKubeBlocksParameterPairs = (
   differences: Pick<ParameterDifference, 'path' | 'newValue'>[]
 ) => differences.map(({ path, newValue }) => ({ key: path, value: newValue }));
 
+export const getPostgreSQLConfigSpecMetadata = (majorVersion: string) => ({
+  constraintRef: `postgresql${majorVersion}-cc`,
+  keys: ['postgresql.conf']
+});
+
+type PostgreSQLConfigItem = {
+  name?: string;
+  configSpec?: {
+    constraintRef?: string;
+    keys?: string[];
+  };
+};
+
+export const getPostgreSQLConfigSpecPatch = ({
+  dbVersion,
+  configItemDetails
+}: {
+  dbVersion: string;
+  configItemDetails: PostgreSQLConfigItem[];
+}) => {
+  const majorVersion = dbVersion.replace(/^postgresql-/, '').split('.')[0];
+  const expected = getPostgreSQLConfigSpecMetadata(majorVersion);
+  const index = configItemDetails.findIndex(({ name }) => name === 'postgresql-configuration');
+  if (index < 0) {
+    throw new Error('PostgreSQL configuration item not found');
+  }
+
+  const configSpec = configItemDetails[index].configSpec;
+  if (!configSpec) {
+    throw new Error('PostgreSQL configSpec not found');
+  }
+
+  const basePath = `/spec/configItemDetails/${index}/configSpec`;
+  const patch = [];
+  if (configSpec.constraintRef !== expected.constraintRef) {
+    patch.push({
+      op: 'add',
+      path: `${basePath}/constraintRef`,
+      value: expected.constraintRef
+    });
+  }
+  if (
+    configSpec.keys?.length !== expected.keys.length ||
+    !expected.keys.every((key) => configSpec.keys?.includes(key))
+  ) {
+    patch.push({
+      op: 'add',
+      path: `${basePath}/keys`,
+      value: expected.keys
+    });
+  }
+  return patch;
+};
+
 type ParameterPath = {
   current: string;
   requested: string;

--- a/frontend/providers/dbprovider/src/utils/parameterChanges.ts
+++ b/frontend/providers/dbprovider/src/utils/parameterChanges.ts
@@ -2,6 +2,29 @@ import type { DBEditType } from '@/types/db';
 
 type ParameterConfig = NonNullable<DBEditType['parameterConfig']>;
 
+export const mergeRedisParameterValues = (
+  configMapValues: Record<string, string>,
+  configurationValues: Record<string, string | number>
+): Record<string, string> =>
+  Object.fromEntries(
+    Object.entries({ ...configMapValues, ...configurationValues }).map(([key, value]) => [
+      key,
+      String(value)
+    ])
+  );
+
+export const getDefaultMaxConnections = (dbType: string, cpu: number, memory: number) => {
+  const cpuCores = cpu / 1000;
+  const memoryGB = memory / 1024;
+  let score = 0;
+  if (['postgresql', 'mongodb', 'apecloud-mysql'].includes(dbType)) {
+    score = Math.min(cpuCores * 400 + memoryGB * 300, 100000);
+  } else if (dbType === 'redis') {
+    score = Math.min(cpuCores * 1000 + memoryGB * 500, 100000);
+  }
+  return Math.floor(score);
+};
+
 export type ParameterDifference = {
   path: string;
   currentPath?: string;
@@ -100,6 +123,13 @@ const parameterPathsByDbType: Record<
   }
 };
 
+const normalizeMySQLTimeZone = (value: string) =>
+  value === 'UTC' || value === '+00:00'
+    ? '+00:00'
+    : value === 'Asia/Shanghai' || value === '+08:00'
+      ? '+08:00'
+      : value;
+
 export function getParameterConfigFromRuntimeValues({
   dbType,
   currentValues,
@@ -167,14 +197,22 @@ export function getParameterDifferences({
     if (newValue === undefined) return [];
 
     const oldValue = current[paths.current];
-    if (String(oldValue ?? '') === String(newValue)) return [];
+    const comparableOldValue =
+      dbType === 'apecloud-mysql' && key === 'timeZone'
+        ? normalizeMySQLTimeZone(String(oldValue ?? ''))
+        : String(oldValue ?? '');
+    const comparableNewValue =
+      dbType === 'apecloud-mysql' && key === 'timeZone'
+        ? normalizeMySQLTimeZone(String(newValue))
+        : String(newValue);
+    if (comparableOldValue === comparableNewValue) return [];
 
     return [
       {
         path: paths.requested,
         currentPath: paths.current,
         oldValue: String(oldValue ?? ''),
-        newValue: String(newValue)
+        newValue: comparableNewValue
       }
     ];
   });

--- a/frontend/providers/dbprovider/src/utils/parameterChanges.ts
+++ b/frontend/providers/dbprovider/src/utils/parameterChanges.ts
@@ -13,6 +13,14 @@ export const mergeRedisParameterValues = (
     ])
   );
 
+export const shouldUseRedisConfigurationFallback = ({
+  includeConfigurationOverrides,
+  hasConfigMapValues
+}: {
+  includeConfigurationOverrides: boolean;
+  hasConfigMapValues: boolean;
+}) => includeConfigurationOverrides || !hasConfigMapValues;
+
 export const getDefaultMaxConnections = (dbType: string, cpu: number, memory: number) => {
   const cpuCores = cpu / 1000;
   const memoryGB = memory / 1024;

--- a/frontend/providers/dbprovider/src/utils/parameterChanges.ts
+++ b/frontend/providers/dbprovider/src/utils/parameterChanges.ts
@@ -9,6 +9,10 @@ export type ParameterDifference = {
   newValue: string;
 };
 
+export const toKubeBlocksParameterPairs = (
+  differences: Pick<ParameterDifference, 'path' | 'newValue'>[]
+) => differences.map(({ path, newValue }) => ({ key: path, value: newValue }));
+
 type ParameterPath = {
   current: string;
   requested: string;
@@ -41,6 +45,43 @@ const parameterPathsByDbType: Record<
     maxmemory: { current: 'maxmemory', requested: 'maxmemory' }
   }
 };
+
+export function getParameterConfigFromRuntimeValues({
+  dbType,
+  currentValues,
+  dynamicMaxConnections
+}: {
+  dbType: string;
+  currentValues: Record<string, string>;
+  dynamicMaxConnections: number;
+}): DBEditType['parameterConfig'] {
+  const paths = parameterPathsByDbType[dbType];
+  if (!paths) return undefined;
+
+  const parameterConfig: ParameterConfig = {};
+  for (const [field, path] of Object.entries(paths)) {
+    const value = currentValues[path.current];
+    if (value !== undefined) {
+      parameterConfig[field as keyof ParameterConfig] = String(value) as never;
+    }
+  }
+
+  if (parameterConfig.maxConnections !== undefined) {
+    parameterConfig.isMaxConnectionsCustomized =
+      parameterConfig.maxConnections !== dynamicMaxConnections.toString();
+  }
+
+  if (dbType === 'apecloud-mysql') {
+    parameterConfig.timeZone =
+      parameterConfig.timeZone === '+00:00'
+        ? 'UTC'
+        : parameterConfig.timeZone === '+08:00'
+          ? 'Asia/Shanghai'
+          : parameterConfig.timeZone;
+  }
+
+  return Object.keys(parameterConfig).length > 0 ? parameterConfig : undefined;
+}
 
 export function getParameterDifferences({
   dbType,
@@ -93,33 +134,3 @@ export const areParameterValuesApplied = (
     (difference) =>
       String(currentValues[difference.currentPath || difference.path] ?? '') === difference.newValue
   );
-
-export function applyParameterDifferences({
-  configuration,
-  configItemName,
-  configMapKey,
-  differences
-}: {
-  configuration: any;
-  configItemName: string;
-  configMapKey: string;
-  differences: ParameterDifference[];
-}) {
-  const configItem = configuration?.spec?.configItemDetails?.find(
-    (item: any) => item.name === configItemName
-  );
-
-  if (!configItem) {
-    throw new Error(`Configuration item not found: ${configItemName}`);
-  }
-
-  configItem.configFileParams ||= {};
-  configItem.configFileParams[configMapKey] ||= {};
-  configItem.configFileParams[configMapKey].parameters ||= {};
-
-  for (const difference of differences) {
-    configItem.configFileParams[configMapKey].parameters[difference.path] = difference.newValue;
-  }
-
-  return configuration;
-}

--- a/frontend/providers/dbprovider/src/utils/parameterChanges.ts
+++ b/frontend/providers/dbprovider/src/utils/parameterChanges.ts
@@ -1,0 +1,125 @@
+import type { DBEditType } from '@/types/db';
+
+type ParameterConfig = NonNullable<DBEditType['parameterConfig']>;
+
+export type ParameterDifference = {
+  path: string;
+  currentPath?: string;
+  oldValue: string;
+  newValue: string;
+};
+
+type ParameterPath = {
+  current: string;
+  requested: string;
+};
+
+const parameterPathsByDbType: Record<
+  string,
+  Partial<Record<keyof ParameterConfig, ParameterPath>>
+> = {
+  postgresql: {
+    maxConnections: { current: 'max_connections', requested: 'max_connections' },
+    timeZone: { current: 'timezone', requested: 'timezone' }
+  },
+  'apecloud-mysql': {
+    maxConnections: { current: 'mysqld.max_connections', requested: 'max_connections' },
+    timeZone: { current: 'mysqld.default-time-zone', requested: 'default-time-zone' },
+    lowerCaseTableNames: {
+      current: 'mysqld.lower_case_table_names',
+      requested: 'lower_case_table_names'
+    }
+  },
+  mongodb: {
+    maxConnections: {
+      current: 'net.maxIncomingConnections',
+      requested: 'net.maxIncomingConnections'
+    }
+  },
+  redis: {
+    maxConnections: { current: 'maxclients', requested: 'maxclients' },
+    maxmemory: { current: 'maxmemory', requested: 'maxmemory' }
+  }
+};
+
+export function getParameterDifferences({
+  dbType,
+  current,
+  requested,
+  dynamicMaxConnections
+}: {
+  dbType: string;
+  current: Record<string, string>;
+  requested: DBEditType['parameterConfig'];
+  dynamicMaxConnections: number;
+}): ParameterDifference[] {
+  const paths = parameterPathsByDbType[dbType];
+  if (!paths) return [];
+
+  const desired: ParameterConfig = {
+    ...requested,
+    maxConnections: requested?.isMaxConnectionsCustomized
+      ? requested.maxConnections
+      : dynamicMaxConnections.toString(),
+    ...(dbType === 'apecloud-mysql' && {
+      lowerCaseTableNames: requested?.lowerCaseTableNames || '0'
+    })
+  };
+
+  return Object.entries(paths).flatMap(([field, paths]) => {
+    const key = field as keyof ParameterConfig;
+    const newValue = desired[key];
+    if (newValue === undefined) return [];
+
+    const oldValue = current[paths.current];
+    if (String(oldValue ?? '') === String(newValue)) return [];
+
+    return [
+      {
+        path: paths.requested,
+        currentPath: paths.current,
+        oldValue: String(oldValue ?? ''),
+        newValue: String(newValue)
+      }
+    ];
+  });
+}
+
+export const areParameterValuesApplied = (
+  currentValues: Record<string, string>,
+  differences: ParameterDifference[]
+) =>
+  differences.every(
+    (difference) =>
+      String(currentValues[difference.currentPath || difference.path] ?? '') === difference.newValue
+  );
+
+export function applyParameterDifferences({
+  configuration,
+  configItemName,
+  configMapKey,
+  differences
+}: {
+  configuration: any;
+  configItemName: string;
+  configMapKey: string;
+  differences: ParameterDifference[];
+}) {
+  const configItem = configuration?.spec?.configItemDetails?.find(
+    (item: any) => item.name === configItemName
+  );
+
+  if (!configItem) {
+    throw new Error(`Configuration item not found: ${configItemName}`);
+  }
+
+  configItem.configFileParams ||= {};
+  configItem.configFileParams[configMapKey] ||= {};
+  configItem.configFileParams[configMapKey].parameters ||= {};
+
+  for (const difference of differences) {
+    configItem.configFileParams[configMapKey].parameters[difference.path] = difference.newValue;
+  }
+
+  return configuration;
+}

--- a/frontend/providers/dbprovider/src/utils/parameterConfig.ts
+++ b/frontend/providers/dbprovider/src/utils/parameterConfig.ts
@@ -6,8 +6,15 @@ import {
   areParameterValuesApplied,
   getParameterDifferences,
   getPostgreSQLConfigSpecPatch,
-  mergeRedisParameterValues
+  mergeRedisParameterValues,
+  shouldUseRedisConfigurationFallback
 } from './parameterChanges';
+
+const isNotFoundError = (error: any) =>
+  error?.response?.statusCode === 404 ||
+  error?.statusCode === 404 ||
+  error?.body?.code === 404 ||
+  error?.body?.reason === 'NotFound';
 
 export {
   areParameterValuesApplied,
@@ -50,12 +57,20 @@ export async function getCurrentParameterValues({
       );
     }
   } catch (error) {
-    if (dbType !== 'redis' || !k8sCustomObjects) throw error;
+    if (dbType !== 'redis' || !k8sCustomObjects || !isNotFoundError(error)) throw error;
   }
 
-  // Configuration is the fallback source for edit/display reads. History
-  // polling explicitly disables this so desired state cannot look applied.
-  if (dbType === 'redis' && k8sCustomObjects && includeConfigurationOverrides) {
+  // Use the Configuration CR as a fallback when Redis has no generated
+  // ConfigMap. When runtime values exist, history polling can disable this
+  // override to avoid treating desired values as applied.
+  if (
+    dbType === 'redis' &&
+    k8sCustomObjects &&
+    shouldUseRedisConfigurationFallback({
+      includeConfigurationOverrides,
+      hasConfigMapValues: Object.keys(configMapValues).length > 0
+    })
+  ) {
     try {
       const { body: configuration } = (await k8sCustomObjects.getNamespacedCustomObject(
         'apps.kubeblocks.io',

--- a/frontend/providers/dbprovider/src/utils/parameterConfig.ts
+++ b/frontend/providers/dbprovider/src/utils/parameterConfig.ts
@@ -1,125 +1,21 @@
 import { DBReconfigureMap } from '@/constants/db';
 import type { DBEditType } from '@/types/db';
 import { flattenObject, parseConfig, parseRedisConfig } from '@/utils/tools';
-import type { CoreV1Api, CustomObjectsApi } from '@kubernetes/client-node';
-import {
-  applyParameterDifferences,
-  areParameterValuesApplied,
-  getParameterDifferences,
-  type ParameterDifference
-} from './parameterChanges';
+import type { CoreV1Api } from '@kubernetes/client-node';
+import { areParameterValuesApplied, getParameterDifferences } from './parameterChanges';
 
-type ParameterConfig = NonNullable<DBEditType['parameterConfig']>;
-
-export {
-  applyParameterDifferences,
-  areParameterValuesApplied,
-  getParameterDifferences
-} from './parameterChanges';
-
-export const getDBConfigurationName = (dbName: string, dbType: string) => {
-  const suffixByDbType: Record<string, string> = {
-    postgresql: 'postgresql',
-    'apecloud-mysql': 'mysql',
-    mongodb: 'mongodb',
-    redis: 'redis'
-  };
-  const suffix = suffixByDbType[dbType];
-
-  if (!suffix) {
-    throw new Error(`Unsupported database type: ${dbType}`);
-  }
-
-  return `${dbName}-${suffix}`;
-};
-
-export function extractParameterConfigFromConfiguration(
-  configuration: any,
-  dbType: string
-): DBEditType['parameterConfig'] {
-  if (!configuration?.spec?.configItemDetails) {
-    return undefined;
-  }
-
-  const parameterConfig: ParameterConfig = {};
-  let hasParams = false;
-
-  for (const configItem of configuration.spec.configItemDetails) {
-    if (!configItem.configFileParams) continue;
-
-    switch (dbType) {
-      case 'postgresql': {
-        const params = configItem.configFileParams['postgresql.conf']?.parameters || {};
-        if (params.max_connections !== undefined) {
-          parameterConfig.maxConnections = String(params.max_connections);
-          parameterConfig.isMaxConnectionsCustomized = true;
-          hasParams = true;
-        }
-        if (params.timezone !== undefined) {
-          parameterConfig.timeZone = String(params.timezone);
-          hasParams = true;
-        }
-        break;
-      }
-      case 'apecloud-mysql': {
-        const params = configItem.configFileParams['my.cnf']?.parameters || {};
-        if (params.max_connections !== undefined) {
-          parameterConfig.maxConnections = String(params.max_connections);
-          parameterConfig.isMaxConnectionsCustomized = true;
-          hasParams = true;
-        }
-        if (params['default-time-zone'] !== undefined) {
-          const timezone = String(params['default-time-zone']);
-          parameterConfig.timeZone =
-            timezone === '+00:00' ? 'UTC' : timezone === '+08:00' ? 'Asia/Shanghai' : timezone;
-          hasParams = true;
-        }
-        if (params.lower_case_table_names !== undefined) {
-          parameterConfig.lowerCaseTableNames = String(params.lower_case_table_names);
-          hasParams = true;
-        }
-        break;
-      }
-      case 'mongodb': {
-        const params = configItem.configFileParams['mongodb.conf']?.parameters || {};
-        if (params['net.maxIncomingConnections'] !== undefined) {
-          parameterConfig.maxConnections = String(params['net.maxIncomingConnections']);
-          parameterConfig.isMaxConnectionsCustomized = true;
-          hasParams = true;
-        }
-        break;
-      }
-      case 'redis': {
-        const params = configItem.configFileParams['redis.conf']?.parameters || {};
-        if (params.maxclients !== undefined) {
-          parameterConfig.maxConnections = String(params.maxclients);
-          parameterConfig.isMaxConnectionsCustomized = true;
-          hasParams = true;
-        }
-        if (params.maxmemory !== undefined) {
-          parameterConfig.maxmemory = String(params.maxmemory);
-          hasParams = true;
-        }
-        break;
-      }
-    }
-  }
-
-  return hasParams ? parameterConfig : undefined;
-}
+export { areParameterValuesApplied, getParameterDifferences } from './parameterChanges';
 
 export async function getCurrentParameterValues({
   dbName,
   dbType,
   namespace,
-  k8sCore,
-  k8sCustomObjects
+  k8sCore
 }: {
   dbName: string;
   dbType: DBEditType['dbType'];
   namespace: string;
   k8sCore: CoreV1Api;
-  k8sCustomObjects: CustomObjectsApi;
 }) {
   const dbConfig = DBReconfigureMap[dbType];
   if (!dbConfig?.configMapName || !dbConfig.configMapKey) {
@@ -138,70 +34,5 @@ export async function getCurrentParameterValues({
     dbType === 'redis'
       ? parseRedisConfig(configData)
       : parseConfig({ configString: configData, type: dbConfig.type });
-  const currentValues = Object.fromEntries(
-    flattenObject(parsedConfig).map(({ key, value }) => [key, value])
-  );
-
-  if (dbType === 'redis') {
-    try {
-      const { body: configuration } = (await k8sCustomObjects.getNamespacedCustomObject(
-        'apps.kubeblocks.io',
-        'v1alpha1',
-        namespace,
-        'configurations',
-        getDBConfigurationName(dbName, dbType)
-      )) as { body: any };
-      const redisConfig = configuration?.spec?.configItemDetails?.find(
-        (item: any) => item.name === dbConfig.reconfigureName
-      );
-      Object.assign(currentValues, redisConfig?.configFileParams?.['redis.conf']?.parameters || {});
-    } catch (error) {
-      console.warn('Failed to read Redis configuration overrides:', error);
-    }
-  }
-
-  return currentValues;
-}
-
-export async function updateParameterConfiguration({
-  dbName,
-  dbType,
-  namespace,
-  k8sCustomObjects,
-  differences
-}: {
-  dbName: string;
-  dbType: DBEditType['dbType'];
-  namespace: string;
-  k8sCustomObjects: CustomObjectsApi;
-  differences: ParameterDifference[];
-}) {
-  const dbConfig = DBReconfigureMap[dbType];
-  if (!dbConfig) {
-    throw new Error(`Parameter configuration is not supported for database type: ${dbType}`);
-  }
-
-  const configurationName = getDBConfigurationName(dbName, dbType);
-  const { body: configuration } = (await k8sCustomObjects.getNamespacedCustomObject(
-    'apps.kubeblocks.io',
-    'v1alpha1',
-    namespace,
-    'configurations',
-    configurationName
-  )) as { body: any };
-  applyParameterDifferences({
-    configuration,
-    configItemName: dbConfig.reconfigureName,
-    configMapKey: dbConfig.configMapKey,
-    differences
-  });
-
-  await k8sCustomObjects.replaceNamespacedCustomObject(
-    'apps.kubeblocks.io',
-    'v1alpha1',
-    namespace,
-    'configurations',
-    configurationName,
-    configuration
-  );
+  return Object.fromEntries(flattenObject(parsedConfig).map(({ key, value }) => [key, value]));
 }

--- a/frontend/providers/dbprovider/src/utils/parameterConfig.ts
+++ b/frontend/providers/dbprovider/src/utils/parameterConfig.ts
@@ -1,8 +1,12 @@
 import { DBReconfigureMap } from '@/constants/db';
 import type { DBEditType } from '@/types/db';
 import { flattenObject, parseConfig, parseRedisConfig } from '@/utils/tools';
-import type { CoreV1Api } from '@kubernetes/client-node';
-import { areParameterValuesApplied, getParameterDifferences } from './parameterChanges';
+import { CoreV1Api, CustomObjectsApi, PatchUtils } from '@kubernetes/client-node';
+import {
+  areParameterValuesApplied,
+  getParameterDifferences,
+  getPostgreSQLConfigSpecPatch
+} from './parameterChanges';
 
 export { areParameterValuesApplied, getParameterDifferences } from './parameterChanges';
 
@@ -35,4 +39,49 @@ export async function getCurrentParameterValues({
       ? parseRedisConfig(configData)
       : parseConfig({ configString: configData, type: dbConfig.type });
   return Object.fromEntries(flattenObject(parsedConfig).map(({ key, value }) => [key, value]));
+}
+
+export async function ensurePostgreSQLConfigSpec({
+  dbName,
+  dbVersion,
+  namespace,
+  k8sCustomObjects
+}: {
+  dbName: string;
+  dbVersion: string;
+  namespace: string;
+  k8sCustomObjects: CustomObjectsApi;
+}) {
+  const configurationName = `${dbName}-postgresql`;
+  const { body } = (await k8sCustomObjects.getNamespacedCustomObject(
+    'apps.kubeblocks.io',
+    'v1alpha1',
+    namespace,
+    'configurations',
+    configurationName
+  )) as {
+    body: {
+      spec?: {
+        configItemDetails?: Parameters<typeof getPostgreSQLConfigSpecPatch>[0]['configItemDetails'];
+      };
+    };
+  };
+  const patch = getPostgreSQLConfigSpecPatch({
+    dbVersion,
+    configItemDetails: body.spec?.configItemDetails || []
+  });
+  if (patch.length === 0) return;
+
+  await k8sCustomObjects.patchNamespacedCustomObject(
+    'apps.kubeblocks.io',
+    'v1alpha1',
+    namespace,
+    'configurations',
+    configurationName,
+    patch,
+    undefined,
+    undefined,
+    undefined,
+    { headers: { 'Content-type': PatchUtils.PATCH_FORMAT_JSON_PATCH } }
+  );
 }

--- a/frontend/providers/dbprovider/src/utils/parameterConfig.ts
+++ b/frontend/providers/dbprovider/src/utils/parameterConfig.ts
@@ -5,40 +5,80 @@ import { CoreV1Api, CustomObjectsApi, PatchUtils } from '@kubernetes/client-node
 import {
   areParameterValuesApplied,
   getParameterDifferences,
-  getPostgreSQLConfigSpecPatch
+  getPostgreSQLConfigSpecPatch,
+  mergeRedisParameterValues
 } from './parameterChanges';
 
-export { areParameterValuesApplied, getParameterDifferences } from './parameterChanges';
+export {
+  areParameterValuesApplied,
+  getDefaultMaxConnections,
+  getParameterDifferences
+} from './parameterChanges';
 
 export async function getCurrentParameterValues({
   dbName,
   dbType,
   namespace,
-  k8sCore
+  k8sCore,
+  k8sCustomObjects,
+  includeConfigurationOverrides = true
 }: {
   dbName: string;
   dbType: DBEditType['dbType'];
   namespace: string;
   k8sCore: CoreV1Api;
+  k8sCustomObjects?: CustomObjectsApi;
+  includeConfigurationOverrides?: boolean;
 }) {
   const dbConfig = DBReconfigureMap[dbType];
   if (!dbConfig?.configMapName || !dbConfig.configMapKey) {
     throw new Error(`Parameter configuration is not supported for database type: ${dbType}`);
   }
 
-  const configMapName = dbName + dbConfig.configMapName;
-  const { body: configMap } = await k8sCore.readNamespacedConfigMap(configMapName, namespace);
-  const configData = configMap.data?.[dbConfig.configMapKey];
-
-  if (!configData) {
-    throw new Error(`Parameter configuration is empty for database: ${dbName}`);
+  let configMapValues: Record<string, string> = {};
+  try {
+    const configMapName = dbName + dbConfig.configMapName;
+    const { body: configMap } = await k8sCore.readNamespacedConfigMap(configMapName, namespace);
+    const configData = configMap.data?.[dbConfig.configMapKey];
+    if (configData) {
+      const parsedConfig =
+        dbType === 'redis'
+          ? parseRedisConfig(configData)
+          : parseConfig({ configString: configData, type: dbConfig.type });
+      configMapValues = Object.fromEntries(
+        flattenObject(parsedConfig).map(({ key, value }) => [key, value])
+      );
+    }
+  } catch (error) {
+    if (dbType !== 'redis' || !k8sCustomObjects) throw error;
   }
 
-  const parsedConfig =
-    dbType === 'redis'
-      ? parseRedisConfig(configData)
-      : parseConfig({ configString: configData, type: dbConfig.type });
-  return Object.fromEntries(flattenObject(parsedConfig).map(({ key, value }) => [key, value]));
+  // Configuration is the fallback source for edit/display reads. History
+  // polling explicitly disables this so desired state cannot look applied.
+  if (dbType === 'redis' && k8sCustomObjects && includeConfigurationOverrides) {
+    try {
+      const { body: configuration } = (await k8sCustomObjects.getNamespacedCustomObject(
+        'apps.kubeblocks.io',
+        'v1alpha1',
+        namespace,
+        'configurations',
+        `${dbName}-redis`
+      )) as { body: any };
+      const configItem = configuration?.spec?.configItemDetails?.find(
+        (item: any) => item.name === dbConfig.reconfigureName
+      );
+      const configurationValues =
+        configItem?.configFileParams?.[dbConfig.configMapKey]?.parameters || {};
+      configMapValues = mergeRedisParameterValues(configMapValues, configurationValues);
+    } catch (error) {
+      if (Object.keys(configMapValues).length === 0) throw error;
+    }
+  }
+
+  if (Object.keys(configMapValues).length === 0) {
+    throw new Error(`Parameter configuration is empty for database: ${dbName}`);
+  }
+  return configMapValues;
 }
 
 export async function ensurePostgreSQLConfigSpec({

--- a/frontend/providers/dbprovider/src/utils/parameterConfig.ts
+++ b/frontend/providers/dbprovider/src/utils/parameterConfig.ts
@@ -108,28 +108,6 @@ export function extractParameterConfigFromConfiguration(
   return hasParams ? parameterConfig : undefined;
 }
 
-export async function waitForParameterValues({
-  differences,
-  timeoutMs = 50_000,
-  intervalMs = 2_000,
-  ...options
-}: Parameters<typeof getCurrentParameterValues>[0] & {
-  differences: ParameterDifference[];
-  timeoutMs?: number;
-  intervalMs?: number;
-}) {
-  const deadline = Date.now() + timeoutMs;
-
-  while (Date.now() < deadline) {
-    const currentValues = await getCurrentParameterValues(options);
-    if (areParameterValuesApplied(currentValues, differences)) return;
-
-    await new Promise((resolve) => setTimeout(resolve, intervalMs));
-  }
-
-  throw new Error('Timed out waiting for database parameters to take effect');
-}
-
 export async function getCurrentParameterValues({
   dbName,
   dbType,

--- a/frontend/providers/dbprovider/src/utils/parameterConfig.ts
+++ b/frontend/providers/dbprovider/src/utils/parameterConfig.ts
@@ -2,40 +2,20 @@ import { DBReconfigureMap } from '@/constants/db';
 import type { DBEditType } from '@/types/db';
 import { flattenObject, parseConfig, parseRedisConfig } from '@/utils/tools';
 import type { CoreV1Api, CustomObjectsApi } from '@kubernetes/client-node';
+import {
+  applyParameterDifferences,
+  areParameterValuesApplied,
+  getParameterDifferences,
+  type ParameterDifference
+} from './parameterChanges';
 
 type ParameterConfig = NonNullable<DBEditType['parameterConfig']>;
-type ParameterPath = {
-  current: string;
-  requested: string;
-};
 
-const parameterPathsByDbType: Record<
-  string,
-  Partial<Record<keyof ParameterConfig, ParameterPath>>
-> = {
-  postgresql: {
-    maxConnections: { current: 'max_connections', requested: 'max_connections' },
-    timeZone: { current: 'timezone', requested: 'timezone' }
-  },
-  'apecloud-mysql': {
-    maxConnections: { current: 'mysqld.max_connections', requested: 'max_connections' },
-    timeZone: { current: 'mysqld.default-time-zone', requested: 'default-time-zone' },
-    lowerCaseTableNames: {
-      current: 'mysqld.lower_case_table_names',
-      requested: 'lower_case_table_names'
-    }
-  },
-  mongodb: {
-    maxConnections: {
-      current: 'net.maxIncomingConnections',
-      requested: 'net.maxIncomingConnections'
-    }
-  },
-  redis: {
-    maxConnections: { current: 'maxclients', requested: 'maxclients' },
-    maxmemory: { current: 'maxmemory', requested: 'maxmemory' }
-  }
-};
+export {
+  applyParameterDifferences,
+  areParameterValuesApplied,
+  getParameterDifferences
+} from './parameterChanges';
 
 export const getDBConfigurationName = (dbName: string, dbType: string) => {
   const suffixByDbType: Record<string, string> = {
@@ -128,46 +108,26 @@ export function extractParameterConfigFromConfiguration(
   return hasParams ? parameterConfig : undefined;
 }
 
-export function getParameterDifferences({
-  dbType,
-  current,
-  requested,
-  dynamicMaxConnections
-}: {
-  dbType: string;
-  current: Record<string, string>;
-  requested: DBEditType['parameterConfig'];
-  dynamicMaxConnections: number;
+export async function waitForParameterValues({
+  differences,
+  timeoutMs = 50_000,
+  intervalMs = 2_000,
+  ...options
+}: Parameters<typeof getCurrentParameterValues>[0] & {
+  differences: ParameterDifference[];
+  timeoutMs?: number;
+  intervalMs?: number;
 }) {
-  const paths = parameterPathsByDbType[dbType];
-  if (!paths) return [];
+  const deadline = Date.now() + timeoutMs;
 
-  const desired: ParameterConfig = {
-    ...requested,
-    maxConnections: requested?.isMaxConnectionsCustomized
-      ? requested.maxConnections
-      : dynamicMaxConnections.toString(),
-    ...(dbType === 'apecloud-mysql' && {
-      lowerCaseTableNames: requested?.lowerCaseTableNames || '0'
-    })
-  };
+  while (Date.now() < deadline) {
+    const currentValues = await getCurrentParameterValues(options);
+    if (areParameterValuesApplied(currentValues, differences)) return;
 
-  return Object.entries(paths).flatMap(([field, paths]) => {
-    const key = field as keyof ParameterConfig;
-    const newValue = desired[key];
-    if (newValue === undefined) return [];
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
 
-    const oldValue = current[paths.current];
-    if (String(oldValue ?? '') === String(newValue)) return [];
-
-    return [
-      {
-        path: paths.requested,
-        oldValue: String(oldValue ?? ''),
-        newValue: String(newValue)
-      }
-    ];
-  });
+  throw new Error('Timed out waiting for database parameters to take effect');
 }
 
 export async function getCurrentParameterValues({
@@ -223,4 +183,47 @@ export async function getCurrentParameterValues({
   }
 
   return currentValues;
+}
+
+export async function updateParameterConfiguration({
+  dbName,
+  dbType,
+  namespace,
+  k8sCustomObjects,
+  differences
+}: {
+  dbName: string;
+  dbType: DBEditType['dbType'];
+  namespace: string;
+  k8sCustomObjects: CustomObjectsApi;
+  differences: ParameterDifference[];
+}) {
+  const dbConfig = DBReconfigureMap[dbType];
+  if (!dbConfig) {
+    throw new Error(`Parameter configuration is not supported for database type: ${dbType}`);
+  }
+
+  const configurationName = getDBConfigurationName(dbName, dbType);
+  const { body: configuration } = (await k8sCustomObjects.getNamespacedCustomObject(
+    'apps.kubeblocks.io',
+    'v1alpha1',
+    namespace,
+    'configurations',
+    configurationName
+  )) as { body: any };
+  applyParameterDifferences({
+    configuration,
+    configItemName: dbConfig.reconfigureName,
+    configMapKey: dbConfig.configMapKey,
+    differences
+  });
+
+  await k8sCustomObjects.replaceNamespacedCustomObject(
+    'apps.kubeblocks.io',
+    'v1alpha1',
+    namespace,
+    'configurations',
+    configurationName,
+    configuration
+  );
 }

--- a/frontend/providers/dbprovider/src/utils/parameterConfig.ts
+++ b/frontend/providers/dbprovider/src/utils/parameterConfig.ts
@@ -1,0 +1,226 @@
+import { DBReconfigureMap } from '@/constants/db';
+import type { DBEditType } from '@/types/db';
+import { flattenObject, parseConfig, parseRedisConfig } from '@/utils/tools';
+import type { CoreV1Api, CustomObjectsApi } from '@kubernetes/client-node';
+
+type ParameterConfig = NonNullable<DBEditType['parameterConfig']>;
+type ParameterPath = {
+  current: string;
+  requested: string;
+};
+
+const parameterPathsByDbType: Record<
+  string,
+  Partial<Record<keyof ParameterConfig, ParameterPath>>
+> = {
+  postgresql: {
+    maxConnections: { current: 'max_connections', requested: 'max_connections' },
+    timeZone: { current: 'timezone', requested: 'timezone' }
+  },
+  'apecloud-mysql': {
+    maxConnections: { current: 'mysqld.max_connections', requested: 'max_connections' },
+    timeZone: { current: 'mysqld.default-time-zone', requested: 'default-time-zone' },
+    lowerCaseTableNames: {
+      current: 'mysqld.lower_case_table_names',
+      requested: 'lower_case_table_names'
+    }
+  },
+  mongodb: {
+    maxConnections: {
+      current: 'net.maxIncomingConnections',
+      requested: 'net.maxIncomingConnections'
+    }
+  },
+  redis: {
+    maxConnections: { current: 'maxclients', requested: 'maxclients' },
+    maxmemory: { current: 'maxmemory', requested: 'maxmemory' }
+  }
+};
+
+export const getDBConfigurationName = (dbName: string, dbType: string) => {
+  const suffixByDbType: Record<string, string> = {
+    postgresql: 'postgresql',
+    'apecloud-mysql': 'mysql',
+    mongodb: 'mongodb',
+    redis: 'redis'
+  };
+  const suffix = suffixByDbType[dbType];
+
+  if (!suffix) {
+    throw new Error(`Unsupported database type: ${dbType}`);
+  }
+
+  return `${dbName}-${suffix}`;
+};
+
+export function extractParameterConfigFromConfiguration(
+  configuration: any,
+  dbType: string
+): DBEditType['parameterConfig'] {
+  if (!configuration?.spec?.configItemDetails) {
+    return undefined;
+  }
+
+  const parameterConfig: ParameterConfig = {};
+  let hasParams = false;
+
+  for (const configItem of configuration.spec.configItemDetails) {
+    if (!configItem.configFileParams) continue;
+
+    switch (dbType) {
+      case 'postgresql': {
+        const params = configItem.configFileParams['postgresql.conf']?.parameters || {};
+        if (params.max_connections !== undefined) {
+          parameterConfig.maxConnections = String(params.max_connections);
+          parameterConfig.isMaxConnectionsCustomized = true;
+          hasParams = true;
+        }
+        if (params.timezone !== undefined) {
+          parameterConfig.timeZone = String(params.timezone);
+          hasParams = true;
+        }
+        break;
+      }
+      case 'apecloud-mysql': {
+        const params = configItem.configFileParams['my.cnf']?.parameters || {};
+        if (params.max_connections !== undefined) {
+          parameterConfig.maxConnections = String(params.max_connections);
+          parameterConfig.isMaxConnectionsCustomized = true;
+          hasParams = true;
+        }
+        if (params['default-time-zone'] !== undefined) {
+          const timezone = String(params['default-time-zone']);
+          parameterConfig.timeZone =
+            timezone === '+00:00' ? 'UTC' : timezone === '+08:00' ? 'Asia/Shanghai' : timezone;
+          hasParams = true;
+        }
+        if (params.lower_case_table_names !== undefined) {
+          parameterConfig.lowerCaseTableNames = String(params.lower_case_table_names);
+          hasParams = true;
+        }
+        break;
+      }
+      case 'mongodb': {
+        const params = configItem.configFileParams['mongodb.conf']?.parameters || {};
+        if (params['net.maxIncomingConnections'] !== undefined) {
+          parameterConfig.maxConnections = String(params['net.maxIncomingConnections']);
+          parameterConfig.isMaxConnectionsCustomized = true;
+          hasParams = true;
+        }
+        break;
+      }
+      case 'redis': {
+        const params = configItem.configFileParams['redis.conf']?.parameters || {};
+        if (params.maxclients !== undefined) {
+          parameterConfig.maxConnections = String(params.maxclients);
+          parameterConfig.isMaxConnectionsCustomized = true;
+          hasParams = true;
+        }
+        if (params.maxmemory !== undefined) {
+          parameterConfig.maxmemory = String(params.maxmemory);
+          hasParams = true;
+        }
+        break;
+      }
+    }
+  }
+
+  return hasParams ? parameterConfig : undefined;
+}
+
+export function getParameterDifferences({
+  dbType,
+  current,
+  requested,
+  dynamicMaxConnections
+}: {
+  dbType: string;
+  current: Record<string, string>;
+  requested: DBEditType['parameterConfig'];
+  dynamicMaxConnections: number;
+}) {
+  const paths = parameterPathsByDbType[dbType];
+  if (!paths) return [];
+
+  const desired: ParameterConfig = {
+    ...requested,
+    maxConnections: requested?.isMaxConnectionsCustomized
+      ? requested.maxConnections
+      : dynamicMaxConnections.toString(),
+    ...(dbType === 'apecloud-mysql' && {
+      lowerCaseTableNames: requested?.lowerCaseTableNames || '0'
+    })
+  };
+
+  return Object.entries(paths).flatMap(([field, paths]) => {
+    const key = field as keyof ParameterConfig;
+    const newValue = desired[key];
+    if (newValue === undefined) return [];
+
+    const oldValue = current[paths.current];
+    if (String(oldValue ?? '') === String(newValue)) return [];
+
+    return [
+      {
+        path: paths.requested,
+        oldValue: String(oldValue ?? ''),
+        newValue: String(newValue)
+      }
+    ];
+  });
+}
+
+export async function getCurrentParameterValues({
+  dbName,
+  dbType,
+  namespace,
+  k8sCore,
+  k8sCustomObjects
+}: {
+  dbName: string;
+  dbType: DBEditType['dbType'];
+  namespace: string;
+  k8sCore: CoreV1Api;
+  k8sCustomObjects: CustomObjectsApi;
+}) {
+  const dbConfig = DBReconfigureMap[dbType];
+  if (!dbConfig?.configMapName || !dbConfig.configMapKey) {
+    throw new Error(`Parameter configuration is not supported for database type: ${dbType}`);
+  }
+
+  const configMapName = dbName + dbConfig.configMapName;
+  const { body: configMap } = await k8sCore.readNamespacedConfigMap(configMapName, namespace);
+  const configData = configMap.data?.[dbConfig.configMapKey];
+
+  if (!configData) {
+    throw new Error(`Parameter configuration is empty for database: ${dbName}`);
+  }
+
+  const parsedConfig =
+    dbType === 'redis'
+      ? parseRedisConfig(configData)
+      : parseConfig({ configString: configData, type: dbConfig.type });
+  const currentValues = Object.fromEntries(
+    flattenObject(parsedConfig).map(({ key, value }) => [key, value])
+  );
+
+  if (dbType === 'redis') {
+    try {
+      const { body: configuration } = (await k8sCustomObjects.getNamespacedCustomObject(
+        'apps.kubeblocks.io',
+        'v1alpha1',
+        namespace,
+        'configurations',
+        getDBConfigurationName(dbName, dbType)
+      )) as { body: any };
+      const redisConfig = configuration?.spec?.configItemDetails?.find(
+        (item: any) => item.name === dbConfig.reconfigureName
+      );
+      Object.assign(currentValues, redisConfig?.configFileParams?.['redis.conf']?.parameters || {});
+    } catch (error) {
+      console.warn('Failed to read Redis configuration overrides:', error);
+    }
+  }
+
+  return currentValues;
+}

--- a/frontend/providers/dbprovider/src/utils/parameterHistory.ts
+++ b/frontend/providers/dbprovider/src/utils/parameterHistory.ts
@@ -7,10 +7,14 @@ import {
 } from '@/constants/db';
 import type { DBType, OpsRequestItemType } from '@/types/db';
 import type { CoreV1Api, V1ConfigMap } from '@kubernetes/client-node';
-import { nanoid } from 'nanoid';
+import { customAlphabet } from 'nanoid';
 import type { ParameterDifference } from './parameterChanges';
+import { areParameterValuesApplied } from './parameterChanges';
 
-type ParameterHistoryData = {
+export const ParameterHistoryTimeoutMs = 5 * 60 * 1000;
+const createHistorySuffix = customAlphabet('0123456789abcdefghijklmnopqrstuvwxyz', 4);
+
+export type ParameterHistoryData = {
   dbType: DBType;
   status: ReconfigStatus;
   createdAt: string;
@@ -20,9 +24,39 @@ type ParameterHistoryData = {
 };
 
 export const getParameterHistoryName = (dbName: string) =>
-  `${dbName}-param-${Date.now().toString(36)}-${nanoid(4).toLowerCase()}`;
+  `${dbName}-param-${Date.now().toString(36)}-${createHistorySuffix()}`;
 
 const serializeHistory = (history: ParameterHistoryData) => JSON.stringify(history);
+
+export function resolveParameterHistoryStatus({
+  history,
+  currentValues = {},
+  now = Date.now(),
+  timeoutMs = ParameterHistoryTimeoutMs
+}: {
+  history: ParameterHistoryData;
+  currentValues?: Record<string, string>;
+  now?: number;
+  timeoutMs?: number;
+}): ReconfigStatus {
+  if (history.status !== ReconfigStatus.Running) return history.status;
+  if (areParameterValuesApplied(currentValues, history.differences)) return ReconfigStatus.Succeed;
+  return now - new Date(history.createdAt).getTime() >= timeoutMs
+    ? ReconfigStatus.Failed
+    : ReconfigStatus.Running;
+}
+
+export function readParameterHistory(configMap: V1ConfigMap): ParameterHistoryData | undefined {
+  const rawHistory = configMap.data?.[DBParameterHistoryDataKey];
+  if (!rawHistory) return undefined;
+
+  try {
+    return JSON.parse(rawHistory) as ParameterHistoryData;
+  } catch (error) {
+    console.error('Failed to parse parameter history:', error);
+    return undefined;
+  }
+}
 
 export async function createParameterHistory({
   k8sCore,
@@ -103,11 +137,10 @@ export async function completeParameterHistory({
 }
 
 export function adaptParameterHistory(configMap: V1ConfigMap): OpsRequestItemType | undefined {
-  const rawHistory = configMap.data?.[DBParameterHistoryDataKey];
-  if (!rawHistory || !configMap.metadata?.name) return undefined;
+  const history = readParameterHistory(configMap);
+  if (!history || !configMap.metadata?.name) return undefined;
 
   try {
-    const history = JSON.parse(rawHistory) as ParameterHistoryData;
     return {
       id: configMap.metadata.uid || configMap.metadata.name,
       name: configMap.metadata.name,

--- a/frontend/providers/dbprovider/src/utils/parameterHistory.ts
+++ b/frontend/providers/dbprovider/src/utils/parameterHistory.ts
@@ -20,6 +20,7 @@ export type ParameterHistoryData = {
   createdAt: string;
   completedAt?: string;
   error?: string;
+  opsRequestName?: string;
   differences: ParameterDifference[];
 };
 
@@ -64,7 +65,8 @@ export async function createParameterHistory({
   dbName,
   dbType,
   dbUid,
-  differences
+  differences,
+  opsRequestName
 }: {
   k8sCore: CoreV1Api;
   namespace: string;
@@ -72,11 +74,13 @@ export async function createParameterHistory({
   dbType: DBType;
   dbUid: string;
   differences: ParameterDifference[];
+  opsRequestName?: string;
 }) {
   const history: ParameterHistoryData = {
     dbType,
     status: ReconfigStatus.Running,
     createdAt: new Date().toISOString(),
+    ...(opsRequestName ? { opsRequestName } : {}),
     differences
   };
   const configMap: V1ConfigMap = {

--- a/frontend/providers/dbprovider/src/utils/parameterHistory.ts
+++ b/frontend/providers/dbprovider/src/utils/parameterHistory.ts
@@ -1,0 +1,127 @@
+import {
+  DBNameLabel,
+  DBParameterHistoryDataKey,
+  DBParameterHistoryLabel,
+  DBReconfigStatusMap,
+  ReconfigStatus
+} from '@/constants/db';
+import type { DBType, OpsRequestItemType } from '@/types/db';
+import type { CoreV1Api, V1ConfigMap } from '@kubernetes/client-node';
+import { nanoid } from 'nanoid';
+import type { ParameterDifference } from './parameterChanges';
+
+type ParameterHistoryData = {
+  dbType: DBType;
+  status: ReconfigStatus;
+  createdAt: string;
+  completedAt?: string;
+  error?: string;
+  differences: ParameterDifference[];
+};
+
+export const getParameterHistoryName = (dbName: string) =>
+  `${dbName}-param-${Date.now().toString(36)}-${nanoid(4).toLowerCase()}`;
+
+const serializeHistory = (history: ParameterHistoryData) => JSON.stringify(history);
+
+export async function createParameterHistory({
+  k8sCore,
+  namespace,
+  dbName,
+  dbType,
+  dbUid,
+  differences
+}: {
+  k8sCore: CoreV1Api;
+  namespace: string;
+  dbName: string;
+  dbType: DBType;
+  dbUid: string;
+  differences: ParameterDifference[];
+}) {
+  const history: ParameterHistoryData = {
+    dbType,
+    status: ReconfigStatus.Running,
+    createdAt: new Date().toISOString(),
+    differences
+  };
+  const configMap: V1ConfigMap = {
+    metadata: {
+      name: getParameterHistoryName(dbName),
+      namespace,
+      labels: {
+        [DBNameLabel]: dbName,
+        [DBParameterHistoryLabel]: 'true'
+      },
+      ownerReferences: [
+        {
+          apiVersion: 'apps.kubeblocks.io/v1alpha1',
+          kind: 'Cluster',
+          name: dbName,
+          uid: dbUid
+        }
+      ]
+    },
+    data: { [DBParameterHistoryDataKey]: serializeHistory(history) }
+  };
+
+  const { body } = await k8sCore.createNamespacedConfigMap(namespace, configMap);
+  return body;
+}
+
+export async function completeParameterHistory({
+  k8sCore,
+  configMap,
+  status,
+  error
+}: {
+  k8sCore: CoreV1Api;
+  configMap: V1ConfigMap;
+  status: ReconfigStatus.Succeed | ReconfigStatus.Failed;
+  error?: string;
+}) {
+  const rawHistory = configMap.data?.[DBParameterHistoryDataKey];
+  if (!configMap.metadata?.name || !configMap.metadata.namespace || !rawHistory) return;
+
+  const history = JSON.parse(rawHistory) as ParameterHistoryData;
+  const updatedHistory: ParameterHistoryData = {
+    ...history,
+    status,
+    completedAt: new Date().toISOString(),
+    ...(error ? { error } : {})
+  };
+  const updatedConfigMap: V1ConfigMap = {
+    ...configMap,
+    data: { ...configMap.data, [DBParameterHistoryDataKey]: serializeHistory(updatedHistory) }
+  };
+
+  await k8sCore.replaceNamespacedConfigMap(
+    configMap.metadata.name,
+    configMap.metadata.namespace,
+    updatedConfigMap
+  );
+}
+
+export function adaptParameterHistory(configMap: V1ConfigMap): OpsRequestItemType | undefined {
+  const rawHistory = configMap.data?.[DBParameterHistoryDataKey];
+  if (!rawHistory || !configMap.metadata?.name) return undefined;
+
+  try {
+    const history = JSON.parse(rawHistory) as ParameterHistoryData;
+    return {
+      id: configMap.metadata.uid || configMap.metadata.name,
+      name: configMap.metadata.name,
+      namespace: configMap.metadata.namespace || '',
+      status: DBReconfigStatusMap[history.status] || DBReconfigStatusMap.Creating,
+      startTime: new Date(history.createdAt),
+      configurations: history.differences.map((difference) => ({
+        parameterName: difference.path,
+        oldValue: difference.oldValue,
+        newValue: difference.newValue
+      }))
+    };
+  } catch (error) {
+    console.error('Failed to parse parameter history:', error);
+    return undefined;
+  }
+}

--- a/frontend/providers/dbprovider/src/utils/tools.ts
+++ b/frontend/providers/dbprovider/src/utils/tools.ts
@@ -495,10 +495,10 @@ export const flattenObject = (ob: any, prefix: string = ''): { key: string; valu
 };
 
 export const adjustDifferencesForIni = (
-  differences: { path: string; oldValue: any; newValue: any }[],
+  differences: { path: string; oldValue: any; newValue: any; currentPath?: string }[],
   type: 'ini' | 'yaml',
   dbType: DBType
-): { path: string; newValue: string; oldValue: string }[] => {
+): { path: string; newValue: string; oldValue: string; currentPath?: string }[] => {
   if (type !== 'ini' || dbType !== 'apecloud-mysql') {
     return differences;
   }
@@ -508,7 +508,8 @@ export const adjustDifferencesForIni = (
     return {
       path: adjustedPath,
       newValue: diff.newValue,
-      oldValue: diff.oldValue
+      oldValue: diff.oldValue,
+      currentPath: diff.currentPath || diff.path
     };
   });
 };


### PR DESCRIPTION
## Summary

Fix DBProvider parameter editing and history tracking across PostgreSQL, MySQL, MongoDB, and Redis. Parameter changes now use KubeBlocks `Reconfiguring` OpsRequests, persist runtime-aware history, preserve independent resource updates, and handle Redis ConfigMap fallback and duplicate history safely.

## Sequence Diagram

```mermaid
sequenceDiagram
    participant User
    participant DBProvider as DBProvider API
    participant K8s as Kubernetes/KubeBlocks
    participant History as Parameter History ConfigMap

    User->>DBProvider: Submit database resource and parameter changes
    DBProvider->>K8s: Read runtime configuration
    alt Redis ConfigMap is missing or empty
        DBProvider->>K8s: Read Redis Configuration CR fallback
    end
    DBProvider->>K8s: Create resource and Reconfiguring OpsRequests
    DBProvider->>History: Persist OpsRequest-linked old/new values
    DBProvider-->>User: Return success or expose parameter preparation failure
    User->>DBProvider: Refresh operation history
    DBProvider->>K8s: Read runtime values only for status polling
    K8s-->>DBProvider: Return applied values
    DBProvider->>History: Mark the change succeeded or timed out
    DBProvider-->>User: Show deduplicated parameter history
```

## Changes

- Separate runtime parameter paths from KubeBlocks submission paths and normalize equivalent MySQL time zones.
- Align Redis defaults, expose MongoDB `net.maxIncomingConnections`, and repair PostgreSQL configuration metadata before reconfiguration.
- Record parameter history in owned ConfigMaps, link it to OpsRequests, and resolve status from runtime values.
- Keep scaling and storage OpsRequests independent while surfacing parameter preparation errors.
- Prevent Redis desired-state values from being treated as applied and preserve repeated identical edits in history.

## Verification

- `pnpm --filter dbprovider run typecheck`
- `pnpm --filter dbprovider run lint`
- `cd frontend/providers/dbprovider && npx --yes tsx --test __tests__/unit/utils/parameterConfig.test.ts` (15/15 passed)
- `pnpm --filter dbprovider run build`
- `git diff origin/release-v5.1...HEAD --check`

## Checklist

- [x] Tests and production build pass
- [x] No unrelated files changed
- [ ] End-to-end UI parameter submission has not been run in a live cluster
