### PR TITLE
fix(applaunchpad): make StatefulSet network updates safe

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/pages/api/updateApp.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/pages/api/updateApp.test.ts
@@ -285,9 +285,9 @@ describe('/api/updateApp', () => {
     expect(k8s.k8sNetworkingApp.patchNamespacedIngress.mock.invocationCallOrder[0]).toBeLessThan(
       k8s.k8sApp.deleteNamespacedDeployment.mock.invocationCallOrder[0]
     );
-    expect(k8s.k8sCore.patchNamespacedPersistentVolumeClaim.mock.invocationCallOrder[0]).toBeLessThan(
-      k8s.k8sApp.deleteNamespacedDeployment.mock.invocationCallOrder[0]
-    );
+    expect(
+      k8s.k8sCore.patchNamespacedPersistentVolumeClaim.mock.invocationCallOrder[0]
+    ).toBeLessThan(k8s.k8sApp.deleteNamespacedDeployment.mock.invocationCallOrder[0]);
     expect(res.json).toHaveBeenCalledWith({
       code: 200,
       message: 'Success',
@@ -298,8 +298,9 @@ describe('/api/updateApp', () => {
 
   it('returns an error instead of deleting and recreating a StatefulSet when patching fails', async () => {
     const k8s = createK8sContext();
-    k8s.k8sApp.patchNamespacedStatefulSet.mockRejectedValueOnce(new Error('patch failed'));
-    k8s.k8sApp.replaceNamespacedStatefulSet.mockRejectedValueOnce(new Error('replace failed'));
+    k8s.k8sApp.patchNamespacedStatefulSet
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error('patch failed'));
     initK8sMock.mockResolvedValue(k8s);
     const res = createResponse();
 
@@ -326,15 +327,246 @@ describe('/api/updateApp', () => {
       res
     );
 
+    expect(k8s.k8sApp.patchNamespacedStatefulSet).toHaveBeenNthCalledWith(
+      1,
+      'demo',
+      'ns-demo',
+      expect.anything(),
+      undefined,
+      'All',
+      undefined,
+      undefined,
+      undefined,
+      expect.anything()
+    );
+    expect(k8s.k8sApp.replaceNamespacedStatefulSet).not.toHaveBeenCalled();
     expect(k8s.k8sApp.deleteNamespacedStatefulSet).not.toHaveBeenCalled();
     expect(k8s.k8sApp.createNamespacedStatefulSet).not.toHaveBeenCalled();
     expect(k8s.k8sCore.patchNamespacedPersistentVolumeClaim).not.toHaveBeenCalled();
     expect(res.json).toHaveBeenCalledWith({
       code: 500,
-      message: 'replace failed',
+      message: 'patch failed',
       data: undefined,
       error: undefined
     });
   });
 
+  it('rejects an immutable StatefulSet serviceName change before creating dependencies', async () => {
+    const k8s = createK8sContext();
+    k8s.k8sApp.readNamespacedStatefulSet.mockResolvedValue({
+      body: {
+        metadata: { uid: 'statefulset-uid' },
+        spec: { serviceName: 'demo-service' }
+      }
+    });
+    initK8sMock.mockResolvedValue(k8s);
+    const res = createResponse();
+
+    await handler(
+      {
+        body: {
+          appName: 'demo',
+          stateFulSetYaml: statefulSetYaml,
+          patch: [
+            {
+              type: 'create',
+              kind: 'Service',
+              value: 'apiVersion: v1\nkind: Service\nmetadata:\n  name: new-service\n'
+            },
+            {
+              type: 'patch',
+              kind: 'StatefulSet',
+              value: {
+                kind: 'StatefulSet',
+                metadata: { name: 'demo' },
+                spec: { serviceName: 'new-service' }
+              }
+            }
+          ]
+        }
+      } as any,
+      res
+    );
+
+    expect(k8s.applyYamlList).not.toHaveBeenCalled();
+    expect(k8s.k8sApp.patchNamespacedStatefulSet).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 422,
+        message: expect.stringContaining('spec.serviceName is immutable')
+      })
+    );
+  });
+
+  it('inherits a stable Instance owner and rolls back new dependencies when workload patch fails', async () => {
+    const k8s = createK8sContext();
+    const instanceOwnerReference = {
+      apiVersion: 'app.sealos.io/v1',
+      kind: 'Instance',
+      name: 'demo',
+      uid: 'instance-uid',
+      controller: false,
+      blockOwnerDeletion: false
+    };
+    k8s.k8sApp.readNamespacedDeployment.mockRejectedValue({ body: { code: 404 } });
+    k8s.k8sApp.readNamespacedStatefulSet.mockResolvedValue({
+      body: {
+        metadata: {
+          uid: 'statefulset-uid',
+          ownerReferences: [instanceOwnerReference]
+        },
+        spec: { serviceName: 'demo-service' }
+      }
+    });
+    k8s.k8sApp.patchNamespacedStatefulSet
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error('workload patch failed'));
+    initK8sMock.mockResolvedValue(k8s);
+    const res = createResponse();
+
+    await handler(
+      {
+        body: {
+          appName: 'demo',
+          stateFulSetYaml: statefulSetYaml,
+          patch: [
+            {
+              type: 'create',
+              kind: 'Service',
+              value: 'apiVersion: v1\nkind: Service\nmetadata:\n  name: new-service\n'
+            },
+            {
+              type: 'patch',
+              kind: 'StatefulSet',
+              value: {
+                kind: 'StatefulSet',
+                metadata: { name: 'demo' },
+                spec: { serviceName: 'demo-service' }
+              }
+            }
+          ]
+        }
+      } as any,
+      res
+    );
+
+    const createdYaml = k8s.applyYamlList.mock.calls[0][0][0];
+    expect(createdYaml).toContain('kind: Instance');
+    expect(createdYaml).toContain('uid: instance-uid');
+    expect(k8s.applyYamlList.mock.invocationCallOrder[0]).toBeLessThan(
+      k8s.k8sApp.patchNamespacedStatefulSet.mock.invocationCallOrder[1]
+    );
+    expect(k8s.k8sCore.deleteNamespacedService).toHaveBeenCalledWith('new-service', 'ns-demo');
+    expect(k8s.k8sCore.deleteNamespacedService.mock.invocationCallOrder[0]).toBeGreaterThan(
+      k8s.k8sApp.patchNamespacedStatefulSet.mock.invocationCallOrder[1]
+    );
+  });
+
+  it('does not retry a conflicting dependency creation without ownerReferences', async () => {
+    const k8s = createK8sContext();
+    k8s.applyYamlList.mockRejectedValue({
+      body: { code: 409, message: 'services "new-service" already exists' }
+    });
+    initK8sMock.mockResolvedValue(k8s);
+    const res = createResponse();
+
+    await handler(
+      {
+        body: {
+          appName: 'demo',
+          stateFulSetYaml: statefulSetYaml,
+          patch: [
+            {
+              type: 'create',
+              kind: 'Service',
+              value: 'apiVersion: v1\nkind: Service\nmetadata:\n  name: new-service\n'
+            }
+          ]
+        }
+      } as any,
+      res
+    );
+
+    expect(k8s.applyYamlList).toHaveBeenCalledTimes(1);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 409,
+        message: 'services "new-service" already exists'
+      })
+    );
+  });
+
+  it('treats an already missing Certificate as a successful idempotent delete', async () => {
+    const k8s = createK8sContext();
+    k8s.k8sCustomObjects.deleteNamespacedCustomObject.mockImplementation(
+      (_group: string, _version: string, _namespace: string, plural: string) =>
+        plural === 'certificates'
+          ? Promise.reject({ body: { code: 404, message: 'certificate not found' } })
+          : Promise.resolve({})
+    );
+    initK8sMock.mockResolvedValue(k8s);
+    const res = createResponse();
+
+    await handler(
+      {
+        body: {
+          appName: 'demo',
+          stateFulSetYaml: statefulSetYaml,
+          patch: [
+            { type: 'delete', kind: 'Issuer', name: 'old-network' },
+            { type: 'delete', kind: 'Certificate', name: 'old-network' }
+          ]
+        }
+      } as any,
+      res
+    );
+
+    expect(k8s.k8sCustomObjects.deleteNamespacedCustomObject).toHaveBeenCalledWith(
+      'cert-manager.io',
+      'v1',
+      'ns-demo',
+      'issuers',
+      'old-network'
+    );
+    expect(k8s.k8sCustomObjects.deleteNamespacedCustomObject).toHaveBeenCalledWith(
+      'cert-manager.io',
+      'v1',
+      'ns-demo',
+      'certificates',
+      'old-network'
+    );
+    expect(res.json).toHaveBeenCalledWith({
+      code: 200,
+      message: 'Success',
+      data: undefined,
+      error: undefined
+    });
+  });
+
+  it('still returns non-404 cleanup errors', async () => {
+    const k8s = createK8sContext();
+    k8s.k8sCustomObjects.deleteNamespacedCustomObject.mockRejectedValue({
+      body: { code: 403, message: 'certificates.cert-manager.io is forbidden' }
+    });
+    initK8sMock.mockResolvedValue(k8s);
+    const res = createResponse();
+
+    await handler(
+      {
+        body: {
+          appName: 'demo',
+          stateFulSetYaml: statefulSetYaml,
+          patch: [{ type: 'delete', kind: 'Certificate', name: 'old-network' }]
+        }
+      } as any,
+      res
+    );
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 403,
+        message: 'Insufficient permissions'
+      })
+    );
+  });
 });

