### PR TITLE
fix(template): sync managed categories across catalog reads

### DIFF
--- a/frontend/packages/shared/src/hooks/useClientAppConfig.ts
+++ b/frontend/packages/shared/src/hooks/useClientAppConfig.ts
@@ -3,20 +3,51 @@
 import { useQuery } from '@tanstack/react-query';
 import type { QueryClient } from '@tanstack/react-query';
 
+const CLIENT_APP_CONFIG_STALE_TIME = 60 * 1000;
+const CLIENT_APP_CONFIG_CACHE_TIME = 10 * 60 * 1000;
+const CLIENT_APP_CONFIG_REFETCH_INTERVAL = 60 * 1000;
+
+type ClientAppConfigResponse<T> = {
+  code?: number;
+  data?: T;
+  message?: string;
+};
+
+async function fetchClientAppConfig<T>() {
+  const response = await fetch('/api/platform/getClientAppConfig', {
+    credentials: 'include'
+  });
+
+  if (!response.ok) {
+    throw new Error(`[Client App Config] Request failed with status ${response.status}.`);
+  }
+
+  const payload = (await response.json()) as ClientAppConfigResponse<T>;
+
+  if (payload.code !== 200 || payload.data === undefined) {
+    throw new Error(payload.message || '[Client App Config] Failed to load client app config.');
+  }
+
+  return payload.data;
+}
+
 /**
- * Create prefetch-only hook for client app config.
- * Must be pre-fetched on server side (getInitialProps/getServerSideProps).
+ * Create a hook for client app config.
+ * Uses server-side prefetch as initial data, then refreshes from the platform API.
  */
