### PR TITLE
fix(applaunchpad): normalize log field labels

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/utils/logFieldLabel.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/logFieldLabel.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { getLogFieldLabel } from '@/utils/logFieldLabel';
+
+describe('getLogFieldLabel', () => {
+  it('removes the leading underscore from built-in log fields', () => {
+    expect(getLogFieldLabel('_time')).toBe('time');
+    expect(getLogFieldLabel('_msg')).toBe('msg');
+  });
+
+  it('keeps ordinary fields unchanged', () => {
+    expect(getLogFieldLabel('container')).toBe('container');
+    expect(getLogFieldLabel('pod')).toBe('pod');
+  });
+
+  it('removes only one leading underscore', () => {
+    expect(getLogFieldLabel('__custom')).toBe('_custom');
+  });
+});

--- a/frontend/providers/applaunchpad/src/components/app/detail/logs/LogTable.tsx
+++ b/frontend/providers/applaunchpad/src/components/app/detail/logs/LogTable.tsx
@@ -65,13 +65,10 @@ export const LogTable = ({
       });
     });
 
-    const prevFieldStates = prevFieldList.reduce(
-      (acc, field) => {
-        acc[field.value] = field.checked;
-        return acc;
-      },
-      {} as Record<string, boolean>
-    );
+    const prevFieldStates = prevFieldList.reduce((acc, field) => {
+      acc[field.value] = field.checked;
+      return acc;
+    }, {} as Record<string, boolean>);
 
     return Array.from(uniqueKeys).map((key) => ({
       value: key,

--- a/frontend/providers/applaunchpad/src/components/app/detail/logs/LogTable.tsx
+++ b/frontend/providers/applaunchpad/src/components/app/detail/logs/LogTable.tsx
@@ -21,6 +21,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import MyIcon from '@/components/Icon';
 import { formatTime } from '@/utils/tools';
+import { getLogFieldLabel } from '@/utils/logFieldLabel';
 import { LogsFormData } from '@/pages/app/detail/logs';
 import { UseFormReturn } from 'react-hook-form';
 import { useLogStore } from '@/store/logStore';
@@ -64,10 +65,13 @@ export const LogTable = ({
       });
     });
 
-    const prevFieldStates = prevFieldList.reduce((acc, field) => {
-      acc[field.value] = field.checked;
-      return acc;
-    }, {} as Record<string, boolean>);
+    const prevFieldStates = prevFieldList.reduce(
+      (acc, field) => {
+        acc[field.value] = field.checked;
+        return acc;
+      },
+      {} as Record<string, boolean>
+    );
 
     return Array.from(uniqueKeys).map((key) => ({
       value: key,
@@ -85,7 +89,7 @@ export const LogTable = ({
       'filterKeys',
       generateFieldList(data)
         .filter((field) => !excludeFields.includes(field.value))
-        .map((field) => ({ value: field.value, label: field.value }))
+        .map((field) => ({ value: field.value, label: getLogFieldLabel(field.value) }))
     );
   }, [data, generateFieldList, formHook]);
 
@@ -103,7 +107,7 @@ export const LogTable = ({
         header: () => {
           return (
             <Text as="span" textTransform="none">
-              {field.value}
+              {getLogFieldLabel(field.value)}
             </Text>
           );
         },
@@ -265,7 +269,7 @@ export const LogTable = ({
                     }
                   }}
                 >
-                  {item.value}
+                  {getLogFieldLabel(item.value)}
                 </Checkbox>
               ))}
             </CheckboxGroup>

--- a/frontend/providers/applaunchpad/src/utils/logFieldLabel.ts
+++ b/frontend/providers/applaunchpad/src/utils/logFieldLabel.ts
@@ -1,0 +1,1 @@
+export const getLogFieldLabel = (fieldKey: string) => fieldKey.replace(/^_/, '');


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->

## Summary

Normalize Applaunchpad log field labels by removing one leading underscore from displayed labels while preserving raw keys for accessors and filtering. Apply the repository's Prettier formatting to the affected table code.

## Sequence Diagram

```mermaid
sequenceDiagram
    participant User
    participant LogTable
    participant LogRows
    LogRows-->>LogTable: Provide rows with raw field keys
    LogTable->>LogTable: Derive display labels
    LogTable-->>User: Render headers, settings, and filter options
```

## Verification

- `pnpm --dir frontend exec prettier --check providers/applaunchpad/src/utils/logFieldLabel.ts providers/applaunchpad/src/components/app/detail/logs/LogTable.tsx providers/applaunchpad/__tests__/unit/utils/logFieldLabel.test.ts`
- `pnpm --dir frontend/providers/applaunchpad exec tsc --noEmit -p tsconfig.json`
- `pnpm --dir frontend/providers/applaunchpad lint` (passes with existing React Hook dependency warnings)