--- a/frontend/providers/applaunchpad/__tests__/unit/pages/app/edit/index.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/pages/app/edit/index.test.ts
@@ -29,7 +29,8 @@ describe('EditApp yaml display state', () => {
 
     expect(start).toBeGreaterThanOrEqual(0);
     expect(source.indexOf('removeStoreList(originalIndex)')).toBeGreaterThan(start);
-    expect(source).toContain('existingStores.some((store) => store.path === item.path)');
+    expect(source).toContain('existingStores.some(');
+    expect(source).toContain('(store) => store.path === item.path');
     expect(source).toContain("t('Store At Least One')");
     expect(source).not.toContain('localStores.length === 1');
   });
@@ -47,5 +48,15 @@ describe('EditApp yaml display state', () => {
     expect(handleDomainVerified).toContain('json2Service(data, ownerReferences, {');
     expect(handleDomainVerified).toContain('includeNodePort: false');
     expect(handleDomainVerified).toContain("postDeployApp(yamlList, 'replace')");
+  });
+
+  it('verifies only new or changed custom-domain bindings on update', () => {
+    const source = readFileSync(
+      new URL('../../../../../src/pages/app/edit/index.tsx', import.meta.url),
+      'utf8'
+    );
+
+    expect(source).toContain('getChangedCustomDomainBindings(');
+    expect(source).toContain('oldAppEditData.current?.networks');
   });
 });

--- a/frontend/providers/applaunchpad/__tests__/unit/services/backend/response.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/services/backend/response.test.ts
@@ -65,4 +65,51 @@ describe('handleK8sError', () => {
       message: ResponseMessages[ResponseCode.FORBIDDEN]
     });
   });
+
+  it('keeps Kubernetes resource conflicts distinct from application name conflicts', () => {
+    expect(
+      handleK8sError({
+        body: {
+          kind: 'Status',
+          code: 409,
+          message: 'services "demo-service" already exists',
+          details: { kind: 'services', name: 'demo-service' }
+        }
+      })
+    ).toEqual({
+      code: ResponseCode.RESOURCE_ALREADY_EXISTS,
+      message: 'services "demo-service" already exists'
+    });
+  });
+
+  it('keeps workload conflicts mapped to application name conflicts', () => {
+    expect(
+      handleK8sError({
+        body: {
+          kind: 'Status',
+          code: 409,
+          message: 'statefulsets.apps "demo" already exists',
+          details: { kind: 'statefulsets', name: 'demo' }
+        }
+      })
+    ).toEqual({
+      code: ResponseCode.APP_ALREADY_EXISTS,
+      message: ResponseMessages[ResponseCode.APP_ALREADY_EXISTS]
+    });
+  });
+
+  it('returns immutable-field validation errors without masking them as permissions', () => {
+    expect(
+      handleK8sError({
+        body: {
+          kind: 'Status',
+          code: 422,
+          message: 'StatefulSet spec.serviceName is immutable'
+        }
+      })
+    ).toEqual({
+      code: ResponseCode.UNPROCESSABLE_ENTITY,
+      message: 'StatefulSet spec.serviceName is immutable'
+    });
+  });
 });

