### PR TITLE
fix(frontend): gate recharge actions by payment availability

### DIFF
--- a/frontend/providers/applaunchpad/src/api/platform.ts
+++ b/frontend/providers/applaunchpad/src/api/platform.ts
@@ -4,6 +4,7 @@ import { getUserSession } from '@/utils/user';
 import { AuthCnamePrams, AuthDomainChallengeParams } from './params';
 import type { EnvResponse } from '@/types';
 import type { PublicDomainConflictOwner } from '@/utils/public-domain';
+import type { PaymentConfigResponse } from '@/pages/api/platform/paymentConfig';
 
 export type CustomDomainCertificateCoverageStatus =
   'covered' | 'pendingSync' | 'notConfigured' | 'unsupported';
@@ -17,6 +18,8 @@ export type CustomDomainCertificateCoverageResult = {
 };
 
 export const getResourcePrice = () => GET<userPriceType>('/api/platform/resourcePrice');
+
+export const getPaymentConfig = () => GET<PaymentConfigResponse>('/api/platform/paymentConfig');
 
 export const getInitData = () => GET<EnvResponse>('/api/platform/getInitData');
 

--- a/frontend/providers/applaunchpad/src/pages/api/platform/paymentConfig.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/platform/paymentConfig.ts
@@ -1,0 +1,93 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { jsonRes } from '@/services/backend/response';
+
+type CostCenterConfigResponse = {
+  code: number;
+  data?: {
+    RECHARGE_ENABLED?: boolean;
+    STRIPE_ENABLED?: boolean;
+    WECHAT_ENABLED?: boolean;
+    ALIPAY_ENABLED?: boolean;
+  };
+};
+
+export type PaymentConfigResponse = {
+  paymentEnabled: boolean;
+};
+
+const COSTCENTER_SERVICE_CONFIG_URL =
+  'http://costcenter-frontend.costcenter-frontend.svc:3000/api/platform/getAppConfig';
+const COSTCENTER_CONFIG_TIMEOUT_MS = 5000;
+
+const normalizePort = (value: string) => {
+  if (!/^\d+$/.test(value)) return '';
+  const port = Number(value);
+  return port >= 1 && port <= 65535 ? String(port) : '';
+};
+
+const getExternalConfigUrl = (domain: string, protocol: 'http' | 'https', rawPort: string) => {
+  const port = normalizePort(rawPort.trim().replace(/^:/, ''));
+  const isDefaultPort =
+    (protocol === 'http' && port === '80') || (protocol === 'https' && port === '443');
+  const portSuffix = port && !isDefaultPort ? `:${port}` : '';
+
+  return `${protocol}://costcenter.${domain}${portSuffix}/api/platform/getAppConfig`;
+};
+
+const getCostCenterConfigUrls = () => {
+  const cloudConfig = global.AppConfig?.cloud;
+  const domain = cloudConfig?.domain || 'cloud.sealos.io';
+  const disableHttps = !!cloudConfig?.disableHttps;
+  const protocol = disableHttps ? 'http' : 'https';
+  const port = disableHttps ? cloudConfig?.httpPort : cloudConfig?.port;
+  const configuredUrl = getExternalConfigUrl(domain, protocol, String(port || ''));
+
+  const urls = [COSTCENTER_SERVICE_CONFIG_URL, configuredUrl];
+  return [...new Set(urls)];
+};
+
+async function getCostCenterConfig(): Promise<CostCenterConfigResponse> {
+  let lastError: unknown;
+
+  for (const url of getCostCenterConfigUrls()) {
+    try {
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(COSTCENTER_CONFIG_TIMEOUT_MS)
+      });
+      if (!response.ok) {
+        throw new Error(`CostCenter config request failed with status ${response.status}`);
+      }
+      const result = (await response.json()) as CostCenterConfigResponse;
+      if (result.code !== 200 || !result.data) {
+        throw new Error(`CostCenter config request failed with code ${result.code}`);
+      }
+      return result;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError || new Error('CostCenter config request failed');
+}
+
+export default async function handler(_req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const result = await getCostCenterConfig();
+    const config = result.data;
+    const hasPaymentMethod =
+      !!config?.STRIPE_ENABLED || !!config?.WECHAT_ENABLED || !!config?.ALIPAY_ENABLED;
+
+    jsonRes<PaymentConfigResponse>(res, {
+      data: {
+        paymentEnabled: !!config?.RECHARGE_ENABLED && hasPaymentMethod
+      }
+    });
+  } catch (error) {
+    console.log('error: /api/platform/paymentConfig', error);
+    jsonRes<PaymentConfigResponse>(res, {
+      data: {
+        paymentEnabled: false
+      }
+    });
+  }
+}

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/ErrorModal.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/ErrorModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Modal,
   ModalOverlay,
