### PR TITLE
fix(desktop): preserve marketing attribution through Cloud auth

### DIFF
--- a/frontend/desktop/data/config.yaml
+++ b/frontend/desktop/data/config.yaml
@@ -95,6 +95,7 @@ desktop:
       internal: "thisisinternaljwt"
       regional: "thisisregionaljwt"
       global: "thisisglobaljwt"
+      marketingConsent: ""
     billingUrl: "http://account-service.account-system.svc:2333"
     workorderUrl: ""
     cloudVitrualMachineUrl: ""

--- a/frontend/desktop/deploy/HELM_VALUES_GUIDE.md
+++ b/frontend/desktop/deploy/HELM_VALUES_GUIDE.md
@@ -58,6 +58,7 @@ desktopConfig:
   jwtInternal: 'your-jwt-internal-key' # 内部 JWT 密钥
   jwtRegional: 'your-jwt-regional-key' # 区域 JWT 密钥
   jwtGlobal: 'your-jwt-global-key' # 全局 JWT 密钥
+  jwtMarketingConsent: 'your-marketing-consent-key' # Marketing consent JWT secret shared with Brain
 ```
 
 ### 4. 计费配置

--- a/frontend/desktop/deploy/HELM_VALUES_GUIDE_CN.md
+++ b/frontend/desktop/deploy/HELM_VALUES_GUIDE_CN.md
@@ -58,6 +58,7 @@ desktopConfig:
   jwtInternal: 'your-jwt-internal-key' # 内部 JWT 密钥
   jwtRegional: 'your-jwt-regional-key' # 区域 JWT 密钥
   jwtGlobal: 'your-jwt-global-key' # 全局 JWT 密钥
+  jwtMarketingConsent: 'your-marketing-consent-key' # 与 Brain 共享的营销 consent JWT 密钥
 ```
 
 ### 4. 计费配置