--- a/frontend/providers/applaunchpad/__tests__/unit/utils/adapt.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/adapt.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { adaptAppDetail } from '@/utils/adapt';
+import { adaptAppDetail, adaptEditAppData } from '@/utils/adapt';
 import type { DeployKindsType } from '@/types/app';
 
 const createDeployment = (): DeployKindsType =>
@@ -150,6 +150,20 @@ const createIngress = (): DeployKindsType =>
   } as DeployKindsType);
 
 describe('adaptAppDetail', () => {
+  it('preserves the governing Service name of an existing StatefulSet in edit data', async () => {
+    const statefulSet = createDeployment() as any;
+    statefulSet.kind = 'StatefulSet';
+    statefulSet.spec.serviceName = 'demo-governing';
+
+    const detail = await adaptAppDetail([statefulSet, createService('demo-governing')], {
+      SEALOS_DOMAIN: '192.168.13.209.nip.io',
+      SEALOS_USER_DOMAINS: []
+    });
+
+    expect(detail.statefulSetServiceName).toBe('demo-governing');
+    expect(adaptEditAppData(detail).statefulSetServiceName).toBe('demo-governing');
+  });
+
   it('keeps a multi-path ingress as one public network with route rules', async () => {
     const app = await adaptAppDetail([createDeployment(), createService(), createIngress()], {
       SEALOS_DOMAIN: '192.168.13.209.nip.io',

--- a/frontend/providers/applaunchpad/__tests__/unit/utils/custom-domain.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/custom-domain.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   findMatchingCertificateDomain,
+  getChangedCustomDomainBindings,
   getCustomDomainBindings,
   getPublicDomainHost,
   isDomainCoveredByCertificateDomain,
@@ -64,6 +65,28 @@ describe('custom domain helpers', () => {
         networkIndex: 0,
         customDomain: 'hello.icloud.xxx.io',
         publicDomain: 'codex-ms100066-launch.192.168.13.209.nip.io'
+      }
+    ]);
+  });
+
+  it('returns only newly added or retargeted custom domain bindings', () => {
+    const unchanged = createNetwork({ customDomain: 'stable.example.com' });
+    const changed = createNetwork({
+      networkName: 'network-changed',
+      customDomain: 'changed.example.com',
+      publicDomain: 'new-target'
+    });
+
+    expect(
+      getChangedCustomDomainBindings(
+        [unchanged, changed],
+        [unchanged, { ...changed, publicDomain: 'old-target' }]
+      )
+    ).toEqual([
+      {
+        networkIndex: 1,
+        customDomain: 'changed.example.com',
+        publicDomain: 'new-target.192.168.13.209.nip.io'
       }
     ]);
   });

--- a/frontend/providers/applaunchpad/__tests__/unit/utils/deployYaml2Json.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/deployYaml2Json.test.ts
@@ -486,6 +486,36 @@ describe('json2DeployCr', () => {
     expect(paths).not.toContain('/spec/template/metadata/labels/restartTime');
     expect(paths.some((path) => path.startsWith('/spec/template'))).toBe(false);
   });
+
+  it('keeps the existing StatefulSet governing Service when ports change', () => {
+    const app = createApp();
+    app.kind = 'statefulset';
+    app.statefulSetServiceName = 'demo-governing';
+    app.networks = [{ ...app.networks[0], serviceName: '', port: 4819 }];
+
+    const statefulSet = yamlString2Objects(json2DeployCr(app, 'statefulset'))[0] as any;
+    const service = yamlString2Objects(json2Service(app))[0] as any;
+
+    expect(statefulSet.spec.serviceName).toBe('demo-governing');
+    expect(service.metadata.name).toBe('demo-governing');
+    expect(service.spec.ports[0].port).toBe(4819);
+  });
+
+  it('keeps a governing ClusterIP Service when every StatefulSet port uses NodePort', () => {
+    const app = createApp();
+    app.kind = 'statefulset';
+    app.statefulSetServiceName = 'demo-governing';
+    app.networks = [{ ...app.networks[0], openNodePort: true, nodePort: 30080 }];
+
+    const services = yamlString2Objects(json2Service(app)) as any[];
+
+    expect(services.map((service) => service.metadata.name)).toEqual([
+      'demo-governing',
+      expect.stringContaining('-nodeport-')
+    ]);
+    expect(services[0].spec.type).toBeUndefined();
+    expect(services[0].spec.ports[0]).not.toHaveProperty('nodePort');
+  });
 });
 
 describe('json2Secret', () => {

--- a/frontend/providers/applaunchpad/src/pages/api/updateApp.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/updateApp.ts
@@ -8,7 +8,7 @@ import { PatchUtils } from '@kubernetes/client-node';
 import type { AppPatchPropsType } from '@/types/app';
 import { initK8s } from 'sealos-desktop-sdk/service';
 import { errLog, infoLog, warnLog } from 'sealos-desktop-sdk';
-import type { V1Service } from '@kubernetes/client-node';
+import type { V1OwnerReference, V1Service } from '@kubernetes/client-node';
 import { generateOwnerReference, shouldHaveOwnerReference } from '@/utils/deployYaml2Json';
 import { appDeployKey } from '@/constants/app';
 import { buildExternalUrl } from '@/utils/network-url';
@@ -69,6 +69,12 @@ type CreateResourceItem = {
   resource: Record<string, any>;
 };
 
+type WorkloadKind = 'Deployment' | 'StatefulSet';
+type ResourceIdentity = {
+  kind: `${YamlKindEnum}`;
+  name: string;
+};
+
 const getK8sErrorCode = (error: any) =>
   error?.body?.code || error?.response?.body?.code || error?.response?.statusCode;
 
@@ -102,6 +108,14 @@ async function getWorkloadOwnerReferences({
       targetKind === 'Deployment'
         ? await k8sApp.readNamespacedDeployment(appName, namespace)
         : await k8sApp.readNamespacedStatefulSet(appName, namespace);
+    const instanceOwnerReference = workload.body.metadata?.ownerReferences?.find(
+      (ownerReference: V1OwnerReference) =>
+        ownerReference.apiVersion === 'app.sealos.io/v1' && ownerReference.kind === 'Instance'
+    );
+    if (instanceOwnerReference) {
+      return [instanceOwnerReference];
+    }
+
     const uid = workload.body.metadata?.uid;
     if (!uid) {
       throw new Error(`${targetKind} UID is empty`);
@@ -123,10 +137,24 @@ async function getWorkloadOwnerReferences({
   }
 }
 
-const withOwnerReferences = (
-  yamlStr: string,
-  ownerReferences: ReturnType<typeof generateOwnerReference>
-) => {
+const createK8sStatusError = (code: number, reason: string, message: string) => ({
+  body: {
+    apiVersion: 'v1',
+    kind: 'Status',
+    status: 'Failure',
+    code,
+    reason,
+    message
+  }
+});
+
+const hasInstanceOwnerReference = (ownerReferences?: V1OwnerReference[]) =>
+  ownerReferences?.some(
+    (ownerReference) =>
+      ownerReference.apiVersion === 'app.sealos.io/v1' && ownerReference.kind === 'Instance'
+  ) ?? false;
+
+const withOwnerReferences = (yamlStr: string, ownerReferences: V1OwnerReference[]) => {
   const resource = normalizeNetworkResource(yaml.load(yamlStr) as any);
   if (resource?.kind && shouldHaveOwnerReference(resource.kind)) {
     resource.metadata = resource.metadata || {};
@@ -154,7 +182,7 @@ async function patchExistingOwnerReferences({
   k8sCustomObjects: CustomObjectsApi;
   namespace: string;
   appName: string;
-  ownerReferences: ReturnType<typeof generateOwnerReference>;
+  ownerReferences: V1OwnerReference[];
 }) {
   const mergePatchOptions = {
     headers: { 'Content-type': PatchUtils.PATCH_FORMAT_JSON_MERGE_PATCH }
@@ -431,6 +459,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       `${YamlKindEnum}`,
       {
         patch: (jsonPatch: Object) => Promise<any>;
+        preflight?: (jsonPatch: Object) => Promise<any>;
         delete: (name: string) => Promise<any>;
       }
     > = {
@@ -447,11 +476,22 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
             undefined,
             { headers: { 'Content-type': PatchUtils.PATCH_FORMAT_JSON_MERGE_PATCH } }
           ),
+        preflight: (jsonPatch: Object) =>
+          k8sApp.patchNamespacedDeployment(
+            appName,
+            namespace,
+            jsonPatch,
+            undefined,
+            'All',
+            undefined,
+            undefined,
+            undefined,
+            { headers: { 'Content-type': PatchUtils.PATCH_FORMAT_JSON_MERGE_PATCH } }
+          ),
         delete: (name) => k8sApp.deleteNamespacedDeployment(name, namespace)
       },
       [YamlKindEnum.StatefulSet]: {
         patch: async (jsonPatch: Object) => {
-          // patch -> replace; fail closed if both fail
           try {
             await k8sApp.patchNamespacedStatefulSet(
               appName,
@@ -465,18 +505,29 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
               { headers: { 'Content-type': PatchUtils.PATCH_FORMAT_JSON_MERGE_PATCH } }
             );
             return { recreated: false, kind: YamlKindEnum.StatefulSet };
-          } catch (patchError) {
-            try {
-              await k8sApp.replaceNamespacedStatefulSet(appName, namespace, jsonPatch);
-              return { recreated: false, kind: YamlKindEnum.StatefulSet };
-            } catch (replaceError) {
-              warnLog('statefulSet patch/replace failed; not falling back to delete/create', {
-                yaml: yaml.dump(jsonPatch)
-              });
-              throw replaceError || patchError;
-            }
+          } catch (patchError: any) {
+            warnLog('StatefulSet patch failed; not falling back to replace or recreate', {
+              code: getK8sErrorCode(patchError),
+              message:
+                patchError?.body?.message ||
+                patchError?.response?.body?.message ||
+                patchError?.message
+            });
+            throw patchError;
           }
         },
+        preflight: (jsonPatch: Object) =>
+          k8sApp.patchNamespacedStatefulSet(
+            appName,
+            namespace,
+            jsonPatch,
+            undefined,
+            'All',
+            undefined,
+            undefined,
+            undefined,
+            { headers: { 'Content-type': PatchUtils.PATCH_FORMAT_JSON_MERGE_PATCH } }
+          ),
         delete: (name) => k8sApp.deleteNamespacedStatefulSet(name, namespace)
       },
       [YamlKindEnum.Service]: {
@@ -596,6 +647,57 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       }
     };
 
+    const patchItems = patch.filter(
+      (item): item is Extract<AppPatchPropsType[number], { type: 'patch' }> => {
+        const cr = crMap[item.kind];
+        return !!cr && item.type === 'patch' && !!item.value?.metadata;
+      }
+    );
+    const workloadPatches = patchItems.filter((item) => isWorkloadKind(item.kind));
+    const regularPatches = patchItems.filter((item) => !isWorkloadKind(item.kind));
+    const serviceDeleteNames = new Set(
+      patch
+        .filter(
+          (item): item is Extract<AppPatchPropsType[number], { type: 'delete' }> =>
+            item.type === 'delete' && item.kind === YamlKindEnum.Service
+        )
+        .map((item) => item.name)
+    );
+    const statefulSetPatch = workloadPatches.find((item) => item.kind === YamlKindEnum.StatefulSet);
+    const currentStatefulSet =
+      statefulSetPatch || serviceDeleteNames.size > 0
+        ? await ignoreNotFound(k8sApp.readNamespacedStatefulSet(appName, namespace))
+        : undefined;
+    const currentStatefulSetServiceName = currentStatefulSet?.body.spec?.serviceName;
+
+    if (currentStatefulSetServiceName && serviceDeleteNames.has(currentStatefulSetServiceName)) {
+      throw createK8sStatusError(
+        422,
+        'Invalid',
+        `Service "${currentStatefulSetServiceName}" is the governing Service of StatefulSet "${appName}" and cannot be deleted`
+      );
+    }
+
+    // Validate the complete workload plan before applying PVC, dependency, or workload changes.
+    // Dry-run catches immutable fields and admission/RBAC failures without leaving partial state.
+    await Promise.all(
+      workloadPatches.map(async (item) => {
+        const cr = crMap[item.kind];
+        if (item.kind === YamlKindEnum.StatefulSet && item.value?.spec?.serviceName) {
+          const currentServiceName = currentStatefulSetServiceName;
+          const nextServiceName = item.value.spec.serviceName;
+          if (currentServiceName && currentServiceName !== nextServiceName) {
+            throw createK8sStatusError(
+              422,
+              'Invalid',
+              `StatefulSet spec.serviceName is immutable: cannot change "${currentServiceName}" to "${nextServiceName}"`
+            );
+          }
+        }
+        await cr.preflight?.(item.value);
+      })
+    );
+
     // update pvc data
     const stateFulSet = stateFulSetYaml ? (yaml.load(stateFulSetYaml) as V1StatefulSet) : {};
     // filer delete pvc
@@ -665,14 +767,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       })
     );
 
-    const patchItems = patch.filter(
-      (item): item is Extract<AppPatchPropsType[number], { type: 'patch' }> => {
-        const cr = crMap[item.kind];
-        return !!cr && item.type === 'patch' && !!item.value?.metadata;
-      }
-    );
-    const workloadPatches = patchItems.filter((item) => isWorkloadKind(item.kind));
-    const regularPatches = patchItems.filter((item) => !isWorkloadKind(item.kind));
     const applyPatchItem = (
       item: Extract<AppPatchPropsType[number], { type: 'patch' }>
     ): Promise<any> | undefined => {
@@ -682,10 +776,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       infoLog('patch cr', { kind: item.kind, name: item.value?.metadata?.name });
       return cr.patch(item.value);
     };
-
-    // Patch ConfigMap/Service/etc. first. Workload patches can create fresh Pods, so run them
-    // after referenced resources are patched or created.
-    await Promise.all(regularPatches.map(applyPatchItem));
 
     // create
     const createItems = patch
@@ -713,88 +803,162 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       patch.some(
         (item) => item.type === 'delete' && isWorkloadKind(item.kind) && item.name === appName
       );
-    let createdWorkloadOwnerReferences: ReturnType<typeof generateOwnerReference> | undefined;
-
-    if (workloadCreateItems.length > 0) {
-      await applyYamlList(
-        workloadCreateItems.map(({ resource }) => yaml.dump(resource)),
-        'create'
-      );
-
-      const createdWorkloadKind = workloadCreateItems[0].resource.kind as
-        'Deployment' | 'StatefulSet';
-      createdWorkloadOwnerReferences = await getWorkloadOwnerReferences({
-        k8sApp,
-        namespace,
-        appName,
-        kind: createdWorkloadKind
+    let createdWorkloadOwnerReferences: V1OwnerReference[] | undefined;
+    let currentWorkloadOwnerReferences: V1OwnerReference[] | undefined;
+    const createdResources: ResourceIdentity[] = [];
+    const rememberCreatedResources = (items: CreateResourceItem[]) => {
+      items.forEach(({ resource }) => {
+        if (resource.kind && resource.metadata?.name && crMap[resource.kind as YamlKindEnum]) {
+          createdResources.push({
+            kind: resource.kind as `${YamlKindEnum}`,
+            name: resource.metadata.name
+          });
+        }
       });
+    };
+    const rollbackCreatedResources = async () => {
+      for (const resource of [...createdResources].reverse()) {
+        try {
+          await crMap[resource.kind].delete(resource.name);
+          infoLog('Rolled back newly created resource', resource);
+        } catch (rollbackError: any) {
+          if (Number(getK8sErrorCode(rollbackError)) !== 404) {
+            errLog('Failed to roll back newly created resource', {
+              ...resource,
+              code: getK8sErrorCode(rollbackError),
+              message:
+                rollbackError?.body?.message ||
+                rollbackError?.response?.body?.message ||
+                rollbackError?.message
+            });
+          }
+        }
+      }
+    };
 
-      if (dependentCreateItems.length > 0) {
+    try {
+      if (workloadCreateItems.length > 0) {
+        const stableInstanceOwnerReferences =
+          workloadCreateItems[0].resource.metadata?.ownerReferences?.filter(
+            (ownerReference: V1OwnerReference) =>
+              ownerReference.apiVersion === 'app.sealos.io/v1' && ownerReference.kind === 'Instance'
+          );
+        currentWorkloadOwnerReferences =
+          stableInstanceOwnerReferences?.length > 0
+            ? stableInstanceOwnerReferences
+            : await getWorkloadOwnerReferences({
+                k8sApp,
+                namespace,
+                appName
+              });
+
+        if (dependentCreateItems.length > 0) {
+          await applyYamlList(
+            dependentCreateItems.map(({ resource }) =>
+              withOwnerReferences(yaml.dump(resource), currentWorkloadOwnerReferences!)
+            ),
+            'create'
+          );
+          rememberCreatedResources(dependentCreateItems);
+        }
+
         await applyYamlList(
-          dependentCreateItems.map(({ resource }) =>
-            withOwnerReferences(yaml.dump(resource), createdWorkloadOwnerReferences!)
-          ),
+          workloadCreateItems.map(({ resource }) => yaml.dump(resource)),
           'create'
         );
-      }
-    } else if (dependentCreateItems.length > 0) {
-      try {
+        rememberCreatedResources(workloadCreateItems);
+
+        const createdWorkloadKind = workloadCreateItems[0].resource.kind as WorkloadKind;
+        createdWorkloadOwnerReferences = await getWorkloadOwnerReferences({
+          k8sApp,
+          namespace,
+          appName,
+          kind: createdWorkloadKind
+        });
+      } else if (dependentCreateItems.length > 0) {
         const ownerReferences = await getWorkloadOwnerReferences({
           k8sApp,
           namespace,
           appName
         });
+        currentWorkloadOwnerReferences = ownerReferences;
         await applyYamlList(
           dependentCreateItems.map(({ resource }) =>
             withOwnerReferences(yaml.dump(resource), ownerReferences)
           ),
           'create'
         );
-      } catch (error) {
-        warnLog('Could not find workload for ownerReferences', { appName });
-        await applyYamlList(
-          dependentCreateItems.map(({ resource }) => yaml.dump(resource)),
-          'create'
-        );
+        rememberCreatedResources(dependentCreateItems);
       }
-    }
 
-    const workloadPatchResults = await Promise.all(workloadPatches.map(applyPatchItem));
-    const recreatedWorkloadPatch = workloadPatchResults.find((result) => result?.recreated);
+      // Dependencies must be ready before a workload update can create fresh Pods (#7064).
+      // Run regular patches only after new dependency creation so a create conflict has no
+      // preceding patch side effects.
+      await Promise.all(regularPatches.map(applyPatchItem));
 
-    if (recreatedWorkloadPatch) {
-      createdWorkloadOwnerReferences = await getWorkloadOwnerReferences({
-        k8sApp,
-        namespace,
-        appName,
-        kind: recreatedWorkloadPatch.kind
-      });
-    }
+      const workloadPatchResults = await Promise.all(workloadPatches.map(applyPatchItem));
+      const recreatedWorkloadPatch = workloadPatchResults.find((result) => result?.recreated);
 
-    if (createdWorkloadOwnerReferences && (replacingWorkload || recreatedWorkloadPatch)) {
-      await patchExistingOwnerReferences({
-        k8sCore,
-        k8sNetworkingApp,
-        k8sAutoscaling,
-        k8sCustomObjects,
-        namespace,
-        appName,
-        ownerReferences: createdWorkloadOwnerReferences
-      });
-    }
+      // The workload now references the new dependencies. They must remain if a later ownership
+      // migration or cleanup operation fails.
+      createdResources.length = 0;
 
-    // delete
-    await Promise.all(
-      patch.map((item) => {
-        const cr = crMap[item.kind];
-        if (!cr || item.type !== 'delete' || !item?.name) {
-          return;
+      if (recreatedWorkloadPatch) {
+        createdWorkloadOwnerReferences = await getWorkloadOwnerReferences({
+          k8sApp,
+          namespace,
+          appName,
+          kind: recreatedWorkloadPatch.kind
+        });
+      }
+
+      if (createdWorkloadOwnerReferences && (replacingWorkload || recreatedWorkloadPatch)) {
+        await patchExistingOwnerReferences({
+          k8sCore,
+          k8sNetworkingApp,
+          k8sAutoscaling,
+          k8sCustomObjects,
+          namespace,
+          appName,
+          ownerReferences: createdWorkloadOwnerReferences
+        });
+      } else {
+        currentWorkloadOwnerReferences ??= await getWorkloadOwnerReferences({
+          k8sApp,
+          namespace,
+          appName
+        });
+        if (hasInstanceOwnerReference(currentWorkloadOwnerReferences)) {
+          await patchExistingOwnerReferences({
+            k8sCore,
+            k8sNetworkingApp,
+            k8sAutoscaling,
+            k8sCustomObjects,
+            namespace,
+            appName,
+            ownerReferences: currentWorkloadOwnerReferences
+          });
         }
-        infoLog('delete cr', { kind: item.kind, name: item?.name });
-        return cr.delete(item.name);
-      })
-    );
+      }
+
+      // delete
+      await Promise.all(
+        patch.map((item) => {
+          const cr = crMap[item.kind];
+          if (!cr || item.type !== 'delete' || !item?.name) {
+            return;
+          }
+          infoLog('delete cr', { kind: item.kind, name: item?.name });
+          // Deletion is idempotent: ownerReference GC or another controller may have already
+          // removed a resource from the generated cleanup plan. Only ignore a real K8s 404;
+          // permission, validation, conflict, and server errors must still fail the update.
+          return ignoreNotFound(cr.delete(item.name));
+        })
+      );
+    } catch (error) {
+      await rollbackCreatedResources();
+      throw error;
+    }
 
     // Update AppCR URL in background (non-blocking)
     updateAppCRUrl(k8sCustomObjects, namespace, appName, patch).catch((error) => {

--- a/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/index.tsx
@@ -56,11 +56,8 @@ import {
   getDuplicateManagedPublicDomainHosts,
   validatePublicDomainPrefix
 } from '@/utils/public-domain';
-import { getCustomDomainBindings } from '@/utils/custom-domain';
-import {
-  APP_NAME_BASE_MAX_LENGTH,
-  getInvalidNameMessageI18nKey
-} from '@/utils/appNameValidation';
+import { getChangedCustomDomainBindings } from '@/utils/custom-domain';
+import { APP_NAME_BASE_MAX_LENGTH, getInvalidNameMessageI18nKey } from '@/utils/appNameValidation';
 
 const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz', 12);
 
@@ -298,7 +295,10 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
   const { createCompleted } = useGuideStore();
 
   const checkCustomDomainBindings = useCallback(async (data: AppEditType) => {
-    const bindings = getCustomDomainBindings(data.networks);
+    const bindings = getChangedCustomDomainBindings(
+      data.networks,
+      oldAppEditData.current?.networks
+    );
 
     for (const binding of bindings) {
       if (CUSTOM_DOMAIN_MODE === 'certificate') {
@@ -476,7 +476,7 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
           );
           setErrorCode(ResponseCode.BAD_REQUEST);
         } else {
-          setErrorMessage(JSON.stringify(error));
+          setErrorMessage(error?.message || JSON.stringify(error));
         }
       }
       setIsLoading(false);
@@ -530,9 +530,15 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
           (item) => item.kind === YamlKindEnum.Deployment || item.kind === YamlKindEnum.StatefulSet
         );
         if (workload) {
+          const instanceOwnerReferences = workload.metadata?.ownerReferences?.filter(
+            (ownerReference) =>
+              ownerReference.apiVersion === 'app.sealos.io/v1' && ownerReference.kind === 'Instance'
+          );
           const workloadUid = workload.metadata?.uid;
           const workloadKind = workload.kind as 'Deployment' | 'StatefulSet';
-          if (workloadUid && workloadKind) {
+          if (instanceOwnerReferences?.length) {
+            ownerReferences = instanceOwnerReferences;
+          } else if (workloadUid && workloadKind) {
             ownerReferences = generateOwnerReference(data.appName, workloadKind, workloadUid);
           }
         }
@@ -555,6 +561,7 @@ const EditApp = ({ appName, tabType }: { appName?: string; tabType: string }) =>
         postDeployApp(yamlList, 'replace')
           .then(() => {
             toast({ status: 'success', title: t('Deployment Successful') });
+            oldAppEditData.current = JSON.parse(JSON.stringify(data));
             formOldYamls.current = formData2Yamls(data);
             setYamlList(formData2DisplayYamls(data));
           })

--- a/frontend/providers/applaunchpad/src/services/backend/response.ts
+++ b/frontend/providers/applaunchpad/src/services/backend/response.ts
@@ -90,9 +90,22 @@ export const handleK8sError = (
       };
     }
     if ((k8sApiErr.code ?? statusCode) === 409 && errMessage.includes('already exists')) {
+      const resourceKind = String((body as any)?.details?.kind || '').toLowerCase();
+      if (resourceKind === 'deployments' || resourceKind === 'statefulsets') {
+        return {
+          code: ResponseCode.APP_ALREADY_EXISTS,
+          message: ResponseMessages[ResponseCode.APP_ALREADY_EXISTS]
+        };
+      }
       return {
-        code: ResponseCode.APP_ALREADY_EXISTS,
-        message: ResponseMessages[ResponseCode.APP_ALREADY_EXISTS]
+        code: ResponseCode.RESOURCE_ALREADY_EXISTS,
+        message: errMessage || ResponseMessages[ResponseCode.RESOURCE_ALREADY_EXISTS]
+      };
+    }
+    if ((k8sApiErr.code ?? statusCode) === 422) {
+      return {
+        code: ResponseCode.UNPROCESSABLE_ENTITY,
+        message: errMessage || ResponseMessages[ResponseCode.UNPROCESSABLE_ENTITY]
       };
     }
   }

--- a/frontend/providers/applaunchpad/src/types/app.d.ts
+++ b/frontend/providers/applaunchpad/src/types/app.d.ts
@@ -163,6 +163,8 @@ export interface AppEditType {
   volumes: V1Volume[];
   volumeMounts: V1VolumeMount[];
   kind: 'deployment' | 'statefulset';
+  /** Stable governing Service used by an existing StatefulSet. */
+  statefulSetServiceName?: string;
   // ephemeral-storage limit (unit: Gi)
   ephemeralStorage?: number;
   // shared memory (tmpfs mounted at /dev/shm)

--- a/frontend/providers/applaunchpad/src/types/response.ts
+++ b/frontend/providers/applaunchpad/src/types/response.ts
@@ -4,6 +4,8 @@ export enum ResponseCode {
   UNAUTHORIZED = 401,
   FORBIDDEN = 403,
   NOT_FOUND = 404,
+  RESOURCE_ALREADY_EXISTS = 409,
+  UNPROCESSABLE_ENTITY = 422,
   SERVER_ERROR = 500,
 
   BALANCE_NOT_ENOUGH = 40001,
@@ -18,6 +20,8 @@ export const ResponseMessages: Record<ResponseCode | number, string> = {
   [ResponseCode.UNAUTHORIZED]: 'Unauthorized, please login again',
   [ResponseCode.FORBIDDEN]: 'Insufficient permissions',
   [ResponseCode.NOT_FOUND]: 'Requested resource not found',
+  [ResponseCode.RESOURCE_ALREADY_EXISTS]: 'The Kubernetes resource already exists',
+  [ResponseCode.UNPROCESSABLE_ENTITY]: 'The requested update cannot be applied',
   [ResponseCode.SERVER_ERROR]: 'Server error',
   [ResponseCode.BALANCE_NOT_ENOUGH]:
     'Almost there! You need additional credits for this deployment.',

--- a/frontend/providers/applaunchpad/src/utils/adapt.ts
+++ b/frontend/providers/applaunchpad/src/utils/adapt.ts
@@ -577,7 +577,7 @@ export const adaptAppDetail = async (
         // and only fall back to HTTP when an Ingress proves this TCP port is application traffic.
         const appProtocol = APPLICATION_PROTOCOLS.includes(serviceAppProtocol)
           ? (serviceAppProtocol as ApplicationProtocolType)
-          : ingressAppProtocol ?? (ingress && protocol === 'TCP' ? 'HTTP' : undefined);
+          : (ingressAppProtocol ?? (ingress && protocol === 'TCP' ? 'HTTP' : undefined));
 
         const isCustomDomain =
           !domain.endsWith(SEALOS_DOMAIN) &&
@@ -600,8 +600,8 @@ export const adaptAppDetail = async (
           domain: isCustomDomain
             ? SEALOS_DOMAIN
             : item?.nodePort
-            ? domain
-            : domain.split('.').slice(1).join('.') || SEALOS_DOMAIN,
+              ? domain
+              : domain.split('.').slice(1).join('.') || SEALOS_DOMAIN,
           routes: ingressPaths.length
             ? ingressPaths.map((path) => ({
                 path: path.path || '/',
@@ -670,6 +670,10 @@ export const adaptAppDetail = async (
     volumeMounts: getFilteredVolumeMounts(),
     volumes: getFilteredVolumes(),
     kind: appDeploy?.kind?.toLowerCase() as 'deployment' | 'statefulset',
+    statefulSetServiceName:
+      appDeploy?.kind === YamlKindEnum.StatefulSet
+        ? (appDeploy as V1StatefulSet).spec?.serviceName
+        : undefined,
     source: getAppSource(appDeploy),
     openapi: {
       status: {
@@ -703,6 +707,7 @@ export const adaptEditAppData = (app: AppDetailType): AppEditType => {
     'gpu',
     'labels',
     'kind',
+    'statefulSetServiceName',
     'volumes',
     'volumeMounts',
     'ephemeralStorage',
@@ -736,8 +741,8 @@ export const sliderNumber2MarkList = ({
           ? `${item / 1024} G`
           : `${item} M`
         : type === 'ephemeralStorage'
-        ? `${item}`
-        : `${item / 1000}`,
+          ? `${item}`
+          : `${item / 1000}`,
     value: item
   }));
 };

--- a/frontend/providers/applaunchpad/src/utils/custom-domain.ts
+++ b/frontend/providers/applaunchpad/src/utils/custom-domain.ts
@@ -72,3 +72,18 @@ export const getCustomDomainBindings = (networks: AppEditType['networks']) =>
         publicDomain: string;
       } => !!item
     );
+
+export const getChangedCustomDomainBindings = (
+  networks: AppEditType['networks'],
+  originalNetworks: AppEditType['networks'] = []
+) => {
+  const originalBindings = new Set(
+    getCustomDomainBindings(originalNetworks).map(
+      ({ customDomain, publicDomain }) => `${customDomain}|${publicDomain}`
+    )
+  );
+
+  return getCustomDomainBindings(networks).filter(
+    ({ customDomain, publicDomain }) => !originalBindings.has(`${customDomain}|${publicDomain}`)
+  );
+};

--- a/frontend/providers/applaunchpad/src/utils/deployYaml2Json.ts
+++ b/frontend/providers/applaunchpad/src/utils/deployYaml2Json.ts
@@ -84,6 +84,12 @@ export const shouldHaveOwnerReference = (kind: string): boolean => {
 
 // Unified service name generation function
 const getServiceName = (data: AppEditType, forNodePort: boolean = false): string => {
+  // StatefulSet.spec.serviceName is immutable. Keep its governing ClusterIP Service stable
+  // while ports and their public exposure are edited.
+  if (!forNodePort && data.kind === 'statefulset' && data.statefulSetServiceName) {
+    return data.statefulSetServiceName;
+  }
+
   const existingServiceName = data.networks.find((network) => {
     return network.openNodePort === forNodePort && network.serviceName;
   })?.serviceName;
@@ -650,7 +656,17 @@ export const json2Service = (
 
   const includeClusterIp = options?.includeClusterIp ?? true;
   const includeNodePort = options?.includeNodePort ?? true;
-  const clusterIpYaml = includeClusterIp && closedPublicPorts.length > 0 ? yaml.dump(template) : '';
+  const governingServicePorts =
+    data.kind === 'statefulset' && closedPublicPorts.length === 0
+      ? namedPorts.map(({ nodePort: _nodePort, ...port }) => port)
+      : closedPublicPorts;
+  template.spec.ports = governingServicePorts;
+  // A StatefulSet always needs its stable governing Service, even when all user ports are
+  // exposed through NodePort Services.
+  const clusterIpYaml =
+    includeClusterIp && (closedPublicPorts.length > 0 || data.kind === 'statefulset')
+      ? yaml.dump(template)
+      : '';
   const nodePortYaml =
     includeNodePort && openPublicPorts.length > 0 ? yaml.dump(templateNodePort) : '';
 


### PR DESCRIPTION
# fix(applaunchpad): make StatefulSet network updates safe

Fixes #7187 

## What does this PR do?

This PR fixes multiple AppLaunchpad update failures triggered when adding, replacing, or deleting network ports on StatefulSet applications.

Previously, changing ports could:

- Recalculate and modify the immutable `StatefulSet.spec.serviceName`.
- Create new Services or Ingresses before the workload update failed, leaving partial resources behind.
- Attach dependent resources to an unstable workload UID instead of the application-store Instance.
- Retry failed resource creation without owner references.
- Report Service conflicts as application name conflicts.
- Report successful cleanup as failed when an Issuer or Certificate had already been removed.
- Block unrelated application updates when an unchanged custom domain could no longer be verified.

## Changes

- Preserve the existing StatefulSet governing Service name across network updates.
- Keep the governing ClusterIP Service available even when all exposed ports use NodePort.
- Prevent deletion of the Service referenced by `StatefulSet.spec.serviceName`.
- Validate workload updates with Kubernetes dry-run before mutating resources.
- Preserve the dependency-first update order introduced by #7064.
- Roll back resources created during the current request if a later workload update fails.
- Remove the unsafe StatefulSet replace and delete/recreate fallback.
- Prefer the stable `app.sealos.io/v1` Instance owner reference for application-store resources.
- Fall back to the workload owner reference only when no Instance owner exists.
- Fail when owner resolution fails instead of creating unmanaged resources.
- Separate owner lookup failures from dependency creation failures.
- Avoid retrying conflicting resource creation without owner references.
- Treat Kubernetes `404 Not Found` responses during cleanup as successful idempotent deletion.
- Continue returning errors for cleanup failures such as 403, 409, 422, and 5xx.
- Distinguish workload name conflicts, dependent resource conflicts, permission errors, and immutable-field validation errors.
- Validate only newly added or changed custom-domain bindings during application updates.
- Display structured backend error messages instead of serialized error objects.

The update flow applies consistently to HTTP, GRPC, WebSocket, TCP, UDP, and SCTP ports. Certificate and Issuer cleanup applies only to domain-based application protocols.

## Why is this needed?

Kubernetes does not allow `StatefulSet.spec.serviceName` to be changed after creation. AppLaunchpad previously derived this field from the mutable network-port configuration, so deleting or replacing a port could generate an invalid StatefulSet update.

The update process also created dependent resources before updating the workload without compensating for later failures. This caused partially applied updates and subsequent `AlreadyExists` conflicts.

Application-store workloads already have a stable Instance owner. Reusing that owner for Services, Ingresses, Certificates, and other dependent resources prevents them from being garbage-collected when a workload UID changes.

Finally, cleanup resources may already have been removed by Kubernetes garbage collection or another controller. A delete operation returning 404 already satisfies the desired final state and should not make an otherwise successful update appear to fail.

## User-visible behavior

- StatefulSet ports can be added, replaced, and deleted without changing the governing Service identity.
- Failed workload updates no longer leave newly created network resources behind.
- Deleting a port succeeds when its Certificate or Issuer has already been removed.
- Unchanged custom domains no longer block unrelated application updates.
- Error messages now identify resource conflicts, permission failures, and invalid updates more accurately.

## Testing

- TypeScript type checking passed.
- AppLaunchpad unit test suite passed:
  - 26 test files
  - 175 tests
- Next.js lint passed.
  - Only pre-existing React Hook dependency warnings remain.
- `git diff --check` passed.
- Manually verified:
  - Adding a port while preserving an existing port.
  - Replacing an existing port.
  - Deleting a newly added port.
  - Deleting the original HTTPS port.
  - Idempotent Certificate cleanup when the Certificate is already absent.

## Release note

Fixed AppLaunchpad network updates for StatefulSet applications by preserving the governing Service, preventing partial updates, stabilizing resource ownership, and making cleanup idempotent.