@@ -14,6 +14,7 @@ import MyIcon from '@/components/Icon';
 import { useTranslation } from 'next-i18next';
 import { ResponseCode } from '@/types/response';
 import { sealosApp } from 'sealos-desktop-sdk/app';
+import { getPaymentConfig } from '@/api/platform';
 
 const ErrorModal = ({
   title,
@@ -27,6 +28,37 @@ const ErrorModal = ({
   errorCode?: ResponseCode;
 }) => {
   const { t } = useTranslation();
+  const [paymentEnabled, setPaymentEnabled] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let ignore = false;
+
+    if (errorCode !== ResponseCode.BALANCE_NOT_ENOUGH) {
+      setPaymentEnabled(null);
+      return;
+    }
+
+    setPaymentEnabled(null);
+    getPaymentConfig()
+      .then((config) => {
+        if (!ignore) {
+          setPaymentEnabled(config.paymentEnabled);
+        }
+      })
+      .catch(() => {
+        if (!ignore) {
+          setPaymentEnabled(false);
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [errorCode]);
+
+  const shouldRecharge = errorCode === ResponseCode.BALANCE_NOT_ENOUGH && paymentEnabled === true;
+  const isCheckingPayment =
+    errorCode === ResponseCode.BALANCE_NOT_ENOUGH && paymentEnabled === null;
 
   const openCostCenterApp = () => {
     sealosApp.runEvents('openDesktopApp', {
@@ -52,24 +84,27 @@ const ErrorModal = ({
           {content}
         </ModalBody>
         <ModalFooter>
+          {(errorCode !== ResponseCode.BALANCE_NOT_ENOUGH || shouldRecharge) && (
+            <Button
+              onClick={() => {
+                onClose();
+              }}
+              variant={'outline'}
+            >
+              {t('Cancel')}
+            </Button>
+          )}
           <Button
+            ml={errorCode !== ResponseCode.BALANCE_NOT_ENOUGH || shouldRecharge ? '12px' : 0}
+            isDisabled={isCheckingPayment}
             onClick={() => {
-              onClose();
-            }}
-            variant={'outline'}
-          >
-            {t('Cancel')}
-          </Button>
-          <Button
-            ml={'12px'}
-            onClick={() => {
-              if (errorCode === ResponseCode.BALANCE_NOT_ENOUGH) {
+              if (shouldRecharge) {
                 openCostCenterApp();
               }
               onClose();
             }}
           >
-            {errorCode === ResponseCode.BALANCE_NOT_ENOUGH ? t('add_credit') : t('Confirm')}
+            {shouldRecharge ? t('add_credit') : t('Confirm')}
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/frontend/providers/dbprovider/src/api/platform.ts
+++ b/frontend/providers/dbprovider/src/api/platform.ts
@@ -2,12 +2,15 @@ import { SystemEnvResponse } from '@/pages/api/getEnv';
 import type { Response as DBVersionMapType } from '@/pages/api/platform/getVersion';
 import type { Response as resourcePriceResponse } from '@/pages/api/platform/resourcePrice';
 import type { AddonItem } from '@/pages/api/getAddonList';
+import type { PaymentConfigResponse } from '@/pages/api/platform/paymentConfig';
 import { GET, POST } from '@/services/request';
 import type { UserQuotaItemType, UserTask } from '@/types/user';
 import { getUserSession } from '@/utils/user';
 import { AxiosProgressEvent } from 'axios';
 
 export const getResourcePrice = () => GET<resourcePriceResponse>('/api/platform/resourcePrice');
+
+export const getPaymentConfig = () => GET<PaymentConfigResponse>('/api/platform/paymentConfig');
 
 export const getAppEnv = () => GET<SystemEnvResponse>('/api/getEnv');
 

--- a/frontend/providers/dbprovider/src/components/ErrorModal/index.tsx
+++ b/frontend/providers/dbprovider/src/components/ErrorModal/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Modal,
   ModalOverlay,
@@ -14,6 +14,7 @@ import MyIcon from '@/components/Icon';
 import { useTranslation } from 'next-i18next';
 import { ResponseCode } from '@/types/response';
 import { sealosApp } from 'sealos-desktop-sdk/app';
+import { getPaymentConfig } from '@/api/platform';
 
 const ErrorModal = ({
   title,
@@ -27,6 +28,37 @@ const ErrorModal = ({
   errorCode?: ResponseCode;
 }) => {
   const { t } = useTranslation();
+  const [paymentEnabled, setPaymentEnabled] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let ignore = false;
+
+    if (errorCode !== ResponseCode.BALANCE_NOT_ENOUGH) {
+      setPaymentEnabled(null);
+      return;
+    }
+
+    setPaymentEnabled(null);
+    getPaymentConfig()
+      .then((config) => {
+        if (!ignore) {
+          setPaymentEnabled(config.paymentEnabled);
+        }
+      })
+      .catch(() => {
+        if (!ignore) {
+          setPaymentEnabled(false);
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [errorCode]);
+
+  const shouldRecharge = errorCode === ResponseCode.BALANCE_NOT_ENOUGH && paymentEnabled === true;
+  const isCheckingPayment =
+    errorCode === ResponseCode.BALANCE_NOT_ENOUGH && paymentEnabled === null;
 
   const openCostCenterApp = () => {
     sealosApp.runEvents('openDesktopApp', {
@@ -52,24 +84,27 @@ const ErrorModal = ({
           {content}
         </ModalBody>
         <ModalFooter>
+          {(errorCode !== ResponseCode.BALANCE_NOT_ENOUGH || shouldRecharge) && (
+            <Button
+              onClick={() => {
+                onClose();
+              }}
+              variant={'outline'}
+            >
+              {t('Cancel')}
+            </Button>
+          )}
           <Button
+            ml={errorCode !== ResponseCode.BALANCE_NOT_ENOUGH || shouldRecharge ? '12px' : 0}
+            isDisabled={isCheckingPayment}
             onClick={() => {
-              onClose();
-            }}
-            variant={'outline'}
-          >
-            {t('Cancel')}
-          </Button>
-          <Button
-            ml={'12px'}
-            onClick={() => {
-              if (errorCode === ResponseCode.BALANCE_NOT_ENOUGH) {
+              if (shouldRecharge) {
                 openCostCenterApp();
               }
               onClose();
             }}
           >
-            {errorCode === ResponseCode.BALANCE_NOT_ENOUGH ? t('add_credit') : t('confirm')}
+            {shouldRecharge ? t('add_credit') : t('confirm')}
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/frontend/providers/dbprovider/src/pages/api/platform/paymentConfig.ts
+++ b/frontend/providers/dbprovider/src/pages/api/platform/paymentConfig.ts
@@ -1,0 +1,94 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { jsonRes } from '@/services/backend/response';
+
+type CostCenterConfigResponse = {
+  code: number;
+  data?: {
+    RECHARGE_ENABLED?: boolean;
+    STRIPE_ENABLED?: boolean;
+    WECHAT_ENABLED?: boolean;
+    ALIPAY_ENABLED?: boolean;
+  };
+};
+
+export type PaymentConfigResponse = {
+  paymentEnabled: boolean;
+};
+
+const COSTCENTER_SERVICE_CONFIG_URL =
+  'http://costcenter-frontend.costcenter-frontend.svc:3000/api/platform/getAppConfig';
+const COSTCENTER_CONFIG_TIMEOUT_MS = 5000;
+
+const getCostCenterDomain = () =>
+  process.env.DESKTOP_DOMAIN || process.env.SEALOS_DOMAIN || 'cloud.sealos.io';
+
+const normalizePort = (value: string) => {
+  if (!/^\d+$/.test(value)) return '';
+  const port = Number(value);
+  return port >= 1 && port <= 65535 ? String(port) : '';
+};
+
+const getExternalConfigUrl = (domain: string, protocol: 'http' | 'https', rawPort: string) => {
+  const port = normalizePort(rawPort.trim().replace(/^:/, ''));
+  const isDefaultPort =
+    (protocol === 'http' && port === '80') || (protocol === 'https' && port === '443');
+  const portSuffix = port && !isDefaultPort ? `:${port}` : '';
+
+  return `${protocol}://costcenter.${domain}${portSuffix}/api/platform/getAppConfig`;
+};
+
+const getCostCenterConfigUrls = () => {
+  const disableHttps = ['true', '1'].includes((process.env.DISABLE_HTTPS || '').toLowerCase());
+  const protocol = disableHttps ? 'http' : 'https';
+  const urls = [
+    COSTCENTER_SERVICE_CONFIG_URL,
+    getExternalConfigUrl(getCostCenterDomain(), protocol, process.env.SEALOS_PORT || '')
+  ];
+  return [...new Set(urls)];
+};
+
+async function getCostCenterConfig(): Promise<CostCenterConfigResponse> {
+  let lastError: unknown;
+
+  for (const url of getCostCenterConfigUrls()) {
+    try {
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(COSTCENTER_CONFIG_TIMEOUT_MS)
+      });
+      if (!response.ok) {
+        throw new Error(`CostCenter config request failed with status ${response.status}`);
+      }
+      const result = (await response.json()) as CostCenterConfigResponse;
+      if (result.code !== 200 || !result.data) {
+        throw new Error(`CostCenter config request failed with code ${result.code}`);
+      }
+      return result;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError || new Error('CostCenter config request failed');
+}
+
+export default async function handler(_req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const result = await getCostCenterConfig();
+    const config = result.data;
+    const hasPaymentMethod =
+      !!config?.STRIPE_ENABLED || !!config?.WECHAT_ENABLED || !!config?.ALIPAY_ENABLED;
+
+    jsonRes<PaymentConfigResponse>(res, {
+      data: {
+        paymentEnabled: !!config?.RECHARGE_ENABLED && hasPaymentMethod
+      }
+    });
+  } catch (error) {
+    console.log('error: /api/platform/paymentConfig', error);
+    jsonRes<PaymentConfigResponse>(res, {
+      data: {
+        paymentEnabled: false
+      }
+    });
+  }
+}

--- a/frontend/providers/dbprovider/src/pages/db/edit/index.tsx
+++ b/frontend/providers/dbprovider/src/pages/db/edit/index.tsx
@@ -202,7 +202,6 @@ const EditApp = ({ dbName, tabType }: { dbName?: string; tabType?: 'form' | 'yam
       });
       router.replace(`/db/detail?name=${formData.dbName}&dbType=${formData.dbType}`);
     } catch (error: any) {
-      toast({ title: t(applyError), status: 'error' });
       if (error?.code === ResponseCode.BALANCE_NOT_ENOUGH) {
         setErrorMessage(t('user_balance_not_enough'));
         setErrorCode(ResponseCode.BALANCE_NOT_ENOUGH);


### PR DESCRIPTION
<!--
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR,
because it will be placed in the release note.
-->

## Summary

- Gate insufficient-balance recharge actions in App Launchpad and Database on CostCenter payment availability.
- Add provider-local, fail-closed payment configuration endpoints with trusted runtime URL fallbacks.
- Remove the duplicate deployment error toast from the Database edit flow.

## Sequence Diagram

```mermaid
sequenceDiagram
    participant User
    participant Provider
    participant CostCenter
    participant Desktop
    User->>Provider: Deployment fails with insufficient balance
    Provider->>CostCenter: Read payment configuration
    alt Recharge enabled and payment method available
        CostCenter-->>Provider: paymentEnabled = true
        Provider-->>User: Show Add credit action
        User->>Provider: Select Add credit
        Provider->>Desktop: Open CostCenter recharge
    else Disabled or unavailable
        CostCenter-->>Provider: Disabled or request failure
        Provider-->>User: Show confirmation-only dialog
    end
```

## Verification

- App Launchpad and Database lint passed.
- App Launchpad and Database typechecks passed.
- App Launchpad and Database production builds passed.
- Enabled, disabled, and unavailable CostCenter API smoke cases passed; unavailable configuration fails closed.
- `git diff --check` passed.
- Vitest is unavailable in this checkout (`vitest` command not found).