--- a/frontend/desktop/deploy/README.md
+++ b/frontend/desktop/deploy/README.md
@@ -150,6 +150,7 @@ The following values are **automatically retrieved** from the `sealos-system/sea
 | `jwtInternal`                  | `desktopConfig.jwtInternal`                  | Internal JWT secret    |
 | `jwtRegional`                  | `desktopConfig.jwtRegional`                  | Regional JWT secret    |
 | `jwtGlobal`                    | `desktopConfig.jwtGlobal`                    | Global JWT secret      |
+| `jwtMarketingConsent`          | `desktopConfig.jwtMarketingConsent`          | Marketing consent JWT secret |
 | `regionUID`                    | `desktopConfig.regionUID`                    | Region UID             |
 | `databaseMongodbURI`           | `desktopConfig.databaseMongodbURI`           | MongoDB connection URI |
 | `databaseGlobalCockroachdbURI` | `desktopConfig.databaseGlobalCockroachdbURI` | Global CockroachDB URI |

--- a/frontend/desktop/deploy/README_CN.md
+++ b/frontend/desktop/deploy/README_CN.md
@@ -150,6 +150,7 @@ Helm Chart 使用两个 values 文件来管理配置：
 | `jwtInternal`                  | `desktopConfig.jwtInternal`                  | 内部 JWT 密钥        |
 | `jwtRegional`                  | `desktopConfig.jwtRegional`                  | 区域 JWT 密钥        |
 | `jwtGlobal`                    | `desktopConfig.jwtGlobal`                    | 全局 JWT 密钥        |
+| `jwtMarketingConsent`          | `desktopConfig.jwtMarketingConsent`          | 营销 consent JWT 密钥 |
 | `regionUID`                    | `desktopConfig.regionUID`                    | 区域 UID             |
 | `databaseMongodbURI`           | `desktopConfig.databaseMongodbURI`           | MongoDB 连接 URI     |
 | `databaseGlobalCockroachdbURI` | `desktopConfig.databaseGlobalCockroachdbURI` | 全局 CockroachDB URI |

--- a/frontend/desktop/deploy/charts/desktop-frontend/desktop-frontend-values.yaml
+++ b/frontend/desktop/deploy/charts/desktop-frontend/desktop-frontend-values.yaml
@@ -4,7 +4,7 @@
 # Note: The following configurations are automatically fetched from sealos-system/sealos-config ConfigMap
 # and do NOT need to be manually configured:
 #   - cloudDomain, cloudPort, regionUID
-#   - jwtInternal, jwtRegional, jwtGlobal
+#   - jwtInternal, jwtRegional, jwtGlobal, jwtMarketingConsent
 #   - passwordSalt
 #   - databaseMongodbURI, databaseGlobalCockroachdbURI, databaseLocalCockroachdbURI
 #

--- a/frontend/desktop/deploy/charts/desktop-frontend/templates/configmap.yaml
+++ b/frontend/desktop/deploy/charts/desktop-frontend/templates/configmap.yaml
@@ -111,6 +111,7 @@ data:
           internal: "{{ .Values.desktopConfig.jwtInternal }}"
           regional: "{{ .Values.desktopConfig.jwtRegional }}"
           global: "{{ .Values.desktopConfig.jwtGlobal }}"
+          marketingConsent: "{{ .Values.desktopConfig.jwtMarketingConsent }}"
         invite:
           enabled: {{ .Values.desktopConfig.inviteEnabled }}
           lafSecretKey: "{{ .Values.desktopConfig.inviteLafSecretKey }}"

--- a/frontend/desktop/deploy/charts/desktop-frontend/values.yaml
+++ b/frontend/desktop/deploy/charts/desktop-frontend/values.yaml
@@ -80,6 +80,7 @@ desktopConfig:
   jwtInternal: ""                  # Auto-fetched from sealos-config.jwtInternal
   jwtRegional: ""                  # Auto-fetched from sealos-config.jwtRegional
   jwtGlobal: ""                    # Auto-fetched from sealos-config.jwtGlobal
+  jwtMarketingConsent: ""           # Auto-fetched from sealos-config.jwtMarketingConsent
 
   # Render-safe defaults for nested layout fields. CI/sealos build may render
   # the chart with only this base values file loaded.

--- a/frontend/desktop/deploy/desktop-frontend-entrypoint.sh
+++ b/frontend/desktop/deploy/desktop-frontend-entrypoint.sh
@@ -63,6 +63,7 @@ if [ "$AUTO_CONFIG_ENABLED" = "true" ]; then
   SEALOS_JWT_INTERNAL=$(get_cm_value sealos-system sealos-config jwtInternal)
   SEALOS_JWT_REGIONAL=$(get_cm_value sealos-system sealos-config jwtRegional)
   SEALOS_JWT_GLOBAL=$(get_cm_value sealos-system sealos-config jwtGlobal)
+  SEALOS_JWT_MARKETING_CONSENT=$(get_cm_value sealos-system sealos-config jwtMarketingConsent)
   SEALOS_REGION_UID=$(get_cm_value sealos-system sealos-config regionUID)
   SEALOS_DATABASE_MONGODB_URI=$(get_cm_value sealos-system sealos-config databaseMongodbURI)
   SEALOS_DATABASE_GLOBAL_COCKROACHDB_URI=$(get_cm_value sealos-system sealos-config databaseGlobalCockroachdbURI)
@@ -83,6 +84,7 @@ if [ "$AUTO_CONFIG_ENABLED" = "true" ]; then
   [ -n "$SEALOS_JWT_INTERNAL" ] && HELM_ARGS="$HELM_ARGS --set-string desktopConfig.jwtInternal=$SEALOS_JWT_INTERNAL"
   [ -n "$SEALOS_JWT_REGIONAL" ] && HELM_ARGS="$HELM_ARGS --set-string desktopConfig.jwtRegional=$SEALOS_JWT_REGIONAL"
   [ -n "$SEALOS_JWT_GLOBAL" ] && HELM_ARGS="$HELM_ARGS --set-string desktopConfig.jwtGlobal=$SEALOS_JWT_GLOBAL"
+  [ -n "$SEALOS_JWT_MARKETING_CONSENT" ] && HELM_ARGS="$HELM_ARGS --set-string desktopConfig.jwtMarketingConsent=$SEALOS_JWT_MARKETING_CONSENT"
   [ -n "$SEALOS_REGION_UID" ] && HELM_ARGS="$HELM_ARGS --set-string desktopConfig.regionUID=$SEALOS_REGION_UID"
   [ -n "$SEALOS_DATABASE_MONGODB_URI" ] && HELM_ARGS="$HELM_ARGS --set-string desktopConfig.databaseMongodbURI=$SEALOS_DATABASE_MONGODB_URI"
   [ -n "$SEALOS_DATABASE_GLOBAL_COCKROACHDB_URI" ] && HELM_ARGS="$HELM_ARGS --set-string desktopConfig.databaseGlobalCockroachdbURI=$SEALOS_DATABASE_GLOBAL_COCKROACHDB_URI"

--- a/frontend/desktop/src/__tests__/unit/backend/auth/marketing-consent.test.ts
+++ b/frontend/desktop/src/__tests__/unit/backend/auth/marketing-consent.test.ts
@@ -1,0 +1,44 @@
+import { verify } from 'jsonwebtoken';
+
+import { generateMarketingConsentToken, marketingConsentJwtSecret } from '@/services/backend/auth';
+
+describe('marketing consent token', () => {
+  const previousConfig = global.AppConfig;
+
+  beforeEach(() => {
+    global.AppConfig = {
+      cloud: { regionUID: 'region-test' },
+      desktop: { auth: { jwt: { marketingConsent: 'marketing-secret-test' } } }
+    } as typeof global.AppConfig;
+  });
+
+  afterEach(() => {
+    global.AppConfig = previousConfig;
+  });
+
+  it('issues a short-lived token with the Brain contract claims', () => {
+    const token = generateMarketingConsentToken({
+      ad_personalization: 'granted',
+      ad_user_data_consent: 'granted',
+      attribution_hash: 'hash-test',
+      region: 'region-test',
+      sub: 'user-test'
+    });
+    const payload = verify(token, marketingConsentJwtSecret(), {
+      audience: 'brain-marketing-attribution',
+      issuer: 'sealos-desktop'
+    });
+
+    expect(payload).toMatchObject({
+      ad_personalization: 'granted',
+      ad_user_data_consent: 'granted',
+      attribution_hash: 'hash-test',
+      consent_source: 'desktop_oauth',
+      region: 'region-test',
+      sub: 'user-test'
+    });
+    expect(payload).toHaveProperty('jti');
+    expect(payload).toHaveProperty('iat');
+    expect(payload).toHaveProperty('exp');
+  });
+});

--- a/frontend/desktop/src/__tests__/unit/backend/auth/marketing-consent.test.ts
+++ b/frontend/desktop/src/__tests__/unit/backend/auth/marketing-consent.test.ts
@@ -34,7 +34,7 @@ describe('marketing consent token', () => {
     const token = generateMarketingConsentToken({
       ad_personalization: 'granted',
       ad_user_data_consent: 'granted',
-      attribution_hash: 'hash-test',
+      attribution_hash: 'a'.repeat(64),
       region: 'region-test',
       sub: 'user-test'
     });
@@ -46,7 +46,7 @@ describe('marketing consent token', () => {
     expect(payload).toMatchObject({
       ad_personalization: 'granted',
       ad_user_data_consent: 'granted',
-      attribution_hash: 'hash-test',
+      attribution_hash: 'a'.repeat(64),
       consent_source: 'desktop_oauth',
       region: 'region-test',
       sub: 'user-test'
@@ -56,7 +56,7 @@ describe('marketing consent token', () => {
     expect(payload).toHaveProperty('exp');
   });
 
-  it('does not elevate consent from browser attribution input', async () => {
+  it('propagates consent from the versioned browser attribution input', async () => {
     const globalToken = generateGlobalAccessToken({
       preferred_username: 'user-test',
       sub: 'user-test',
@@ -70,12 +70,53 @@ describe('marketing consent token', () => {
       setHeader: vi.fn()
     } as any;
     const seaAttr = Buffer.from(
-      JSON.stringify({ ad_personalization: 'granted', ad_user_data_consent: 'granted' })
+      JSON.stringify({
+        ad_personalization: 'granted',
+        ad_user_data_consent: true,
+        version: 2
+      })
     ).toString('base64url');
 
     await handler(
       {
         body: { sea_attr: seaAttr },
+        cookies: {},
+        headers: { authorization: encodeURIComponent(globalToken) },
+        method: 'POST'
+      } as any,
+      res
+    );
+
+    expect(
+      verify(responseBody.data.token, marketingConsentJwtSecret(), {
+        audience: 'brain-marketing-attribution',
+        issuer: 'sealos-desktop'
+      })
+    ).toMatchObject({
+      ad_personalization: 'granted',
+      ad_user_data_consent: 'granted',
+      attribution_hash: expect.any(String),
+      sub: 'user-test'
+    });
+  });
+
+  it('keeps opaque attribution input unspecified', async () => {
+    const globalToken = generateGlobalAccessToken({
+      preferred_username: 'user-test',
+      sub: 'user-test',
+      user_id: '10001'
+    });
+    let responseBody: any;
+    const res = {
+      json: vi.fn((body) => {
+        responseBody = body;
+      }),
+      setHeader: vi.fn()
+    } as any;
+
+    await handler(
+      {
+        body: { sea_attr: 'opaque-attribution-test' },
         cookies: {},
         headers: { authorization: encodeURIComponent(globalToken) },
         method: 'POST'

--- a/frontend/desktop/src/__tests__/unit/backend/auth/marketing-consent.test.ts
+++ b/frontend/desktop/src/__tests__/unit/backend/auth/marketing-consent.test.ts
@@ -4,6 +4,7 @@ import handler from '@/pages/api/marketing/consent-token';
 import {
   generateGlobalAccessToken,
   generateMarketingConsentToken,
+  generateRegionalToken,
   marketingConsentJwtSecret
 } from '@/services/backend/auth';
 
@@ -13,7 +14,15 @@ describe('marketing consent token', () => {
   beforeEach(() => {
     global.AppConfig = {
       cloud: { regionUID: 'region-test' },
-      desktop: { auth: { jwt: { marketingConsent: 'marketing-secret-test' } } }
+      desktop: {
+        auth: {
+          jwt: {
+            global: 'global-secret-test',
+            marketingConsent: 'marketing-secret-test',
+            regional: 'regional-secret-test'
+          }
+        }
+      }
     } as typeof global.AppConfig;
   });
 
@@ -84,5 +93,41 @@ describe('marketing consent token', () => {
       ad_user_data_consent: 'unspecified',
       sub: 'user-test'
     });
+  });
+
+  it('accepts an authenticated regional session without a shared global cookie', async () => {
+    const regionalToken = generateRegionalToken({
+      regionUid: 'region-test',
+      userCrName: 'user-cr-test',
+      userCrUid: 'user-cr-uid-test',
+      userId: '10002',
+      userUid: 'regional-user-test',
+      workspaceId: 'workspace-test',
+      workspaceUid: 'workspace-uid-test'
+    });
+    let responseBody: any;
+    const res = {
+      json: vi.fn((body) => {
+        responseBody = body;
+      }),
+      setHeader: vi.fn()
+    } as any;
+
+    await handler(
+      {
+        body: { sea_attr: 'regional-attribution-test' },
+        cookies: {},
+        headers: { authorization: encodeURIComponent(regionalToken) },
+        method: 'POST'
+      } as any,
+      res
+    );
+
+    expect(
+      verify(responseBody.data.token, marketingConsentJwtSecret(), {
+        audience: 'brain-marketing-attribution',
+        issuer: 'sealos-desktop'
+      })
+    ).toMatchObject({ sub: 'regional-user-test' });
   });
 });

--- a/frontend/desktop/src/__tests__/unit/backend/auth/marketing-consent.test.ts
+++ b/frontend/desktop/src/__tests__/unit/backend/auth/marketing-consent.test.ts
@@ -56,7 +56,7 @@ describe('marketing consent token', () => {
     expect(payload).toHaveProperty('exp');
   });
 
-  it('propagates consent from the versioned browser attribution input', async () => {
+  it('does not elevate browser-asserted consent', async () => {
     const globalToken = generateGlobalAccessToken({
       preferred_username: 'user-test',
       sub: 'user-test',
@@ -93,8 +93,8 @@ describe('marketing consent token', () => {
         issuer: 'sealos-desktop'
       })
     ).toMatchObject({
-      ad_personalization: 'granted',
-      ad_user_data_consent: 'granted',
+      ad_personalization: 'unspecified',
+      ad_user_data_consent: 'unspecified',
       attribution_hash: expect.any(String),
       sub: 'user-test'
     });

--- a/frontend/desktop/src/__tests__/unit/backend/auth/marketing-consent.test.ts
+++ b/frontend/desktop/src/__tests__/unit/backend/auth/marketing-consent.test.ts
@@ -1,6 +1,11 @@
 import { verify } from 'jsonwebtoken';
 
-import { generateMarketingConsentToken, marketingConsentJwtSecret } from '@/services/backend/auth';
+import handler from '@/pages/api/marketing/consent-token';
+import {
+  generateGlobalAccessToken,
+  generateMarketingConsentToken,
+  marketingConsentJwtSecret
+} from '@/services/backend/auth';
 
 describe('marketing consent token', () => {
   const previousConfig = global.AppConfig;
@@ -40,5 +45,44 @@ describe('marketing consent token', () => {
     expect(payload).toHaveProperty('jti');
     expect(payload).toHaveProperty('iat');
     expect(payload).toHaveProperty('exp');
+  });
+
+  it('does not elevate consent from browser attribution input', async () => {
+    const globalToken = generateGlobalAccessToken({
+      preferred_username: 'user-test',
+      sub: 'user-test',
+      user_id: '10001'
+    });
+    let responseBody: any;
+    const res = {
+      json: vi.fn((body) => {
+        responseBody = body;
+      }),
+      setHeader: vi.fn()
+    } as any;
+    const seaAttr = Buffer.from(
+      JSON.stringify({ ad_personalization: 'granted', ad_user_data_consent: 'granted' })
+    ).toString('base64url');
+
+    await handler(
+      {
+        body: { sea_attr: seaAttr },
+        cookies: {},
+        headers: { authorization: encodeURIComponent(globalToken) },
+        method: 'POST'
+      } as any,
+      res
+    );
+
+    expect(
+      verify(responseBody.data.token, marketingConsentJwtSecret(), {
+        audience: 'brain-marketing-attribution',
+        issuer: 'sealos-desktop'
+      })
+    ).toMatchObject({
+      ad_personalization: 'unspecified',
+      ad_user_data_consent: 'unspecified',
+      sub: 'user-test'
+    });
   });
 });

--- a/frontend/desktop/src/__tests__/unit/utils/gtm.test.ts
+++ b/frontend/desktop/src/__tests__/unit/utils/gtm.test.ts
@@ -59,4 +59,24 @@ describe('gtmLoginSuccess', () => {
       context: 'app'
     });
   });
+
+  it('queues login events before the GTM script initializes', () => {
+    window.dataLayer = undefined as unknown as any[];
+
+    gtmLoginSuccess({
+      method: 'oauth2',
+      user_type: 'existing'
+    });
+
+    expect(window.dataLayer).toEqual([
+      {
+        event: 'login_success',
+        method: 'oauth2',
+        oauth2_provider: undefined,
+        user_type: 'existing',
+        module: 'auth',
+        context: 'app'
+      }
+    ]);
+  });
 });

--- a/frontend/desktop/src/__tests__/unit/utils/marketing-attribution.test.ts
+++ b/frontend/desktop/src/__tests__/unit/utils/marketing-attribution.test.ts
@@ -1,0 +1,55 @@
+import {
+  appendMarketingQuery,
+  marketingQueryFromRecord,
+  mergeMarketingQuery,
+  marketingQueryFromSearch,
+  resolveMarketingQuery
+} from '@/utils/marketing-attribution';
+
+describe('marketing attribution query propagation', () => {
+  it('keeps only the signed attribution parameters from router input', () => {
+    expect(
+      marketingQueryFromRecord({
+        consent_token: 'token-1',
+        sea_attr: ['state-1', 'state-2'],
+        openapp: 'system-brain'
+      })
+    ).toEqual({ consent_token: 'token-1', sea_attr: 'state-1' });
+  });
+
+  it('merges attribution into an app query without changing app parameters', () => {
+    expect(
+      mergeMarketingQuery('templateName=n8n', {
+        consent_token: 'token-1',
+        sea_attr: 'state-1'
+      })
+    ).toBe('templateName=n8n&sea_attr=state-1&consent_token=token-1');
+  });
+
+  it('appends attribution to redirects and parses encoded search strings', () => {
+    const query = marketingQueryFromSearch('?sea_attr=state-1&ignored=value');
+    expect(appendMarketingQuery('/?openapp=system-brain', query)).toBe(
+      '/?openapp=system-brain&sea_attr=state-1'
+    );
+  });
+
+  it('drops a persisted consent token when a new attribution payload arrives', () => {
+    const storage = new Map<string, string>([
+      [
+        'sealos_marketing_query_v1',
+        JSON.stringify({ consent_token: 'old-token', sea_attr: 'old-state' })
+      ]
+    ]);
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('sessionStorage', {
+      getItem: (key: string) => storage.get(key) || null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+      removeItem: (key: string) => storage.delete(key)
+    });
+
+    expect(resolveMarketingQuery({ sea_attr: 'new-state' })).toEqual({
+      sea_attr: 'new-state'
+    });
+    vi.unstubAllGlobals();
+  });
+});

--- a/frontend/desktop/src/__tests__/unit/utils/marketing-attribution.test.ts
+++ b/frontend/desktop/src/__tests__/unit/utils/marketing-attribution.test.ts
@@ -1,5 +1,6 @@
 import {
   appendMarketingQuery,
+  clearPersistedMarketingQuery,
   marketingQueryFromRecord,
   mergeMarketingQuery,
   resolveMarketingQuery
@@ -48,6 +49,22 @@ describe('marketing attribution query propagation', () => {
     expect(resolveMarketingQuery({ sea_attr: 'new-state' })).toEqual({
       sea_attr: 'new-state'
     });
+    vi.unstubAllGlobals();
+  });
+
+  it('clears persisted attribution on logout', () => {
+    const storage = new Map<string, string>([
+      ['sealos_marketing_query_v1', JSON.stringify({ sea_attr: 'state-1' })]
+    ]);
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('sessionStorage', {
+      getItem: (key: string) => storage.get(key) || null,
+      removeItem: (key: string) => storage.delete(key)
+    });
+
+    clearPersistedMarketingQuery();
+
+    expect(storage.has('sealos_marketing_query_v1')).toBe(false);
     vi.unstubAllGlobals();
   });
 });

--- a/frontend/desktop/src/__tests__/unit/utils/marketing-attribution.test.ts
+++ b/frontend/desktop/src/__tests__/unit/utils/marketing-attribution.test.ts
@@ -2,7 +2,6 @@ import {
   appendMarketingQuery,
   marketingQueryFromRecord,
   mergeMarketingQuery,
-  marketingQueryFromSearch,
   resolveMarketingQuery
 } from '@/utils/marketing-attribution';
 
@@ -17,18 +16,17 @@ describe('marketing attribution query propagation', () => {
     ).toEqual({ consent_token: 'token-1', sea_attr: 'state-1' });
   });
 
-  it('merges attribution into an app query without changing app parameters', () => {
+  it('merges current attribution over stale query parameters', () => {
     expect(
-      mergeMarketingQuery('templateName=n8n', {
+      mergeMarketingQuery('templateName=n8n&sea_attr=old-state&consent_token=old-token', {
         consent_token: 'token-1',
         sea_attr: 'state-1'
       })
     ).toBe('templateName=n8n&sea_attr=state-1&consent_token=token-1');
   });
 
-  it('appends attribution to redirects and parses encoded search strings', () => {
-    const query = marketingQueryFromSearch('?sea_attr=state-1&ignored=value');
-    expect(appendMarketingQuery('/?openapp=system-brain', query)).toBe(
+  it('appends attribution to redirects', () => {
+    expect(appendMarketingQuery('/?openapp=system-brain', { sea_attr: 'state-1' })).toBe(
       '/?openapp=system-brain&sea_attr=state-1'
     );
   });

--- a/frontend/desktop/src/api/auth.ts
+++ b/frontend/desktop/src/api/auth.ts
@@ -23,6 +23,11 @@ import { type AxiosInstance } from 'axios';
 import { ProviderType } from 'prisma/global/generated/client';
 import { SubscriptionInfoResponse, WorkspacesPlansResponse } from '@/types/plan';
 
+export const issueMarketingConsentToken = (seaAttr?: string) =>
+  request.post<any, ApiResp<{ token: string }>>('/api/marketing/consent-token', {
+    ...(seaAttr ? { sea_attr: seaAttr } : {})
+  });
+
 export const _getRegionToken = (request: AxiosInstance) => () =>
   request.post<any, ApiResp<{ token: string; kubeconfig: string; appToken: string }>>(
     '/api/auth/regionToken'

--- a/frontend/desktop/src/components/account/AccountCenter/DeleteAccountModal.tsx
+++ b/frontend/desktop/src/components/account/AccountCenter/DeleteAccountModal.tsx
@@ -1,64 +1,69 @@
 import {
-    checkRemainResource,
-    deleteUserRequest,
-    forceDeleteUser,
-    getAmount,
-    getDeleteUserStatus,
-    getWorkspacesPlans
+  checkRemainResource,
+  deleteUserRequest,
+  forceDeleteUser,
+  getAmount,
+  getDeleteUserStatus,
+  getWorkspacesPlans
 } from '@/api/auth';
-import {nsListRequest} from '@/api/namespace';
-import {RegionResourceType, ResourceType} from '@/services/backend/svc/checkResource';
+import { nsListRequest } from '@/api/namespace';
+import { RegionResourceType, ResourceType } from '@/services/backend/svc/checkResource';
 import useAppStore from '@/stores/app';
 import useSessionStore from '@/stores/session';
-import {ApiResp, ValueOf} from '@/types';
-import {RESOURCE_STATUS} from '@/types/response/checkResource';
+import { ApiResp, ValueOf } from '@/types';
+import { RESOURCE_STATUS } from '@/types/response/checkResource';
 import {
-    DELETE_USER_EXECUTION_STATUS,
-    DeleteUserFailure,
-    DeleteUserFinalStatusResponse,
-    DeleteUserInitiateResponse
+  DELETE_USER_EXECUTION_STATUS,
+  DeleteUserFailure,
+  DeleteUserFinalStatusResponse,
+  DeleteUserInitiateResponse
 } from '@/types/response/deleteUser';
-import {getPlanBackgroundClass} from '@/utils/styling';
+import { getPlanBackgroundClass } from '@/utils/styling';
+import { clearPersistedMarketingQuery } from '@/utils/marketing-attribution';
 import {
-    Alert,
-    AlertDescription,
-    AlertIcon,
-    AlertTitle,
-    Button,
-    ButtonProps,
-    Center,
-    Divider,
-    FormControl,
-    HStack,
-    IconButton,
-    Modal,
-    ModalBody,
-    ModalCloseButton,
-    ModalContent,
-    ModalHeader,
-    ModalOverlay,
-    Spinner,
-    Table,
-    TableContainer,
-    Tbody,
-    Td,
-    Text,
-    Th,
-    Thead,
-    Tr,
-    useDisclosure,
-    VStack
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  AlertTitle,
+  Button,
+  ButtonProps,
+  Center,
+  Divider,
+  FormControl,
+  HStack,
+  IconButton,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Spinner,
+  Table,
+  TableContainer,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Thead,
+  Tr,
+  useDisclosure,
+  VStack
 } from '@chakra-ui/react';
-import {Badge} from '@sealos/shadcn-ui/badge';
-import {cn} from '@sealos/shadcn-ui';
-import {InfoCircleIcon, LinkIcon, WarnTriangeIcon} from '@sealos/ui';
-import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
-import {useTranslation} from 'next-i18next';
-import {useRouter} from 'next/router';
-import {useCallback, useEffect, useMemo, useState} from 'react';
-import {buildSubscribedWorkspaceRows, DeleteFlowStep, getDeleteFlowStepFromStatus} from './DeleteAccountModal.utils';
-import {SettingInput} from './SettingInput';
-import {SettingInputGroup} from './SettingInputGroup';
+import { Badge } from '@sealos/shadcn-ui/badge';
+import { cn } from '@sealos/shadcn-ui';
+import { InfoCircleIcon, LinkIcon, WarnTriangeIcon } from '@sealos/ui';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'next-i18next';
+import { useRouter } from 'next/router';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  buildSubscribedWorkspaceRows,
+  DeleteFlowStep,
+  getDeleteFlowStepFromStatus
+} from './DeleteAccountModal.utils';
+import { SettingInput } from './SettingInput';
+import { SettingInputGroup } from './SettingInputGroup';
 
 type DeleteExecutionState = {
   deleteId: string;
@@ -139,6 +144,7 @@ export default function DeleteAccount(props: ButtonProps) {
   }, [disclosureOnClose, resetFormState]);
 
   const handleLogout = useCallback(async () => {
+    clearPersistedMarketingQuery();
     delSession();
     queryClient.clear();
     setToken('');

--- a/frontend/desktop/src/components/account/index.tsx
+++ b/frontend/desktop/src/components/account/index.tsx
@@ -4,6 +4,7 @@ import { useConfigStore } from '@/stores/config';
 import useSessionStore from '@/stores/session';
 import download from '@/utils/downloadFIle';
 import { clearSharedAuthCookie } from '@/utils/cookieUtils';
+import { clearPersistedMarketingQuery } from '@/utils/marketing-attribution';
 import {
   Box,
   Center,
@@ -100,6 +101,7 @@ export default function Account() {
   const logout = (e: React.MouseEvent<HTMLElement>) => {
     e.preventDefault();
     clearSharedAuthCookie(); // Clear shared cookie for cross-domain logout
+    clearPersistedMarketingQuery();
     delSession();
     queryclient.clear();
     router.replace('/signin');

--- a/frontend/desktop/src/components/region/RegionToggle.tsx
+++ b/frontend/desktop/src/components/region/RegionToggle.tsx
@@ -26,6 +26,7 @@ import { useMemo } from 'react';
 import { useConfigStore } from '@/stores/config';
 import { CheckIcon, ChevronDown } from 'lucide-react';
 import { I18nCloudProvidersKey } from '@/types/i18next';
+import { persistMarketingQuery, resolveMarketingQuery } from '@/utils/marketing-attribution';
 
 export default function RegionToggle() {
   const { setWorkSpaceId, session } = useSessionStore();
@@ -61,6 +62,11 @@ export default function RegionToggle() {
     target.searchParams.append('token', token);
     target.searchParams.append('regionId', region.uid);
     target.searchParams.append('regionDomain', region.domain);
+    const marketingQuery = resolveMarketingQuery(router.query);
+    persistMarketingQuery(marketingQuery);
+    Object.entries(marketingQuery).forEach(([key, value]) => {
+      if (value) target.searchParams.set(key, value);
+    });
     await router.replace(target);
   };
 

--- a/frontend/desktop/src/components/v2/Workspace.tsx
+++ b/frontend/desktop/src/components/v2/Workspace.tsx
@@ -31,6 +31,12 @@ import { SwitchRegionType } from '@/constants/account';
 import { I18nCloudProvidersKey } from '@/types/i18next';
 import { ChevronDownIcon } from '@chakra-ui/icons';
 import { useGuideModalStore } from '@/stores/guideModal';
+import { gtmLoginSuccess } from '@/utils/gtm';
+import {
+  appendMarketingQuery,
+  persistMarketingQuery,
+  resolveMarketingQuery
+} from '@/utils/marketing-attribution';
 
 export default function Workspace() {
   const { t } = useTranslation();
@@ -73,13 +79,18 @@ export default function Workspace() {
         });
         return;
       }
+      const marketingQuery = resolveMarketingQuery(router.query);
+      persistMarketingQuery(marketingQuery);
       if (selectedRegion.uid !== cloudConfig?.regionUID) {
-        const target = new URL(`https://${selectedRegion.domain}/switchRegion`);
+        const target = new URL(`https://${selectedRegion.domain}/oauth`);
         if (!globalToken) throw Error('No global token found');
         target.searchParams.append('token', globalToken);
         target.searchParams.append('workspaceName', encodeURIComponent(workspaceName.trim()));
         // target.searchParams.append('regionUid', encodeURIComponent(region.uid));
         target.searchParams.append('switchRegionType', SwitchRegionType.INIT);