-export function createClientAppConfigHook<T = unknown>(queryKey: readonly unknown[]) {
+export function createClientAppConfigHook<T = unknown>(
+  queryKey: readonly unknown[],
+  queryFn: () => Promise<T> | T = () => fetchClientAppConfig<T>()
+) {
   return function useClientAppConfig(): T {
     const query = useQuery({
-      queryFn: () => {
-        throw new Error('[Client App Config] Not pre-fetched on server side');
-      },
+      queryFn,
       queryKey,
       suspense: true,
-      staleTime: Infinity,
-      cacheTime: Infinity
+      staleTime: CLIENT_APP_CONFIG_STALE_TIME,
+      cacheTime: CLIENT_APP_CONFIG_CACHE_TIME,
+      refetchInterval: CLIENT_APP_CONFIG_REFETCH_INTERVAL,
+      refetchIntervalInBackground: false
     });
 
     if (!query.data) {
@@ -29,7 +60,7 @@ export function createClientAppConfigHook<T = unknown>(queryKey: readonly unknow
 }
 
 /**
- * Prefetch client app config on server side.
+ * Prefetch client app config on server side as initial data.
  * Use in getInitialProps or getServerSideProps.
  */
 export async function prefetchClientAppConfig<T>(
@@ -38,8 +69,8 @@ export async function prefetchClientAppConfig<T>(
   getData: () => T | Promise<T>
 ): Promise<void> {
   queryClient.setQueryDefaults(queryKey, {
-    cacheTime: Infinity,
-    staleTime: Infinity
+    cacheTime: CLIENT_APP_CONFIG_CACHE_TIME,
+    staleTime: CLIENT_APP_CONFIG_STALE_TIME
   });
 
   await queryClient.prefetchQuery({
@@ -57,7 +88,7 @@ export function setupClientAppConfigDefaults(
   queryKey: readonly unknown[]
 ): void {
   queryClient.setQueryDefaults(queryKey, {
-    cacheTime: Infinity,
-    staleTime: Infinity
+    cacheTime: CLIENT_APP_CONFIG_CACHE_TIME,
+    staleTime: CLIENT_APP_CONFIG_STALE_TIME
   });
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -1666,6 +1666,9 @@ importers:
       typescript:
         specifier: 5.2.2
         version: 5.2.2
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@18.13.0)(sass@1.69.5)
 
   providers/terminal:
     dependencies:
@@ -1939,6 +1942,7 @@ packages:
   /@alloc/quick-lru@5.2.0:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+    dev: false
 
   /@ampproject/remapping@2.2.1:
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
@@ -1965,616 +1969,6 @@ packages:
       json-schema: 0.4.0
       jsonpointer: 5.0.1
       leven: 3.1.0
-    dev: false
-
-  /@aws-crypto/crc32@3.0.0:
-    resolution: {integrity: sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==}
-    dependencies:
-      '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.460.0
-      tslib: 1.14.1
-    dev: false
-
-  /@aws-crypto/crc32c@3.0.0:
-    resolution: {integrity: sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==}
-    dependencies:
-      '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.460.0
-      tslib: 1.14.1
-    dev: false
-
-  /@aws-crypto/ie11-detection@3.0.0:
-    resolution: {integrity: sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==}
-    dependencies:
-      tslib: 1.14.1
-    dev: false
-
-  /@aws-crypto/sha1-browser@3.0.0:
-    resolution: {integrity: sha512-NJth5c997GLHs6nOYTzFKTbYdMNA6/1XlKVgnZoaZcQ7z7UJlOgj2JdbHE8tiYLS3fzXNCguct77SPGat2raSw==}
-    dependencies:
-      '@aws-crypto/ie11-detection': 3.0.0
-      '@aws-crypto/supports-web-crypto': 3.0.0
-      '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.460.0
-      '@aws-sdk/util-locate-window': 3.310.0
-      '@aws-sdk/util-utf8-browser': 3.259.0
-      tslib: 1.14.1
-    dev: false
-
-  /@aws-crypto/sha256-browser@3.0.0:
-    resolution: {integrity: sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==}
-    dependencies:
-      '@aws-crypto/ie11-detection': 3.0.0
-      '@aws-crypto/sha256-js': 3.0.0
-      '@aws-crypto/supports-web-crypto': 3.0.0
-      '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.460.0
-      '@aws-sdk/util-locate-window': 3.310.0
-      '@aws-sdk/util-utf8-browser': 3.259.0
-      tslib: 1.14.1
-    dev: false
-
-  /@aws-crypto/sha256-js@3.0.0:
-    resolution: {integrity: sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==}
-    dependencies:
-      '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.460.0
-      tslib: 1.14.1
-    dev: false
-
-  /@aws-crypto/supports-web-crypto@3.0.0:
-    resolution: {integrity: sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==}
-    dependencies:
-      tslib: 1.14.1
-    dev: false
-
-  /@aws-crypto/util@3.0.0:
-    resolution: {integrity: sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==}
-    dependencies:
-      '@aws-sdk/types': 3.460.0
-      '@aws-sdk/util-utf8-browser': 3.259.0
-      tslib: 1.14.1
-    dev: false
-
-  /@aws-sdk/client-s3@3.461.0:
-    resolution: {integrity: sha512-pvEWMb2djn3bjD9lelYQhyG8KKKrUMm5MlSaSPwqVTL97iKm/Zbk+Ord6n8qMyPl5JHGmNdfg0tZFxC1qXeHTw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-crypto/sha1-browser': 3.0.0
-      '@aws-crypto/sha256-browser': 3.0.0
-      '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.461.0
-      '@aws-sdk/core': 3.451.0
-      '@aws-sdk/credential-provider-node': 3.460.0
-      '@aws-sdk/middleware-bucket-endpoint': 3.460.0
-      '@aws-sdk/middleware-expect-continue': 3.460.0
-      '@aws-sdk/middleware-flexible-checksums': 3.461.0
-      '@aws-sdk/middleware-host-header': 3.460.0
-      '@aws-sdk/middleware-location-constraint': 3.461.0
-      '@aws-sdk/middleware-logger': 3.460.0
-      '@aws-sdk/middleware-recursion-detection': 3.460.0
-      '@aws-sdk/middleware-sdk-s3': 3.461.0
-      '@aws-sdk/middleware-signing': 3.461.0
-      '@aws-sdk/middleware-ssec': 3.460.0
-      '@aws-sdk/middleware-user-agent': 3.460.0
-      '@aws-sdk/region-config-resolver': 3.451.0
-      '@aws-sdk/signature-v4-multi-region': 3.461.0
-      '@aws-sdk/types': 3.460.0
-      '@aws-sdk/util-endpoints': 3.460.0
-      '@aws-sdk/util-user-agent-browser': 3.460.0
-      '@aws-sdk/util-user-agent-node': 3.460.0
-      '@aws-sdk/xml-builder': 3.310.0
-      '@smithy/config-resolver': 2.0.19
-      '@smithy/eventstream-serde-browser': 2.0.14
-      '@smithy/eventstream-serde-config-resolver': 2.0.14
-      '@smithy/eventstream-serde-node': 2.0.14
-      '@smithy/fetch-http-handler': 2.2.7
-      '@smithy/hash-blob-browser': 2.0.15
-      '@smithy/hash-node': 2.0.16
-      '@smithy/hash-stream-node': 2.0.16
-      '@smithy/invalid-dependency': 2.0.14
-      '@smithy/md5-js': 2.0.16
-      '@smithy/middleware-content-length': 2.0.16
-      '@smithy/middleware-endpoint': 2.2.1
-      '@smithy/middleware-retry': 2.0.21
-      '@smithy/middleware-serde': 2.0.14
-      '@smithy/middleware-stack': 2.0.8
-      '@smithy/node-config-provider': 2.1.6
-      '@smithy/node-http-handler': 2.1.10
-      '@smithy/protocol-http': 3.0.10
-      '@smithy/smithy-client': 2.1.16
-      '@smithy/types': 2.6.0
-      '@smithy/url-parser': 2.0.14
-      '@smithy/util-base64': 2.0.1
-      '@smithy/util-body-length-browser': 2.0.0
-      '@smithy/util-body-length-node': 2.1.0
-      '@smithy/util-defaults-mode-browser': 2.0.20
-      '@smithy/util-defaults-mode-node': 2.0.26
-      '@smithy/util-endpoints': 1.0.5
-      '@smithy/util-retry': 2.0.7
-      '@smithy/util-stream': 2.0.21
-      '@smithy/util-utf8': 2.0.2
-      '@smithy/util-waiter': 2.0.14
-      fast-xml-parser: 4.2.5
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - aws-crt
-    dev: false
-
-  /@aws-sdk/client-sso@3.460.0:
-    resolution: {integrity: sha512-p5D9C8LKJs5yoBn5cCs2Wqzrp5YP5BYcP774bhGMFEu/LCIUyWzudwN3+/AObSiq8R8SSvBY2zQD4h+k3NjgTQ==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-crypto/sha256-browser': 3.0.0
-      '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/core': 3.451.0
-      '@aws-sdk/middleware-host-header': 3.460.0
-      '@aws-sdk/middleware-logger': 3.460.0
-      '@aws-sdk/middleware-recursion-detection': 3.460.0
-      '@aws-sdk/middleware-user-agent': 3.460.0
-      '@aws-sdk/region-config-resolver': 3.451.0
-      '@aws-sdk/types': 3.460.0
-      '@aws-sdk/util-endpoints': 3.460.0
-      '@aws-sdk/util-user-agent-browser': 3.460.0
-      '@aws-sdk/util-user-agent-node': 3.460.0
-      '@smithy/config-resolver': 2.0.19
-      '@smithy/fetch-http-handler': 2.2.7
-      '@smithy/hash-node': 2.0.16
-      '@smithy/invalid-dependency': 2.0.14
-      '@smithy/middleware-content-length': 2.0.16
-      '@smithy/middleware-endpoint': 2.2.1
-      '@smithy/middleware-retry': 2.0.21
-      '@smithy/middleware-serde': 2.0.14
-      '@smithy/middleware-stack': 2.0.8
-      '@smithy/node-config-provider': 2.1.6
-      '@smithy/node-http-handler': 2.1.10
-      '@smithy/protocol-http': 3.0.10
-      '@smithy/smithy-client': 2.1.16
-      '@smithy/types': 2.6.0
-      '@smithy/url-parser': 2.0.14
-      '@smithy/util-base64': 2.0.1
-      '@smithy/util-body-length-browser': 2.0.0
-      '@smithy/util-body-length-node': 2.1.0
-      '@smithy/util-defaults-mode-browser': 2.0.20
-      '@smithy/util-defaults-mode-node': 2.0.26
-      '@smithy/util-endpoints': 1.0.5
-      '@smithy/util-retry': 2.0.7
-      '@smithy/util-utf8': 2.0.2
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - aws-crt
-    dev: false
-
-  /@aws-sdk/client-sts@3.461.0:
-    resolution: {integrity: sha512-1u+t31m23vuc9zkiUk51L4QbwuRQEuBeMArHK/thmq4V+A0VmjoAr/x2D0eQ0deOuBqG5YC62oaqUfIhj03SIw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-crypto/sha256-browser': 3.0.0
-      '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/core': 3.451.0
-      '@aws-sdk/credential-provider-node': 3.460.0
-      '@aws-sdk/middleware-host-header': 3.460.0
-      '@aws-sdk/middleware-logger': 3.460.0
-      '@aws-sdk/middleware-recursion-detection': 3.460.0
-      '@aws-sdk/middleware-sdk-sts': 3.461.0
-      '@aws-sdk/middleware-signing': 3.461.0
-      '@aws-sdk/middleware-user-agent': 3.460.0
-      '@aws-sdk/region-config-resolver': 3.451.0
-      '@aws-sdk/types': 3.460.0
-      '@aws-sdk/util-endpoints': 3.460.0
-      '@aws-sdk/util-user-agent-browser': 3.460.0
-      '@aws-sdk/util-user-agent-node': 3.460.0
-      '@smithy/config-resolver': 2.0.19
-      '@smithy/fetch-http-handler': 2.2.7
-      '@smithy/hash-node': 2.0.16
-      '@smithy/invalid-dependency': 2.0.14
-      '@smithy/middleware-content-length': 2.0.16
-      '@smithy/middleware-endpoint': 2.2.1
-      '@smithy/middleware-retry': 2.0.21
-      '@smithy/middleware-serde': 2.0.14
-      '@smithy/middleware-stack': 2.0.8
-      '@smithy/node-config-provider': 2.1.6
-      '@smithy/node-http-handler': 2.1.10
-      '@smithy/protocol-http': 3.0.10
-      '@smithy/smithy-client': 2.1.16
-      '@smithy/types': 2.6.0
-      '@smithy/url-parser': 2.0.14
-      '@smithy/util-base64': 2.0.1
-      '@smithy/util-body-length-browser': 2.0.0
-      '@smithy/util-body-length-node': 2.1.0
-      '@smithy/util-defaults-mode-browser': 2.0.20
-      '@smithy/util-defaults-mode-node': 2.0.26
-      '@smithy/util-endpoints': 1.0.5
-      '@smithy/util-retry': 2.0.7
-      '@smithy/util-utf8': 2.0.2
-      fast-xml-parser: 4.2.5
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - aws-crt
-    dev: false
-
-  /@aws-sdk/core@3.451.0:
-    resolution: {integrity: sha512-SamWW2zHEf1ZKe3j1w0Piauryl8BQIlej0TBS18A4ACzhjhWXhCs13bO1S88LvPR5mBFXok3XOT6zPOnKDFktw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/smithy-client': 2.1.16
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/credential-provider-env@3.460.0:
-    resolution: {integrity: sha512-WWdaRJFuYRc2Ue9NKDy2NIf8pQRNx/QRVmrsk6EkIID8uWlQIOePk3SWTVV0TZIyPrbfSEaSnJRZoShphJ6PAg==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.460.0
-      '@smithy/property-provider': 2.0.15
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/credential-provider-ini@3.460.0:
-    resolution: {integrity: sha512-1IEUmyaWzt2M3mONO8QyZtPy0f9ccaEjCo48ZQLgptWxUI+Ohga9gPK0mqu1kTJOjv4JJGACYHzLwEnnpltGlA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.460.0
-      '@aws-sdk/credential-provider-process': 3.460.0
-      '@aws-sdk/credential-provider-sso': 3.460.0
-      '@aws-sdk/credential-provider-web-identity': 3.460.0
-      '@aws-sdk/types': 3.460.0
-      '@smithy/credential-provider-imds': 2.1.2
-      '@smithy/property-provider': 2.0.15
-      '@smithy/shared-ini-file-loader': 2.2.5
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - aws-crt
-    dev: false
-
-  /@aws-sdk/credential-provider-node@3.460.0:
-    resolution: {integrity: sha512-PbPo92WIgNlF6V4eWKehYGYjTqf0gU9vr09LeQUc3bTm1DJhJw1j+HU/3PfQ8LwTkBQePO7MbJ5A2n6ckMwfMg==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.460.0
-      '@aws-sdk/credential-provider-ini': 3.460.0
-      '@aws-sdk/credential-provider-process': 3.460.0
-      '@aws-sdk/credential-provider-sso': 3.460.0
-      '@aws-sdk/credential-provider-web-identity': 3.460.0
-      '@aws-sdk/types': 3.460.0
-      '@smithy/credential-provider-imds': 2.1.2
-      '@smithy/property-provider': 2.0.15
-      '@smithy/shared-ini-file-loader': 2.2.5
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - aws-crt
-    dev: false
-
-  /@aws-sdk/credential-provider-process@3.460.0:
-    resolution: {integrity: sha512-ng+0FMc4EaxLAwdttCwf2nzNf4AgcqAHZ8pKXUf8qF/KVkoyTt3UZKW7P2FJI01zxwP+V4yAwVt95PBUKGn4YQ==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.460.0
-      '@smithy/property-provider': 2.0.15
-      '@smithy/shared-ini-file-loader': 2.2.5
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/credential-provider-sso@3.460.0:
-    resolution: {integrity: sha512-KnrQieOw17+aHEzE3SwfxjeSQ5ZTe2HeAzxkaZF++GxhNul/PkVnLzjGpIuB9bn71T9a2oNfG3peDUA+m2l2kw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/client-sso': 3.460.0
-      '@aws-sdk/token-providers': 3.460.0
-      '@aws-sdk/types': 3.460.0
-      '@smithy/property-provider': 2.0.15
-      '@smithy/shared-ini-file-loader': 2.2.5
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - aws-crt
-    dev: false
-
-  /@aws-sdk/credential-provider-web-identity@3.460.0:
-    resolution: {integrity: sha512-7OeaZgC3HmJZGE0I0ZiKInUMF2LyA0IZiW85AYFnAZzAIfv1cXk/1UnDAoFIQhOZfnUBXivStagz892s480ryw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.460.0
-      '@smithy/property-provider': 2.0.15
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/middleware-bucket-endpoint@3.460.0:
-    resolution: {integrity: sha512-AmrCDT/r+m7q3OogZ3UeWpVdllMeR4Wdo+3YEfefPfcZc6SilnP2uCBUHletxbw3tXhNt56bUMUzQ+SUhyuUmA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.460.0
-      '@aws-sdk/util-arn-parser': 3.310.0
-      '@smithy/node-config-provider': 2.1.6
-      '@smithy/protocol-http': 3.0.10
-      '@smithy/types': 2.6.0
-      '@smithy/util-config-provider': 2.0.0
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/middleware-expect-continue@3.460.0:
-    resolution: {integrity: sha512-8VxMFTR+IszcMZLUZvxVCBOO1CUBmIWmDIQKd7w/U9xyMEXmBA0cx6ZEfMOIZF9NNh9OGCzTvwK+++8OTGBwAw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.460.0
-      '@smithy/protocol-http': 3.0.10
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/middleware-flexible-checksums@3.461.0:
-    resolution: {integrity: sha512-MNY7xMl2Qzoinj6Pos23TgD+WQtC9/G/VkNW/v8Ky5faRAt7bbS+ZEkkK3KcCrjnb8x4Bl/FzYNTCZRzRoQOtA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-crypto/crc32': 3.0.0
-      '@aws-crypto/crc32c': 3.0.0
-      '@aws-sdk/types': 3.460.0
-      '@smithy/is-array-buffer': 2.0.0
-      '@smithy/protocol-http': 3.0.10
-      '@smithy/types': 2.6.0
-      '@smithy/util-utf8': 2.0.2
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/middleware-host-header@3.460.0:
-    resolution: {integrity: sha512-qBeDyuJkEuHe87Xk6unvFO9Zg5j6zM8bQOOZITocTLfu9JN0u5V4GQ/yopvpv+nQHmC/MGr0G7p+kIXMrg/Q2A==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.460.0
-      '@smithy/protocol-http': 3.0.10
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/middleware-location-constraint@3.461.0:
-    resolution: {integrity: sha512-dibimciNOV2kuhBBmHbS+29X559xNw4BdZviGzjGAQPkqPx+7Adgvp5BHqSDgh7FIJpgN2+QGbrubIQ+V1Bn4A==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.460.0
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/middleware-logger@3.460.0:
-    resolution: {integrity: sha512-w2AJ6HOJ+Ggx9+VDKuWBHk5S0ZxYEo2EY2IFh0qtCQ1RDix/ur1QEzOOL5vNjHlZKPv/dseIwhgsTCac8UHXbQ==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.460.0
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/middleware-recursion-detection@3.460.0:
-    resolution: {integrity: sha512-wmzm1/2NzpcCVCAsGqqiTBK+xNyLmQwTOq63rcW6eeq6gYOO0cyTZROOkVRrrsKWPBigrSFFHvDrEvonOMtKAg==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.460.0
-      '@smithy/protocol-http': 3.0.10
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/middleware-sdk-s3@3.461.0:
-    resolution: {integrity: sha512-sOFUBWROq0xQxNoXp+3eepXrUAuMc/JPH+sI/r5QOznk7JVemYoBj99lknbTzJ4ssSK0yVrSUxxwGiGvDQb0Gg==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.460.0
-      '@aws-sdk/util-arn-parser': 3.310.0
-      '@smithy/node-config-provider': 2.1.6
-      '@smithy/protocol-http': 3.0.10
-      '@smithy/signature-v4': 2.0.16
-      '@smithy/smithy-client': 2.1.16
-      '@smithy/types': 2.6.0
-      '@smithy/util-config-provider': 2.0.0
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/middleware-sdk-sts@3.461.0:
-    resolution: {integrity: sha512-sgNxkwKdJ/NZm7SJZBnbYPkbspmzn3lDyRSJH7PTCvyzDBzY2PB6yS/dfnGkitR+PYwromuOYMha37W4su2SOw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/middleware-signing': 3.461.0
-      '@aws-sdk/types': 3.460.0
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/middleware-signing@3.461.0:
-    resolution: {integrity: sha512-aM/7VupHlsgeRG1UZSAQMWJX+2Jam4GG8ZGVAbLfBr9yh9cBwnUUndpUpYI9rU7atA8n+vISr162EbR7WTiFhQ==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.460.0
-      '@smithy/property-provider': 2.0.15
-      '@smithy/protocol-http': 3.0.10
-      '@smithy/signature-v4': 2.0.16
-      '@smithy/types': 2.6.0
-      '@smithy/util-middleware': 2.0.7
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/middleware-ssec@3.460.0:
-    resolution: {integrity: sha512-1PSCmkq9BRX8isxyDyf785xvjldtwhdUzI+37oZ1qfDXGmRyB+KjtRBNnz5Fz+VSiOfVzfhp3sjrc4fs4BfJ0w==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.460.0
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/middleware-user-agent@3.460.0:
-    resolution: {integrity: sha512-0gBSOCr+RtwRUCSRLn9H3RVnj9ercvk/QKTHIr33CgfEdyZtIGpHWUSs6uqiQydPTRzjCm5SfUa6ESGhRVMM6A==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.460.0
-      '@aws-sdk/util-endpoints': 3.460.0
-      '@smithy/protocol-http': 3.0.10
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/region-config-resolver@3.451.0:
-    resolution: {integrity: sha512-3iMf4OwzrFb4tAAmoROXaiORUk2FvSejnHIw/XHvf/jjR4EqGGF95NZP/n/MeFZMizJWVssrwS412GmoEyoqhg==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/node-config-provider': 2.1.6
-      '@smithy/types': 2.6.0
-      '@smithy/util-config-provider': 2.0.0
-      '@smithy/util-middleware': 2.0.7
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/s3-request-presigner@3.461.0:
-    resolution: {integrity: sha512-EffKSCd8tbBw32+AZyxTAIzpicqPu9A+97q7p/9tJo5175j1HTHwf68zmiR/C60kdJNHu+A4YNdQ9pLeg47CFA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/signature-v4-multi-region': 3.461.0
-      '@aws-sdk/types': 3.460.0
-      '@aws-sdk/util-format-url': 3.460.0
-      '@smithy/middleware-endpoint': 2.2.1
-      '@smithy/protocol-http': 3.0.10
-      '@smithy/smithy-client': 2.1.16
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/signature-v4-multi-region@3.461.0:
-    resolution: {integrity: sha512-9tsdJ5KMPZzJN1x28AZKoS9J3xfwftFwutqcU1qsXXeouck0CztLfX+wr3etO4acPQO2zU305fnR2ulSsnns4g==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/middleware-sdk-s3': 3.461.0
-      '@aws-sdk/types': 3.460.0
-      '@smithy/protocol-http': 3.0.10
-      '@smithy/signature-v4': 2.0.16
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/token-providers@3.460.0:
-    resolution: {integrity: sha512-EvSIPMI1gXk3gEkdtbZCW+p3Bjmt2gOR1m7ibQD7qLj4l0dKXhp4URgTqB1ExH3S4qUq0M/XSGKbGLZpvunHNg==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-crypto/sha256-browser': 3.0.0
-      '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/middleware-host-header': 3.460.0
-      '@aws-sdk/middleware-logger': 3.460.0
-      '@aws-sdk/middleware-recursion-detection': 3.460.0
-      '@aws-sdk/middleware-user-agent': 3.460.0
-      '@aws-sdk/region-config-resolver': 3.451.0
-      '@aws-sdk/types': 3.460.0
-      '@aws-sdk/util-endpoints': 3.460.0
-      '@aws-sdk/util-user-agent-browser': 3.460.0
-      '@aws-sdk/util-user-agent-node': 3.460.0
-      '@smithy/config-resolver': 2.0.19
-      '@smithy/fetch-http-handler': 2.2.7
-      '@smithy/hash-node': 2.0.16
-      '@smithy/invalid-dependency': 2.0.14
-      '@smithy/middleware-content-length': 2.0.16
-      '@smithy/middleware-endpoint': 2.2.1
-      '@smithy/middleware-retry': 2.0.21
-      '@smithy/middleware-serde': 2.0.14
-      '@smithy/middleware-stack': 2.0.8
-      '@smithy/node-config-provider': 2.1.6
-      '@smithy/node-http-handler': 2.1.10
-      '@smithy/property-provider': 2.0.15
-      '@smithy/protocol-http': 3.0.10
-      '@smithy/shared-ini-file-loader': 2.2.5
-      '@smithy/smithy-client': 2.1.16
-      '@smithy/types': 2.6.0
-      '@smithy/url-parser': 2.0.14
-      '@smithy/util-base64': 2.0.1
-      '@smithy/util-body-length-browser': 2.0.0
-      '@smithy/util-body-length-node': 2.1.0
-      '@smithy/util-defaults-mode-browser': 2.0.20
-      '@smithy/util-defaults-mode-node': 2.0.26
-      '@smithy/util-endpoints': 1.0.5
-      '@smithy/util-retry': 2.0.7
-      '@smithy/util-utf8': 2.0.2
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - aws-crt
-    dev: false
-
-  /@aws-sdk/types@3.460.0:
-    resolution: {integrity: sha512-MyZSWS/FV8Bnux5eD9en7KLgVxevlVrGNEP3X2D7fpnUlLhl0a7k8+OpSI2ozEQB8hIU2DLc/XXTKRerHSefxQ==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/util-arn-parser@3.310.0:
-    resolution: {integrity: sha512-jL8509owp/xB9+Or0pvn3Fe+b94qfklc2yPowZZIFAkFcCSIdkIglz18cPDWnYAcy9JGewpMS1COXKIUhZkJsA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/util-endpoints@3.460.0:
-    resolution: {integrity: sha512-myH6kM5WP4IWULHDHMYf2Q+BCYVGlzqJgiBmO10kQEtJSeAGZZ49eoFFYgKW8ZAYB5VnJ+XhXVB1TRA+vR4l5A==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.460.0
-      '@smithy/util-endpoints': 1.0.5
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/util-format-url@3.460.0:
-    resolution: {integrity: sha512-TfXehLG9wS8bvsFujggkvLy284JJxdot0m/yfzp+nc0PANP5VuQoePvBpXzUvGEAUHoDdu5Eh2gs1nOkPN05/g==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.460.0
-      '@smithy/querystring-builder': 2.0.14
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/util-locate-window@3.310.0:
-    resolution: {integrity: sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/util-user-agent-browser@3.460.0:
-    resolution: {integrity: sha512-FRCzW+TyjKnvxsargPVrjayBfp/rvObYHZyZ2OSqrVw8lkkPCb4e/WZOeIiXZuhdhhoah7wMuo6zGwtFF3bYKg==}
-    dependencies:
-      '@aws-sdk/types': 3.460.0
-      '@smithy/types': 2.6.0
-      bowser: 2.11.0
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/util-user-agent-node@3.460.0:
-    resolution: {integrity: sha512-+kSoR9ABGpJ5Xc7v0VwpgTQbgyI4zuezC8K4pmKAGZsSsVWg4yxptoy2bDqoFL7qfRlWviMVTkQRMvR4D44WxA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      aws-crt: '>=1.0.0'
-    peerDependenciesMeta:
-      aws-crt:
-        optional: true
-    dependencies:
-      '@aws-sdk/types': 3.460.0
-      '@smithy/node-config-provider': 2.1.6
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/util-utf8-browser@3.259.0:
-    resolution: {integrity: sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==}
-    dependencies:
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/xml-builder@3.310.0:
-    resolution: {integrity: sha512-TqELu4mOuSIKQCqj63fGVs86Yh+vBx5nHRpWKNUNhB2nPTpfbziTs5c1X358be3peVWA4wPxW7Nt53KIg1tnNw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      tslib: 2.6.2
     dev: false
 
   /@babel/code-frame@7.23.4:
@@ -3770,6 +3164,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.0
+    dev: true
 
   /@babel/runtime@7.24.0:
     resolution: {integrity: sha512-Chk32uHMg6TnQdvw2e9IlqPpFX/6NLuK0Ys2PqLb7/gL5uFn9mXvK715FGLlOLQrcO4qIkNHkvPGktzzXexsFw==}
@@ -4222,7 +3617,7 @@ packages:
       react: 18.2.0
     dependencies:
       '@chakra-ui/react': 2.8.2(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.37)(framer-motion@10.16.5)(react-dom@18.2.0)(react@18.2.0)
-      '@emotion/cache': 11.14.0
+      '@emotion/cache': 11.11.0
       '@emotion/react': 11.11.1(@types/react@18.2.37)(react@18.2.0)
       next: 13.1.6(@babel/core@7.23.5)(react-dom@18.2.0)(react@18.2.0)(sass@1.69.5)
       react: 18.2.0
@@ -4252,24 +3647,9 @@ packages:
       react: 18.2.0
     dependencies:
       '@chakra-ui/react': 2.8.2(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.37)(framer-motion@10.16.5)(react-dom@18.2.0)(react@18.2.0)
-      '@emotion/cache': 11.14.0
+      '@emotion/cache': 11.11.0
       '@emotion/react': 11.11.1(@types/react@18.2.37)(react@18.2.0)
       next: 13.5.11(@babel/core@7.23.5)(react-dom@18.2.0)(react@18.2.0)(sass@1.69.5)
-      react: 18.2.0
-    dev: false
-
-  /@chakra-ui/next-js@2.2.0(@chakra-ui/react@2.8.2)(@emotion/react@11.11.1)(next@13.5.6)(react@18.2.0):
-    resolution: {integrity: sha512-brCz0UEOlImX4Np2jDIaljZJkW6kiDSuXG5erxvYjZlklLhmti1zj0o1sSjt5yff1xndfgHoOJb+BYG5wx+vDg==}
-    peerDependencies:
-      '@chakra-ui/react': '>=2.4.0'
-      '@emotion/react': '>=11'
-      next: '>=13'
-      react: 18.2.0
-    dependencies:
-      '@chakra-ui/react': 2.8.2(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.37)(framer-motion@10.16.5)(react-dom@18.2.0)(react@18.2.0)
-      '@emotion/cache': 11.14.0
-      '@emotion/react': 11.11.1(@types/react@18.2.37)(react@18.2.0)
-      next: 13.5.6(@babel/core@7.23.5)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
     dev: false
 
@@ -5261,8 +4641,26 @@ packages:
   /@emotion/weak-memoize@0.4.0:
     resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
 
+  /@esbuild/aix-ppc64@0.21.5:
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-arm64@0.17.19:
     resolution: {integrity: sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.21.5:
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -5279,8 +4677,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-arm@0.21.5:
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-x64@0.17.19:
     resolution: {integrity: sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.21.5:
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -5297,8 +4713,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/darwin-arm64@0.21.5:
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/darwin-x64@0.17.19:
     resolution: {integrity: sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.21.5:
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -5315,8 +4749,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/freebsd-arm64@0.21.5:
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/freebsd-x64@0.17.19:
     resolution: {integrity: sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.21.5:
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -5333,8 +4785,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-arm64@0.21.5:
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-arm@0.17.19:
     resolution: {integrity: sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.21.5:
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -5351,8 +4821,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-ia32@0.21.5:
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-loong64@0.17.19:
     resolution: {integrity: sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.21.5:
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -5369,8 +4857,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-mips64el@0.21.5:
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-ppc64@0.17.19:
     resolution: {integrity: sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.21.5:
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -5387,8 +4893,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-riscv64@0.21.5:
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-s390x@0.17.19:
     resolution: {integrity: sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.21.5:
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -5405,8 +4929,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-x64@0.21.5:
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/netbsd-x64@0.17.19:
     resolution: {integrity: sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.21.5:
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -5423,8 +4965,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/openbsd-x64@0.21.5:
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/sunos-x64@0.17.19:
     resolution: {integrity: sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.21.5:
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -5441,6 +5001,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-arm64@0.21.5:
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-ia32@0.17.19:
     resolution: {integrity: sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==}
     engines: {node: '>=12'}
@@ -5450,8 +5019,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-ia32@0.21.5:
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-x64@0.17.19:
     resolution: {integrity: sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.21.5:
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -5477,16 +5064,6 @@ packages:
       eslint: 8.38.0
       eslint-visitor-keys: 3.4.3
     dev: false
-
-  /@eslint-community/eslint-utils@4.4.0(eslint@8.42.0):
-    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-    dependencies:
-      eslint: 8.42.0
-      eslint-visitor-keys: 3.4.3
-    dev: true
 
   /@eslint-community/eslint-utils@4.4.0(eslint@8.57.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
@@ -5524,7 +5101,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
+      debug: 4.4.1
       espree: 9.6.1
       globals: 13.23.0
       ignore: 5.3.0
@@ -5560,11 +5137,6 @@ packages:
     resolution: {integrity: sha512-IoD2MfUnOV58ghIHCiil01PcohxjbYR/qCxsoC+xNgUwh1EY8jOOrYmu3d3a71+tJJ23uscEV4X2HJWMsPJu4g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
-
-  /@eslint/js@8.42.0:
-    resolution: {integrity: sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
 
   /@eslint/js@8.57.0:
     resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
@@ -5714,6 +5286,7 @@ packages:
       strip-ansi-cjs: /strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: /wrap-ansi@7.0.0
+    dev: false
 
   /@isaacs/fs-minipass@4.0.1:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -5957,7 +5530,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/set-array': 1.1.2
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.20
 
   /@jridgewell/gen-mapping@0.3.8:
@@ -5965,7 +5538,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.25
 
   /@jridgewell/resolve-uri@3.1.1:
@@ -5986,27 +5559,24 @@ packages:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  /@jridgewell/sourcemap-codec@1.4.15:
-    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-
   /@jridgewell/sourcemap-codec@1.5.0:
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+    dev: true
 
   /@jridgewell/sourcemap-codec@1.5.5:
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
-    dev: false
 
   /@jridgewell/trace-mapping@0.3.20:
     resolution: {integrity: sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==}
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   /@jridgewell/trace-mapping@0.3.25:
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   /@kubernetes/client-node@0.18.0:
     resolution: {integrity: sha512-Mp6q0OkZQBp+HslIgvHYpsPJk8z6mch231QWtIZQHvs+PaTE6mkUfusYE8fNw3jMjru5mVO/JDz6PTjB9YT2rQ==}
@@ -6060,30 +5630,6 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-
-  /@kubernetes/client-node@0.19.0:
-    resolution: {integrity: sha512-WTOjGuFQ8yeW3+qD6JrAYhpwpoQbe9R8cA/61WCyFrNawSTUgLstHu7EsZRYEs39er3jDn3wCEaczz+VOFlc2Q==}
-    dependencies:
-      '@types/js-yaml': 4.0.9
-      '@types/node': 20.17.32
-      '@types/request': 2.48.12
-      '@types/ws': 8.5.10
-      byline: 5.0.0
-      isomorphic-ws: 5.0.0(ws@8.14.2)
-      js-yaml: 4.1.0
-      jsonpath-plus: 7.2.0
-      request: 2.88.2
-      rfc4648: 1.5.3
-      stream-buffers: 3.0.2
-      tar: 6.2.0
-      tslib: 2.6.2
-      ws: 8.14.2
-    optionalDependencies:
-      openid-client: 5.6.1
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-    dev: false
 
   /@lezer/common@1.1.1:
     resolution: {integrity: sha512-aAPB9YbvZHqAW+bIwiuuTDGB4DG0sYNRObGLxud8cW7osw1ZQxfDuTZ8KQiqfZ0QJGcR34CvpTMDXEyo/+Htgg==}
@@ -6206,6 +5752,15 @@ packages:
     dev: false
     optional: true
 
+  /@napi-rs/lzma-linux-x64-gnu@1.5.1:
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@next/bundle-analyzer@14.1.3:
     resolution: {integrity: sha512-QjMT5RGqvaObprL4Oim4SsjWUW6DxxfG+Fhq9arGw4CHbPBsjQkNWgUtW3WWW/Bjh4VhT+YBsJfxTyBVPHIlVw==}
     dependencies:
@@ -6225,10 +5780,6 @@ packages:
 
   /@next/env@13.5.11:
     resolution: {integrity: sha512-fbb2C7HChgM7CemdCY+y3N1n8pcTKdqtQLbC7/EQtPdLvlMUT9JX/dBYl8MMZAtYG4uVMyPFHXckb68q/NRwqg==}
-    dev: false
-
-  /@next/env@13.5.6:
-    resolution: {integrity: sha512-Yac/bV5sBGkkEXmAX5FWPS9Mmo2rthrOPRQQNfycJPkjUAUclomCPH7QFVCDQ4Mp2k2K1SSM6m0zrxYrOwtFQw==}
     dev: false
 
   /@next/env@13.5.9:
@@ -6252,12 +5803,6 @@ packages:
     dependencies:
       glob: 7.1.7
     dev: false
-
-  /@next/eslint-plugin-next@13.5.4:
-    resolution: {integrity: sha512-vI94U+D7RNgX6XypSyjeFrOzxGlZyxOplU0dVE5norIfZGn/LDjJYPHdvdsR5vN1eRtl6PDAsOHmycFEOljK5A==}
-    dependencies:
-      glob: 7.1.7
-    dev: true
 
   /@next/eslint-plugin-next@13.5.9:
     resolution: {integrity: sha512-WCGb9o3dqbJn7wfSIjAj5j9zHEJdWg99DRydJFRD+8xapb5buOEqm+EImEc22zskvw3NY4Igzj94s3jpD33voQ==}
@@ -6312,15 +5857,6 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-darwin-arm64@13.5.6:
-    resolution: {integrity: sha512-5nvXMzKtZfvcu4BhtV0KH1oGv4XEW+B+jOfmBdpFI3C7FrB/MfujRpWYSBBO64+qbW8pkZiSyQv9eiwnn5VIQA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@next/swc-darwin-arm64@13.5.9:
     resolution: {integrity: sha512-pVyd8/1y1l5atQRvOaLOvfbmRwefxLhqQOzYo/M7FQ5eaRwA1+wuCn7t39VwEgDd7Aw1+AIWwd+MURXUeXhwDw==}
     engines: {node: '>= 10'}
@@ -6341,15 +5877,6 @@ packages:
 
   /@next/swc-darwin-x64@13.3.0:
     resolution: {integrity: sha512-oQoqFa88OGgwnYlnAGHVct618FRI/749se0N3S8t9Bzdv5CRbscnO0RcX901+YnNK4Q6yeiizfgO3b7kogtsZg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@next/swc-darwin-x64@13.5.6:
-    resolution: {integrity: sha512-6cgBfxg98oOCSr4BckWjLLgiVwlL3vlLj8hXg2b+nDgm4bC/qVXXLfpLB9FHdoDu4057hzywbxKvmYGmi7yUzA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -6404,16 +5931,6 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-arm64-gnu@13.5.6:
-    resolution: {integrity: sha512-txagBbj1e1w47YQjcKgSU4rRVQ7uF29YpnlHV5xuVUsgCUf2FmyfJ3CPjZUvpIeXCJAoMCFAoGnbtX86BK7+sg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@next/swc-linux-arm64-gnu@13.5.9:
     resolution: {integrity: sha512-wdQsKsIsGSNdFojvjW3Ozrh8Q00+GqL3wTaMjDkQxVtRbAqfFBtrLPO0IuWChVUP2UeuQcHpVeUvu0YgOP00+g==}
     engines: {node: '>= 10'}
@@ -6436,16 +5953,6 @@ packages:
 
   /@next/swc-linux-arm64-musl@13.3.0:
     resolution: {integrity: sha512-xPVrIQOQo9WXJYgmoTlMnAD/HlR/1e1ZIWGbwIzEirXBVBqMARUulBEIKdC19zuvoJ477qZJgBDCKtKEykCpyQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@next/swc-linux-arm64-musl@13.5.6:
-    resolution: {integrity: sha512-cGd+H8amifT86ZldVJtAKDxUqeFyLWW+v2NlBULnLAdWsiuuN8TuhVBt8ZNpCqcAuoruoSWynvMWixTFcroq+Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -6484,16 +5991,6 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-x64-gnu@13.5.6:
-    resolution: {integrity: sha512-Mc2b4xiIWKXIhBy2NBTwOxGD3nHLmq4keFk+d4/WL5fMsB8XdJRdtUlL87SqVCTSaf1BRuQQf1HvXZcy+rq3Nw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@next/swc-linux-x64-gnu@13.5.9:
     resolution: {integrity: sha512-XxG3yj61WDd28NA8gFASIR+2viQaYZEFQagEodhI/R49gXWnYhiflTeeEmCn7Vgnxa/OfK81h1gvhUZ66lozpw==}
     engines: {node: '>= 10'}
@@ -6516,16 +6013,6 @@ packages:
 
   /@next/swc-linux-x64-musl@13.3.0:
     resolution: {integrity: sha512-2OwKlzaBgmuet9XYHc3KwsEilzb04F540rlRXkAcjMHL7eCxB7uZIGtsVvKOnQLvC/elrUegwSw1+5f7WmfyOw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@next/swc-linux-x64-musl@13.5.6:
-    resolution: {integrity: sha512-CFHvP9Qz98NruJiUnCe61O6GveKKHpJLloXbDSWRhqhkJdZD2zU5hG+gtVJR//tyW897izuHpM6Gtf6+sNgJPQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -6562,15 +6049,6 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-arm64-msvc@13.5.6:
-    resolution: {integrity: sha512-aFv1ejfkbS7PUa1qVPwzDHjQWQtknzAZWGTKYIAaS4NMtBlk3VyA6AYn593pqNanlicewqyl2jUhQAaFV/qXsg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@next/swc-win32-arm64-msvc@13.5.9:
     resolution: {integrity: sha512-T/iPnyurOK5a4HRUcxAlss8uzoEf5h9tkd+W2dSWAfzxv8WLKlUgbfk+DH43JY3Gc2xK5URLuXrxDZ2mGfk/jw==}
     engines: {node: '>= 10'}
@@ -6598,15 +6076,6 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-ia32-msvc@13.5.6:
-    resolution: {integrity: sha512-XqqpHgEIlBHvzwG8sp/JXMFkLAfGLqkbVsyN+/Ih1mR8INb6YCc2x/Mbwi6hsAgUnqQztz8cvEbHJUbSl7RHDg==}
-    engines: {node: '>= 10'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@next/swc-win32-ia32-msvc@13.5.9:
     resolution: {integrity: sha512-BLiPKJomaPrTAb7ykjA0LPcuuNMLDVK177Z1xe0nAem33+9FIayU4k/OWrtSn9SAJW/U60+1hoey5z+KCHdRLQ==}
     engines: {node: '>= 10'}
@@ -6627,15 +6096,6 @@ packages:
 
   /@next/swc-win32-x64-msvc@13.3.0:
     resolution: {integrity: sha512-Reer6rkLLcoOvB0dd66+Y7WrWVFH7sEEkF/4bJCIfsSKnTStTYaHtwIJAwbqnt9I392Tqvku0KkoqZOryWV9LQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@next/swc-win32-x64-msvc@13.5.6:
-    resolution: {integrity: sha512-Cqfe1YmOS7k+5mGu92nl5ULkzpKuxJrP3+4AEuPmrpFZ3BHxTY3TnHmU1On3bFmFFs6FbTcdF58CCUProGpIGQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -6919,6 +6379,7 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
     requiresBuild: true
+    dev: false
     optional: true
 
   /@polka/url@1.0.0-next.23:
@@ -8077,6 +7538,206 @@ packages:
       rollup: 2.79.1
     dev: true
 
+  /@rollup/rollup-android-arm-eabi@4.62.4:
+    resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-android-arm64@4.62.4:
+    resolution: {integrity: sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-arm64@4.62.4:
+    resolution: {integrity: sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-x64@4.62.4:
+    resolution: {integrity: sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-freebsd-arm64@4.62.4:
+    resolution: {integrity: sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-freebsd-x64@4.62.4:
+    resolution: {integrity: sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-gnueabihf@4.62.4:
+    resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-musleabihf@4.62.4:
+    resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-gnu@4.62.4:
+    resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-musl@4.62.4:
+    resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-loong64-gnu@4.62.4:
+    resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-loong64-musl@4.62.4:
+    resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-ppc64-gnu@4.62.4:
+    resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-ppc64-musl@4.62.4:
+    resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-riscv64-gnu@4.62.4:
+    resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-riscv64-musl@4.62.4:
+    resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-s390x-gnu@4.62.4:
+    resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-gnu@4.62.4:
+    resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-musl@4.62.4:
+    resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-openbsd-x64@4.62.4:
+    resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-openharmony-arm64@4.62.4:
+    resolution: {integrity: sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==}
+    cpu: [arm64]
+    os: [openharmony]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-arm64-msvc@4.62.4:
+    resolution: {integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-ia32-msvc@4.62.4:
+    resolution: {integrity: sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-gnu@4.62.4:
+    resolution: {integrity: sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-msvc@4.62.4:
+    resolution: {integrity: sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rtsao/scc@1.1.0:
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -8561,444 +8222,6 @@ packages:
       '@sinonjs/commons': 3.0.0
     dev: true
 
-  /@smithy/abort-controller@2.0.14:
-    resolution: {integrity: sha512-zXtteuYLWbSXnzI3O6xq3FYvigYZFW8mdytGibfarLL2lxHto9L3ILtGVnVGmFZa7SDh62l39EnU5hesLN87Fw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/chunked-blob-reader-native@2.0.1:
-    resolution: {integrity: sha512-N2oCZRglhWKm7iMBu7S6wDzXirjAofi7tAd26cxmgibRYOBS4D3hGfmkwCpHdASZzwZDD8rluh0Rcqw1JeZDRw==}
-    dependencies:
-      '@smithy/util-base64': 2.0.1
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/chunked-blob-reader@2.0.0:
-    resolution: {integrity: sha512-k+J4GHJsMSAIQPChGBrjEmGS+WbPonCXesoqP9fynIqjn7rdOThdH8FAeCmokP9mxTYKQAKoHCLPzNlm6gh7Wg==}
-    dependencies:
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/config-resolver@2.0.19:
-    resolution: {integrity: sha512-JsghnQ5zjWmjEVY8TFOulLdEOCj09SjRLugrHlkPZTIBBm7PQitCFVLThbsKPZQOP7N3ME1DU1nKUc1UaVnBog==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/node-config-provider': 2.1.6
-      '@smithy/types': 2.6.0
-      '@smithy/util-config-provider': 2.0.0
-      '@smithy/util-middleware': 2.0.7
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/credential-provider-imds@2.1.2:
-    resolution: {integrity: sha512-Y62jBWdoLPSYjr9fFvJf+KwTa1EunjVr6NryTEWCnwIY93OJxwV4t0qxjwdPl/XMsUkq79ppNJSEQN6Ohnhxjw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/node-config-provider': 2.1.6
-      '@smithy/property-provider': 2.0.15
-      '@smithy/types': 2.6.0
-      '@smithy/url-parser': 2.0.14
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/eventstream-codec@2.0.14:
-    resolution: {integrity: sha512-g/OU/MeWGfHDygoXgMWfG/Xb0QqDnAGcM9t2FRrVAhleXYRddGOEnfanR5cmHgB9ue52MJsyorqFjckzXsylaA==}
-    dependencies:
-      '@aws-crypto/crc32': 3.0.0
-      '@smithy/types': 2.6.0
-      '@smithy/util-hex-encoding': 2.0.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/eventstream-serde-browser@2.0.14:
-    resolution: {integrity: sha512-41wmYE9smDGJi1ZXp+LogH6BR7MkSsQD91wneIFISF/mupKULvoOJUkv/Nf0NMRxWlM3Bf1Vvi9FlR2oV4KU8Q==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/eventstream-serde-universal': 2.0.14
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/eventstream-serde-config-resolver@2.0.14:
-    resolution: {integrity: sha512-43IyRIzQ82s+5X+t/3Ood00CcWtAXQdmUIUKMed2Qg9REPk8SVIHhpm3rwewLwg+3G2Nh8NOxXlEQu6DsPUcMw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/eventstream-serde-node@2.0.14:
-    resolution: {integrity: sha512-jVh9E2qAr6DxH5tWfCAl9HV6tI0pEQ3JVmu85JknDvYTC66djcjDdhctPV2EHuKWf2kjRiFJcMIn0eercW4THA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/eventstream-serde-universal': 2.0.14
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/eventstream-serde-universal@2.0.14:
-    resolution: {integrity: sha512-Ie35+AISNn1NmEjn5b2SchIE49pvKp4Q74bE9ME5RULWI1MgXyGkQUajWd5E6OBSr/sqGcs+rD3IjPErXnCm9g==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/eventstream-codec': 2.0.14
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/fetch-http-handler@2.2.7:
-    resolution: {integrity: sha512-iSDBjxuH9TgrtMYAr7j5evjvkvgwLY3y+9D547uep+JNkZ1ZT+BaeU20j6I/bO/i26ilCWFImrlXTPsfQtZdIQ==}
-    dependencies:
-      '@smithy/protocol-http': 3.0.10
-      '@smithy/querystring-builder': 2.0.14
-      '@smithy/types': 2.6.0
-      '@smithy/util-base64': 2.0.1
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/hash-blob-browser@2.0.15:
-    resolution: {integrity: sha512-HX/7GIyPUT/HDWVYe2HYQu0iRnSYpF4uZVNhAhZsObPRawk5Mv0PbyluBgIFI2DDCCKgL/tloCYYwycff1GtQg==}
-    dependencies:
-      '@smithy/chunked-blob-reader': 2.0.0
-      '@smithy/chunked-blob-reader-native': 2.0.1
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/hash-node@2.0.16:
-    resolution: {integrity: sha512-Wbi9A0PacMYUOwjAulQP90Wl3mQ6NDwnyrZQzFjDz+UzjXOSyQMgBrTkUBz+pVoYVlX3DUu24gWMZBcit+wOGg==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/types': 2.6.0
-      '@smithy/util-buffer-from': 2.0.0
-      '@smithy/util-utf8': 2.0.2
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/hash-stream-node@2.0.16:
-    resolution: {integrity: sha512-4x24GFdeWos1Z49MC5sYdM1j+z32zcUr6oWM9Ggm3WudFAcRIcbG9uDQ1XgJ0Kl+ZTjpqLKniG0iuWvQb2Ud1A==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/types': 2.6.0
-      '@smithy/util-utf8': 2.0.2
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/invalid-dependency@2.0.14:
-    resolution: {integrity: sha512-d8ohpwZo9RzTpGlAfsWtfm1SHBSU7+N4iuZ6MzR10xDTujJJWtmXYHK1uzcr7rggbpUTaWyHpPFgnf91q0EFqQ==}
-    dependencies:
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/is-array-buffer@2.0.0:
-    resolution: {integrity: sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/md5-js@2.0.16:
-    resolution: {integrity: sha512-YhWt9aKl+EMSNXyUTUo7I01WHf3HcCkPu/Hl2QmTNwrHT49eWaY7hptAMaERZuHFH0V5xHgPKgKZo2I93DFtgQ==}
-    dependencies:
-      '@smithy/types': 2.6.0
-      '@smithy/util-utf8': 2.0.2
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/middleware-content-length@2.0.16:
-    resolution: {integrity: sha512-9ddDia3pp1d3XzLXKcm7QebGxLq9iwKf+J1LapvlSOhpF8EM9SjMeSrMOOFgG+2TfW5K3+qz4IAJYYm7INYCng==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/protocol-http': 3.0.10
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/middleware-endpoint@2.2.1:
-    resolution: {integrity: sha512-dVDS7HNJl/wb0lpByXor6whqDbb1YlLoaoWYoelyYzLHioXOE7y/0iDwJWtDcN36/tVCw9EPBFZ3aans84jLpg==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/middleware-serde': 2.0.14
-      '@smithy/node-config-provider': 2.1.6
-      '@smithy/shared-ini-file-loader': 2.2.5
-      '@smithy/types': 2.6.0
-      '@smithy/url-parser': 2.0.14
-      '@smithy/util-middleware': 2.0.7
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/middleware-retry@2.0.21:
-    resolution: {integrity: sha512-EZS1EXv1k6IJX6hyu/0yNQuPcPaXwG8SWljQHYueyRbOxmqYgoWMWPtfZj0xRRQ4YtLawQSpBgAeiJltq8/MPw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/node-config-provider': 2.1.6
-      '@smithy/protocol-http': 3.0.10
-      '@smithy/service-error-classification': 2.0.7
-      '@smithy/types': 2.6.0
-      '@smithy/util-middleware': 2.0.7
-      '@smithy/util-retry': 2.0.7
-      tslib: 2.6.2
-      uuid: 8.3.2
-    dev: false
-
-  /@smithy/middleware-serde@2.0.14:
-    resolution: {integrity: sha512-hFi3FqoYWDntCYA2IGY6gJ6FKjq2gye+1tfxF2HnIJB5uW8y2DhpRNBSUMoqP+qvYzRqZ6ntv4kgbG+o3pX57g==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/middleware-stack@2.0.8:
-    resolution: {integrity: sha512-7/N59j0zWqVEKExJcA14MrLDZ/IeN+d6nbkN8ucs+eURyaDUXWYlZrQmMOd/TyptcQv0+RDlgag/zSTTV62y/Q==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/node-config-provider@2.1.6:
-    resolution: {integrity: sha512-HLqTs6O78m3M3z1cPLFxddxhEPv5MkVatfPuxoVO3A+cHZanNd/H5I6btcdHy6N2CB1MJ/lihJC92h30SESsBA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/property-provider': 2.0.15
-      '@smithy/shared-ini-file-loader': 2.2.5
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/node-http-handler@2.1.10:
-    resolution: {integrity: sha512-lkALAwtN6odygIM4nB8aHDahINM6WXXjNrZmWQAh0RSossySRT2qa31cFv0ZBuAYVWeprskRk13AFvvLmf1WLw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/abort-controller': 2.0.14
-      '@smithy/protocol-http': 3.0.10
-      '@smithy/querystring-builder': 2.0.14
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/property-provider@2.0.15:
-    resolution: {integrity: sha512-YbRFBn8oiiC3o1Kn3a4KjGa6k47rCM9++5W9cWqYn9WnkyH+hBWgfJAckuxpyA2Hq6Ys4eFrWzXq6fqHEw7iew==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/protocol-http@3.0.10:
-    resolution: {integrity: sha512-6+tjNk7rXW7YTeGo9qwxXj/2BFpJTe37kTj3EnZCoX/nH+NP/WLA7O83fz8XhkGqsaAhLUPo/bB12vvd47nsmg==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/querystring-builder@2.0.14:
-    resolution: {integrity: sha512-lQ4pm9vTv9nIhl5jt6uVMPludr6syE2FyJmHsIJJuOD7QPIJnrf9HhUGf1iHh9KJ4CUv21tpOU3X6s0rB6uJ0g==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/types': 2.6.0
-      '@smithy/util-uri-escape': 2.0.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/querystring-parser@2.0.14:
-    resolution: {integrity: sha512-+cbtXWI9tNtQjlgQg3CA+pvL3zKTAxPnG3Pj6MP89CR3vi3QMmD0SOWoq84tqZDnJCxlsusbgIXk1ngMReXo+A==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/service-error-classification@2.0.7:
-    resolution: {integrity: sha512-LLxgW12qGz8doYto15kZ4x1rHjtXl0BnCG6T6Wb8z2DI4PT9cJfOSvzbuLzy7+5I24PAepKgFeWHRd9GYy3Z9w==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/types': 2.6.0
-    dev: false
-
-  /@smithy/shared-ini-file-loader@2.2.5:
-    resolution: {integrity: sha512-LHA68Iu7SmNwfAVe8egmjDCy648/7iJR/fK1UnVw+iAOUJoEYhX2DLgVd5pWllqdDiRbQQzgaHLcRokM+UFR1w==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/signature-v4@2.0.16:
-    resolution: {integrity: sha512-ilLY85xS2kZZzTb83diQKYLIYALvart0KnBaKnIRnMBHAGEio5aHSlANQoxVn0VsonwmQ3CnWhnCT0sERD8uTg==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/eventstream-codec': 2.0.14
-      '@smithy/is-array-buffer': 2.0.0
-      '@smithy/types': 2.6.0
-      '@smithy/util-hex-encoding': 2.0.0
-      '@smithy/util-middleware': 2.0.7
-      '@smithy/util-uri-escape': 2.0.0
-      '@smithy/util-utf8': 2.0.2
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/smithy-client@2.1.16:
-    resolution: {integrity: sha512-Lw67+yQSpLl4YkDLUzI2KgS8TXclXmbzSeOJUmRFS4ueT56B4pw3RZRF/SRzvgyxM/HxgkUan8oSHXCujPDafQ==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/middleware-stack': 2.0.8
-      '@smithy/types': 2.6.0
-      '@smithy/util-stream': 2.0.21
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/types@2.6.0:
-    resolution: {integrity: sha512-PgqxJq2IcdMF9iAasxcqZqqoOXBHufEfmbEUdN1pmJrJltT42b0Sc8UiYSWWzKkciIp9/mZDpzYi4qYG1qqg6g==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/url-parser@2.0.14:
-    resolution: {integrity: sha512-kbu17Y1AFXi5lNlySdDj7ZzmvupyWKCX/0jNZ8ffquRyGdbDZb+eBh0QnWqsSmnZa/ctyWaTf7n4l/pXLExrnw==}
-    dependencies:
-      '@smithy/querystring-parser': 2.0.14
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/util-base64@2.0.1:
-    resolution: {integrity: sha512-DlI6XFYDMsIVN+GH9JtcRp3j02JEVuWIn/QOZisVzpIAprdsxGveFed0bjbMRCqmIFe8uetn5rxzNrBtIGrPIQ==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/util-buffer-from': 2.0.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/util-body-length-browser@2.0.0:
-    resolution: {integrity: sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==}
-    dependencies:
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/util-body-length-node@2.1.0:
-    resolution: {integrity: sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/util-buffer-from@2.0.0:
-    resolution: {integrity: sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/is-array-buffer': 2.0.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/util-config-provider@2.0.0:
-    resolution: {integrity: sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/util-defaults-mode-browser@2.0.20:
-    resolution: {integrity: sha512-QJtnbTIl0/BbEASkx1MUFf6EaoWqWW1/IM90N++8NNscePvPf77GheYfpoPis6CBQawUWq8QepTP2QUSAdrVkw==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@smithy/property-provider': 2.0.15
-      '@smithy/smithy-client': 2.1.16
-      '@smithy/types': 2.6.0
-      bowser: 2.11.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/util-defaults-mode-node@2.0.26:
-    resolution: {integrity: sha512-lGFPOFCHv1ql019oegYqa54BZH7HREw6EBqjDLbAr0wquMX0BDi2sg8TJ6Eq+JGLijkZbJB73m4+aK8OFAapMg==}
-    engines: {node: '>= 10.0.0'}
-    dependencies:
-      '@smithy/config-resolver': 2.0.19
-      '@smithy/credential-provider-imds': 2.1.2
-      '@smithy/node-config-provider': 2.1.6
-      '@smithy/property-provider': 2.0.15
-      '@smithy/smithy-client': 2.1.16
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/util-endpoints@1.0.5:
-    resolution: {integrity: sha512-K7qNuCOD5K/90MjHvHm9kJldrfm40UxWYQxNEShMFxV/lCCCRIg8R4uu1PFAxRvPxNpIdcrh1uK6I1ISjDXZJw==}
-    engines: {node: '>= 14.0.0'}
-    dependencies:
-      '@smithy/node-config-provider': 2.1.6
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/util-hex-encoding@2.0.0:
-    resolution: {integrity: sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/util-middleware@2.0.7:
-    resolution: {integrity: sha512-tRINOTlf1G9B0ECarFQAtTgMhpnrMPSa+5j4ZEwEawCLfTFTavk6757sxhE4RY5RMlD/I3x+DCS8ZUiR8ho9Pw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/util-retry@2.0.7:
-    resolution: {integrity: sha512-fIe5yARaF0+xVT1XKcrdnHKTJ1Vc4+3e3tLDjCuIcE9b6fkBzzGFY7AFiX4M+vj6yM98DrwkuZeHf7/hmtVp0Q==}
-    engines: {node: '>= 14.0.0'}
-    dependencies:
-      '@smithy/service-error-classification': 2.0.7
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/util-stream@2.0.21:
-    resolution: {integrity: sha512-0BUE16d7n1x7pi1YluXJdB33jOTyBChT0j/BlOkFa9uxfg6YqXieHxjHNuCdJRARa7AZEj32LLLEPJ1fSa4inA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/fetch-http-handler': 2.2.7
-      '@smithy/node-http-handler': 2.1.10
-      '@smithy/types': 2.6.0
-      '@smithy/util-base64': 2.0.1
-      '@smithy/util-buffer-from': 2.0.0
-      '@smithy/util-hex-encoding': 2.0.0
-      '@smithy/util-utf8': 2.0.2
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/util-uri-escape@2.0.0:
-    resolution: {integrity: sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/util-utf8@2.0.2:
-    resolution: {integrity: sha512-qOiVORSPm6Ce4/Yu6hbSgNHABLP2VMv8QOC3tTDNHHlWY19pPyc++fBTbZPtx6egPXi4HQxKDnMxVxpbtX2GoA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/util-buffer-from': 2.0.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/util-waiter@2.0.14:
-    resolution: {integrity: sha512-Q6gSz4GUNjNGhrfNg+2Mjy+7K4pEI3r82x1b/+3dSc03MQqobMiUrRVN/YK/4nHVagvBELCoXsiHAFQJNQ5BeA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/abort-controller': 2.0.14
-      '@smithy/types': 2.6.0
-      tslib: 2.6.2
-    dev: false
-
   /@standard-schema/spec@1.1.0:
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
     dev: false
@@ -9199,7 +8422,7 @@ packages:
       enhanced-resolve: 5.18.1
       jiti: 2.4.2
       lightningcss: 1.30.1
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       source-map-js: 1.2.1
       tailwindcss: 4.1.10
     dev: false
@@ -9601,6 +8824,10 @@ packages:
 
   /@types/estree@1.0.8:
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  /@types/estree@1.0.9:
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+    dev: true
 
   /@types/express-serve-static-core@4.17.41:
     resolution: {integrity: sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==}
@@ -10114,27 +9341,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/parser@6.21.0(eslint@8.42.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
-    engines: {node: ^16.0.0 || >=18.0.0}
-    peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.2.2)
-      '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.1
-      eslint: 8.42.0
-      typescript: 5.2.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.9.3):
     resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -10351,6 +9557,45 @@ packages:
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
     dev: false
+
+  /@vitest/expect@1.6.1:
+    resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
+    dependencies:
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      chai: 4.5.0
+    dev: true
+
+  /@vitest/runner@1.6.1:
+    resolution: {integrity: sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==}
+    dependencies:
+      '@vitest/utils': 1.6.1
+      p-limit: 5.0.0
+      pathe: 1.1.2
+    dev: true
+
+  /@vitest/snapshot@1.6.1:
+    resolution: {integrity: sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==}
+    dependencies:
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      pretty-format: 29.7.0
+    dev: true
+
+  /@vitest/spy@1.6.1:
+    resolution: {integrity: sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==}
+    dependencies:
+      tinyspy: 2.2.1
+    dev: true
+
+  /@vitest/utils@1.6.1:
+    resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
+    dependencies:
+      diff-sequences: 29.6.3
+      estree-walker: 3.0.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
+    dev: true
 
   /@vue/compiler-core@3.5.30:
     resolution: {integrity: sha512-s3DfdZkcu/qExZ+td75015ljzHc6vE+30cFMGRPROYjqkroYI5NV2X1yAMX9UeyBNWB9MxCfPcsjpLS11nzkkw==}
@@ -10683,7 +9928,7 @@ packages:
   /acorn-globals@7.0.1:
     resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
     dependencies:
-      acorn: 8.11.2
+      acorn: 8.15.0
       acorn-walk: 8.3.0
     dev: true
 
@@ -10707,6 +9952,13 @@ packages:
     resolution: {integrity: sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==}
     engines: {node: '>=0.4.0'}
 
+  /acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
+    dependencies:
+      acorn: 8.15.0
+    dev: true
+
   /acorn@8.11.2:
     resolution: {integrity: sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==}
     engines: {node: '>=0.4.0'}
@@ -10716,6 +9968,12 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  /acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
 
   /after@0.8.1:
     resolution: {integrity: sha512-SuI3vWhCFeSmkmmJ3efyuOkrhGyp/AuHthh3F5DinGYh2kR9t/0xUlm3/Vn2qMScfgg+cKho5fW7TUEYUhYeiA==}
@@ -11046,6 +10304,10 @@ packages:
   /assert-plus@1.0.0:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
+
+  /assertion-error@1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
+    dev: true
 
   /ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -11410,10 +10672,6 @@ packages:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
     dev: false
 
-  /bowser@2.11.0:
-    resolution: {integrity: sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==}
-    dev: false
-
   /brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
     dependencies:
@@ -11529,6 +10787,11 @@ packages:
     engines: {node: '>= 0.8'}
     dev: false
 
+  /cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+    dev: true
+
   /call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -11587,10 +10850,6 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /caniuse-lite@1.0.30001565:
-    resolution: {integrity: sha512-xrE//a3O7TP0vaJ8ikzkD2c2NgcVUvsEe2IvFTntV4Yd1Z9FVzh+gW+enX96L0psrbaFMcVcH2l90xNuGDWc8w==}
-    dev: false
-
   /caniuse-lite@1.0.30001594:
     resolution: {integrity: sha512-VblSX6nYqyJVs8DKFMldE2IVCJjZ225LW00ydtUWwh5hk9IfkTOffO6r8gJNsH0qqqeAF8KrbMYA2VEwTlGW5g==}
 
@@ -11604,6 +10863,19 @@ packages:
   /ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
     dev: false
+
+  /chai@4.5.0:
+    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
+    engines: {node: '>=4'}
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.4
+      get-func-name: 2.0.2
+      loupe: 2.3.7
+      pathval: 1.1.1
+      type-detect: 4.1.0
+    dev: true
 
   /chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -11666,6 +10938,12 @@ packages:
   /character-reference-invalid@1.1.4:
     resolution: {integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==}
     dev: false
+
+  /check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+    dependencies:
+      get-func-name: 2.0.2
+    dev: true
 
   /chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
@@ -11959,6 +11237,10 @@ packages:
       typedarray: 0.0.6
     dev: false
 
+  /confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+    dev: true
+
   /connect@3.0.2:
     resolution: {integrity: sha512-k3kqw6T2Fc5ihvh5VVjwuJHA++qvh0/rPfe2GkJ5QNSQ9tRigQXMjtX2CYf73KZFe4+IV3HfQ3VR3W+nkt0eWQ==}
     engines: {node: '>= 0.10.0'}
@@ -12075,25 +11357,6 @@ packages:
       - ts-node
     dev: true
 
-  /create-jest@29.7.0(@types/node@20.10.0):
-    resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.10.0)
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    dev: true
-
   /create-react-context@0.3.0(prop-types@15.8.1)(react@18.2.0):
     resolution: {integrity: sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==}
     peerDependencies:
@@ -12186,6 +11449,7 @@ packages:
     dependencies:
       mdn-data: 2.0.14
       source-map: 0.6.1
+    dev: true
 
   /css-what@6.1.0:
     resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
@@ -12421,6 +11685,13 @@ packages:
     peerDependenciesMeta:
       babel-plugin-macros:
         optional: true
+    dev: true
+
+  /deep-eql@4.1.4:
+    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
+    dependencies:
+      type-detect: 4.1.0
     dev: true
 
   /deep-equal@2.2.3:
@@ -12710,6 +11981,7 @@ packages:
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+    dev: false
 
   /ecc-jsbn@0.1.2:
     resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
@@ -13099,6 +12371,37 @@ packages:
       '@esbuild/win32-x64': 0.17.19
     dev: true
 
+  /esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+    dev: true
+
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
@@ -13220,31 +12523,6 @@ packages:
       - eslint-import-resolver-webpack
       - supports-color
     dev: false
-
-  /eslint-config-next@13.5.4(eslint@8.42.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-FzQGIj4UEszRX7fcRSJK6L1LrDiVZvDFW320VVntVKh3BSU8Fb9kpaoxQx0cdFgf3MQXdeSbrCXJ/5Z/NndDkQ==}
-    peerDependencies:
-      eslint: ^7.23.0 || ^8.0.0
-      typescript: '>=3.3.1'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@next/eslint-plugin-next': 13.5.4
-      '@rushstack/eslint-patch': 1.6.0
-      '@typescript-eslint/parser': 6.21.0(eslint@8.42.0)(typescript@5.2.2)
-      eslint: 8.42.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.42.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.42.0)
-      eslint-plugin-jsx-a11y: 6.8.0(eslint@8.42.0)
-      eslint-plugin-react: 7.33.2(eslint@8.42.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@8.42.0)
-      typescript: 5.2.2
-    transitivePeerDependencies:
-      - eslint-import-resolver-webpack
-      - supports-color
-    dev: true
 
   /eslint-config-next@13.5.9(eslint@8.33.0)(typescript@5.2.2):
     resolution: {integrity: sha512-XcKvvXkTFJuxDtKyzZNCTLwLdG6KQGOl/9j3NDu5FQbksBPyQETQh7VjdgFcXYtyhhx7VDcKZ+44HAZaRcIWOw==}
@@ -13419,29 +12697,6 @@ packages:
       - eslint-import-resolver-webpack
       - supports-color
 
-  /eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.42.0):
-    resolution: {integrity: sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      eslint-plugin-import: '*'
-    dependencies:
-      debug: 4.4.1
-      enhanced-resolve: 5.18.1
-      eslint: 8.42.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.42.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.42.0)
-      fast-glob: 3.3.2
-      get-tsconfig: 4.7.2
-      is-core-module: 2.15.1
-      is-glob: 4.0.3
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-node
-      - eslint-import-resolver-webpack
-      - supports-color
-    dev: true
-
   /eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.33.0):
     resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
     engines: {node: '>=4'}
@@ -13590,36 +12845,6 @@ packages:
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.36.0)
     transitivePeerDependencies:
       - supports-color
-
-  /eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.42.0):
-    resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.42.0)(typescript@5.2.2)
-      debug: 3.2.7
-      eslint: 8.42.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.42.0)
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
     resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
@@ -13788,43 +13013,6 @@ packages:
       - eslint-import-resolver-webpack
       - supports-color
 
-  /eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.42.0):
-    resolution: {integrity: sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      '@typescript-eslint/parser': 6.21.0(eslint@8.42.0)(typescript@5.2.2)
-      array-includes: 3.1.8
-      array.prototype.findlastindex: 1.2.5
-      array.prototype.flat: 1.3.2
-      array.prototype.flatmap: 1.3.2
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 8.42.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.42.0)
-      hasown: 2.0.2
-      is-core-module: 2.15.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.0
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.8
-      tsconfig-paths: 3.15.0
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-    dev: true
-
   /eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0)(eslint@8.57.0):
     resolution: {integrity: sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==}
     engines: {node: '>=4'}
@@ -13985,31 +13173,6 @@ packages:
       object.fromentries: 2.0.7
     dev: false
 
-  /eslint-plugin-jsx-a11y@6.8.0(eslint@8.42.0):
-    resolution: {integrity: sha512-Hdh937BS3KdwwbBaKd5+PLCOmYY6U4f2h9Z2ktwtNKvIdIEu137rjYbcb9ApSbVJfWxANNuiKTD/9tOKjK9qOA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-    dependencies:
-      '@babel/runtime': 7.26.0
-      aria-query: 5.3.0
-      array-includes: 3.1.7
-      array.prototype.flatmap: 1.3.2
-      ast-types-flow: 0.0.8
-      axe-core: 4.7.0
-      axobject-query: 3.2.1
-      damerau-levenshtein: 1.0.8
-      emoji-regex: 9.2.2
-      es-iterator-helpers: 1.0.15
-      eslint: 8.42.0
-      hasown: 2.0.0
-      jsx-ast-utils: 3.3.5
-      language-tags: 1.0.9
-      minimatch: 3.1.2
-      object.entries: 1.1.7
-      object.fromentries: 2.0.7
-    dev: true
-
   /eslint-plugin-react-hooks@4.6.0(eslint@8.33.0):
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
     engines: {node: '>=10'}
@@ -14035,15 +13198,6 @@ packages:
     dependencies:
       eslint: 8.38.0
     dev: false
-
-  /eslint-plugin-react-hooks@4.6.0(eslint@8.42.0):
-    resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
-    dependencies:
-      eslint: 8.42.0
-    dev: true
 
   /eslint-plugin-react@7.33.2(eslint@8.33.0):
     resolution: {integrity: sha512-73QQMKALArI8/7xGLNI/3LylrEYrlKZSb5C9+q3OtOewTnMQi5cT+aE9E41sLCmli3I9PGGmD1yiZydyo4FEPw==}
@@ -14119,31 +13273,6 @@ packages:
       semver: 6.3.1
       string.prototype.matchall: 4.0.10
     dev: false
-
-  /eslint-plugin-react@7.33.2(eslint@8.42.0):
-    resolution: {integrity: sha512-73QQMKALArI8/7xGLNI/3LylrEYrlKZSb5C9+q3OtOewTnMQi5cT+aE9E41sLCmli3I9PGGmD1yiZydyo4FEPw==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-    dependencies:
-      array-includes: 3.1.7
-      array.prototype.flatmap: 1.3.2
-      array.prototype.tosorted: 1.1.2
-      doctrine: 2.1.0
-      es-iterator-helpers: 1.0.15
-      eslint: 8.42.0
-      estraverse: 5.3.0
-      jsx-ast-utils: 3.3.5
-      minimatch: 3.1.2
-      object.entries: 1.1.7
-      object.fromentries: 2.0.7
-      object.hasown: 1.1.3
-      object.values: 1.1.7
-      prop-types: 15.8.1
-      resolve: 2.0.0-next.5
-      semver: 6.3.1
-      string.prototype.matchall: 4.0.10
-    dev: true
 
   /eslint-plugin-react@7.37.2(eslint@8.33.0):
     resolution: {integrity: sha512-EsTAnj9fLVr/GZleBLFbj/sSuXeWmp1eXIN60ceYnZveqEaUCyW4X+Vh4WTdUhCkW4xutXYqTXCUSyqD4rB75w==}
@@ -14378,54 +13507,6 @@ packages:
       - supports-color
     dev: false
 
-  /eslint@8.42.0:
-    resolution: {integrity: sha512-ulg9Ms6E1WPf67PHaEY4/6E2tEn5/f7FXGzr3t9cBMugOmf1INYvuUwwh1aXQN4MfJ6a5K2iNwP3w4AColvI9A==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    hasBin: true
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.42.0)
-      '@eslint-community/regexpp': 4.10.0
-      '@eslint/eslintrc': 2.1.3
-      '@eslint/js': 8.42.0
-      '@humanwhocodes/config-array': 0.11.13
-      '@humanwhocodes/module-importer': 1.0.1
-      '@nodelib/fs.walk': 1.2.8
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.3
-      debug: 4.3.4
-      doctrine: 3.0.0
-      escape-string-regexp: 4.0.0
-      eslint-scope: 7.2.2
-      eslint-visitor-keys: 3.4.3
-      espree: 9.6.1
-      esquery: 1.5.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      globals: 13.23.0
-      graphemer: 1.4.0
-      ignore: 5.3.0
-      import-fresh: 3.3.0
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      is-path-inside: 3.0.3
-      js-yaml: 4.1.0
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.3
-      strip-ansi: 6.0.1
-      strip-json-comments: 3.1.1
-      text-table: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /eslint@8.57.0:
     resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -14516,6 +13597,12 @@ packages:
   /estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  /estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+    dependencies:
+      '@types/estree': 1.0.8
+    dev: true
+
   /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -14527,6 +13614,7 @@ packages:
 
   /eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+    dev: true
 
   /events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
@@ -14732,13 +13820,6 @@ packages:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
     dev: false
 
-  /fast-xml-parser@4.2.5:
-    resolution: {integrity: sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==}
-    hasBin: true
-    dependencies:
-      strnum: 1.0.5
-    dev: false
-
   /fast-xml-parser@4.3.2:
     resolution: {integrity: sha512-rmrXUXwbJedoXkStenj1kkljNF7ugn5ZjR9FJcwmCfcCbtOMDghPajbc+Tck6vE6F5XsDmx+Pr2le9fw8+pXBg==}
     hasBin: true
@@ -14926,6 +14007,7 @@ packages:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+    dev: false
 
   /forever-agent@0.2.0:
     resolution: {integrity: sha512-IasWSRIlfPnBZY1K9jEUK3PwsScR4mrcK+aNBJzGoPnW+S9b6f8I8ScyH4cehEOFNqnjGpP2gCaA22gqSV1xQA==}
@@ -15109,11 +14191,6 @@ packages:
   /functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
-  /fuse.js@7.0.0:
-    resolution: {integrity: sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q==}
-    engines: {node: '>=10'}
-    dev: false
-
   /fuse.js@7.1.0:
     resolution: {integrity: sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==}
     engines: {node: '>=10'}
@@ -15136,6 +14213,10 @@ packages:
   /get-east-asian-width@1.2.0:
     resolution: {integrity: sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==}
     engines: {node: '>=18'}
+    dev: true
+
+  /get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
     dev: true
 
   /get-intrinsic@1.2.2:
@@ -15269,6 +14350,7 @@ packages:
       minimatch: 9.0.5
       minipass: 7.1.2
       path-scurry: 1.10.1
+    dev: false
 
   /glob@7.1.7:
     resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
@@ -15864,7 +14946,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -16504,6 +15586,7 @@ packages:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+    dev: false
 
   /jake@10.8.7:
     resolution: {integrity: sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==}
@@ -16582,34 +15665,6 @@ packages:
       - ts-node
     dev: true
 
-  /jest-cli@29.7.0(@types/node@20.10.0):
-    resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.10.0)
-      exit: 0.1.2
-      import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.10.0)
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    dev: true
-
   /jest-config@29.7.0(@types/node@18.15.11):
     resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -16626,46 +15681,6 @@ packages:
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 18.15.11
-      babel-jest: 29.7.0(@babel/core@7.23.5)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.7
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-    dev: true
-
-  /jest-config@29.7.0(@types/node@20.10.0):
-    resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    peerDependencies:
-      '@types/node': '*'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      '@babel/core': 7.23.5
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 20.10.0
       babel-jest: 29.7.0(@babel/core@7.23.5)
       chalk: 4.1.2
       ci-info: 3.9.0
@@ -17074,27 +16089,6 @@ packages:
       - ts-node
     dev: true
 
-  /jest@29.7.0(@types/node@20.10.0):
-    resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 29.7.0
-      '@jest/types': 29.6.3
-      import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.10.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    dev: true
-
   /jiti@2.4.2:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
@@ -17130,6 +16124,10 @@ packages:
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  /js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+    dev: true
 
   /js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
@@ -17577,6 +16575,14 @@ packages:
       json5: 2.2.3
     dev: false
 
+  /local-pkg@0.5.1:
+    resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
+    engines: {node: '>=14'}
+    dependencies:
+      mlly: 1.8.2
+      pkg-types: 1.3.1
+    dev: true
+
   /locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -17665,6 +16671,12 @@ packages:
     dependencies:
       js-tokens: 4.0.0
 
+  /loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+    dependencies:
+      get-func-name: 2.0.2
+    dev: true
+
   /lowlight@1.20.0:
     resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
     dependencies:
@@ -17683,6 +16695,7 @@ packages:
   /lru-cache@10.1.0:
     resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
     engines: {node: 14 || >=16.14}
+    dev: false
 
   /lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -17735,14 +16748,6 @@ packages:
       react: 18.2.0
     dev: false
 
-  /lucide-react@0.556.0(react@18.2.0):
-    resolution: {integrity: sha512-iOb8dRk7kLaYBZhR2VlV1CeJGxChBgUthpSP8wom9jfj79qovgG6qcSdiy6vkoREKPnbUYzJsCn4o4PtG3Iy+A==}
-    peerDependencies:
-      react: 18.2.0
-    dependencies:
-      react: 18.2.0
-    dev: false
-
   /luxon@3.4.4:
     resolution: {integrity: sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==}
     engines: {node: '>=12'}
@@ -17770,12 +16775,12 @@ packages:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
+    dev: true
 
   /magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-    dev: false
 
   /make-asynchronous@1.1.0:
     resolution: {integrity: sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==}
@@ -18084,6 +17089,7 @@ packages:
 
   /mdn-data@2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
+    dev: true
 
   /media-typer@0.2.0:
     resolution: {integrity: sha512-TSggxYk75oP4tae7JkT8InpcFGUP4340zg1dOWjcu9qcphaDKtXEuNUv3OD4vJ+gVTvIDK797W0uYeNm8qqsDg==}
@@ -18716,6 +17722,7 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
+    dev: false
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -18752,6 +17759,7 @@ packages:
   /minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
+    dev: false
 
   /minizlib@2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
@@ -18789,6 +17797,15 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dev: false
+
+  /mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+    dependencies:
+      acorn: 8.18.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+    dev: true
 
   /mongodb-connection-string-url@2.6.0:
     resolution: {integrity: sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==}
@@ -18880,6 +17897,7 @@ packages:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+    dev: false
 
   /nanoid@4.0.2:
     resolution: {integrity: sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==}
@@ -19002,26 +18020,6 @@ packages:
       i18next: 23.12.1
       i18next-fs-backend: 2.3.1
       next: 13.5.11(@babel/core@7.23.5)(react-dom@18.2.0)(react@18.2.0)(sass@1.69.5)
-      react: 18.2.0
-      react-i18next: 14.1.2(i18next@23.12.1)(react-dom@18.2.0)(react@18.2.0)
-    dev: false
-
-  /next-i18next@15.3.0(i18next@23.12.1)(next@13.5.6)(react-i18next@14.1.2)(react@18.2.0):
-    resolution: {integrity: sha512-bq7Cc9XJFcmGOCLnyEtHaeJ3+JJNsI/8Pkj9BaHAnhm4sZ9vNNC4ZsaqYnlRZ7VH5ypSo73fEqLK935jLsmCvQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      i18next: '>= 23.7.13'
-      next: '>= 12.0.0'
-      react: 18.2.0
-      react-i18next: '>= 13.5.0'
-    dependencies:
-      '@babel/runtime': 7.24.0
-      '@types/hoist-non-react-statics': 3.3.5
-      core-js: 3.33.3
-      hoist-non-react-statics: 3.3.2
-      i18next: 23.12.1
-      i18next-fs-backend: 2.3.1
-      next: 13.5.6(@babel/core@7.23.5)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-i18next: 14.1.2(i18next@23.12.1)(react-dom@18.2.0)(react@18.2.0)
     dev: false
@@ -19193,45 +18191,6 @@ packages:
       '@next/swc-win32-arm64-msvc': 13.5.9
       '@next/swc-win32-ia32-msvc': 13.5.9
       '@next/swc-win32-x64-msvc': 13.5.9
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-    dev: false
-
-  /next@13.5.6(@babel/core@7.23.5)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-Y2wTcTbO4WwEsVb4A8VSnOsG1I9ok+h74q0ZdxkwM3EODqrs4pasq7O0iUxbcS9VtWMicG7f3+HAj0r1+NtKSw==}
-    engines: {node: '>=16.14.0'}
-    hasBin: true
-    peerDependencies:
-      '@opentelemetry/api': ^1.1.0
-      react: 18.2.0
-      react-dom: 18.2.0
-      sass: ^1.3.0
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-      sass:
-        optional: true
-    dependencies:
-      '@next/env': 13.5.6
-      '@swc/helpers': 0.5.2
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001565
-      postcss: 8.4.31
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.23.5)(react@18.2.0)
-      watchpack: 2.4.0
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 13.5.6
-      '@next/swc-darwin-x64': 13.5.6
-      '@next/swc-linux-arm64-gnu': 13.5.6
-      '@next/swc-linux-arm64-musl': 13.5.6
-      '@next/swc-linux-x64-gnu': 13.5.6
-      '@next/swc-linux-x64-musl': 13.5.6
-      '@next/swc-win32-arm64-msvc': 13.5.6
-      '@next/swc-win32-ia32-msvc': 13.5.6
-      '@next/swc-win32-x64-msvc': 13.5.6
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -19442,6 +18401,7 @@ packages:
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
+    dev: true
 
   /object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
@@ -19650,6 +18610,13 @@ packages:
     dependencies:
       yocto-queue: 0.1.0
 
+  /p-limit@5.0.0:
+    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      yocto-queue: 1.2.2
+    dev: true
+
   /p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
@@ -19781,6 +18748,7 @@ packages:
     dependencies:
       lru-cache: 10.1.0
       minipass: 7.1.2
+    dev: false
 
   /path-to-regexp@0.1.3:
     resolution: {integrity: sha512-sd4vSOW+DCM6A5aRICI1CWaC7nufnzVpZfuh5T0VXshxxzFWuaFcvqKovAFLNGReOc+uZRptpcpPmn7CDvzLuA==}
@@ -19795,9 +18763,16 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  /pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+    dev: true
+
   /pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-    dev: false
+
+  /pathval@1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+    dev: true
 
   /performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
@@ -19818,6 +18793,7 @@ packages:
   /pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
+    dev: false
 
   /pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
@@ -19852,6 +18828,14 @@ packages:
     dependencies:
       find-up: 4.1.0
 
+  /pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+    dev: true
+
   /pkginfo@0.3.1:
     resolution: {integrity: sha512-yO5feByMzAp96LtP58wvPKSbaKAi/1C4kV9XpTctr6EepnP6F33RBNOiVrdz9BrPA98U2BMFsTNHo44TWcbQ2A==}
     engines: {node: '>= 0.4.0'}
@@ -19882,6 +18866,7 @@ packages:
       nanoid: 3.3.7
       picocolors: 1.1.1
       source-map-js: 1.0.2
+    dev: false
 
   /postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -19899,7 +18884,6 @@ packages:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-    dev: false
 
   /prebuild-install@7.1.1:
     resolution: {integrity: sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==}
@@ -20929,6 +19913,42 @@ packages:
     optionalDependencies:
       fsevents: 2.3.3
 
+  /rollup@4.62.4:
+    resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.62.4
+      '@rollup/rollup-android-arm64': 4.62.4
+      '@rollup/rollup-darwin-arm64': 4.62.4
+      '@rollup/rollup-darwin-x64': 4.62.4
+      '@rollup/rollup-freebsd-arm64': 4.62.4
+      '@rollup/rollup-freebsd-x64': 4.62.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.4
+      '@rollup/rollup-linux-arm64-gnu': 4.62.4
+      '@rollup/rollup-linux-arm64-musl': 4.62.4
+      '@rollup/rollup-linux-loong64-gnu': 4.62.4
+      '@rollup/rollup-linux-loong64-musl': 4.62.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.4
+      '@rollup/rollup-linux-ppc64-musl': 4.62.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.4
+      '@rollup/rollup-linux-riscv64-musl': 4.62.4
+      '@rollup/rollup-linux-s390x-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-musl': 4.62.4
+      '@rollup/rollup-openbsd-x64': 4.62.4
+      '@rollup/rollup-openharmony-arm64': 4.62.4
+      '@rollup/rollup-win32-arm64-msvc': 4.62.4
+      '@rollup/rollup-win32-ia32-msvc': 4.62.4
+      '@rollup/rollup-win32-x64-gnu': 4.62.4
+      '@rollup/rollup-win32-x64-msvc': 4.62.4
+      fsevents: 2.3.3
+    dev: true
+
   /router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
@@ -21261,6 +20281,10 @@ packages:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  /siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+    dev: true
+
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -21525,6 +20549,10 @@ packages:
       escape-string-regexp: 2.0.0
     dev: true
 
+  /stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+    dev: true
+
   /statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
@@ -21534,6 +20562,10 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
     dev: false
+
+  /std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+    dev: true
 
   /stop-iteration-iterator@1.0.0:
     resolution: {integrity: sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==}
@@ -21600,6 +20632,7 @@ packages:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
+    dev: false
 
   /string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
@@ -21780,6 +20813,12 @@ packages:
   /strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  /strip-literal@2.1.1:
+    resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
+    dependencies:
+      js-tokens: 9.0.1
+    dev: true
 
   /strnum@1.0.5:
     resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
@@ -22084,10 +21123,24 @@ packages:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
     dev: false
 
+  /tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+    dev: true
+
   /tinycolor@0.0.1:
     resolution: {integrity: sha512-+CorETse1kl98xg0WAzii8DTT4ABF4R3nquhrkIbVGcw1T8JYs5Gfx9xEfGINPUZGDj9C4BmOtuKeaTtuuRolg==}
     engines: {node: '>=0.4.0'}
     dev: false
+
+  /tinypool@0.8.4:
+    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /tinyspy@2.2.1:
+    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+    engines: {node: '>=14.0.0'}
+    dev: true
 
   /tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
@@ -22306,6 +21359,11 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
+    dev: true
+
   /type-fest@0.16.0:
     resolution: {integrity: sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==}
     engines: {node: '>=10'}
@@ -22450,6 +21508,10 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  /ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+    dev: true
 
   /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
@@ -22874,6 +21936,125 @@ packages:
       vfile-message: 4.0.2
     dev: false
 
+  /vite-node@1.6.1(@types/node@18.13.0)(sass@1.69.5):
+    resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 5.4.21(@types/node@18.13.0)(sass@1.69.5)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vite@5.4.21(@types/node@18.13.0)(sass@1.69.5):
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.13.0
+      esbuild: 0.21.5
+      postcss: 8.5.8
+      rollup: 4.62.4
+      sass: 1.69.5
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /vitest@1.6.1(@types/node@18.13.0)(sass@1.69.5):
+    resolution: {integrity: sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 1.6.1
+      '@vitest/ui': 1.6.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/node': 18.13.0
+      '@vitest/expect': 1.6.1
+      '@vitest/runner': 1.6.1
+      '@vitest/snapshot': 1.6.1
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      acorn-walk: 8.3.5
+      chai: 4.5.0
+      debug: 4.4.1
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.10.0
+      strip-literal: 2.1.1
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.21(@types/node@18.13.0)(sass@1.69.5)
+      vite-node: 1.6.1(@types/node@18.13.0)(sass@1.69.5)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
   /void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
@@ -23171,6 +22352,15 @@ packages:
     dependencies:
       isexe: 2.0.0
 
+  /why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+    dev: true
+
   /winston@0.7.3:
     resolution: {integrity: sha512-iVTT8tf9YnTyfZX+aEUj2fl6WBRet7za6vdjMeyF8SA80Vii2rreM5XH+5qmpBV9uJGj8jz8BozvTDcroVq/eA==}
     engines: {node: '>= 0.6.0'}
@@ -23368,6 +22558,7 @@ packages:
       ansi-styles: 6.2.1
       string-width: 5.1.2
       strip-ansi: 7.1.0
+    dev: false
 
   /wrap-ansi@9.0.0:
     resolution: {integrity: sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==}
@@ -23531,6 +22722,11 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  /yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
+    dev: true
 
   /zod-openapi@4.2.4(zod@3.23.8):
     resolution: {integrity: sha512-tsrQpbpqFCXqVXUzi3TPwFhuMtLN3oNZobOtYnK6/5VkXsNdnIgyNr4r8no4wmYluaxzN3F7iS+8xCW8BmMQ8g==}

--- a/frontend/providers/template/.env.template
+++ b/frontend/providers/template/.env.template
@@ -4,7 +4,7 @@ SEALOS_CERT_SECRET_NAME=
 TEMPLATE_REPO_URL="https://github.com/labring-actions/templates"
 TEMPLATE_REPO_BRANCH="main"
 TEMPLATE_REPO_PROVIDER="github"
-TEMPLATE_REPO_FOLDER="templates"
+TEMPLATE_REPO_FOLDER="template"
 TEMPLATE_REPO_AUTO_INJECT="true"
 # The CDN_URL environment variable is used to specify a CDN address; when set, it replaces raw.githubusercontent.com in the resource loading URL. If not set, the default address is used.
 CDN_URL=

--- a/frontend/providers/template/.gitignore
+++ b/frontend/providers/template/.gitignore
@@ -42,4 +42,7 @@ yalc.lock
 # /templates = root-level templates dir only (e.g. local clone); exclude API route src/pages/api/v2alpha/templates/
 /templates
 templates.json
+template-categories.json
 data/config.local.json
+data/*
+!data/config.example.yaml

--- a/frontend/providers/template/README.md
+++ b/frontend/providers/template/README.md
@@ -91,4 +91,6 @@ missing or invalid, the provider falls back to `TEMPLATE_CATEGORIES`.
 Template read APIs run a TTL-bound freshness check before reading the generated
 catalog. `TEMPLATE_REPO_SYNC_INTERVAL_MS` controls the interval and defaults to
 `30000`, so repository category changes made by Admin are picked up without
-manually calling `/api/updateRepo`.
+manually calling `/api/updateRepo`. The App Store sidebar reads the lightweight
+`/api/platform/getClientAppConfig` category response, refreshes it every 60
+seconds, and refreshes again when the window regains focus.

--- a/frontend/providers/template/README.md
+++ b/frontend/providers/template/README.md
@@ -38,7 +38,7 @@
 │   │   ├── useLoading.tsx
 │   │   ├── useScreen.ts
 │   │   └── useToast.ts
-│   ├── mock 
+│   ├── mock
 │   ├── pages
 │   │   ├── 404.tsx
 │   │   ├── _app.tsx
@@ -74,3 +74,16 @@
 │       └── user.ts
 └── tsconfig.json
 ```
+
+## Template repository categories
+
+The provider clones the template repository configured by `TEMPLATE_REPO_URL` and
+`TEMPLATE_REPO_BRANCH`, then builds `templates.json` from the configured template
+directory. Category menus and template category filtering prefer
+`<template-repo>/config/categories.json` when that file exists. The file is a JSON
+array of `{ "slug": string, "i18n": Record<string, string> }`.
+
+`/api/updateRepo` publishes the managed category list after `templates.json` is
+successfully regenerated. The generated `template-categories.json` file is a
+runtime cache and should stay ignored by git. If the repository categories file is
+missing or invalid, the provider falls back to `TEMPLATE_CATEGORIES`.

--- a/frontend/providers/template/README.md
+++ b/frontend/providers/template/README.md
@@ -87,3 +87,8 @@ array of `{ "slug": string, "i18n": Record<string, string> }`.
 successfully regenerated. The generated `template-categories.json` file is a
 runtime cache and should stay ignored by git. If the repository categories file is
 missing or invalid, the provider falls back to `TEMPLATE_CATEGORIES`.
+
+Template read APIs run a TTL-bound freshness check before reading the generated
+catalog. `TEMPLATE_REPO_SYNC_INTERVAL_MS` controls the interval and defaults to
+`30000`, so repository category changes made by Admin are picked up without
+manually calling `/api/updateRepo`.

--- a/frontend/providers/template/__tests__/client-app-config.test.ts
+++ b/frontend/providers/template/__tests__/client-app-config.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { refreshRepo } = vi.hoisted(() => ({
+  refreshRepo: vi.fn().mockResolvedValue(undefined)
+}));
+
+vi.mock('@/services/backend/template-repo', () => ({
+  ensureTemplateRepoFresh: refreshRepo
+}));
+
+import { getClientAppConfigServer } from '@/pages/api/platform/getClientAppConfig';
+
+afterEach(() => {
+  refreshRepo.mockClear();
+  delete process.env.TEMPLATE_CATEGORIES;
+  delete process.env.NEXT_PUBLIC_BRAND_NAME;
+  delete process.env.DESKTOP_DOMAIN;
+  delete process.env.SEALOS_CLOUD_DOMAIN;
+});
+
+describe('client app config readiness', () => {
+  it('can validate the local config without refreshing the repository', async () => {
+    await expect(getClientAppConfigServer({ refreshRepo: false })).resolves.toMatchObject({
+      brandName: 'Sealos'
+    });
+
+    expect(refreshRepo).not.toHaveBeenCalled();
+  });
+
+  it('refreshes the repository for normal client config reads', async () => {
+    await getClientAppConfigServer();
+
+    expect(refreshRepo).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/providers/template/__tests__/sidebar-menu.test.ts
+++ b/frontend/providers/template/__tests__/sidebar-menu.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { buildSideBarMenu } from '@/store/config';
+
+describe('sidebar menu', () => {
+  it('builds the menu from the current managed categories', () => {
+    const menu = buildSideBarMenu(
+      [
+        { slug: 'ai', i18n: { en: 'AI', zh: '人工智能' } },
+        { slug: 'database', i18n: { en: 'Database', zh: '数据库' } }
+      ],
+      '',
+      'zh'
+    );
+
+    expect(menu.map((item) => item.id)).toEqual(['applications', 'ai', 'database']);
+    expect(menu.map((item) => item.value)).toEqual(['SideBar.Applications', '人工智能', '数据库']);
+  });
+
+  it('falls back to legacy menu keys when categories are unavailable', () => {
+    const menu = buildSideBarMenu(undefined, 'ai,database', 'en');
+
+    expect(menu.map((item) => item.id)).toEqual(['applications', 'ai', 'database']);
+    expect(menu.map((item) => item.value)).toEqual([
+      'SideBar.Applications',
+      'SideBar.ai',
+      'SideBar.database'
+    ]);
+  });
+});

--- a/frontend/providers/template/__tests__/sidebar-menu.test.ts
+++ b/frontend/providers/template/__tests__/sidebar-menu.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { buildSideBarMenu } from '@/store/config';
+import { ApplicationType } from '@/types/app';
+import { buildSideBarMenu, shouldResetAppType } from '@/store/config';
 
 describe('sidebar menu', () => {
   it('builds the menu from the current managed categories', () => {
@@ -25,5 +26,12 @@ describe('sidebar menu', () => {
       'SideBar.ai',
       'SideBar.database'
     ]);
+  });
+
+  it('keeps MyApp as a non-category app type', () => {
+    expect(shouldResetAppType(ApplicationType.MyApp, [{ slug: 'ai', i18n: { en: 'AI' } }])).toBe(
+      false
+    );
+    expect(shouldResetAppType('removed', [{ slug: 'ai', i18n: { en: 'AI' } }])).toBe(true);
   });
 });

--- a/frontend/providers/template/__tests__/template-api-refresh.test.ts
+++ b/frontend/providers/template/__tests__/template-api-refresh.test.ts
@@ -1,0 +1,103 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { TemplateCategory } from '@/types/config';
+import {
+  getTemplateCategoriesCachePath,
+  syncTemplateCategoriesFromRepo
+} from '@/services/backend/template-categories';
+
+const { refreshRepo } = vi.hoisted(() => ({
+  refreshRepo: vi.fn()
+}));
+
+vi.mock('@/services/backend/template-repo', () => ({
+  ensureTemplateRepoFresh: refreshRepo
+}));
+
+const originalCwd = process.cwd();
+const tempDirs: string[] = [];
+
+function createTempDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'template-api-refresh-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeCategories(repoRoot: string, categories: TemplateCategory[]) {
+  const categoriesPath = path.join(repoRoot, 'config/categories.json');
+  fs.mkdirSync(path.dirname(categoriesPath), { recursive: true });
+  fs.writeFileSync(categoriesPath, JSON.stringify(categories), 'utf8');
+}
+
+function writeTemplateCatalog(appRoot: string) {
+  fs.writeFileSync(
+    path.join(appRoot, 'templates.json'),
+    JSON.stringify([
+      {
+        apiVersion: 'app.sealos.io/v1',
+        kind: 'Template',
+        metadata: { name: 'database-template' },
+        spec: {
+          categories: ['database'],
+          templateType: 'inline',
+          title: 'Database',
+          readme: '',
+          icon: '',
+          description: '',
+          draft: false
+        }
+      }
+    ]),
+    'utf8'
+  );
+}
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  refreshRepo.mockReset();
+  delete process.env.TEMPLATE_CATEGORIES;
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('template category refresh ordering', () => {
+  it('uses refreshed categories in the same v1 list request', async () => {
+    const appRoot = createTempDir();
+    const repoRoot = path.join(appRoot, 'templates');
+    const fallbackCategories: TemplateCategory[] = [{ slug: 'ai', i18n: { en: 'AI', zh: 'AI' } }];
+    const refreshedCategories: TemplateCategory[] = [
+      { slug: 'database', i18n: { en: 'Database', zh: '数据库' } }
+    ];
+
+    fs.mkdirSync(repoRoot, { recursive: true });
+    writeCategories(repoRoot, fallbackCategories);
+    syncTemplateCategoriesFromRepo(repoRoot, appRoot);
+    writeCategories(repoRoot, refreshedCategories);
+    writeTemplateCatalog(appRoot);
+    process.chdir(appRoot);
+    process.env.TEMPLATE_CATEGORIES = JSON.stringify(fallbackCategories);
+    refreshRepo.mockImplementation(async (basePath: string) => {
+      syncTemplateCategoriesFromRepo(repoRoot, basePath);
+    });
+
+    const { default: handler } = await import('@/pages/api/v1/template/index');
+    const response = { json: vi.fn() } as any;
+
+    await handler({ query: { language: 'en' } } as any, response);
+
+    expect(response.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 200,
+        data: expect.objectContaining({
+          menuKeys: 'database',
+          templates: [expect.objectContaining({ category: ['database'] })]
+        })
+      })
+    );
+    expect(fs.existsSync(getTemplateCategoriesCachePath(appRoot))).toBe(true);
+  });
+});

--- a/frontend/providers/template/__tests__/template-categories.test.ts
+++ b/frontend/providers/template/__tests__/template-categories.test.ts
@@ -23,6 +23,11 @@ import {
   syncTemplateCategoriesFromRepo
 } from '@/services/backend/template-categories';
 
+vi.mock('@/services/backend/template-repo', () => ({
+  ensureTemplateRepoFresh: vi.fn().mockResolvedValue(undefined),
+  updateRepo: vi.fn().mockResolvedValue(undefined)
+}));
+
 const configuredCategories: TemplateCategory[] = [
   { slug: 'ai', i18n: { en: 'AI', zh: 'AI' } },
   { slug: 'database', i18n: { en: 'Database', zh: '数据库' } }
@@ -269,9 +274,9 @@ describe('template category configuration', () => {
     const appRoot = createTempDir();
     const previousCwd = process.cwd();
     const repoRoot = path.join(appRoot, 'templates');
-    const templateFilePath = path.join(repoRoot, 'demo.yaml');
+    const templateFilePath = path.join(repoRoot, 'template', 'demo.yaml');
 
-    fs.mkdirSync(repoRoot, { recursive: true });
+    fs.mkdirSync(path.dirname(templateFilePath), { recursive: true });
     fs.writeFileSync(
       path.join(appRoot, 'templates.json'),
       JSON.stringify([

--- a/frontend/providers/template/__tests__/template-categories.test.ts
+++ b/frontend/providers/template/__tests__/template-categories.test.ts
@@ -249,6 +249,52 @@ describe('template category configuration', () => {
     expect(zhOnly.data.map((template) => template.metadata.name)).toEqual(['chinese']);
   });
 
+  it('replaces the current template cache when the catalog version changes', () => {
+    const appRoot = createTempDir();
+    const jsonPath = path.join(appRoot, 'templates.json');
+    const firstCatalog = JSON.stringify([
+      {
+        apiVersion: 'app.sealos.io/v1',
+        kind: 'Template',
+        metadata: { name: 'first' },
+        spec: { categories: ['ai'], draft: false }
+      }
+    ]);
+    const secondCatalog = JSON.stringify([
+      {
+        apiVersion: 'app.sealos.io/v1',
+        kind: 'Template',
+        metadata: { name: 'second' },
+        spec: { categories: ['ai'], draft: false }
+      }
+    ]);
+
+    fs.writeFileSync(jsonPath, firstCatalog, 'utf-8');
+    expect(
+      getCachedTemplates(jsonPath, undefined, configuredCategories, 'en', undefined, 'v1').data
+    ).toHaveLength(1);
+    fs.writeFileSync(jsonPath, secondCatalog, 'utf-8');
+
+    expect(
+      getCachedTemplates(jsonPath, undefined, configuredCategories, 'en', undefined, 'v2').data[0]
+        .metadata.name
+    ).toBe('second');
+    expect(
+      getCachedTemplates(jsonPath, undefined, configuredCategories, 'en', undefined, 'v1').data[0]
+        .metadata.name
+    ).toBe('second');
+  });
+
+  it('invalidates cached template details when the catalog version changes', async () => {
+    const { getCachedTemplateDetail, setCachedTemplateDetail } = await import(
+      '@/pages/api/v2alpha/templates/templateCache'
+    );
+
+    setCachedTemplateDetail('detail', { cpu: 1 }, 'v1');
+    expect(getCachedTemplateDetail('detail', 'v1')).toEqual({ cpu: 1 });
+    expect(getCachedTemplateDetail('detail', 'v2')).toBeNull();
+  });
+
   it('removes stale category cache when publishing the managed cache fails', () => {
     const appRoot = createTempDir();
     const repoRoot = path.join(appRoot, 'templates');

--- a/frontend/providers/template/__tests__/template-categories.test.ts
+++ b/frontend/providers/template/__tests__/template-categories.test.ts
@@ -1,8 +1,14 @@
 import fs from 'fs';
+import JsYaml from 'js-yaml';
 import os from 'os';
 import path from 'path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { readTemplates } from '@/pages/api/listTemplate';
+import {
+  clearTemplateCache,
+  getCachedTemplates
+} from '@/pages/api/v2alpha/templates/templateCache';
+import { GetTemplateByName } from '@/pages/api/getTemplateSource';
 import {
   filterConfiguredCategorySlugs,
   getCategoryLabel,
@@ -43,6 +49,8 @@ afterEach(() => {
     const dir = tempDirs.pop();
     if (dir) fs.rmSync(dir, { recursive: true, force: true });
   }
+  clearTemplateCache();
+  delete globalThis.__APP_CONFIG__;
 });
 
 describe('template category configuration', () => {
@@ -176,5 +184,184 @@ describe('template category configuration', () => {
     expect(getTemplateCategories(configuredCategories, appRoot)).toEqual(configuredCategories);
     expect(getTemplateCatalogVersion(appRoot)).toContain('missing');
     expect(warnSpy).toHaveBeenCalledOnce();
+  });
+
+  it('does not reuse v2 template cache across category sets or languages', () => {
+    const appRoot = createTempDir();
+    const jsonPath = path.join(appRoot, 'templates.json');
+    const jsonData = JSON.stringify([
+      {
+        apiVersion: 'app.sealos.io/v1',
+        kind: 'Template',
+        metadata: { name: 'english' },
+        spec: {
+          fileName: 'english.yaml',
+          filePath: 'english.yaml',
+          locale: 'en',
+          categories: ['ai', 'database'],
+          templateType: 'inline',
+          gitRepo: '',
+          author: '',
+          title: 'English',
+          url: '',
+          readme: '',
+          icon: '',
+          description: '',
+          draft: false
+        }
+      },
+      {
+        apiVersion: 'app.sealos.io/v1',
+        kind: 'Template',
+        metadata: { name: 'chinese' },
+        spec: {
+          fileName: 'chinese.yaml',
+          filePath: 'chinese.yaml',
+          locale: 'zh',
+          categories: ['database'],
+          templateType: 'inline',
+          gitRepo: '',
+          author: '',
+          title: 'Chinese',
+          url: '',
+          readme: '',
+          icon: '',
+          description: '',
+          draft: false
+        }
+      }
+    ]);
+
+    fs.writeFileSync(jsonPath, jsonData, 'utf-8');
+
+    const aiOnly = getCachedTemplates(jsonPath, undefined, [configuredCategories[0]], 'en');
+    const databaseOnly = getCachedTemplates(jsonPath, undefined, [configuredCategories[1]], 'en');
+    const zhOnly = getCachedTemplates(jsonPath, undefined, configuredCategories, 'zh');
+
+    expect(aiOnly.data.map((template) => template.metadata.name)).toEqual(['english']);
+    expect(aiOnly.data[0].spec.categories).toEqual(['ai']);
+    expect(databaseOnly.data[0].spec.categories).toEqual(['database']);
+    expect(zhOnly.data.map((template) => template.metadata.name)).toEqual(['chinese']);
+  });
+
+  it('removes stale category cache when publishing the managed cache fails', () => {
+    const appRoot = createTempDir();
+    const repoRoot = path.join(appRoot, 'templates');
+    const cachePath = getTemplateCategoriesCachePath(appRoot);
+
+    fs.writeFileSync(
+      cachePath,
+      JSON.stringify([{ slug: 'stale', i18n: { en: 'Stale' } }]),
+      'utf-8'
+    );
+    writeRepoCategories(repoRoot, JSON.stringify(configuredCategories));
+
+    const renameSpy = vi.spyOn(fs, 'renameSync').mockImplementationOnce(() => {
+      throw new Error('rename failed');
+    });
+
+    expect(() => syncTemplateCategoriesFromRepo(repoRoot, appRoot)).toThrow('rename failed');
+    expect(fs.existsSync(cachePath)).toBe(false);
+    expect(renameSpy).toHaveBeenCalledOnce();
+  });
+
+  it('filters managed categories from template source and generated instance yaml', async () => {
+    const appRoot = createTempDir();
+    const previousCwd = process.cwd();
+    const repoRoot = path.join(appRoot, 'templates');
+    const templateFilePath = path.join(repoRoot, 'demo.yaml');
+
+    fs.mkdirSync(repoRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(appRoot, 'templates.json'),
+      JSON.stringify([
+        {
+          apiVersion: 'app.sealos.io/v1',
+          kind: 'Template',
+          metadata: { name: 'demo' },
+          spec: {
+            fileName: 'demo.yaml',
+            filePath: templateFilePath,
+            categories: ['ai', 'removed'],
+            templateType: 'inline',
+            gitRepo: '',
+            author: '',
+            title: 'Demo',
+            url: '',
+            readme: '',
+            icon: '',
+            description: '',
+            draft: false
+          }
+        }
+      ]),
+      'utf-8'
+    );
+    fs.writeFileSync(
+      templateFilePath,
+      `apiVersion: app.sealos.io/v1
+kind: Template
+metadata:
+  name: demo
+spec:
+  categories:
+    - ai
+    - removed
+  defaults:
+    app_name:
+      type: string
+      value: demo-app
+  inputs: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo-app
+`,
+      'utf-8'
+    );
+
+    globalThis.__APP_CONFIG__ = {
+      cloud: {
+        domain: 'cloud.example.com',
+        port: 443,
+        regionUid: 'test',
+        certSecretName: 'cert'
+      },
+      template: {
+        ui: {
+          brandName: 'Template',
+          currencySymbol: 'shellCoin',
+          forcedLanguage: 'en',
+          meta: { canonicalUrl: 'https://template.example.com', customScripts: [] },
+          carousel: { enabled: false, slides: [] }
+        },
+        repo: {
+          url: 'https://github.com/labring-actions/templates',
+          branch: 'main',
+          localDir: '.'
+        },
+        features: { fetchReadme: false, showAuthor: true, guide: false },
+        categories: [configuredCategories[0]],
+        desktopDomain: 'desktop.example.com',
+        billingUrl: 'https://billing.example.com'
+      }
+    };
+    process.chdir(appRoot);
+
+    try {
+      const result = await GetTemplateByName({
+        namespace: 'ns-test',
+        templateName: 'demo',
+        includeReadme: 'false'
+      });
+      const instanceYaml = JsYaml.load(String(result.appYaml).split('---')[0]) as any;
+
+      expect(result.code).toBe(20000);
+      expect(result.templateYaml?.spec.categories).toEqual(['ai']);
+      expect(instanceYaml.spec.categories).toEqual(['ai']);
+    } finally {
+      process.chdir(previousCwd);
+    }
   });
 });

--- a/frontend/providers/template/__tests__/template-categories.test.ts
+++ b/frontend/providers/template/__tests__/template-categories.test.ts
@@ -1,0 +1,180 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readTemplates } from '@/pages/api/listTemplate';
+import {
+  filterConfiguredCategorySlugs,
+  getCategoryLabel,
+  getCategorySlugs
+} from '@/utils/template';
+import type { TemplateCategory } from '@/types/config';
+import {
+  DEFAULT_TEMPLATE_CATEGORIES_REPO_PATH,
+  getTemplateCatalogVersion,
+  getTemplateCategories,
+  getTemplateCategoriesCachePath,
+  syncTemplateCategoriesFromRepo
+} from '@/services/backend/template-categories';
+
+const configuredCategories: TemplateCategory[] = [
+  { slug: 'ai', i18n: { en: 'AI', zh: 'AI' } },
+  { slug: 'database', i18n: { en: 'Database', zh: '数据库' } }
+];
+
+const tempDirs: string[] = [];
+
+function createTempDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'template-categories-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeRepoCategories(repoRoot: string, categoriesContent: string) {
+  const filePath = path.join(repoRoot, DEFAULT_TEMPLATE_CATEGORIES_REPO_PATH);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, categoriesContent, 'utf-8');
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.TEMPLATE_CATEGORIES_PATH;
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('template category configuration', () => {
+  it('derives sidebar slugs and labels from app-defined categories', () => {
+    expect(getCategorySlugs(configuredCategories)).toEqual(['ai', 'database']);
+    expect(getCategoryLabel(configuredCategories[1], 'zh')).toBe('数据库');
+    expect(getCategoryLabel(configuredCategories[1], 'fr')).toBe('Database');
+  });
+
+  it('keeps only repository categories defined by the app config', () => {
+    expect(
+      filterConfiguredCategorySlugs(['unknown', 'database', 'ai'], configuredCategories)
+    ).toEqual(['database', 'ai']);
+  });
+
+  it('sanitizes template repository categories while reading templates', () => {
+    const jsonData = JSON.stringify([
+      {
+        apiVersion: 'app.sealos.io/v1',
+        kind: 'Template',
+        metadata: { name: 'visible' },
+        spec: {
+          fileName: 'visible.yaml',
+          filePath: 'visible.yaml',
+          categories: ['unknown', 'ai'],
+          templateType: 'inline',
+          gitRepo: '',
+          author: '',
+          title: 'Visible',
+          url: '',
+          readme: '',
+          icon: '',
+          description: '',
+          draft: false
+        }
+      },
+      {
+        apiVersion: 'app.sealos.io/v1',
+        kind: 'Template',
+        metadata: { name: 'draft' },
+        spec: {
+          fileName: 'draft.yaml',
+          filePath: 'draft.yaml',
+          categories: ['database'],
+          templateType: 'inline',
+          gitRepo: '',
+          author: '',
+          title: 'Draft',
+          url: '',
+          readme: '',
+          icon: '',
+          description: '',
+          draft: true
+        }
+      }
+    ]);
+
+    const templates = readTemplates(jsonData, undefined, configuredCategories, 'en');
+
+    expect(templates).toHaveLength(1);
+    expect(templates[0].metadata.name).toBe('visible');
+    expect(templates[0].spec.categories).toEqual(['ai']);
+  });
+
+  it('uses categories managed in the template repository cache', () => {
+    const appRoot = createTempDir();
+    const repoRoot = path.join(appRoot, 'templates');
+    const managedCategories: TemplateCategory[] = [
+      { slug: 'tool', i18n: { en: 'Tools', zh: '工具' } }
+    ];
+
+    writeRepoCategories(repoRoot, JSON.stringify(managedCategories));
+
+    expect(syncTemplateCategoriesFromRepo(repoRoot, appRoot)).toEqual(managedCategories);
+    expect(getTemplateCategories(configuredCategories, appRoot)).toEqual(managedCategories);
+  });
+
+  it('keeps an empty repository categories list as a valid override', () => {
+    const appRoot = createTempDir();
+    const repoRoot = path.join(appRoot, 'templates');
+
+    writeRepoCategories(repoRoot, '[]\n');
+
+    expect(syncTemplateCategoriesFromRepo(repoRoot, appRoot)).toEqual([]);
+    expect(getTemplateCategories(configuredCategories, appRoot)).toEqual([]);
+  });
+
+  it('falls back to static categories and removes stale cache when repository categories are invalid', () => {
+    const appRoot = createTempDir();
+    const repoRoot = path.join(appRoot, 'templates');
+    const cachePath = getTemplateCategoriesCachePath(appRoot);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    fs.writeFileSync(
+      cachePath,
+      JSON.stringify([{ slug: 'stale', i18n: { en: 'Stale' } }]),
+      'utf-8'
+    );
+    writeRepoCategories(repoRoot, '{broken');
+
+    expect(syncTemplateCategoriesFromRepo(repoRoot, appRoot)).toBeNull();
+    expect(fs.existsSync(cachePath)).toBe(false);
+    expect(getTemplateCategories(configuredCategories, appRoot)).toEqual(configuredCategories);
+    expect(warnSpy).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to static categories when repository categories are missing', () => {
+    const appRoot = createTempDir();
+    const repoRoot = path.join(appRoot, 'templates');
+
+    expect(syncTemplateCategoriesFromRepo(repoRoot, appRoot)).toBeNull();
+    expect(getTemplateCategories(configuredCategories, appRoot)).toEqual(configuredCategories);
+  });
+
+  it('rejects repository categories that escape the repository through a symlink', () => {
+    const appRoot = createTempDir();
+    const repoRoot = path.join(appRoot, 'templates');
+    const repoCategoriesPath = path.join(repoRoot, DEFAULT_TEMPLATE_CATEGORIES_REPO_PATH);
+    const outsideCategoriesPath = path.join(appRoot, 'outside-categories.json');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    fs.mkdirSync(path.dirname(repoCategoriesPath), { recursive: true });
+    fs.writeFileSync(
+      outsideCategoriesPath,
+      JSON.stringify([{ slug: 'escape', i18n: { en: 'Escape' } }]),
+      'utf-8'
+    );
+    fs.symlinkSync(outsideCategoriesPath, repoCategoriesPath);
+
+    expect(syncTemplateCategoriesFromRepo(repoRoot, appRoot)).toBeNull();
+    expect(getTemplateCategories(configuredCategories, appRoot)).toEqual(configuredCategories);
+    expect(getTemplateCatalogVersion(appRoot)).toContain('missing');
+    expect(warnSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/providers/template/deploy/charts/template-frontend/template-frontend-values.yaml
+++ b/frontend/providers/template/deploy/charts/template-frontend/template-frontend-values.yaml
@@ -40,7 +40,7 @@ templateConfig:
   templateRepoUrl: "https://github.com/labring-actions/templates"
   templateRepoBranch: "main"
   templateRepoProvider: "github"
-  templateRepoPath: "templates"
+  templateRepoPath: "template"
   templateRepoEnableReadmeFetch: "true"
   templateRepoGitSslNoVerify: "false"
   showAuthor: "false"

--- a/frontend/providers/template/deploy/charts/template-frontend/templates/configmap.yaml
+++ b/frontend/providers/template/deploy/charts/template-frontend/templates/configmap.yaml
@@ -23,6 +23,7 @@ data:
     DESKTOP_DOMAIN={{ .Values.templateConfig.cloudDomain }}
     TEMPLATE_REPO_ENABLE_README_FETCH={{ .Values.templateConfig.templateRepoEnableReadmeFetch }}
     TEMPLATE_CATEGORIES={{ .Values.templateConfig.templateCategories }}
+    TEMPLATE_CATEGORIES_PATH=config/categories.json
     TEMPLATE_REPO_GIT_SSL_NO_VERIFY={{ .Values.templateConfig.templateRepoGitSslNoVerify }}
     GIT_SSL_NO_VERIFY={{ .Values.templateConfig.templateRepoGitSslNoVerify }}
   config.yaml: |-

--- a/frontend/providers/template/deploy/charts/template-frontend/templates/deployment.yaml
+++ b/frontend/providers/template/deploy/charts/template-frontend/templates/deployment.yaml
@@ -44,6 +44,18 @@ spec:
           env:
             - name: NODE_TLS_REJECT_UNAUTHORIZED
               value: {{ .Values.templateConfig.tlsRejectUnauthorized | quote }}
+            - name: TEMPLATE_REPO_URL
+              value: {{ .Values.templateConfig.templateRepoUrl | quote }}
+            - name: TEMPLATE_REPO_BRANCH
+              value: {{ .Values.templateConfig.templateRepoBranch | quote }}
+            - name: TEMPLATE_REPO_PROVIDER
+              value: {{ .Values.templateConfig.templateRepoProvider | quote }}
+            - name: TEMPLATE_REPO_FOLDER
+              value: {{ .Values.templateConfig.templateRepoPath | quote }}
+            - name: TEMPLATE_CATEGORIES
+              value: {{ .Values.templateConfig.templateCategories | quote }}
+            - name: TEMPLATE_CATEGORIES_PATH
+              value: "config/categories.json"
           startupProbe:
             {{- toYaml .Values.startupProbe | nindent 12 }}
           readinessProbe:

--- a/frontend/providers/template/deploy/charts/template-frontend/values.yaml
+++ b/frontend/providers/template/deploy/charts/template-frontend/values.yaml
@@ -75,7 +75,7 @@ templateConfig:
   templateRepoUrl: "https://github.com/labring-actions/templates"
   templateRepoBranch: "main"
   templateRepoProvider: "github"
-  templateRepoPath: "templates"
+  templateRepoPath: "template"
   showAuthor: "false"
   accountUrl: "http://account-service.account-system.svc:2333"
   guideEnabled: "true"

--- a/frontend/providers/template/package.json
+++ b/frontend/providers/template/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "vitest run"
   },
   "dependencies": {
     "@chakra-ui/anatomy": "^2.2.1",
@@ -86,6 +87,7 @@
     "eslint-config-next": "13.5.9",
     "prettier": "^2.8.8",
     "svg-inline-loader": "^0.8.2",
-    "typescript": "5.2.2"
+    "typescript": "5.2.2",
+    "vitest": "^1.6.0"
   }
 }

--- a/frontend/providers/template/src/api/platform.ts
+++ b/frontend/providers/template/src/api/platform.ts
@@ -1,7 +1,7 @@
 import { EnvResponse } from '@/types/index';
 import { GET } from '@/services/request';
 import { SystemConfigType, TemplateType } from '@/types/app';
-import type { TemplateCategory } from '@/types/config';
+import type { ClientAppConfig, TemplateCategory } from '@/types/config';
 import type { UserQuotaItemType, UserTask, userPriceType } from '@/types/user';
 import { getUserSession } from '@/utils/user';
 import type { PaymentConfigResponse } from '@/pages/api/platform/paymentConfig';
@@ -16,6 +16,8 @@ export const getTemplates = (language?: string) =>
       language
     }
   );
+
+export const getClientAppConfig = () => GET<ClientAppConfig>('/api/platform/getClientAppConfig');
 
 export const getPlatformEnv = (
   { insideCloud }: { insideCloud: boolean } = { insideCloud: false }

--- a/frontend/providers/template/src/components/layout/appmenu.tsx
+++ b/frontend/providers/template/src/components/layout/appmenu.tsx
@@ -1,4 +1,6 @@
+import { getClientAppConfig } from '@/api/platform';
 import { useCachedStore } from '@/store/cached';
+import { buildSideBarMenu, useSystemConfigStore } from '@/store/config';
 import { useSearchStore } from '@/store/search';
 import { getLangStore, setLangStore } from '@/utils/cookieUtils';
 import {
@@ -21,12 +23,35 @@ import { quitGuideDriverObj, startDriver } from '@/hooks/driver';
 import { useClientSideValue } from '@/hooks/useClientSideValue';
 import { useEffect } from 'react';
 import { track } from '@sealos/gtm';
+import { useQuery } from '@tanstack/react-query';
 
 export default function AppMenu() {
   const { t, i18n } = useTranslation();
   const router = useRouter();
-  const { setSearchValue, setAppType } = useSearchStore();
+  const { appType, setSearchValue, setAppType } = useSearchStore();
+  const { setSideBarMenu } = useSystemConfigStore();
   const { insideCloud } = useCachedStore();
+
+  const { data: clientAppConfig } = useQuery(['client-app-config'], getClientAppConfig, {
+    staleTime: 60 * 1000,
+    refetchInterval: 60 * 1000,
+    refetchIntervalInBackground: false,
+    refetchOnWindowFocus: true,
+    retry: 3
+  });
+
+  useEffect(() => {
+    if (!clientAppConfig) return;
+
+    setSideBarMenu(buildSideBarMenu(clientAppConfig.categories, '', i18n.language));
+
+    if (
+      appType !== ApplicationType.All &&
+      !clientAppConfig.categories.some((category) => category.slug === appType)
+    ) {
+      setAppType(ApplicationType.All);
+    }
+  }, [appType, clientAppConfig, i18n.language, setAppType, setSideBarMenu]);
 
   const changeI18n = () => {
     const lastLang = getLangStore();

--- a/frontend/providers/template/src/components/layout/appmenu.tsx
+++ b/frontend/providers/template/src/components/layout/appmenu.tsx
@@ -1,6 +1,6 @@
 import { getClientAppConfig } from '@/api/platform';
 import { useCachedStore } from '@/store/cached';
-import { buildSideBarMenu, useSystemConfigStore } from '@/store/config';
+import { buildSideBarMenu, shouldResetAppType, useSystemConfigStore } from '@/store/config';
 import { useSearchStore } from '@/store/search';
 import { getLangStore, setLangStore } from '@/utils/cookieUtils';
 import {
@@ -45,10 +45,7 @@ export default function AppMenu() {
 
     setSideBarMenu(buildSideBarMenu(clientAppConfig.categories, '', i18n.language));
 
-    if (
-      appType !== ApplicationType.All &&
-      !clientAppConfig.categories.some((category) => category.slug === appType)
-    ) {
+    if (shouldResetAppType(appType, clientAppConfig.categories)) {
       setAppType(ApplicationType.All);
     }
   }, [appType, clientAppConfig, i18n.language, setAppType, setSideBarMenu]);

--- a/frontend/providers/template/src/pages/api/getTemplateSource.ts
+++ b/frontend/providers/template/src/pages/api/getTemplateSource.ts
@@ -24,6 +24,7 @@ import {
 import { readmeCache } from '@/utils/readmeCache';
 import { proxyTemplateIconUrls, resolveTemplateAssetUrls } from '@/utils/templateAsset';
 import { getTemplateCategories } from '@/services/backend/template-categories';
+import { ensureTemplateRepoFresh } from '@/services/backend/template-repo';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
@@ -128,6 +129,7 @@ export async function GetTemplateByName({
   locale?: string;
   includeReadme?: string;
 }) {
+  await ensureTemplateRepoFresh();
   const categories = getTemplateCategories(
     parseTemplateCategories(process.env.TEMPLATE_CATEGORIES)
   );

--- a/frontend/providers/template/src/pages/api/getTemplateSource.ts
+++ b/frontend/providers/template/src/pages/api/getTemplateSource.ts
@@ -15,9 +15,15 @@ import path from 'path';
 import { replaceRawWithCDN } from './listTemplate';
 import { getTemplateEnvs } from '@/utils/tools';
 import { getResourceUsage, ResourceUsage } from '@/utils/usage';
-import { generateYamlData, getTemplateDefaultValues } from '@/utils/template';
+import {
+  filterConfiguredCategorySlugs,
+  generateYamlData,
+  getTemplateDefaultValues,
+  parseTemplateCategories
+} from '@/utils/template';
 import { readmeCache } from '@/utils/readmeCache';
 import { proxyTemplateIconUrls, resolveTemplateAssetUrls } from '@/utils/templateAsset';
+import { getTemplateCategories } from '@/services/backend/template-categories';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
@@ -122,6 +128,9 @@ export async function GetTemplateByName({
   locale?: string;
   includeReadme?: string;
 }) {
+  const categories = getTemplateCategories(
+    parseTemplateCategories(process.env.TEMPLATE_CATEGORIES)
+  );
   const TemplateEnvs = getTemplateEnvs(namespace);
   let { appYaml, templateYaml } = getTemplateYamlByName(templateName, TemplateEnvs);
 
@@ -131,6 +140,10 @@ export async function GetTemplateByName({
       message: 'Lack of kind template'
     };
   }
+  templateYaml.spec.categories = filterConfiguredCategorySlugs(
+    templateYaml.spec.categories,
+    categories
+  );
 
   templateYaml = parseTemplateVariable(templateYaml, TemplateEnvs);
   const dataSource = getTemplateDataSource(templateYaml);

--- a/frontend/providers/template/src/pages/api/listTemplate.ts
+++ b/frontend/providers/template/src/pages/api/listTemplate.ts
@@ -11,12 +11,12 @@ import { proxyTemplateIconUrls, type TemplateRepo } from '@/utils/templateAsset'
 import fs from 'fs';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import path from 'path';
-import { Cron } from 'croner';
 import {
   createTemplateCatalogEtag,
   getTemplateCatalogVersion,
   getTemplateCategories
 } from '@/services/backend/template-categories';
+import { ensureTemplateRepoFresh } from '@/services/backend/template-repo';
 
 export function replaceRawWithCDN(url: string, cdnUrl: string) {
   let parsedUrl = parseGithubUrl(url);
@@ -91,7 +91,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const originalPath = process.cwd();
   const jsonPath = path.resolve(originalPath, 'templates.json');
   const cdnUrl = process.env.CDN_URL;
-  const baseurl = `http://${process.env.HOSTNAME || 'localhost'}:${process.env.PORT || 3000}`;
   const configuredCategories = parseTemplateCategories(process.env.TEMPLATE_CATEGORIES);
   const templateEnvs = getTemplateEnvs();
   const templateRepo = {
@@ -101,24 +100,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   };
 
   try {
-    if (!global.updateRepoCronJob) {
-      global.updateRepoCronJob = new Cron(
-        '*/5 * * * *',
-        async () => {
-          const result = await (await fetch(`${baseurl}/api/updateRepo`)).json();
-          const now = new Date().toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' });
-          console.log(`[${now}] updateRepoCronJob`);
-        },
-        {
-          timezone: 'Asia/Shanghai'
-        }
-      );
-    }
-
-    if (!fs.existsSync(jsonPath)) {
-      console.log(`${baseurl}/api/updateRepo`);
-      await fetch(`${baseurl}/api/updateRepo`);
-    }
+    await ensureTemplateRepoFresh(originalPath);
 
     const templates = readTemplatesFromFile(
       jsonPath,

--- a/frontend/providers/template/src/pages/api/listTemplate.ts
+++ b/frontend/providers/template/src/pages/api/listTemplate.ts
@@ -12,6 +12,7 @@ import fs from 'fs';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import path from 'path';
 import { Cron } from 'croner';
+import { getTemplateCategories } from '@/services/backend/template-categories';
 
 export function replaceRawWithCDN(url: string, cdnUrl: string) {
   let parsedUrl = parseGithubUrl(url);
@@ -118,7 +119,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const templates = readTemplatesFromFile(
       jsonPath,
       cdnUrl,
-      configuredCategories,
+      getTemplateCategories(configuredCategories),
       language,
       templateRepo
     );
@@ -126,10 +127,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const timestamp = new Date().toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' });
     console.log(`[${timestamp}] language: ${language}, templates count: ${templates.length}`);
 
-    const menuKeys = getCategorySlugs(configuredCategories).join(',');
+    const categories = getTemplateCategories(configuredCategories);
+    const menuKeys = getCategorySlugs(categories).join(',');
+
+    res.setHeader('Cache-Control', 'no-cache, must-revalidate');
 
     jsonRes(res, {
-      data: { templates: templates, menuKeys, categories: configuredCategories },
+      data: { templates: templates, menuKeys, categories },
       code: 200
     });
   } catch (error) {

--- a/frontend/providers/template/src/pages/api/listTemplate.ts
+++ b/frontend/providers/template/src/pages/api/listTemplate.ts
@@ -12,7 +12,11 @@ import fs from 'fs';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import path from 'path';
 import { Cron } from 'croner';
-import { getTemplateCategories } from '@/services/backend/template-categories';
+import {
+  createTemplateCatalogEtag,
+  getTemplateCatalogVersion,
+  getTemplateCategories
+} from '@/services/backend/template-categories';
 
 export function replaceRawWithCDN(url: string, cdnUrl: string) {
   let parsedUrl = parseGithubUrl(url);
@@ -131,6 +135,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const menuKeys = getCategorySlugs(categories).join(',');
 
     res.setHeader('Cache-Control', 'no-cache, must-revalidate');
+    res.setHeader(
+      'ETag',
+      createTemplateCatalogEtag([
+        'listTemplate',
+        language || 'default',
+        getTemplateCatalogVersion()
+      ])
+    );
 
     jsonRes(res, {
       data: { templates: templates, menuKeys, categories },

--- a/frontend/providers/template/src/pages/api/platform/getClientAppConfig.ts
+++ b/frontend/providers/template/src/pages/api/platform/getClientAppConfig.ts
@@ -3,8 +3,10 @@ import { ClientAppConfigSchema } from '@/types/config';
 import { parseTemplateCategories } from '@/utils/template';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getTemplateCategories } from '@/services/backend/template-categories';
+import { ensureTemplateRepoFresh } from '@/services/backend/template-repo';
 
-export function getClientAppConfigServer() {
+export async function getClientAppConfigServer() {
+  await ensureTemplateRepoFresh();
   const categories = getTemplateCategories(
     parseTemplateCategories(process.env.TEMPLATE_CATEGORIES)
   );
@@ -28,6 +30,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   res.setHeader('Cache-Control', 'no-cache, must-revalidate');
   jsonRes(res, {
     code: 200,
-    data: getClientAppConfigServer()
+    data: await getClientAppConfigServer()
   });
 }

--- a/frontend/providers/template/src/pages/api/platform/getClientAppConfig.ts
+++ b/frontend/providers/template/src/pages/api/platform/getClientAppConfig.ts
@@ -2,8 +2,12 @@ import { jsonRes } from '@/services/backend/response';
 import { ClientAppConfigSchema } from '@/types/config';
 import { parseTemplateCategories } from '@/utils/template';
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { getTemplateCategories } from '@/services/backend/template-categories';
 
 export function getClientAppConfigServer() {
+  const categories = getTemplateCategories(
+    parseTemplateCategories(process.env.TEMPLATE_CATEGORIES)
+  );
   return ClientAppConfigSchema.parse({
     brandName: process.env.NEXT_PUBLIC_BRAND_NAME || 'Sealos',
     desktopDomain: process.env.DESKTOP_DOMAIN || process.env.SEALOS_CLOUD_DOMAIN || '',
@@ -11,7 +15,7 @@ export function getClientAppConfigServer() {
       process.env.CURRENCY_SYMBOL === 'cny' || process.env.CURRENCY_SYMBOL === 'usd'
         ? process.env.CURRENCY_SYMBOL
         : 'shellCoin',
-    categories: parseTemplateCategories(process.env.TEMPLATE_CATEGORIES),
+    categories,
     showAuthor: process.env.SHOW_AUTHOR === 'true',
     carousel: {
       enabled: false,
@@ -21,6 +25,7 @@ export function getClientAppConfigServer() {
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.setHeader('Cache-Control', 'no-cache, must-revalidate');
   jsonRes(res, {
     code: 200,
     data: getClientAppConfigServer()

--- a/frontend/providers/template/src/pages/api/platform/getClientAppConfig.ts
+++ b/frontend/providers/template/src/pages/api/platform/getClientAppConfig.ts
@@ -5,8 +5,12 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { getTemplateCategories } from '@/services/backend/template-categories';
 import { ensureTemplateRepoFresh } from '@/services/backend/template-repo';
 
-export async function getClientAppConfigServer() {
-  await ensureTemplateRepoFresh();
+export async function getClientAppConfigServer({
+  refreshRepo = true
+}: { refreshRepo?: boolean } = {}) {
+  if (refreshRepo) {
+    await ensureTemplateRepoFresh();
+  }
   const categories = getTemplateCategories(
     parseTemplateCategories(process.env.TEMPLATE_CATEGORIES)
   );

--- a/frontend/providers/template/src/pages/api/updateRepo.ts
+++ b/frontend/providers/template/src/pages/api/updateRepo.ts
@@ -3,11 +3,11 @@ import { jsonRes } from '@/services/backend/response';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { updateRepo } from '@/services/backend/template-repo';
 import { readmeCache } from '@/utils/readmeCache';
+import { clearTemplateCache } from './v2alpha/templates/templateCache';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
     await updateRepo();
-    readmeCache.clear();
 
     jsonRes(res, {
       data: `success update template`,
@@ -18,5 +18,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       code: 500,
       error: err
     });
+  } finally {
+    clearTemplateCache();
+    readmeCache.clear();
   }
 }

--- a/frontend/providers/template/src/pages/api/v1/template/[name].ts
+++ b/frontend/providers/template/src/pages/api/v1/template/[name].ts
@@ -8,6 +8,7 @@ import { readTemplatesFromFile } from '../../listTemplate';
 import { GetTemplateByName } from '../../getTemplateSource';
 import { parseTemplateCategories } from '@/utils/template';
 import { getTemplateEnvs } from '@/utils/tools';
+import { getTemplateCategories } from '@/services/backend/template-categories';
 
 function simplifyResourceValue(
   resource: { min: number; max: number },
@@ -57,10 +58,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       branch: templateEnvs.TEMPLATE_REPO_BRANCH,
       provider: templateEnvs.TEMPLATE_REPO_PROVIDER
     };
+    const categories = getTemplateCategories(configuredCategories);
     const templates = readTemplatesFromFile(
       jsonPath,
       process.env.CDN_URL,
-      configuredCategories,
+      categories,
       language,
       templateRepo
     );

--- a/frontend/providers/template/src/pages/api/v1/template/[name].ts
+++ b/frontend/providers/template/src/pages/api/v1/template/[name].ts
@@ -9,6 +9,7 @@ import { GetTemplateByName } from '../../getTemplateSource';
 import { parseTemplateCategories } from '@/utils/template';
 import { getTemplateEnvs } from '@/utils/tools';
 import { getTemplateCategories } from '@/services/backend/template-categories';
+import { ensureTemplateRepoFresh } from '@/services/backend/template-repo';
 
 function simplifyResourceValue(
   resource: { min: number; max: number },
@@ -43,6 +44,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   try {
     const originalPath = process.cwd();
     const jsonPath = path.resolve(originalPath, 'templates.json');
+
+    await ensureTemplateRepoFresh(originalPath);
 
     if (!fs.existsSync(jsonPath)) {
       return jsonRes(res, {

--- a/frontend/providers/template/src/pages/api/v1/template/index.ts
+++ b/frontend/providers/template/src/pages/api/v1/template/index.ts
@@ -5,7 +5,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import path from 'path';
 import { readTemplatesFromFile } from '../../listTemplate';
 import { getTemplateEnvs } from '@/utils/tools';
-
+import { getTemplateCategories } from '@/services/backend/template-categories';
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const language = (req.query.language as string) || 'en';
   const originalPath = process.cwd();
@@ -19,10 +19,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       branch: templateEnvs.TEMPLATE_REPO_BRANCH,
       provider: templateEnvs.TEMPLATE_REPO_PROVIDER
     };
+    const categories = getTemplateCategories(configuredCategories);
     const templates = readTemplatesFromFile(
       jsonPath,
       process.env.CDN_URL,
-      configuredCategories,
+      categories,
       language,
       templateRepo
     );
@@ -48,7 +49,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       };
     });
 
-    const menuKeys = getCategorySlugs(configuredCategories).join(',');
+    const menuKeys = getCategorySlugs(categories).join(',');
 
     jsonRes(res, {
       data: {

--- a/frontend/providers/template/src/pages/api/v1/template/index.ts
+++ b/frontend/providers/template/src/pages/api/v1/template/index.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import { readTemplatesFromFile } from '../../listTemplate';
 import { getTemplateEnvs } from '@/utils/tools';
 import { getTemplateCategories } from '@/services/backend/template-categories';
+import { ensureTemplateRepoFresh } from '@/services/backend/template-repo';
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const language = (req.query.language as string) || 'en';
   const originalPath = process.cwd();
@@ -20,6 +21,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       provider: templateEnvs.TEMPLATE_REPO_PROVIDER
     };
     const categories = getTemplateCategories(configuredCategories);
+    await ensureTemplateRepoFresh(originalPath);
     const templates = readTemplatesFromFile(
       jsonPath,
       process.env.CDN_URL,

--- a/frontend/providers/template/src/pages/api/v1/template/index.ts
+++ b/frontend/providers/template/src/pages/api/v1/template/index.ts
@@ -13,6 +13,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const jsonPath = path.resolve(originalPath, 'templates.json');
 
   try {
+    await ensureTemplateRepoFresh(originalPath);
+
     const configuredCategories = parseTemplateCategories(process.env.TEMPLATE_CATEGORIES);
     const templateEnvs = getTemplateEnvs();
     const templateRepo = {
@@ -21,7 +23,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       provider: templateEnvs.TEMPLATE_REPO_PROVIDER
     };
     const categories = getTemplateCategories(configuredCategories);
-    await ensureTemplateRepoFresh(originalPath);
     const templates = readTemplatesFromFile(
       jsonPath,
       process.env.CDN_URL,

--- a/frontend/providers/template/src/pages/api/v1alpha/listTemplate.ts
+++ b/frontend/providers/template/src/pages/api/v1alpha/listTemplate.ts
@@ -1,9 +1,12 @@
 import { jsonRes } from '@/services/backend/response';
 
-import { TemplateType } from '@/types/app';
 import fs from 'fs';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import path from 'path';
+import { Config } from '@/config';
+import { getTemplateCategories } from '@/services/backend/template-categories';
+import { filterConfiguredCategorySlugs } from '@/utils/template';
+import { TemplateType } from '@/types/app';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const originalPath = process.cwd();
@@ -11,9 +14,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   try {
     if (fs.existsSync(jsonPath)) {
+      const config = Config();
+      const categories = getTemplateCategories(config.template.categories);
       const jsonData = fs.readFileSync(jsonPath, 'utf8');
       const _templates: TemplateType[] = JSON.parse(jsonData);
-      const templates = _templates.filter((item) => item?.spec?.draft !== true);
+      const templates = _templates
+        .filter((item) => item?.spec?.draft !== true)
+        .map((item) => ({
+          ...item,
+          spec: {
+            ...item.spec,
+            categories: filterConfiguredCategorySlugs(item.spec.categories, categories)
+          }
+        }));
       return jsonRes(res, { data: templates, code: 200 });
     } else {
       return jsonRes(res, { data: [], code: 200 });

--- a/frontend/providers/template/src/pages/api/v1alpha/listTemplate.ts
+++ b/frontend/providers/template/src/pages/api/v1alpha/listTemplate.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import path from 'path';
 import { getTemplateCategories } from '@/services/backend/template-categories';
-import { filterConfiguredCategorySlugs } from '@/utils/template';
+import { filterConfiguredCategorySlugs, parseTemplateCategories } from '@/utils/template';
 import { TemplateType } from '@/types/app';
 import { ensureTemplateRepoFresh } from '@/services/backend/template-repo';
 

--- a/frontend/providers/template/src/pages/api/v1alpha/listTemplate.ts
+++ b/frontend/providers/template/src/pages/api/v1alpha/listTemplate.ts
@@ -3,19 +3,22 @@ import { jsonRes } from '@/services/backend/response';
 import fs from 'fs';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import path from 'path';
-import { Config } from '@/config';
 import { getTemplateCategories } from '@/services/backend/template-categories';
 import { filterConfiguredCategorySlugs } from '@/utils/template';
 import { TemplateType } from '@/types/app';
+import { ensureTemplateRepoFresh } from '@/services/backend/template-repo';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const originalPath = process.cwd();
   const jsonPath = path.resolve(originalPath, 'templates.json');
 
   try {
+    await ensureTemplateRepoFresh(originalPath);
+
     if (fs.existsSync(jsonPath)) {
-      const config = Config();
-      const categories = getTemplateCategories(config.template.categories);
+      const categories = getTemplateCategories(
+        parseTemplateCategories(process.env.TEMPLATE_CATEGORIES)
+      );
       const jsonData = fs.readFileSync(jsonPath, 'utf8');
       const _templates: TemplateType[] = JSON.parse(jsonData);
       const templates = _templates

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/[name].ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/[name].ts
@@ -166,15 +166,10 @@ async function handleTemplateDetails(
     const i18nData = template.spec?.i18n?.[language];
 
     let simplifiedResource = null;
-    const cacheKey = createTemplateCatalogEtag([
-      'v2alpha-detail-resource',
-      templateName,
-      language,
-      catalogVersion
-    ]);
+    const cacheKey = createTemplateCatalogEtag(['v2alpha-detail-resource', templateName, language]);
 
     // Check cache first
-    simplifiedResource = getCachedTemplateDetail(cacheKey);
+    simplifiedResource = getCachedTemplateDetail(cacheKey, catalogVersion);
 
     if (simplifiedResource === null) {
       try {
@@ -210,7 +205,7 @@ async function handleTemplateDetails(
           simplifiedResource = simplifyResourceUsage(resourceUsage);
 
           // Cache the result using shared cache
-          setCachedTemplateDetail(cacheKey, simplifiedResource);
+          setCachedTemplateDetail(cacheKey, simplifiedResource, catalogVersion);
         }
       } catch (error) {
         console.error('Error getting template details:', error);

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/[name].ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/[name].ts
@@ -13,6 +13,10 @@ import {
 import { parseTemplateCategories } from '@/utils/template';
 import { sendError, ErrorType, ErrorCode } from '@/types/v2alpha/error';
 import { getTemplateEnvs } from '@/utils/tools';
+import {
+  getTemplateCatalogVersion,
+  getTemplateCategories
+} from '@/services/backend/template-categories';
 
 // estimate min—max equality
 function simplifyResourceValue(
@@ -95,10 +99,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     });
   }
 
-  // Add caching headers for GET requests
   if (req.method === 'GET') {
-    res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=600');
-    res.setHeader('ETag', `"${templateName}-${language}"`);
     return handleTemplateDetails(req, res, templateName, language);
   }
 
@@ -135,13 +136,11 @@ async function handleTemplateDetails(
       branch: templateEnvs.TEMPLATE_REPO_BRANCH,
       provider: templateEnvs.TEMPLATE_REPO_PROVIDER
     };
-    getCachedTemplates(
-      jsonPath,
-      process.env.CDN_URL,
-      parseTemplateCategories(process.env.TEMPLATE_CATEGORIES),
-      language,
-      templateRepo
+    const categories = getTemplateCategories(
+      parseTemplateCategories(process.env.TEMPLATE_CATEGORIES)
     );
+    const catalogVersion = getTemplateCatalogVersion(originalPath);
+    getCachedTemplates(jsonPath, process.env.CDN_URL, categories, language, templateRepo);
     const template = getTemplateFromCache(templateName);
 
     if (!template) {
@@ -222,6 +221,9 @@ async function handleTemplateDetails(
       args: template.spec.inputs || {},
       deployCount: template.spec.deployCount || 0
     };
+
+    res.setHeader('Cache-Control', 'no-cache, must-revalidate');
+    res.setHeader('ETag', `"template-v2alpha-${templateName}-${language}-${catalogVersion}"`);
 
     res.status(200).json(result);
   } catch (error) {

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/[name].ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/[name].ts
@@ -18,6 +18,7 @@ import {
   getTemplateCatalogVersion,
   getTemplateCategories
 } from '@/services/backend/template-categories';
+import { ensureTemplateRepoFresh } from '@/services/backend/template-repo';
 
 // estimate min—max equality
 function simplifyResourceValue(
@@ -122,6 +123,8 @@ async function handleTemplateDetails(
   try {
     const originalPath = process.cwd();
     const jsonPath = path.resolve(originalPath, 'templates.json');
+
+    await ensureTemplateRepoFresh(originalPath);
 
     if (!fs.existsSync(jsonPath)) {
       return sendError(res, {

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/[name].ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/[name].ts
@@ -14,6 +14,7 @@ import { parseTemplateCategories } from '@/utils/template';
 import { sendError, ErrorType, ErrorCode } from '@/types/v2alpha/error';
 import { getTemplateEnvs } from '@/utils/tools';
 import {
+  createTemplateCatalogEtag,
   getTemplateCatalogVersion,
   getTemplateCategories
 } from '@/services/backend/template-categories';
@@ -140,8 +141,15 @@ async function handleTemplateDetails(
       parseTemplateCategories(process.env.TEMPLATE_CATEGORIES)
     );
     const catalogVersion = getTemplateCatalogVersion(originalPath);
-    getCachedTemplates(jsonPath, process.env.CDN_URL, categories, language, templateRepo);
-    const template = getTemplateFromCache(templateName);
+    const templateCache = getCachedTemplates(
+      jsonPath,
+      process.env.CDN_URL,
+      categories,
+      language,
+      templateRepo,
+      catalogVersion
+    );
+    const template = getTemplateFromCache(templateCache, templateName);
 
     if (!template) {
       return sendError(res, {
@@ -155,7 +163,12 @@ async function handleTemplateDetails(
     const i18nData = template.spec?.i18n?.[language];
 
     let simplifiedResource = null;
-    const cacheKey = `${templateName}-${language}`;
+    const cacheKey = createTemplateCatalogEtag([
+      'v2alpha-detail-resource',
+      templateName,
+      language,
+      catalogVersion
+    ]);
 
     // Check cache first
     simplifiedResource = getCachedTemplateDetail(cacheKey);
@@ -223,7 +236,10 @@ async function handleTemplateDetails(
     };
 
     res.setHeader('Cache-Control', 'no-cache, must-revalidate');
-    res.setHeader('ETag', `"template-v2alpha-${templateName}-${language}-${catalogVersion}"`);
+    res.setHeader(
+      'ETag',
+      createTemplateCatalogEtag(['v2alpha-detail', templateName, language, catalogVersion])
+    );
 
     res.status(200).json(result);
   } catch (error) {

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/index.ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/index.ts
@@ -5,6 +5,10 @@ import path from 'path';
 import { getCachedTemplates } from './templateCache';
 import { sendError, ErrorType, ErrorCode } from '@/types/v2alpha/error';
 import { getTemplateEnvs } from '@/utils/tools';
+import {
+  getTemplateCatalogVersion,
+  getTemplateCategories
+} from '@/services/backend/template-categories';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
@@ -20,10 +24,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const originalPath = process.cwd();
   const jsonPath = path.resolve(originalPath, 'templates.json');
 
-  // Add caching headers for GET requests
-  res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=600'); // 5min client, 10min CDN
-  res.setHeader('ETag', `"template-list-${language}"`);
-
   try {
     // Use shared cache instead of directly reading templates
     const configuredCategories = parseTemplateCategories(process.env.TEMPLATE_CATEGORIES);
@@ -33,10 +33,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       branch: templateEnvs.TEMPLATE_REPO_BRANCH,
       provider: templateEnvs.TEMPLATE_REPO_PROVIDER
     };
+    const categories = getTemplateCategories(configuredCategories);
+    const catalogVersion = getTemplateCatalogVersion(originalPath);
     const cacheResult = getCachedTemplates(
       jsonPath,
       process.env.CDN_URL,
-      configuredCategories,
+      categories,
       language,
       templateRepo
     );
@@ -62,14 +64,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       };
     });
 
-    const menuKeys = getCategorySlugs(configuredCategories);
+    const menuKeys = getCategorySlugs(categories);
 
-    // Add menuKeys as response header if needed
+    res.setHeader('Cache-Control', 'no-cache, must-revalidate');
+    res.setHeader('ETag', `"template-v2alpha-list-${language}-${catalogVersion}"`);
+
     if (menuKeys.length > 0) {
       res.setHeader('X-Menu-Keys', menuKeys.join(','));
     }
 
-    // Return templates array directly
     res.status(200).json(simplifiedTemplates);
   } catch (error) {
     sendError(res, {

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/index.ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/index.ts
@@ -10,6 +10,7 @@ import {
   getTemplateCatalogVersion,
   getTemplateCategories
 } from '@/services/backend/template-categories';
+import { ensureTemplateRepoFresh } from '@/services/backend/template-repo';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
@@ -26,6 +27,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const jsonPath = path.resolve(originalPath, 'templates.json');
 
   try {
+    await ensureTemplateRepoFresh(originalPath);
+
     // Use shared cache instead of directly reading templates
     const configuredCategories = parseTemplateCategories(process.env.TEMPLATE_CATEGORIES);
     const templateEnvs = getTemplateEnvs();

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/index.ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/index.ts
@@ -6,6 +6,7 @@ import { getCachedTemplates } from './templateCache';
 import { sendError, ErrorType, ErrorCode } from '@/types/v2alpha/error';
 import { getTemplateEnvs } from '@/utils/tools';
 import {
+  createTemplateCatalogEtag,
   getTemplateCatalogVersion,
   getTemplateCategories
 } from '@/services/backend/template-categories';
@@ -40,7 +41,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       process.env.CDN_URL,
       categories,
       language,
-      templateRepo
+      templateRepo,
+      catalogVersion
     );
     const templates = cacheResult.data;
 
@@ -67,7 +69,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const menuKeys = getCategorySlugs(categories);
 
     res.setHeader('Cache-Control', 'no-cache, must-revalidate');
-    res.setHeader('ETag', `"template-v2alpha-list-${language}-${catalogVersion}"`);
+    res.setHeader('ETag', createTemplateCatalogEtag(['v2alpha-list', language, catalogVersion]));
 
     if (menuKeys.length > 0) {
       res.setHeader('X-Menu-Keys', menuKeys.join(','));

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/templateCache.ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/templateCache.ts
@@ -7,11 +7,13 @@ interface TemplatesCache {
   data: TemplateType[];
   timestamp: number;
   map: Map<string, TemplateType>;
+  catalogVersion?: string;
 }
 
 interface TemplateDetailCache {
   data: any;
   timestamp: number;
+  catalogVersion?: string;
 }
 
 const templatesCache = new Map<string, TemplatesCache>();
@@ -24,15 +26,13 @@ function getTemplatesCacheKey({
   cdnUrl,
   configuredCategories,
   language,
-  templateRepo,
-  catalogVersion
+  templateRepo
 }: {
   jsonPath: string;
   cdnUrl?: string;
   configuredCategories: TemplateCategory[];
   language?: string;
   templateRepo?: TemplateRepo;
-  catalogVersion?: string;
 }) {
   return JSON.stringify({
     jsonPath,
@@ -44,8 +44,7 @@ function getTemplatesCacheKey({
           url: templateRepo.url,
           branch: templateRepo.branch
         }
-      : null,
-    catalogVersion: catalogVersion || ''
+      : null
   });
 }
 
@@ -63,12 +62,15 @@ export function getCachedTemplates(
     cdnUrl,
     configuredCategories,
     language,
-    templateRepo,
-    catalogVersion
+    templateRepo
   });
   const cachedTemplates = templatesCache.get(cacheKey);
 
-  if (cachedTemplates && now - cachedTemplates.timestamp < CACHE_TTL) {
+  if (
+    cachedTemplates &&
+    cachedTemplates.catalogVersion === catalogVersion &&
+    now - cachedTemplates.timestamp < CACHE_TTL
+  ) {
     return cachedTemplates;
   }
 
@@ -95,7 +97,8 @@ export function getCachedTemplates(
     const cacheResult = {
       data: templates,
       timestamp: now,
-      map: templateMap
+      map: templateMap,
+      catalogVersion
     };
     templatesCache.set(cacheKey, cacheResult);
 
@@ -114,22 +117,31 @@ export function getTemplateFromCache(
 }
 
 // Get cached template detail
-export function getCachedTemplateDetail(cacheKey: string): any | null {
+export function getCachedTemplateDetail(cacheKey: string, catalogVersion?: string): any | null {
   const cached = templateDetailCache.get(cacheKey);
   const now = Date.now();
 
-  if (cached && now - cached.timestamp < CACHE_TTL) {
+  if (cached && cached.catalogVersion === catalogVersion && now - cached.timestamp < CACHE_TTL) {
     return cached.data;
+  }
+
+  if (cached) {
+    templateDetailCache.delete(cacheKey);
   }
 
   return null;
 }
 
 // Set template detail cache
-export function setCachedTemplateDetail(cacheKey: string, data: any): void {
+export function setCachedTemplateDetail(
+  cacheKey: string,
+  data: any,
+  catalogVersion?: string
+): void {
   templateDetailCache.set(cacheKey, {
     data,
-    timestamp: Date.now()
+    timestamp: Date.now(),
+    catalogVersion
   });
 }
 

--- a/frontend/providers/template/src/pages/api/v2alpha/templates/templateCache.ts
+++ b/frontend/providers/template/src/pages/api/v2alpha/templates/templateCache.ts
@@ -14,30 +14,70 @@ interface TemplateDetailCache {
   timestamp: number;
 }
 
-let templatesCache: TemplatesCache | null = null;
+const templatesCache = new Map<string, TemplatesCache>();
 let templateDetailCache = new Map<string, TemplateDetailCache>();
-let isRefreshingCache = false;
+const refreshingCacheKeys = new Set<string>();
 const CACHE_TTL = 5 * 60 * 1000;
+
+function getTemplatesCacheKey({
+  jsonPath,
+  cdnUrl,
+  configuredCategories,
+  language,
+  templateRepo,
+  catalogVersion
+}: {
+  jsonPath: string;
+  cdnUrl?: string;
+  configuredCategories: TemplateCategory[];
+  language?: string;
+  templateRepo?: TemplateRepo;
+  catalogVersion?: string;
+}) {
+  return JSON.stringify({
+    jsonPath,
+    cdnUrl: cdnUrl || '',
+    categorySlugs: configuredCategories.map((category) => category.slug),
+    language: language || '',
+    templateRepo: templateRepo
+      ? {
+          url: templateRepo.url,
+          branch: templateRepo.branch
+        }
+      : null,
+    catalogVersion: catalogVersion || ''
+  });
+}
 
 export function getCachedTemplates(
   jsonPath: string,
   cdnUrl?: string,
   configuredCategories: TemplateCategory[] = [],
   language?: string,
-  templateRepo?: TemplateRepo
+  templateRepo?: TemplateRepo,
+  catalogVersion?: string
 ) {
   const now = Date.now();
+  const cacheKey = getTemplatesCacheKey({
+    jsonPath,
+    cdnUrl,
+    configuredCategories,
+    language,
+    templateRepo,
+    catalogVersion
+  });
+  const cachedTemplates = templatesCache.get(cacheKey);
 
-  if (templatesCache && now - templatesCache.timestamp < CACHE_TTL) {
-    return templatesCache;
+  if (cachedTemplates && now - cachedTemplates.timestamp < CACHE_TTL) {
+    return cachedTemplates;
   }
 
-  if (isRefreshingCache && templatesCache) {
-    return templatesCache;
+  if (refreshingCacheKeys.has(cacheKey) && cachedTemplates) {
+    return cachedTemplates;
   }
 
   try {
-    isRefreshingCache = true;
+    refreshingCacheKeys.add(cacheKey);
 
     const templates = readTemplatesFromFile(
       jsonPath,
@@ -52,24 +92,25 @@ export function getCachedTemplates(
       templateMap.set(template.metadata.name, template);
     });
 
-    templatesCache = {
+    const cacheResult = {
       data: templates,
       timestamp: now,
       map: templateMap
     };
+    templatesCache.set(cacheKey, cacheResult);
 
-    return templatesCache;
+    return cacheResult;
   } finally {
-    isRefreshingCache = false;
+    refreshingCacheKeys.delete(cacheKey);
   }
 }
 
 // Get specific template from cache
-export function getTemplateFromCache(templateName: string): TemplateType | undefined {
-  if (!templatesCache) {
-    return undefined;
-  }
-  return templatesCache.map.get(templateName);
+export function getTemplateFromCache(
+  cache: TemplatesCache,
+  templateName: string
+): TemplateType | undefined {
+  return cache.map.get(templateName);
 }
 
 // Get cached template detail
@@ -94,6 +135,7 @@ export function setCachedTemplateDetail(cacheKey: string, data: any): void {
 
 // Clear all caches
 export function clearTemplateCache(): void {
-  templatesCache = null;
+  templatesCache.clear();
   templateDetailCache.clear();
+  refreshingCacheKeys.clear();
 }

--- a/frontend/providers/template/src/pages/healthz.ts
+++ b/frontend/providers/template/src/pages/healthz.ts
@@ -17,9 +17,9 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
   return sendHealthz(res);
 };
 
-function sendHealthz(res: GetServerSidePropsContext['res'], head = false) {
+async function sendHealthz(res: GetServerSidePropsContext['res'], head = false) {
   try {
-    assertReady();
+    await assertReady();
   } catch (error) {
     console.error(`[healthz] ${HEALTHZ_SERVICE} is not ready`, error);
     if (head) {

--- a/frontend/providers/template/src/pages/index.tsx
+++ b/frontend/providers/template/src/pages/index.tsx
@@ -50,8 +50,9 @@ export default function AppList({
   const { envs } = useSystemConfigStore();
 
   const { data } = useQuery(['listTemplate', i18n.language], () => getTemplates(i18n.language), {
-    refetchInterval: 5 * 60 * 1000,
-    staleTime: 5 * 60 * 1000,
+    refetchInterval: 60 * 1000,
+    staleTime: 60 * 1000,
+    refetchOnWindowFocus: true,
     retry: 3
   });
 

--- a/frontend/providers/template/src/services/backend/template-categories.ts
+++ b/frontend/providers/template/src/services/backend/template-categories.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import { z } from 'zod';
@@ -102,6 +103,9 @@ function writeTemplateCategoriesCache(cachePath: string, categories: TemplateCat
       flag: 'wx'
     });
     fs.renameSync(tempPath, cachePath);
+  } catch (error) {
+    removeTemplateCategoriesCache(cachePath);
+    throw error;
   } finally {
     if (fs.existsSync(tempPath)) {
       fs.rmSync(tempPath, { force: true });
@@ -161,4 +165,13 @@ export function getTemplateCatalogVersion(basePath = process.cwd()) {
     getFileVersion(path.resolve(basePath, 'templates.json')),
     getFileVersion(getTemplateCategoriesCachePath(basePath))
   ].join('-');
+}
+
+export function createTemplateCatalogEtag(parts: readonly unknown[]) {
+  const digest = crypto
+    .createHash('sha256')
+    .update(JSON.stringify(parts))
+    .digest('hex')
+    .slice(0, 24);
+  return `"template-${digest}"`;
 }

--- a/frontend/providers/template/src/services/backend/template-categories.ts
+++ b/frontend/providers/template/src/services/backend/template-categories.ts
@@ -1,0 +1,164 @@
+import fs from 'fs';
+import path from 'path';
+import { z } from 'zod';
+import { TemplateCategorySchema, type TemplateCategory } from '@/types/config';
+
+export const DEFAULT_TEMPLATE_CATEGORIES_REPO_PATH = 'config/categories.json';
+export const TEMPLATE_CATEGORIES_CACHE_FILE = 'template-categories.json';
+
+const TemplateCategoriesSchema = z.array(TemplateCategorySchema);
+
+function getConfiguredRepoCategoriesPath() {
+  return process.env.TEMPLATE_CATEGORIES_PATH?.trim() || DEFAULT_TEMPLATE_CATEGORIES_REPO_PATH;
+}
+
+function normalizeRepoRelativePath(input: string) {
+  const normalized = path.posix.normalize(input.replace(/\\/g, '/'));
+  if (
+    normalized === '' ||
+    normalized === '.' ||
+    path.posix.isAbsolute(normalized) ||
+    normalized === '..' ||
+    normalized.startsWith('../')
+  ) {
+    throw new Error(`Invalid template categories path: ${input}`);
+  }
+  return normalized;
+}
+
+function resolveRepoContainedFile(repoRootPath: string, targetPath: string) {
+  if (!fs.existsSync(targetPath)) return null;
+
+  const repoRealPath = fs.realpathSync(repoRootPath);
+  const targetStat = fs.lstatSync(targetPath);
+
+  if (!targetStat.isFile() || targetStat.isSymbolicLink()) {
+    throw new Error(`Invalid template categories file: ${targetPath}`);
+  }
+
+  const targetRealPath = fs.realpathSync(targetPath);
+  const relativePath = path.relative(repoRealPath, targetRealPath);
+
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    throw new Error(`Template categories file escapes repository root: ${targetPath}`);
+  }
+
+  return targetRealPath;
+}
+
+export function getTemplateCategoriesCachePath(basePath = process.cwd()) {
+  return path.resolve(basePath, TEMPLATE_CATEGORIES_CACHE_FILE);
+}
+
+export function resolveTemplateCategoriesRepoPath(repoRootPath: string) {
+  const relativePath = normalizeRepoRelativePath(getConfiguredRepoCategoriesPath());
+  return path.resolve(repoRootPath, ...relativePath.split('/'));
+}
+
+function parseTemplateCategories(content: string, source: string): TemplateCategory[] {
+  const json = JSON.parse(content);
+  const result = TemplateCategoriesSchema.safeParse(json);
+  if (!result.success) {
+    throw new Error(`Invalid template categories in ${source}: ${result.error.message}`);
+  }
+  return result.data;
+}
+
+export function readTemplateCategoriesFile(filePath: string): TemplateCategory[] | null {
+  if (!fs.existsSync(filePath)) return null;
+
+  try {
+    return parseTemplateCategories(fs.readFileSync(filePath, 'utf-8'), filePath);
+  } catch (error) {
+    console.warn('[Template Categories] Failed to read categories:', error);
+    return null;
+  }
+}
+
+export function readTemplateCategoriesFromRepo(repoRootPath: string): TemplateCategory[] | null {
+  try {
+    const categoriesPath = resolveRepoContainedFile(
+      repoRootPath,
+      resolveTemplateCategoriesRepoPath(repoRootPath)
+    );
+    if (!categoriesPath) return null;
+    return readTemplateCategoriesFile(categoriesPath);
+  } catch (error) {
+    console.warn('[Template Categories] Failed to resolve categories path:', error);
+    return null;
+  }
+}
+
+function removeTemplateCategoriesCache(cachePath: string) {
+  if (!fs.existsSync(cachePath)) return;
+  fs.rmSync(cachePath, { force: true });
+}
+
+function writeTemplateCategoriesCache(cachePath: string, categories: TemplateCategory[]) {
+  const tempPath = `${cachePath}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    fs.writeFileSync(tempPath, JSON.stringify(categories, null, 2), {
+      encoding: 'utf-8',
+      flag: 'wx'
+    });
+    fs.renameSync(tempPath, cachePath);
+  } finally {
+    if (fs.existsSync(tempPath)) {
+      fs.rmSync(tempPath, { force: true });
+    }
+  }
+}
+
+export function syncTemplateCategoriesFromRepo(repoRootPath: string, basePath = process.cwd()) {
+  const cachePath = getTemplateCategoriesCachePath(basePath);
+  const categories = readTemplateCategoriesFromRepo(repoRootPath);
+
+  if (!categories) {
+    removeTemplateCategoriesCache(cachePath);
+    return null;
+  }
+
+  writeTemplateCategoriesCache(cachePath, categories);
+  return categories;
+}
+
+export function readTemplateCategoriesFromCache(basePath = process.cwd()) {
+  const cachePath = getTemplateCategoriesCachePath(basePath);
+  if (!fs.existsSync(cachePath)) return null;
+
+  try {
+    const cacheStat = fs.lstatSync(cachePath);
+    if (!cacheStat.isFile() || cacheStat.isSymbolicLink()) {
+      throw new Error(`Invalid template categories cache file: ${cachePath}`);
+    }
+    return parseTemplateCategories(fs.readFileSync(cachePath, 'utf-8'), cachePath);
+  } catch (error) {
+    removeTemplateCategoriesCache(cachePath);
+    console.warn('[Template Categories] Failed to read cache categories:', error);
+    return null;
+  }
+}
+
+export function getTemplateCategories(
+  fallbackCategories: TemplateCategory[] = [],
+  basePath = process.cwd()
+) {
+  return readTemplateCategoriesFromCache(basePath) ?? fallbackCategories;
+}
+
+function getFileVersion(filePath: string) {
+  try {
+    const stat = fs.lstatSync(filePath);
+    if (!stat.isFile() || stat.isSymbolicLink()) return 'invalid';
+    return `${stat.mtimeMs}-${stat.size}`;
+  } catch {
+    return 'missing';
+  }
+}
+
+export function getTemplateCatalogVersion(basePath = process.cwd()) {
+  return [
+    getFileVersion(path.resolve(basePath, 'templates.json')),
+    getFileVersion(getTemplateCategoriesCachePath(basePath))
+  ].join('-');
+}

--- a/frontend/providers/template/src/services/backend/template-repo.ts
+++ b/frontend/providers/template/src/services/backend/template-repo.ts
@@ -226,12 +226,11 @@ export async function ensureTemplateRepoFresh(basePath = process.cwd()) {
   const now = Date.now();
   const interval = getTemplateRepoSyncIntervalMs();
 
-  if (fs.existsSync(jsonPath) && templateRepoLastSyncedAt === 0) {
-    templateRepoLastSyncedAt = now;
-    return;
-  }
-
-  if (fs.existsSync(jsonPath) && now - templateRepoLastSyncedAt < interval) {
+  if (
+    fs.existsSync(jsonPath) &&
+    templateRepoLastSyncedAt !== 0 &&
+    now - templateRepoLastSyncedAt < interval
+  ) {
     return;
   }
 

--- a/frontend/providers/template/src/services/backend/template-repo.ts
+++ b/frontend/providers/template/src/services/backend/template-repo.ts
@@ -1,7 +1,7 @@
 import { K8sApiDefault } from '@/services/backend/kubernetes';
 import { jsonRes } from '@/services/backend/response';
 
-import { exec } from 'child_process';
+import { exec, execFile } from 'child_process';
 import fs from 'fs';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import path from 'path';
@@ -14,6 +14,7 @@ import { syncTemplateCategoriesFromRepo } from './template-categories';
 import { readmeCache } from '@/utils/readmeCache';
 
 const execAsync = util.promisify(exec);
+const execFileAsync = util.promisify(execFile);
 const DEFAULT_TEMPLATE_REPO_SYNC_INTERVAL_MS = 30 * 1000;
 
 let templateRepoLastSyncedAt = 0;
@@ -25,6 +26,62 @@ function getTemplateRepoSyncIntervalMs() {
     return DEFAULT_TEMPLATE_REPO_SYNC_INTERVAL_MS;
   }
   return rawValue;
+}
+
+function normalizeTemplateRepoRef(value: string) {
+  return value
+    .trim()
+    .replace(/\/+$/, '')
+    .replace(/\.git$/, '');
+}
+
+async function cloneOrRefreshTemplateRepo(
+  targetPath: string,
+  templateRepoUrl: string,
+  templateRepoBranch: string
+) {
+  let existingRemote = '';
+  let existingBranch = '';
+
+  if (fs.existsSync(targetPath)) {
+    try {
+      const remoteResult = await execFileAsync(
+        'git',
+        ['-C', targetPath, 'remote', 'get-url', 'origin'],
+        { timeout: 10000 }
+      );
+      existingRemote = remoteResult.stdout.trim();
+
+      const branchResult = await execFileAsync(
+        'git',
+        ['-C', targetPath, 'branch', '--show-current'],
+        { timeout: 10000 }
+      );
+      existingBranch = branchResult.stdout.trim();
+    } catch {
+      // A prebuilt image may contain a template directory without a usable Git checkout.
+    }
+  }
+
+  const repositoryChanged =
+    normalizeTemplateRepoRef(existingRemote) !== normalizeTemplateRepoRef(templateRepoUrl) ||
+    existingBranch !== templateRepoBranch;
+
+  if (!existingRemote || repositoryChanged) {
+    if (fs.existsSync(targetPath)) {
+      fs.rmSync(targetPath, { recursive: true, force: true });
+    }
+    await execFileAsync(
+      'git',
+      ['clone', '-b', templateRepoBranch, templateRepoUrl, targetPath, '--depth=1'],
+      { timeout: 60000 }
+    );
+    return;
+  }
+
+  await execFileAsync('git', ['-C', targetPath, 'pull', '--depth=1', '--rebase'], {
+    timeout: 60000
+  });
 }
 
 const writeFileAtomic = (targetPath: string, content: string) => {
@@ -104,13 +161,13 @@ export async function updateRepo() {
       'git config --global --add safe.directory /app/providers/template/templates',
       { timeout: 10000 }
     );
-    const gitCommand = !fs.existsSync(targetPath)
-      ? `git clone -b ${TemplateEnvs.TEMPLATE_REPO_BRANCH} ${TemplateEnvs.TEMPLATE_REPO_URL} ${targetPath} --depth=1`
-      : `cd ${targetPath} && git pull --depth=1 --rebase`;
+    await cloneOrRefreshTemplateRepo(
+      targetPath,
+      TemplateEnvs.TEMPLATE_REPO_URL,
+      TemplateEnvs.TEMPLATE_REPO_BRANCH
+    );
 
-    const result = await execAsync(gitCommand, { timeout: 60000 });
-
-    console.log('git operation:', result);
+    console.log('git operation: template repository refreshed');
   } catch (error) {
     // Note: git operation timeout should not block the process. Just log the error, do not throw.
     console.log('git operation timed out (non-blocking): \n', error);

--- a/frontend/providers/template/src/services/backend/template-repo.ts
+++ b/frontend/providers/template/src/services/backend/template-repo.ts
@@ -10,8 +10,21 @@ import * as k8s from '@kubernetes/client-node';
 import { getYamlTemplate } from '@/utils/json-yaml';
 import { getTemplateEnvs } from '@/utils/tools';
 import { resolveTemplateAssetUrls } from '@/utils/templateAsset';
+import { syncTemplateCategoriesFromRepo } from './template-categories';
 
 const execAsync = util.promisify(exec);
+
+const writeFileAtomic = (targetPath: string, content: string) => {
+  const tempPath = `${targetPath}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    fs.writeFileSync(tempPath, content, { encoding: 'utf-8', flag: 'wx' });
+    fs.renameSync(tempPath, targetPath);
+  } finally {
+    if (fs.existsSync(tempPath)) {
+      fs.rmSync(tempPath, { force: true });
+    }
+  }
+};
 
 const readFileList = (targetPath: string, fileList: unknown[] = []) => {
   // fix ci
@@ -133,5 +146,6 @@ export async function updateRepo() {
   });
 
   const jsonContent = JSON.stringify(jsonObjArr, null, 2);
-  fs.writeFileSync(jsonPath, jsonContent, 'utf-8');
+  writeFileAtomic(jsonPath, jsonContent);
+  syncTemplateCategoriesFromRepo(targetPath, originalPath);
 }

--- a/frontend/providers/template/src/services/backend/template-repo.ts
+++ b/frontend/providers/template/src/services/backend/template-repo.ts
@@ -11,8 +11,21 @@ import { getYamlTemplate } from '@/utils/json-yaml';
 import { getTemplateEnvs } from '@/utils/tools';
 import { resolveTemplateAssetUrls } from '@/utils/templateAsset';
 import { syncTemplateCategoriesFromRepo } from './template-categories';
+import { readmeCache } from '@/utils/readmeCache';
 
 const execAsync = util.promisify(exec);
+const DEFAULT_TEMPLATE_REPO_SYNC_INTERVAL_MS = 30 * 1000;
+
+let templateRepoLastSyncedAt = 0;
+let templateRepoSyncPromise: Promise<void> | null = null;
+
+function getTemplateRepoSyncIntervalMs() {
+  const rawValue = Number(process.env.TEMPLATE_REPO_SYNC_INTERVAL_MS);
+  if (!Number.isFinite(rawValue) || rawValue < 0) {
+    return DEFAULT_TEMPLATE_REPO_SYNC_INTERVAL_MS;
+  }
+  return rawValue;
+}
 
 const writeFileAtomic = (targetPath: string, content: string) => {
   const tempPath = `${targetPath}.${process.pid}.${Date.now()}.tmp`;
@@ -148,4 +161,42 @@ export async function updateRepo() {
   const jsonContent = JSON.stringify(jsonObjArr, null, 2);
   writeFileAtomic(jsonPath, jsonContent);
   syncTemplateCategoriesFromRepo(targetPath, originalPath);
+  templateRepoLastSyncedAt = Date.now();
+}
+
+export async function ensureTemplateRepoFresh(basePath = process.cwd()) {
+  const jsonPath = path.resolve(basePath, 'templates.json');
+  const now = Date.now();
+  const interval = getTemplateRepoSyncIntervalMs();
+
+  if (fs.existsSync(jsonPath) && templateRepoLastSyncedAt === 0) {
+    templateRepoLastSyncedAt = now;
+    return;
+  }
+
+  if (fs.existsSync(jsonPath) && now - templateRepoLastSyncedAt < interval) {
+    return;
+  }
+
+  if (!templateRepoSyncPromise) {
+    templateRepoSyncPromise = updateRepo()
+      .then(() => {
+        readmeCache.clear();
+      })
+      .catch((error) => {
+        if (!fs.existsSync(jsonPath)) {
+          throw error;
+        }
+        templateRepoLastSyncedAt = Date.now();
+        console.warn(
+          '[Template Repo] Failed to refresh repository, using existing catalog:',
+          error
+        );
+      })
+      .finally(() => {
+        templateRepoSyncPromise = null;
+      });
+  }
+
+  await templateRepoSyncPromise;
 }

--- a/frontend/providers/template/src/store/config.ts
+++ b/frontend/providers/template/src/store/config.ts
@@ -18,6 +18,17 @@ type State = {
   setEnvs: (data: EnvResponse) => void;
 };
 
+export function shouldResetAppType(
+  appType: ApplicationType,
+  categories: readonly TemplateCategory[]
+) {
+  if (appType === ApplicationType.All || appType === ApplicationType.MyApp) {
+    return false;
+  }
+
+  return !categories.some((category) => category.slug === appType);
+}
+
 export function buildSideBarMenu(
   categories: TemplateCategory[] | undefined,
   menuKeys: string,

--- a/frontend/providers/template/src/store/config.ts
+++ b/frontend/providers/template/src/store/config.ts
@@ -1,6 +1,7 @@
 import { getPlatformEnv, getSystemConfig, getTemplates } from '@/api/platform';
 import { EnvResponse } from '@/types';
 import { ApplicationType, SideBarMenuType, SystemConfigType } from '@/types/app';
+import type { TemplateCategory } from '@/types/config';
 import { getCategoryLabel } from '@/utils/template';
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
@@ -16,6 +17,33 @@ type State = {
   setSideBarMenu: (data: SideBarMenuType[]) => void;
   setEnvs: (data: EnvResponse) => void;
 };
+
+export function buildSideBarMenu(
+  categories: TemplateCategory[] | undefined,
+  menuKeys: string,
+  language?: string
+): SideBarMenuType[] {
+  const menus =
+    categories?.map((category) => ({
+      id: category.slug,
+      type: category.slug as ApplicationType,
+      value: getCategoryLabel(category, language)
+    })) ??
+    menuKeys.split(',').map((i) => ({
+      id: i,
+      type: i as ApplicationType,
+      value: `SideBar.${i}`
+    }));
+
+  return [
+    {
+      id: 'applications',
+      type: ApplicationType.All,
+      value: 'SideBar.Applications'
+    },
+    ...menus
+  ];
+}
 
 export const useSystemConfigStore = create<State>()(
   devtools(
@@ -33,28 +61,9 @@ export const useSystemConfigStore = create<State>()(
         const data = await getSystemConfig();
         const { menuKeys, categories } = await getTemplates(language);
 
-        const menus =
-          categories?.map((category) => ({
-            id: category.slug,
-            type: category.slug as ApplicationType,
-            value: getCategoryLabel(category, language)
-          })) ??
-          menuKeys.split(',').map((i) => ({
-            id: i,
-            type: i as ApplicationType,
-            value: `SideBar.${i}`
-          }));
-
         set((state) => {
           state.menuKeys = menuKeys;
-          state.sideBarMenu = [
-            {
-              id: 'applications',
-              type: ApplicationType.All,
-              value: 'SideBar.Applications'
-            },
-            ...menus
-          ];
+          state.sideBarMenu = buildSideBarMenu(categories, menuKeys, language);
         });
         set((state) => {
           state.systemConfig = data;

--- a/frontend/providers/template/src/types/apis/v2alpha/index.ts
+++ b/frontend/providers/template/src/types/apis/v2alpha/index.ts
@@ -105,7 +105,7 @@ export const document = createDocument({
         tags: ['Query'],
         summary: 'List all templates',
         description:
-          'Returns metadata only (no resource calculation). Response headers: `Cache-Control` (public, max-age=300, s-maxage=600), `ETag`. When categories exist, top category keys are returned in `X-Menu-Keys` (comma-separated). For full details including resource requirements, use `/templates/{name}`.',
+          'Returns metadata only (no resource calculation). Response headers: `Cache-Control` (no-cache, must-revalidate), `ETag`. When categories exist, top category keys are returned in `X-Menu-Keys` (comma-separated). For full details including resource requirements, use `/templates/{name}`.',
         operationId: 'listTemplates',
         security: [],
         requestParams: {
@@ -116,12 +116,12 @@ export const document = createDocument({
             description: 'Successfully retrieved template list',
             headers: {
               'Cache-Control': {
-                description: 'Caching directive: public, max-age=300, s-maxage=600',
-                schema: { type: 'string', example: 'public, max-age=300, s-maxage=600' }
+                description: 'Caching directive: no-cache, must-revalidate',
+                schema: { type: 'string', example: 'no-cache, must-revalidate' }
               },
               ETag: {
-                description: 'Entity tag for caching, format: "template-list-{language}"',
-                schema: { type: 'string', example: '"template-list-en"' }
+                description: 'Entity tag for the current template catalog and category version',
+                schema: { type: 'string', example: '"template-1f4de80a5eb10e2a5c8b5a5a"' }
               },
               'X-Menu-Keys': {
                 description:
@@ -188,7 +188,7 @@ export const document = createDocument({
         tags: ['Query'],
         summary: 'Get template details',
         description:
-          'Returns complete template metadata with dynamically calculated resource requirements (CPU, memory, storage, NodePort count) derived from the template YAML. Falls back to static configuration if calculation fails. Response headers: `Cache-Control` (public, max-age=300, s-maxage=600), `ETag`.',
+          'Returns complete template metadata with dynamically calculated resource requirements (CPU, memory, storage, NodePort count) derived from the template YAML. Falls back to static configuration if calculation fails. Response headers: `Cache-Control` (no-cache, must-revalidate), `ETag`.',
         operationId: 'getTemplate',
         security: [],
         requestParams: {
@@ -200,12 +200,12 @@ export const document = createDocument({
             description: 'Successfully retrieved template details',
             headers: {
               'Cache-Control': {
-                description: 'Caching directive: public, max-age=300, s-maxage=600',
-                schema: { type: 'string', example: 'public, max-age=300, s-maxage=600' }
+                description: 'Caching directive: no-cache, must-revalidate',
+                schema: { type: 'string', example: 'no-cache, must-revalidate' }
               },
               ETag: {
-                description: 'Entity tag for caching, format: "{name}-{language}"',
-                schema: { type: 'string', example: '"perplexica-en"' }
+                description: 'Entity tag for the current template catalog, template, and language',
+                schema: { type: 'string', example: '"template-08fe4048593c6d166498e697"' }
               }
             },
             content: {

--- a/frontend/providers/template/src/types/config.ts
+++ b/frontend/providers/template/src/types/config.ts
@@ -138,7 +138,7 @@ export type FeaturesConfig = z.infer<typeof FeaturesSchema>;
  * Template category schema.
  * Defines the app-owned sidebar categories and their labels.
  */
-const TemplateCategorySchema = z
+export const TemplateCategorySchema = z
   .object({
     slug: z.string().describe('Slug for identifying the category'),
     i18n: z.record(z.string(), z.string()).describe('Category label translations')

--- a/frontend/providers/template/src/types/index.ts
+++ b/frontend/providers/template/src/types/index.ts
@@ -1,9 +1,3 @@
-import Cron from 'croner';
-
-declare global {
-  var updateRepoCronJob: Cron;
-}
-
 export type QueryType = {
   name: string;
   templateName: string;

--- a/frontend/providers/template/src/utils/healthz.ts
+++ b/frontend/providers/template/src/utils/healthz.ts
@@ -1,6 +1,6 @@
 import { getClientAppConfigServer } from '@/pages/api/platform/getClientAppConfig';
 export const HEALTHZ_SERVICE = 'template';
 
-export function assertReady() {
-  getClientAppConfigServer();
+export async function assertReady() {
+  await getClientAppConfigServer();
 }

--- a/frontend/providers/template/src/utils/healthz.ts
+++ b/frontend/providers/template/src/utils/healthz.ts
@@ -2,5 +2,5 @@ import { getClientAppConfigServer } from '@/pages/api/platform/getClientAppConfi
 export const HEALTHZ_SERVICE = 'template';
 
 export async function assertReady() {
-  await getClientAppConfigServer();
+  await getClientAppConfigServer({ refreshRepo: false });
 }

--- a/frontend/providers/template/vitest.config.ts
+++ b/frontend/providers/template/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src')
+    }
+  },
+  test: {
+    environment: 'node',
+    pool: 'forks'
+  }
+});


### PR DESCRIPTION
<!--
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR,
because it will be placed in the release note.
-->

## Summary

Refresh template repository categories before normal catalog reads, keep the App Store sidebar and template APIs aligned with the managed category source, and make catalog caches version-aware. Preserve the My App selection and keep `/healthz` free of repository-sync side effects. Add regression coverage and the provider's Vitest test configuration.

Related issue: None provided.

## Sequence Diagram

```mermaid
sequenceDiagram
    participant Client
    participant API as Template API
    participant Repo as Template Repo Sync
    participant Cache as Catalog Cache

    Client->>API: Request app config or template catalog
    API->>Repo: Refresh repository for normal reads
    Repo->>Cache: Write templates and managed categories
    API->>Cache: Read catalog with current version
    Cache-->>API: Return current catalog data
    API-->>Client: Return categories and templates
    Client->>API: Probe /healthz
    API->>Cache: Validate local config without repo refresh
    Cache-->>API: Readiness result
    API-->>Client: Return 200 or 503
```

## Verification

- `pnpm --dir frontend/providers/template test` (19 tests passed)
- `pnpm --dir frontend/providers/template exec tsc --noEmit --pretty false`
- `pnpm --dir frontend/providers/template build`
- `helm lint frontend/providers/template/deploy/charts/template-frontend`
- `helm template template-frontend frontend/providers/template/deploy/charts/template-frontend`
- Repeated the provider test suite in an isolated worktree (19 tests passed)