+        Object.entries(marketingQuery).forEach(([key, value]) => {
+          if (value) target.searchParams.set(key, value);
+        });
         await router.replace(target);
         return;
       }
@@ -91,8 +102,13 @@ export default function Workspace() {
         throw new Error('No result data');
       }
       // globalToken is already set in session store, no need to pass it
-      await sessionConfig(initRegionTokenResult.data);
-      await router.replace('/');
+      const productUserTraits = await sessionConfig(initRegionTokenResult.data);
+      gtmLoginSuccess({
+        method: 'oauth2',
+        productUserTraits,
+        user_type: 'new'
+      });
+      await router.replace(appendMarketingQuery('/', marketingQuery));
     } catch (error) {
       console.error(error);
       toast({

--- a/frontend/desktop/src/components/v2/Workspace.tsx
+++ b/frontend/desktop/src/components/v2/Workspace.tsx
@@ -31,7 +31,6 @@ import { SwitchRegionType } from '@/constants/account';
 import { I18nCloudProvidersKey } from '@/types/i18next';
 import { ChevronDownIcon } from '@chakra-ui/icons';
 import { useGuideModalStore } from '@/stores/guideModal';
-import { gtmLoginSuccess } from '@/utils/gtm';
 import {
   appendMarketingQuery,
   persistMarketingQuery,
@@ -102,12 +101,7 @@ export default function Workspace() {
         throw new Error('No result data');
       }
       // globalToken is already set in session store, no need to pass it
-      const productUserTraits = await sessionConfig(initRegionTokenResult.data);
-      gtmLoginSuccess({
-        method: 'oauth2',
-        productUserTraits,
-        user_type: 'new'
-      });
+      await sessionConfig(initRegionTokenResult.data);
       await router.replace(appendMarketingQuery('/', marketingQuery));
     } catch (error) {
       console.error(error);

--- a/frontend/desktop/src/pages/api/marketing/consent-token.ts
+++ b/frontend/desktop/src/pages/api/marketing/consent-token.ts
@@ -13,36 +13,9 @@ import { SHARED_AUTH_COOKIE_NAME } from '@/utils/cookieUtils';
 
 const requestSchema = z
   .object({
-    sea_attr: z.string().trim().max(16384).optional()
+    sea_attr: z.string().trim().min(1).max(16384)
   })
   .strict();
-
-type RawAttribution = {
-  ad_personalization?: unknown;
-  ad_user_data_consent?: unknown;
-};
-
-function decodeAttribution(value: string | undefined): RawAttribution {
-  if (!value) {
-    return {};
-  }
-  try {
-    const decoded = JSON.parse(Buffer.from(value, 'base64url').toString('utf8'));
-    return decoded && typeof decoded === 'object' && !Array.isArray(decoded) ? decoded : {};
-  } catch {
-    return {};
-  }
-}
-
-function consentState(value: unknown): 'granted' | 'denied' | 'unspecified' {
-  if (value === true || value === 'granted') {
-    return 'granted';
-  }
-  if (value === false || value === 'denied') {
-    return 'denied';
-  }
-  return 'unspecified';
-}
 
 function requestToken(req: NextApiRequest): string | undefined {
   const cookieToken = req.cookies[SHARED_AUTH_COOKIE_NAME];
@@ -61,6 +34,9 @@ function requestToken(req: NextApiRequest): string | undefined {
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.setHeader('Cache-Control', 'no-store');
+  res.setHeader('Pragma', 'no-cache');
+
   if (req.method !== 'POST') {
     return jsonRes(res, { code: 405, message: 'Method not allowed' });
   }
@@ -79,15 +55,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return jsonRes(res, { code: 400, message: 'Invalid marketing consent payload' });
     }
 
-    const attribution = decodeAttribution(parsed.data.sea_attr);
     const token = generateMarketingConsentToken({
-      ad_personalization: consentState(attribution.ad_personalization),
-      ad_user_data_consent: consentState(attribution.ad_user_data_consent),
-      ...(parsed.data.sea_attr
-        ? {
-            attribution_hash: createHash('sha256').update(parsed.data.sea_attr).digest('hex')
-          }
-        : {}),
+      ad_personalization: 'unspecified',
+      ad_user_data_consent: 'unspecified',
+      attribution_hash: createHash('sha256').update(parsed.data.sea_attr).digest('hex'),
       region: global.AppConfig?.cloud.regionUID || 'unknown',
       sub: claims.sub
     });

--- a/frontend/desktop/src/pages/api/marketing/consent-token.ts
+++ b/frontend/desktop/src/pages/api/marketing/consent-token.ts
@@ -19,6 +19,33 @@ const requestSchema = z
   })
   .strict();
 
+function consentState(value: unknown): 'granted' | 'denied' | 'unspecified' {
+  if (value === true || value === 'granted') return 'granted';
+  if (value === false || value === 'denied') return 'denied';
+  return 'unspecified';
+}
+
+function browserConsentState(seaAttr: string): {
+  ad_personalization: 'granted' | 'denied' | 'unspecified';
+  ad_user_data_consent: 'granted' | 'denied' | 'unspecified';
+} {
+  try {
+    const value = JSON.parse(Buffer.from(seaAttr, 'base64url').toString('utf8')) as Record<
+      string,
+      unknown
+    >;
+    if (value.version !== 2 && value.version !== 3) {
+      return { ad_personalization: 'unspecified', ad_user_data_consent: 'unspecified' };
+    }
+    return {
+      ad_personalization: consentState(value.ad_personalization),
+      ad_user_data_consent: consentState(value.ad_user_data_consent)
+    };
+  } catch {
+    return { ad_personalization: 'unspecified', ad_user_data_consent: 'unspecified' };
+  }
+}
+
 async function requestUserUid(req: NextApiRequest): Promise<string | undefined> {
   const cookieClaims = ensureGlobalTokenClaims(
     await verifyGlobalJwt<OAuth2AccessTokenPayload | OAuth2RefreshTokenPayload>(
@@ -52,9 +79,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return jsonRes(res, { code: 400, message: 'Invalid marketing consent payload' });
     }
 
+    const consent = browserConsentState(parsed.data.sea_attr);
+
     const token = generateMarketingConsentToken({
-      ad_personalization: 'unspecified',
-      ad_user_data_consent: 'unspecified',
+      ad_personalization: consent.ad_personalization,
+      ad_user_data_consent: consent.ad_user_data_consent,
       attribution_hash: createHash('sha256').update(parsed.data.sea_attr).digest('hex'),
       region: global.AppConfig?.cloud.regionUID || 'unknown',
       sub: userUid

--- a/frontend/desktop/src/pages/api/marketing/consent-token.ts
+++ b/frontend/desktop/src/pages/api/marketing/consent-token.ts
@@ -1,0 +1,100 @@
+import { createHash } from 'node:crypto';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { z } from 'zod';
+
+import {
+  ensureGlobalTokenClaims,
+  generateMarketingConsentToken,
+  verifyGlobalJwt
+} from '@/services/backend/auth';
+import { jsonRes } from '@/services/backend/response';
+import type { OAuth2AccessTokenPayload, OAuth2RefreshTokenPayload } from '@/types/token';
+import { SHARED_AUTH_COOKIE_NAME } from '@/utils/cookieUtils';
+
+const requestSchema = z
+  .object({
+    sea_attr: z.string().trim().max(16384).optional()
+  })
+  .strict();
+
+type RawAttribution = {
+  ad_personalization?: unknown;
+  ad_user_data_consent?: unknown;
+};
+
+function decodeAttribution(value: string | undefined): RawAttribution {
+  if (!value) {
+    return {};
+  }
+  try {
+    const decoded = JSON.parse(Buffer.from(value, 'base64url').toString('utf8'));
+    return decoded && typeof decoded === 'object' && !Array.isArray(decoded) ? decoded : {};
+  } catch {
+    return {};
+  }
+}
+
+function consentState(value: unknown): 'granted' | 'denied' | 'unspecified' {
+  if (value === true || value === 'granted') {
+    return 'granted';
+  }
+  if (value === false || value === 'denied') {
+    return 'denied';
+  }
+  return 'unspecified';
+}
+
+function requestToken(req: NextApiRequest): string | undefined {
+  const cookieToken = req.cookies[SHARED_AUTH_COOKIE_NAME];
+  if (cookieToken) {
+    return cookieToken;
+  }
+  const headerToken = req.headers.authorization;
+  if (!headerToken) {
+    return undefined;
+  }
+  try {
+    return decodeURIComponent(headerToken);
+  } catch {
+    return headerToken;
+  }
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return jsonRes(res, { code: 405, message: 'Method not allowed' });
+  }
+
+  try {
+    const payload = await verifyGlobalJwt<OAuth2AccessTokenPayload | OAuth2RefreshTokenPayload>(
+      requestToken(req)
+    );
+    const claims = ensureGlobalTokenClaims(payload);
+    if (!claims) {
+      return jsonRes(res, { code: 401, message: 'Unauthorized' });
+    }
+
+    const parsed = requestSchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return jsonRes(res, { code: 400, message: 'Invalid marketing consent payload' });
+    }
+
+    const attribution = decodeAttribution(parsed.data.sea_attr);
+    const token = generateMarketingConsentToken({
+      ad_personalization: consentState(attribution.ad_personalization),
+      ad_user_data_consent: consentState(attribution.ad_user_data_consent),
+      ...(parsed.data.sea_attr
+        ? {
+            attribution_hash: createHash('sha256').update(parsed.data.sea_attr).digest('hex')
+          }
+        : {}),
+      region: global.AppConfig?.cloud.regionUID || 'unknown',
+      sub: claims.sub
+    });
+
+    return jsonRes(res, { code: 200, data: { token } });
+  } catch (error) {
+    console.error('Marketing consent token error:', error);
+    return jsonRes(res, { code: 503, message: 'Marketing consent signing is unavailable' });
+  }
+}

--- a/frontend/desktop/src/pages/api/marketing/consent-token.ts
+++ b/frontend/desktop/src/pages/api/marketing/consent-token.ts
@@ -19,33 +19,6 @@ const requestSchema = z
   })
   .strict();
 
-function consentState(value: unknown): 'granted' | 'denied' | 'unspecified' {
-  if (value === true || value === 'granted') return 'granted';
-  if (value === false || value === 'denied') return 'denied';
-  return 'unspecified';
-}
-
-function browserConsentState(seaAttr: string): {
-  ad_personalization: 'granted' | 'denied' | 'unspecified';
-  ad_user_data_consent: 'granted' | 'denied' | 'unspecified';
-} {
-  try {
-    const value = JSON.parse(Buffer.from(seaAttr, 'base64url').toString('utf8')) as Record<
-      string,
-      unknown
-    >;
-    if (value.version !== 2 && value.version !== 3) {
-      return { ad_personalization: 'unspecified', ad_user_data_consent: 'unspecified' };
-    }
-    return {
-      ad_personalization: consentState(value.ad_personalization),
-      ad_user_data_consent: consentState(value.ad_user_data_consent)
-    };
-  } catch {
-    return { ad_personalization: 'unspecified', ad_user_data_consent: 'unspecified' };
-  }
-}
-
 async function requestUserUid(req: NextApiRequest): Promise<string | undefined> {
   const cookieClaims = ensureGlobalTokenClaims(
     await verifyGlobalJwt<OAuth2AccessTokenPayload | OAuth2RefreshTokenPayload>(
@@ -79,11 +52,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return jsonRes(res, { code: 400, message: 'Invalid marketing consent payload' });
     }
 
-    const consent = browserConsentState(parsed.data.sea_attr);
-
     const token = generateMarketingConsentToken({
-      ad_personalization: consent.ad_personalization,
-      ad_user_data_consent: consent.ad_user_data_consent,
+      // Browser attribution is not proof of user consent. Keep the receipt
+      // fail-closed until a trusted CMP/Consent Mode source is wired here.
+      ad_personalization: 'unspecified',
+      ad_user_data_consent: 'unspecified',
       attribution_hash: createHash('sha256').update(parsed.data.sea_attr).digest('hex'),
       region: global.AppConfig?.cloud.regionUID || 'unknown',
       sub: userUid

--- a/frontend/desktop/src/pages/api/marketing/consent-token.ts
+++ b/frontend/desktop/src/pages/api/marketing/consent-token.ts
@@ -5,7 +5,9 @@ import { z } from 'zod';
 import {
   ensureGlobalTokenClaims,
   generateMarketingConsentToken,
-  verifyGlobalJwt
+  verifyAccessToken,
+  verifyGlobalJwt,
+  verifyGlobalToken
 } from '@/services/backend/auth';
 import { jsonRes } from '@/services/backend/response';
 import type { OAuth2AccessTokenPayload, OAuth2RefreshTokenPayload } from '@/types/token';
@@ -17,20 +19,18 @@ const requestSchema = z
   })
   .strict();
 
-function requestToken(req: NextApiRequest): string | undefined {
-  const cookieToken = req.cookies[SHARED_AUTH_COOKIE_NAME];
-  if (cookieToken) {
-    return cookieToken;
-  }
-  const headerToken = req.headers.authorization;
-  if (!headerToken) {
-    return undefined;
-  }
-  try {
-    return decodeURIComponent(headerToken);
-  } catch {
-    return headerToken;
-  }
+async function requestUserUid(req: NextApiRequest): Promise<string | undefined> {
+  const cookieClaims = ensureGlobalTokenClaims(
+    await verifyGlobalJwt<OAuth2AccessTokenPayload | OAuth2RefreshTokenPayload>(
+      req.cookies[SHARED_AUTH_COOKIE_NAME]
+    )
+  );
+  if (cookieClaims) return cookieClaims.sub;
+
+  const globalClaims = await verifyGlobalToken(req.headers);
+  if (globalClaims) return globalClaims.userUid;
+
+  return (await verifyAccessToken(req.headers))?.userUid;
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -42,11 +42,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   try {
-    const payload = await verifyGlobalJwt<OAuth2AccessTokenPayload | OAuth2RefreshTokenPayload>(
-      requestToken(req)
-    );
-    const claims = ensureGlobalTokenClaims(payload);
-    if (!claims) {
+    const userUid = await requestUserUid(req);
+    if (!userUid) {
       return jsonRes(res, { code: 401, message: 'Unauthorized' });
     }
 
@@ -60,7 +57,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       ad_user_data_consent: 'unspecified',
       attribution_hash: createHash('sha256').update(parsed.data.sea_attr).digest('hex'),
       region: global.AppConfig?.cloud.regionUID || 'unknown',
-      sub: claims.sub
+      sub: userUid
     });
 
     return jsonRes(res, { code: 200, data: { token } });

--- a/frontend/desktop/src/pages/callback.tsx
+++ b/frontend/desktop/src/pages/callback.tsx
@@ -8,7 +8,6 @@ import { isString } from 'lodash';
 import {
   bindRequest,
   getRegionToken,
-  issueMarketingConsentToken,
   signInRequest,
   unBindRequest,
   autoInitRegionToken
@@ -120,17 +119,6 @@ export default function Callback() {
             if (data.data && data.code === 200 && !('error' in data.data)) {
               const globalToken = data.data?.token; // This is the global token from OAuth
               setGlobalToken(globalToken); // Sets global token and cookie
-              if (marketingQuery.sea_attr && !marketingQuery.consent_token) {
-                try {
-                  const consentResult = await issueMarketingConsentToken(marketingQuery.sea_attr);
-                  if (consentResult.data?.token) {
-                    marketingQuery.consent_token = consentResult.data.token;
-                    persistMarketingQuery(marketingQuery);
-                  }
-                } catch (error) {
-                  console.warn('[Callback] Marketing consent token unavailable:', error);
-                }
-              }
               const needInit = data.data.needInit;
 
               // Helper function to handle redirect after login
@@ -175,12 +163,7 @@ export default function Callback() {
                   }
                 } catch (error) {
                   console.error('Auto init failed, fallback to manual:', error);
-                  gtmLoginSuccess({
-                    user_type: 'new',
-                    method: 'oauth2',
-                    oauth2Provider: provider
-                  });
-                  await router.push('/workspace');
+                  await router.push(appendMarketingQuery('/workspace', marketingQuery));
                 }
                 return;
               }

--- a/frontend/desktop/src/pages/callback.tsx
+++ b/frontend/desktop/src/pages/callback.tsx
@@ -8,6 +8,7 @@ import { isString } from 'lodash';
 import {
   bindRequest,
   getRegionToken,
+  issueMarketingConsentToken,
   signInRequest,
   unBindRequest,
   autoInitRegionToken
@@ -24,6 +25,12 @@ import { useGuideModalStore } from '@/stores/guideModal';
 import { ensureLocaleCookie } from '@/utils/ssrLocale';
 import useAppStore from '@/stores/app';
 import { consumePendingOauth2RedirectPath } from '@/utils/oauth2';
+import {
+  appendMarketingQuery,
+  persistMarketingQuery,
+  resolveMarketingQuery,
+  type MarketingQuery
+} from '@/utils/marketing-attribution';
 
 export default function Callback() {
   const router = useRouter();
@@ -36,6 +43,10 @@ export default function Callback() {
   useEffect(() => {
     if (!router.isReady) return;
     let isProxy: boolean = false;
+    const marketingQuery: MarketingQuery = {
+      ...resolveMarketingQuery(router.query)
+    };
+    persistMarketingQuery(marketingQuery);
     (async () => {
       try {
         if (!provider || !['GITHUB', 'WECHAT', 'GOOGLE', 'OAUTH2'].includes(provider))
@@ -102,22 +113,31 @@ export default function Callback() {
               data.data.error === 'OAUTH_PROVIDER_CONFLICT'
             ) {
               setSigninPageAction('PROMPT_REAUTH_GITHUB');
-              await router.push({
-                pathname: '/signin'
-              });
+              await router.push(appendMarketingQuery('/signin', marketingQuery));
               return;
             }
 
             if (data.data && data.code === 200 && !('error' in data.data)) {
               const globalToken = data.data?.token; // This is the global token from OAuth
               setGlobalToken(globalToken); // Sets global token and cookie
+              if (marketingQuery.sea_attr && !marketingQuery.consent_token) {
+                try {
+                  const consentResult = await issueMarketingConsentToken(marketingQuery.sea_attr);
+                  if (consentResult.data?.token) {
+                    marketingQuery.consent_token = consentResult.data.token;
+                    persistMarketingQuery(marketingQuery);
+                  }
+                } catch (error) {
+                  console.warn('[Callback] Marketing consent token unavailable:', error);
+                }
+              }
               const needInit = data.data.needInit;
 
               // Helper function to handle redirect after login
               const handleLoginRedirect = async () => {
                 const oauth2RedirectPath = consumePendingOauth2RedirectPath();
                 if (oauth2RedirectPath) {
-                  await router.replace(oauth2RedirectPath);
+                  await router.replace(appendMarketingQuery(oauth2RedirectPath, marketingQuery));
                   return;
                 }
                 const appState = useAppStore.getState();
@@ -129,9 +149,11 @@ export default function Callback() {
                   if (appState.autolaunch) {
                     params.append('openapp', appState.autolaunch);
                   }
-                  await router.replace(`/oauth?${params.toString()}`);
+                  await router.replace(
+                    appendMarketingQuery(`/oauth?${params.toString()}`, marketingQuery)
+                  );
                 } else {
-                  await router.replace('/');
+                  await router.replace(appendMarketingQuery('/', marketingQuery));
                 }
               };
 
@@ -181,7 +203,7 @@ export default function Callback() {
               const response = await bindRequest(provider)({ code });
               if (response.message === BIND_STATUS.RESULT_SUCCESS) {
                 setProvider();
-                await router.replace('/');
+                await router.replace(appendMarketingQuery('/', marketingQuery));
               } else if (response.message === MERGE_USER_READY.MERGE_USER_CONTINUE) {
                 const code = response.data?.code;
                 if (!code) return;
@@ -191,19 +213,19 @@ export default function Callback() {
                 });
                 setMergeUserStatus(MergeUserStatus.CANMERGE);
                 setProvider();
-                await router.replace('/');
+                await router.replace(appendMarketingQuery('/', marketingQuery));
               } else if (response.message === MERGE_USER_READY.MERGE_USER_PROVIDER_CONFLICT) {
                 setMergeUserData();
                 setMergeUserStatus(MergeUserStatus.CONFLICT);
                 setProvider();
-                await router.replace('/');
+                await router.replace(appendMarketingQuery('/', marketingQuery));
               }
             } catch (bindError) {
               if ((bindError as any)?.message === MERGE_USER_READY.MERGE_USER_PROVIDER_CONFLICT) {
                 setMergeUserData();
                 setMergeUserStatus(MergeUserStatus.CONFLICT);
                 setProvider();
-                await router.replace('/');
+                await router.replace(appendMarketingQuery('/', marketingQuery));
               } else {
                 console.log('unkownerror', bindError);
                 throw Error();
@@ -212,12 +234,12 @@ export default function Callback() {
           } else if (action === 'UNBIND') {
             await unBindRequest(provider)({ code });
             setProvider();
-            await router.replace('/');
+            await router.replace(appendMarketingQuery('/', marketingQuery));
           }
         }
       } catch (error) {
         console.error(error);
-        await router.replace('/signin');
+        await router.replace(appendMarketingQuery('/signin', marketingQuery));
       }
     })();
   }, [router]);

--- a/frontend/desktop/src/pages/index.tsx
+++ b/frontend/desktop/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { getPlanInfo, UserInfo } from '@/api/auth';
+import { getPlanInfo, issueMarketingConsentToken, UserInfo } from '@/api/auth';
 import { nsListRequest, switchRequest } from '@/api/namespace';
 import DesktopContent from '@/components/desktop_content';
 import { PhoneBindingModal } from '@/components/account/AccountCenter/PhoneBindingModal';
@@ -219,6 +219,17 @@ export default function Home({ sealos_cloud_domain }: { sealos_cloud_domain: str
           return;
         }
 
+        if (appKey === BRAIN_APP_KEY && isUserLogin() && marketingQuery.sea_attr) {
+          try {
+            const result = await issueMarketingConsentToken(marketingQuery.sea_attr);
+            if (result.data?.token) {
+              marketingQuery.consent_token = result.data.token;
+              persistMarketingQuery(marketingQuery);
+            }
+          } catch (error) {
+            console.warn('[Home] Marketing consent token unavailable:', error);
+          }
+        }
         let appQuery = appKey === BRAIN_APP_KEY ? mergeMarketingQuery(raw, marketingQuery) : raw;
         let appRoute = pathname;
         if (appKey === BRAIN_APP_KEY && appRoute === '/trial') {
@@ -322,7 +333,10 @@ export default function Home({ sealos_cloud_domain }: { sealos_cloud_domain: str
             setAutoLaunch(
               parsedOpenApp.appkey,
               {
-                raw: mergeMarketingQuery(parsedOpenApp.appQuery, marketingQuery),
+                raw:
+                  parsedOpenApp.appkey === BRAIN_APP_KEY
+                    ? mergeMarketingQuery(parsedOpenApp.appQuery, marketingQuery)
+                    : parsedOpenApp.appQuery,
                 pathname: parsedOpenApp.appPath
               },
               workspaceUid

--- a/frontend/desktop/src/pages/index.tsx
+++ b/frontend/desktop/src/pages/index.tsx
@@ -20,6 +20,13 @@ import type { InitialAppLaunchState } from '@/utils/initialAppTarget';
 import { sessionConfig, setAdClickData, setUserSemData } from '@/utils/sessionConfig';
 import { switchKubeconfigNamespace } from '@/utils/switchKubeconfigNamespace';
 import { ensureLocaleCookie } from '@/utils/ssrLocale';
+import {
+  appendMarketingQuery,
+  mergeMarketingQuery,
+  persistMarketingQuery,
+  resolveMarketingQuery,
+  type MarketingQuery
+} from '@/utils/marketing-attribution';
 import { Box, useColorMode, useDisclosure } from '@chakra-ui/react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import dayjs from 'dayjs';
@@ -176,6 +183,11 @@ export default function Home({ sealos_cloud_domain }: { sealos_cloud_domain: str
       };
     }
 
+    const marketingQuery: MarketingQuery = {
+      ...resolveMarketingQuery(router.query)
+    };
+    persistMarketingQuery(marketingQuery);
+
     const handleInit = async () => {
       initialLaunchInFlightRef.current = true;
       const { query } = router;
@@ -207,7 +219,7 @@ export default function Home({ sealos_cloud_domain }: { sealos_cloud_domain: str
           return;
         }
 
-        let appQuery = raw;
+        let appQuery = appKey === BRAIN_APP_KEY ? mergeMarketingQuery(raw, marketingQuery) : raw;
         let appRoute = pathname;
         if (appKey === BRAIN_APP_KEY && appRoute === '/trial') {
           appRoute = '/';
@@ -309,7 +321,10 @@ export default function Home({ sealos_cloud_domain }: { sealos_cloud_domain: str
           if (parsedOpenApp.appkey && (parsedOpenApp.appQuery || parsedOpenApp.appPath)) {
             setAutoLaunch(
               parsedOpenApp.appkey,
-              { raw: parsedOpenApp.appQuery, pathname: parsedOpenApp.appPath },
+              {
+                raw: mergeMarketingQuery(parsedOpenApp.appQuery, marketingQuery),
+                pathname: parsedOpenApp.appPath
+              },
               workspaceUid
             );
           }
@@ -317,7 +332,7 @@ export default function Home({ sealos_cloud_domain }: { sealos_cloud_domain: str
           if (hasLoggedInBefore) {
             // logged in user (logged out) → redirect to login page
             initialLaunchResolvedRef.current = true;
-            await router.replace('/signin');
+            await router.replace(appendMarketingQuery('/signin', marketingQuery));
             return;
           }
 
@@ -334,7 +349,7 @@ export default function Home({ sealos_cloud_domain }: { sealos_cloud_domain: str
             // Clear guest session
             useSessionStore.getState().delSession();
             initialLaunchResolvedRef.current = true;
-            await router.replace('/signin');
+            await router.replace(appendMarketingQuery('/signin', marketingQuery));
             return;
           }
 

--- a/frontend/desktop/src/pages/oauth.tsx
+++ b/frontend/desktop/src/pages/oauth.tsx
@@ -6,7 +6,7 @@ import { useConfigStore } from '@/stores/config';
 import useAppStore, { BRAIN_APP_KEY } from '@/stores/app';
 import { useGuideModalStore } from '@/stores/guideModal';
 import { parseOpenappQuery } from '@/utils/format';
-import { gtmLoginStart, gtmLoginSuccess } from '@/utils/gtm';
+import { gtmLoginStart } from '@/utils/gtm';
 import { ensureLocaleCookie } from '@/utils/ssrLocale';
 import { createTemplateInstance } from '@/api/platform';
 import { getRegionToken, initRegionToken } from '@/api/auth';
@@ -122,7 +122,6 @@ export default function OAuth() {
         setGlobalToken(globalToken); // Sets global token and cookie immediately
 
         // INIT mode: initialize new region
-        let productUserTraits;
         if (switchRegionType === SwitchRegionType.INIT) {
           if (!isString(workspaceName)) throw Error('workspace not found');
           const decodedWorkspaceName = decodeURIComponent(workspaceName);
@@ -135,7 +134,7 @@ export default function OAuth() {
             throw new Error('No result data');
           }
 
-          productUserTraits = await sessionConfig(initRegionTokenResult.data);
+          await sessionConfig(initRegionTokenResult.data);
         } else {
           // Normal mode: get region token
           const regionTokenRes = await getRegionToken();
@@ -144,7 +143,7 @@ export default function OAuth() {
             throw new Error('Failed to get region token');
           }
 
-          productUserTraits = await sessionConfig(regionTokenRes.data);
+          await sessionConfig(regionTokenRes.data);
 
           // Switch workspace if needed
           const currentSession = useSessionStore.getState().session;
@@ -163,12 +162,6 @@ export default function OAuth() {
             }
           }
         }
-
-        gtmLoginSuccess({
-          method: 'oauth2',
-          productUserTraits,
-          user_type: switchRegionType === SwitchRegionType.INIT ? 'new' : 'existing'
-        });
 
         if (await openBrainTemplateDeploy(marketingQuery)) {
           return;

--- a/frontend/desktop/src/pages/oauth.tsx
+++ b/frontend/desktop/src/pages/oauth.tsx
@@ -9,7 +9,7 @@ import { parseOpenappQuery } from '@/utils/format';
 import { gtmLoginStart } from '@/utils/gtm';
 import { ensureLocaleCookie } from '@/utils/ssrLocale';
 import { createTemplateInstance } from '@/api/platform';
-import { getRegionToken, initRegionToken } from '@/api/auth';
+import { getRegionToken, initRegionToken, issueMarketingConsentToken } from '@/api/auth';
 import { nsListRequest, switchRequest } from '@/api/namespace';
 import { SwitchRegionType } from '@/constants/account';
 import { sessionConfig } from '@/utils/sessionConfig';
@@ -19,6 +19,13 @@ import { jwtDecode } from 'jwt-decode';
 import { isString } from 'lodash';
 import { useMutation } from '@tanstack/react-query';
 import { useCustomToast } from '@/hooks/useCustomToast';
+import {
+  appendMarketingQuery,
+  mergeMarketingQuery,
+  persistMarketingQuery,
+  resolveMarketingQuery,
+  type MarketingQuery
+} from '@/utils/marketing-attribution';
 
 export default function OAuth() {
   const router = useRouter();
@@ -74,7 +81,29 @@ export default function OAuth() {
       workspaceName
     } = router.query;
 
-    const openBrainTemplateDeploy = async () => {
+    const marketingQuery: MarketingQuery = {
+      ...resolveMarketingQuery(router.query)
+    };
+    persistMarketingQuery(marketingQuery);
+
+    const ensureMarketingConsentToken = async (): Promise<MarketingQuery> => {
+      if (!marketingQuery.sea_attr || marketingQuery.consent_token) {
+        return marketingQuery;
+      }
+      try {
+        const result = await issueMarketingConsentToken(marketingQuery.sea_attr);
+        const token = result.data?.token;
+        if (token) {
+          marketingQuery.consent_token = token;
+          persistMarketingQuery(marketingQuery);
+        }
+      } catch (error) {
+        console.warn('[OAuth] Marketing consent token unavailable:', error);
+      }
+      return marketingQuery;
+    };
+
+    const openBrainTemplateDeploy = async (activeMarketingQuery = marketingQuery) => {
       if (
         openapp !== 'system-brain' ||
         typeof templateName !== 'string' ||
@@ -87,13 +116,14 @@ export default function OAuth() {
         templateName,
         templateForm
       });
+      const rawQuery = mergeMarketingQuery(brainDeployQuery.toString(), activeMarketingQuery);
 
       setAutoLaunch('system-brain', {
         pathname: '/deploy',
-        raw: brainDeployQuery.toString()
+        raw: rawQuery
       });
       cancelAutoDeployTemplate();
-      await router.replace('/');
+      await router.replace(appendMarketingQuery('/', activeMarketingQuery));
 
       return true;
     };
@@ -150,7 +180,9 @@ export default function OAuth() {
           }
         }
 
-        if (await openBrainTemplateDeploy()) {
+        const activeMarketingQuery = await ensureMarketingConsentToken();
+
+        if (await openBrainTemplateDeploy(activeMarketingQuery)) {
           return;
         }
 
@@ -170,10 +202,16 @@ export default function OAuth() {
 
           const { appkey, appQuery, appPath } = parseOpenappQuery(finalOpenapp);
           if (appkey) {
-            setAutoLaunch(appkey, { raw: appQuery, pathname: appPath });
+            setAutoLaunch(appkey, {
+              raw: mergeMarketingQuery(appQuery, activeMarketingQuery),
+              pathname: appPath
+            });
           }
 
-          const redirectUrl = `/?openapp=${encodeURIComponent(finalOpenapp)}`;
+          const redirectUrl = appendMarketingQuery(
+            `/?openapp=${encodeURIComponent(finalOpenapp)}`,
+            activeMarketingQuery
+          );
           await router.replace(redirectUrl);
           if (deploymentError) {
             setTimeout(() => {
@@ -187,7 +225,7 @@ export default function OAuth() {
             }, 500);
           }
         } else {
-          await router.replace('/');
+          await router.replace(appendMarketingQuery('/', activeMarketingQuery));
           if (deploymentError) {
             setTimeout(() => {
               toast({
@@ -202,7 +240,7 @@ export default function OAuth() {
         }
       } catch (error) {
         setGlobalToken('');
-        await router.replace('/signin');
+        await router.replace(appendMarketingQuery('/signin', marketingQuery));
       }
     };
 
@@ -292,13 +330,17 @@ export default function OAuth() {
         try {
           const { appkey, appQuery, appPath } = parseOpenappQuery(openapp);
           if (appkey) {
-            setAutoLaunch(appkey, { raw: appQuery, pathname: appPath });
+            setAutoLaunch(appkey, {
+              raw: mergeMarketingQuery(appQuery, marketingQuery),
+              pathname: appPath
+            });
           }
         } catch (error) {}
       }
     };
 
     const handleOAuthLogin = async (provider: OauthProvider) => {
+      persistMarketingQuery(marketingQuery);
       gtmLoginStart();
       const state = generateState();
       setProvider(provider);
@@ -371,12 +413,12 @@ export default function OAuth() {
             break;
           }
           default: {
-            router.replace('/signin');
+            router.replace(appendMarketingQuery('/signin', marketingQuery));
             return;
           }
         }
       } catch (error) {
-        router.replace('/signin');
+        router.replace(appendMarketingQuery('/signin', marketingQuery));
       }
     };
 
@@ -389,7 +431,8 @@ export default function OAuth() {
       hasProcessedRef.current = true;
 
       (async () => {
-        if (await openBrainTemplateDeploy()) {
+        const activeMarketingQuery = await ensureMarketingConsentToken();
+        if (await openBrainTemplateDeploy(activeMarketingQuery)) {
           return;
         }
 
@@ -420,7 +463,7 @@ export default function OAuth() {
             }
 
             const redirectUrl = `/?openapp=${encodeURIComponent(finalOpenapp)}`;
-            router.replace(redirectUrl);
+            router.replace(appendMarketingQuery(redirectUrl, activeMarketingQuery));
 
             if (deploymentError) {
               setTimeout(() => {
@@ -434,7 +477,7 @@ export default function OAuth() {
               }, 500);
             }
           } else {
-            router.replace('/');
+            router.replace(appendMarketingQuery('/', activeMarketingQuery));
 
             if (deploymentError) {
               setTimeout(() => {
@@ -457,7 +500,7 @@ export default function OAuth() {
     handleSaveParams();
 
     if (!login || typeof login !== 'string') {
-      router.replace('/signin');
+      router.replace(appendMarketingQuery('/signin', marketingQuery));
       return;
     }
 
@@ -466,7 +509,7 @@ export default function OAuth() {
     } else if (login === 'google' && authConfig.idp.google?.enabled) {
       handleOAuthLogin('GOOGLE');
     } else {
-      router.replace('/signin');
+      router.replace(appendMarketingQuery('/signin', marketingQuery));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router.isReady, router.query, authConfig]);

--- a/frontend/desktop/src/pages/oauth.tsx
+++ b/frontend/desktop/src/pages/oauth.tsx
@@ -3,13 +3,13 @@ import { useEffect, useRef } from 'react';
 import useSessionStore from '@/stores/session';
 import { OauthProvider } from '@/types/user';
 import { useConfigStore } from '@/stores/config';
-import useAppStore from '@/stores/app';
+import useAppStore, { BRAIN_APP_KEY } from '@/stores/app';
 import { useGuideModalStore } from '@/stores/guideModal';
 import { parseOpenappQuery } from '@/utils/format';
-import { gtmLoginStart } from '@/utils/gtm';
+import { gtmLoginStart, gtmLoginSuccess } from '@/utils/gtm';
 import { ensureLocaleCookie } from '@/utils/ssrLocale';
 import { createTemplateInstance } from '@/api/platform';
-import { getRegionToken, initRegionToken, issueMarketingConsentToken } from '@/api/auth';
+import { getRegionToken, initRegionToken } from '@/api/auth';
 import { nsListRequest, switchRequest } from '@/api/namespace';
 import { SwitchRegionType } from '@/constants/account';
 import { sessionConfig } from '@/utils/sessionConfig';
@@ -86,23 +86,6 @@ export default function OAuth() {
     };
     persistMarketingQuery(marketingQuery);
 
-    const ensureMarketingConsentToken = async (): Promise<MarketingQuery> => {
-      if (!marketingQuery.sea_attr || marketingQuery.consent_token) {
-        return marketingQuery;
-      }
-      try {
-        const result = await issueMarketingConsentToken(marketingQuery.sea_attr);
-        const token = result.data?.token;
-        if (token) {
-          marketingQuery.consent_token = token;
-          persistMarketingQuery(marketingQuery);
-        }
-      } catch (error) {
-        console.warn('[OAuth] Marketing consent token unavailable:', error);
-      }
-      return marketingQuery;
-    };
-
     const openBrainTemplateDeploy = async (activeMarketingQuery = marketingQuery) => {
       if (
         openapp !== 'system-brain' ||
@@ -139,6 +122,7 @@ export default function OAuth() {
         setGlobalToken(globalToken); // Sets global token and cookie immediately
 
         // INIT mode: initialize new region
+        let productUserTraits;
         if (switchRegionType === SwitchRegionType.INIT) {
           if (!isString(workspaceName)) throw Error('workspace not found');
           const decodedWorkspaceName = decodeURIComponent(workspaceName);
@@ -151,7 +135,7 @@ export default function OAuth() {
             throw new Error('No result data');
           }
 
-          await sessionConfig(initRegionTokenResult.data);
+          productUserTraits = await sessionConfig(initRegionTokenResult.data);
         } else {
           // Normal mode: get region token
           const regionTokenRes = await getRegionToken();
@@ -160,7 +144,7 @@ export default function OAuth() {
             throw new Error('Failed to get region token');
           }
 
-          await sessionConfig(regionTokenRes.data);
+          productUserTraits = await sessionConfig(regionTokenRes.data);
 
           // Switch workspace if needed
           const currentSession = useSessionStore.getState().session;
@@ -180,9 +164,13 @@ export default function OAuth() {
           }
         }
 
-        const activeMarketingQuery = await ensureMarketingConsentToken();
+        gtmLoginSuccess({
+          method: 'oauth2',
+          productUserTraits,
+          user_type: switchRegionType === SwitchRegionType.INIT ? 'new' : 'existing'
+        });
 
-        if (await openBrainTemplateDeploy(activeMarketingQuery)) {
+        if (await openBrainTemplateDeploy(marketingQuery)) {
           return;
         }
 
@@ -203,14 +191,15 @@ export default function OAuth() {
           const { appkey, appQuery, appPath } = parseOpenappQuery(finalOpenapp);
           if (appkey) {
             setAutoLaunch(appkey, {
-              raw: mergeMarketingQuery(appQuery, activeMarketingQuery),
+              raw:
+                appkey === BRAIN_APP_KEY ? mergeMarketingQuery(appQuery, marketingQuery) : appQuery,
               pathname: appPath
             });
           }
 
           const redirectUrl = appendMarketingQuery(
             `/?openapp=${encodeURIComponent(finalOpenapp)}`,
-            activeMarketingQuery
+            marketingQuery
           );
           await router.replace(redirectUrl);
           if (deploymentError) {
@@ -225,7 +214,7 @@ export default function OAuth() {
             }, 500);
           }
         } else {
-          await router.replace(appendMarketingQuery('/', activeMarketingQuery));
+          await router.replace(appendMarketingQuery('/', marketingQuery));
           if (deploymentError) {
             setTimeout(() => {
               toast({
@@ -331,7 +320,8 @@ export default function OAuth() {
           const { appkey, appQuery, appPath } = parseOpenappQuery(openapp);
           if (appkey) {
             setAutoLaunch(appkey, {
-              raw: mergeMarketingQuery(appQuery, marketingQuery),
+              raw:
+                appkey === BRAIN_APP_KEY ? mergeMarketingQuery(appQuery, marketingQuery) : appQuery,
               pathname: appPath
             });
           }
@@ -431,8 +421,7 @@ export default function OAuth() {
       hasProcessedRef.current = true;
 
       (async () => {
-        const activeMarketingQuery = await ensureMarketingConsentToken();
-        if (await openBrainTemplateDeploy(activeMarketingQuery)) {
+        if (await openBrainTemplateDeploy(marketingQuery)) {
           return;
         }
 
@@ -463,7 +452,7 @@ export default function OAuth() {
             }
 
             const redirectUrl = `/?openapp=${encodeURIComponent(finalOpenapp)}`;
-            router.replace(appendMarketingQuery(redirectUrl, activeMarketingQuery));
+            router.replace(appendMarketingQuery(redirectUrl, marketingQuery));
 
             if (deploymentError) {
               setTimeout(() => {
@@ -477,7 +466,7 @@ export default function OAuth() {
               }, 500);
             }
           } else {
-            router.replace(appendMarketingQuery('/', activeMarketingQuery));
+            router.replace(appendMarketingQuery('/', marketingQuery));
 
             if (deploymentError) {
               setTimeout(() => {

--- a/frontend/desktop/src/pages/switchRegion.tsx
+++ b/frontend/desktop/src/pages/switchRegion.tsx
@@ -1,7 +1,7 @@
 import { getRegionToken, initRegionToken } from '@/api/auth';
 import { nsListRequest, switchRequest } from '@/api/namespace';
 import { SwitchRegionType } from '@/constants/account';
-import useAppStore from '@/stores/app';
+import useAppStore, { BRAIN_APP_KEY } from '@/stores/app';
 import { useGuideModalStore } from '@/stores/guideModal';
 import { useInitWorkspaceStore } from '@/stores/initWorkspace';
 import useSessionStore from '@/stores/session';
@@ -16,6 +16,14 @@ import { isString } from 'lodash';
 import type { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
+import { track } from '@sealos/gtm';
+import { gtmLoginSuccess } from '@/utils/gtm';
+import {
+  appendMarketingQuery,
+  mergeMarketingQuery,
+  persistMarketingQuery,
+  resolveMarketingQuery
+} from '@/utils/marketing-attribution';
 
 const Callback: NextPage = () => {
   const router = useRouter();
@@ -95,7 +103,8 @@ const Callback: NextPage = () => {
     const { query } = router;
     const { appkey, appQuery, appPath } = parseOpenappQuery((query?.openapp as string) || '');
     let workspaceUid: string | undefined;
-
+    const marketingQuery = resolveMarketingQuery(query);
+    persistMarketingQuery(marketingQuery);
     const switchRegionType = query.switchRegionType;
     const globalToken = router.query.token;
     if (!isString(globalToken)) throw new Error('failed to get globalToken');
@@ -119,8 +128,13 @@ const Callback: NextPage = () => {
           if (!initRegionTokenResult.data) {
             throw new Error('No result data');
           }
-          await sessionConfig(initRegionTokenResult.data);
-          await router.replace('/');
+          const productUserTraits = await sessionConfig(initRegionTokenResult.data);
+          gtmLoginSuccess({
+            method: 'oauth2',
+            productUserTraits,
+            user_type: 'new'
+          });
+          await router.replace(appendMarketingQuery('/', marketingQuery));
           return;
         } catch (error) {
           console.error(error);
@@ -132,7 +146,15 @@ const Callback: NextPage = () => {
     } else {
       if (isString(query?.workspaceUid)) workspaceUid = query.workspaceUid;
       if (appkey && (appQuery || appPath)) {
-        setAutoLaunch(appkey, { raw: appQuery, pathname: appPath }, workspaceUid);
+        setAutoLaunch(
+          appkey,
+          {
+            raw:
+              appkey === BRAIN_APP_KEY ? mergeMarketingQuery(appQuery, marketingQuery) : appQuery,
+            pathname: appPath
+          },
+          workspaceUid
+        );
       }
       (async () => {
         try {
@@ -152,7 +174,10 @@ const Callback: NextPage = () => {
                 await mutation.mutateAsync(existNamespace.uid);
               }
             }
-            await router.replace('/');
+            track('workspace_switch', {
+              module: 'workspace'
+            });
+            await router.replace(appendMarketingQuery('/', marketingQuery));
             return;
           } else {
             throw new Error();

--- a/frontend/desktop/src/pages/switchRegion.tsx
+++ b/frontend/desktop/src/pages/switchRegion.tsx
@@ -17,7 +17,6 @@ import type { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { track } from '@sealos/gtm';
-import { gtmLoginSuccess } from '@/utils/gtm';
 import {
   appendMarketingQuery,
   mergeMarketingQuery,
@@ -128,12 +127,7 @@ const Callback: NextPage = () => {
           if (!initRegionTokenResult.data) {
             throw new Error('No result data');
           }
-          const productUserTraits = await sessionConfig(initRegionTokenResult.data);
-          gtmLoginSuccess({
-            method: 'oauth2',
-            productUserTraits,
-            user_type: 'new'
-          });
+          await sessionConfig(initRegionTokenResult.data);
           await router.replace(appendMarketingQuery('/', marketingQuery));
           return;
         } catch (error) {

--- a/frontend/desktop/src/services/backend/auth.ts
+++ b/frontend/desktop/src/services/backend/auth.ts
@@ -9,6 +9,7 @@ import {
   OAuth2RefreshTokenPayload,
   OnceTokenPayload
 } from '@/types/token';
+import { randomUUID } from 'node:crypto';
 import { IncomingHttpHeaders } from 'http';
 import { sign, verify } from 'jsonwebtoken';
 
@@ -16,6 +17,8 @@ const regionUID = () => global.AppConfig?.cloud.regionUID || '123456789';
 export const globalJwtSecret = () => global.AppConfig?.desktop.auth.jwt.global || '123456789';
 const regionalJwtSecret = () => global.AppConfig?.desktop.auth.jwt.regional || '123456789';
 const internalJwtSecret = () => global.AppConfig?.desktop.auth.jwt.internal || '123456789';
+export const marketingConsentJwtSecret = () =>
+  global.AppConfig?.desktop.auth.jwt.marketingConsent || '';
 
 const ACCESS_TOKEN_TYPE = 'access_token' as const;
 const REFRESH_TOKEN_TYPE = 'refresh_token' as const;
@@ -240,6 +243,38 @@ export const generateGlobalAccessToken = (
     },
     expiresIn
   );
+
+export type MarketingConsentState = 'granted' | 'denied' | 'unspecified';
+
+export type MarketingConsentTokenInput = {
+  ad_personalization: MarketingConsentState;
+  ad_user_data_consent: MarketingConsentState;
+  attribution_hash?: string;
+  region: string;
+  sub: string;
+};
+
+/** Issues the short-lived, server-authenticated consent receipt consumed by Brain. */
+export const generateMarketingConsentToken = (props: MarketingConsentTokenInput) => {
+  const secret = marketingConsentJwtSecret();
+  if (!secret) {
+    throw new Error('Marketing consent signing secret is not configured');
+  }
+  return sign(
+    {
+      ...props,
+      consent_source: 'desktop_oauth'
+    },
+    secret,
+    {
+      algorithm: 'HS256',
+      audience: 'brain-marketing-attribution',
+      expiresIn: '15m',
+      issuer: 'sealos-desktop',
+      jwtid: randomUUID()
+    }
+  );
+};
 
 const verifyOAuth2TokenByType = async (
   token: string | undefined,

--- a/frontend/desktop/src/services/backend/auth.ts
+++ b/frontend/desktop/src/services/backend/auth.ts
@@ -249,7 +249,7 @@ export type MarketingConsentState = 'granted' | 'denied' | 'unspecified';
 export type MarketingConsentTokenInput = {
   ad_personalization: MarketingConsentState;
   ad_user_data_consent: MarketingConsentState;
-  attribution_hash?: string;
+  attribution_hash: string;
   region: string;
   sub: string;
 };

--- a/frontend/desktop/src/services/request.ts
+++ b/frontend/desktop/src/services/request.ts
@@ -1,4 +1,5 @@
 import useSessionStore from '@/stores/session';
+import { clearPersistedMarketingQuery } from '@/utils/marketing-attribution';
 import type { ApiResp } from '@/types';
 import axios, { AxiosHeaders, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 const request = axios.create({
@@ -40,6 +41,7 @@ request.interceptors.response.use(
     if (data.code === 401 && !isGuest) {
       console.log('鉴权失败');
       console.log(data.message);
+      clearPersistedMarketingQuery();
       useSessionStore.getState().delSession();
       useSessionStore.getState().setToken('');
       return window.location.replace('/signin');

--- a/frontend/desktop/src/stores/app.ts
+++ b/frontend/desktop/src/stores/app.ts
@@ -310,7 +310,8 @@ const useAppStore = create<TOSState>()(
 
           const iframe = document.getElementById(`app-window-${appKey}`) as HTMLIFrameElement;
           if (!iframe) return;
-          iframe.contentWindow?.postMessage(messageData, app.data.url);
+          const targetOrigin = new URL(app.data.url, window.location.origin).origin;
+          iframe.contentWindow?.postMessage(messageData, targetOrigin);
         },
         // maximize app
         switchAppById: (pid: number) => {

--- a/frontend/desktop/src/stores/app.ts
+++ b/frontend/desktop/src/stores/app.ts
@@ -310,8 +310,7 @@ const useAppStore = create<TOSState>()(
 
           const iframe = document.getElementById(`app-window-${appKey}`) as HTMLIFrameElement;
           if (!iframe) return;
-          const targetOrigin = new URL(app.data.url, window.location.origin).origin;
-          iframe.contentWindow?.postMessage(messageData, targetOrigin);
+          iframe.contentWindow?.postMessage(messageData, app.data.url);
         },
         // maximize app
         switchAppById: (pid: number) => {

--- a/frontend/desktop/src/types/system.ts
+++ b/frontend/desktop/src/types/system.ts
@@ -242,6 +242,7 @@ export type JwtConfigType = {
   internal?: string;
   regional?: string;
   global?: string;
+  marketingConsent?: string;
 };
 
 export type DesktopConfigType<T = AuthConfigType> = {

--- a/frontend/desktop/src/utils/gtm.ts
+++ b/frontend/desktop/src/utils/gtm.ts
@@ -1,9 +1,15 @@
 // Legacy GTM v1 events
 import { ProductUserTraits } from '@/types/analytics';
 
+const pushGtmEvent = (event: Record<string, unknown>) => {
+  if (typeof window === 'undefined') return;
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push(event);
+};
+
 /** @deprecated */
 export const gtmLoginStart = () =>
-  window?.dataLayer?.push?.({
+  pushGtmEvent({
     event: 'login_start',
     module: 'auth',
     context: 'app'
@@ -21,7 +27,7 @@ export const gtmLoginSuccess = ({
   user_type: 'new' | 'existing';
   productUserTraits?: ProductUserTraits;
 }) =>
-  window?.dataLayer?.push?.({
+  pushGtmEvent({
     event: 'login_success',
     method,
     oauth2_provider: oauth2Provider,

--- a/frontend/desktop/src/utils/marketing-attribution.ts
+++ b/frontend/desktop/src/utils/marketing-attribution.ts
@@ -1,0 +1,104 @@
+const MARKETING_QUERY_KEYS = ['sea_attr', 'consent_token'] as const;
+const MARKETING_QUERY_STORAGE_KEY = 'sealos_marketing_query_v1';
+
+export type MarketingQuery = Partial<Record<(typeof MARKETING_QUERY_KEYS)[number], string>>;
+
+function firstQueryValue(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim()) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    const first = value.find((item) => typeof item === 'string' && item.trim());
+    return typeof first === 'string' ? first : undefined;
+  }
+  return undefined;
+}
+
+export function marketingQueryFromRecord(record: Record<string, unknown>): MarketingQuery {
+  const result: MarketingQuery = {};
+  for (const key of MARKETING_QUERY_KEYS) {
+    const value = firstQueryValue(record[key]);
+    if (value) {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+export function marketingQueryFromSearch(search: string): MarketingQuery {
+  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+  return marketingQueryFromRecord(Object.fromEntries(params.entries()));
+}
+
+export function resolveMarketingQuery(record: Record<string, unknown>): MarketingQuery {
+  const persisted = readPersistedMarketingQuery();
+  const current = marketingQueryFromRecord(record);
+  const query = { ...persisted, ...current };
+  if (current.sea_attr && current.sea_attr !== persisted.sea_attr && !current.consent_token) {
+    delete query.consent_token;
+  }
+  return query;
+}
+
+export function hasMarketingQuery(query: MarketingQuery): boolean {
+  return MARKETING_QUERY_KEYS.some((key) => !!query[key]);
+}
+
+export function mergeMarketingQuery(raw: string | undefined, query: MarketingQuery): string {
+  const params = new URLSearchParams(raw || '');
+  for (const key of MARKETING_QUERY_KEYS) {
+    const value = query[key];
+    if (value && !params.has(key)) {
+      params.set(key, value);
+    }
+  }
+  return params.toString();
+}
+
+export function appendMarketingQuery(path: string, query: MarketingQuery): string {
+  if (!hasMarketingQuery(query)) {
+    return path;
+  }
+  const url = new URL(path, 'https://desktop.sealos.local');
+  for (const key of MARKETING_QUERY_KEYS) {
+    const value = query[key];
+    if (value) {
+      url.searchParams.set(key, value);
+    }
+  }
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+export function persistMarketingQuery(query: MarketingQuery): void {
+  if (!hasMarketingQuery(query) || typeof window === 'undefined') {
+    return;
+  }
+  try {
+    sessionStorage.setItem(MARKETING_QUERY_STORAGE_KEY, JSON.stringify(query));
+  } catch {
+    // Session storage is optional in private browsing contexts.
+  }
+}
+
+export function readPersistedMarketingQuery(): MarketingQuery {
+  if (typeof window === 'undefined') {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(sessionStorage.getItem(MARKETING_QUERY_STORAGE_KEY) || '{}');
+    return marketingQueryFromRecord(parsed && typeof parsed === 'object' ? parsed : {});
+  } catch {
+    return {};
+  }
+}
+
+export function clearPersistedMarketingQuery(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    sessionStorage.removeItem(MARKETING_QUERY_STORAGE_KEY);
+  } catch {
+    // Session storage is optional in private browsing contexts.
+  }
+}

--- a/frontend/desktop/src/utils/marketing-attribution.ts
+++ b/frontend/desktop/src/utils/marketing-attribution.ts
@@ -81,6 +81,17 @@ export function persistMarketingQuery(query: MarketingQuery): void {
   }
 }
 
+export function clearPersistedMarketingQuery(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    sessionStorage.removeItem(MARKETING_QUERY_STORAGE_KEY);
+  } catch {
+    // Session storage is optional in private browsing contexts.
+  }
+}
+
 function readPersistedMarketingQuery(): MarketingQuery {
   if (typeof window === 'undefined') {
     return {};

--- a/frontend/desktop/src/utils/marketing-attribution.ts
+++ b/frontend/desktop/src/utils/marketing-attribution.ts
@@ -1,14 +1,20 @@
 const MARKETING_QUERY_KEYS = ['sea_attr', 'consent_token'] as const;
 const MARKETING_QUERY_STORAGE_KEY = 'sealos_marketing_query_v1';
+const MARKETING_QUERY_MAX_LENGTH = {
+  sea_attr: 16384,
+  consent_token: 8192
+} as const;
 
 export type MarketingQuery = Partial<Record<(typeof MARKETING_QUERY_KEYS)[number], string>>;
 
-function firstQueryValue(value: unknown): string | undefined {
-  if (typeof value === 'string' && value.trim()) {
+function firstQueryValue(value: unknown, maxLength: number): string | undefined {
+  if (typeof value === 'string' && value.trim() && value.length <= maxLength) {
     return value;
   }
   if (Array.isArray(value)) {
-    const first = value.find((item) => typeof item === 'string' && item.trim());
+    const first = value.find(
+      (item) => typeof item === 'string' && item.trim() && item.length <= maxLength
+    );
     return typeof first === 'string' ? first : undefined;
   }
   return undefined;
@@ -17,17 +23,12 @@ function firstQueryValue(value: unknown): string | undefined {
 export function marketingQueryFromRecord(record: Record<string, unknown>): MarketingQuery {
   const result: MarketingQuery = {};
   for (const key of MARKETING_QUERY_KEYS) {
-    const value = firstQueryValue(record[key]);
+    const value = firstQueryValue(record[key], MARKETING_QUERY_MAX_LENGTH[key]);
     if (value) {
       result[key] = value;
     }
   }
   return result;
-}
-
-export function marketingQueryFromSearch(search: string): MarketingQuery {
-  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
-  return marketingQueryFromRecord(Object.fromEntries(params.entries()));
 }
 
 export function resolveMarketingQuery(record: Record<string, unknown>): MarketingQuery {
@@ -40,7 +41,7 @@ export function resolveMarketingQuery(record: Record<string, unknown>): Marketin
   return query;
 }
 
-export function hasMarketingQuery(query: MarketingQuery): boolean {
+function hasMarketingQuery(query: MarketingQuery): boolean {
   return MARKETING_QUERY_KEYS.some((key) => !!query[key]);
 }
 
@@ -48,7 +49,7 @@ export function mergeMarketingQuery(raw: string | undefined, query: MarketingQue
   const params = new URLSearchParams(raw || '');
   for (const key of MARKETING_QUERY_KEYS) {
     const value = query[key];
-    if (value && !params.has(key)) {
+    if (value) {
       params.set(key, value);
     }
   }
@@ -80,7 +81,7 @@ export function persistMarketingQuery(query: MarketingQuery): void {
   }
 }
 
-export function readPersistedMarketingQuery(): MarketingQuery {
+function readPersistedMarketingQuery(): MarketingQuery {
   if (typeof window === 'undefined') {
     return {};
   }
@@ -89,16 +90,5 @@ export function readPersistedMarketingQuery(): MarketingQuery {
     return marketingQueryFromRecord(parsed && typeof parsed === 'object' ? parsed : {});
   } catch {
     return {};
-  }
-}
-
-export function clearPersistedMarketingQuery(): void {
-  if (typeof window === 'undefined') {
-    return;
-  }
-  try {
-    sessionStorage.removeItem(MARKETING_QUERY_STORAGE_KEY);
-  } catch {
-    // Session storage is optional in private browsing contexts.
   }
 }

--- a/scripts/cloud/install-v2.sh
+++ b/scripts/cloud/install-v2.sh
@@ -387,6 +387,16 @@ run_cloud(){
        run_and_log "sealos pull --policy=always -q  ${registry_domain}/${sealos_cloud_image_repository}/${cloudImages[$name]}:${sealos_cloud_version}"
     done
     if [[ "${dry_run,,}" == "false" ]]; then
+      varJwtMarketingConsent=$(kubectl get configmap sealos-config -n sealos-system -o jsonpath='{.data.jwtMarketingConsent}')
+      if [[ -z "${varJwtMarketingConsent}" ]]; then
+        if ! command -v openssl >/dev/null 2>&1; then
+          error "openssl is required to generate the marketing consent signing secret"
+        fi
+        varJwtMarketingConsent=$(openssl rand -hex 32)
+        kubectl patch configmap sealos-config -n sealos-system --type merge \
+          --patch "{\"data\":{\"jwtMarketingConsent\":\"${varJwtMarketingConsent}\"}}" >/dev/null
+        info "Generated the marketing consent signing secret in sealos-config."
+      fi
       varCloudDomain=$(kubectl get configmap sealos-config -n sealos-system -o jsonpath='{.data.cloudDomain}')
       varCloudPort=$(kubectl get configmap sealos-config -n sealos-system -o jsonpath='{.data.cloudPort}')
       varRegionUID=$(kubectl get configmap sealos-config -n sealos-system -o jsonpath='{.data.regionUID}')


### PR DESCRIPTION
## Summary

- preserve bounded `sea_attr` and `consent_token` through Cloud auth, workspace, and region handoffs
- keep `login_success` at authoritative login-completion paths only (OAuth callback, email, and phone); remove page-load and handoff emissions that caused duplicate or false events
- issue a user-bound, short-lived Brain receipt bound to the raw attribution hash
- fail closed for consent: browser-provided consent fields are transport data only and are always signed as `unspecified` until a trusted CMP / Google Consent Mode source is wired
- clear persisted attribution on logout, auth expiry, and account deletion

## Validation

- `pnpm exec vitest run --project unit src/__tests__/unit/backend/auth/marketing-consent.test.ts src/__tests__/unit/utils/marketing-attribution.test.ts src/__tests__/unit/utils/gtm.test.ts` — 12 passed
- `pnpm exec tsc --noEmit`
- Prettier and `git diff --check`

## Consent contract

`sea_attr` is not evidence of consent. The signed receipt proves the authenticated subject and attribution payload hash, while consent remains `unspecified` until a trusted consent source is integrated. Brain must continue redacting click IDs and enhanced-conversion data for this state.

## Release notes

Brain must be deployed with the compatible marketing contract and the same signing value as Cloud `jwtMarketingConsent` / Brain `MARKETING_CONSENT_SIGNING_KEY`.

Companion Brain PR: https://github.com/labring/brain/pull/267
