### PR TITLE
fix(frontend): unify resource units on release-v5.1

### DIFF
--- a/frontend/providers/applaunchpad/src/components/app/detail/index/AdvancedInfo.tsx
+++ b/frontend/providers/applaunchpad/src/components/app/detail/index/AdvancedInfo.tsx
@@ -290,7 +290,7 @@ const AdvancedInfo = ({ app = MOCK_APP_DETAIL }: { app: AppDetailType }) => {
                                 color={'grayModern.600'}
                                 fontSize={'sm'}
                               >
-                                {item.value} Gi
+                                {item.value} GiB
                               </Box>
                             </Box>
                           </Flex>

--- a/frontend/providers/applaunchpad/src/components/apps/appList.tsx
+++ b/frontend/providers/applaunchpad/src/components/apps/appList.tsx
@@ -380,7 +380,7 @@ const AppList = ({
         title: t('Storage'),
         key: 'store',
         render: (item: AppListItemType) => (
-          <>{item.localStoreAmount > 0 ? `${item.localStoreAmount}Gi` : '-'}</>
+          <>{item.localStoreAmount > 0 ? `${item.localStoreAmount}GiB` : '-'}</>
         )
       },
       {

--- a/frontend/providers/applaunchpad/src/utils/tools.ts
+++ b/frontend/providers/applaunchpad/src/utils/tools.ts
@@ -277,10 +277,10 @@ export const storageQuantityToMi = (quantity: string) => {
 };
 
 /**
- * print memory to Mi of Gi
+ * Print memory in GiB for the app detail view.
  */
 export const printMemory = (val: number) => {
-  return val >= 1024 ? `${val / 1024} Gi` : `${val} Mi`;
+  return `${val / 1024} GiB`;
 };
 
 /**

--- a/frontend/providers/costcenter/src/components/valuation/CalculatorPanel/index.tsx
+++ b/frontend/providers/costcenter/src/components/valuation/CalculatorPanel/index.tsx
@@ -274,7 +274,7 @@ export default function CalculatorPanel({
               </HStack>
               <HStack gap={'40px'}>
                 <CalculatorSlider
-                  unit={'G'}
+                  unit={'GiB'}
                   rangeList={MEMORY_RANGE}
                   value={config.resources.memory.idx}
                   onChange={(v) => {
@@ -282,7 +282,7 @@ export default function CalculatorPanel({
                   }}
                 />
                 <CalculatorNumberInput
-                  unit={'G'}
+                  unit={'GiB'}
                   value={config.resources.memory.val}
                   onChange={(str, v) => {
                     updateMemoryVal(v);
@@ -301,7 +301,7 @@ export default function CalculatorPanel({
               </HStack>
               <HStack gap={'40px'}>
                 <CalculatorNumberInput
-                  unit="G"
+                  unit="GiB"
                   value={config.resources.storage}
                   width={'280px'}
                   onChange={(str, val) => {

--- a/frontend/providers/costcenter/src/components/valuation/quota.tsx
+++ b/frontend/providers/costcenter/src/components/valuation/quota.tsx
@@ -29,9 +29,9 @@ type QuotaMeta = {
 
 const quotaMeta: Record<UserQuotaItemType['type'], QuotaMeta> = {
   cpu: { unit: 'Core', bg: '#33BABB', icon: CpuIcon },
-  memory: { unit: 'GB', bg: '#36ADEF', icon: MemoryIcon },
-  storage: { unit: 'GB', bg: '#9A8EE0', icon: StorageIcon },
-  'ephemeral-storage': { unit: 'GB', bg: '#7A8BEA', icon: StorageIcon },
+  memory: { unit: 'GiB', bg: '#36ADEF', icon: MemoryIcon },
+  storage: { unit: 'GiB', bg: '#9A8EE0', icon: StorageIcon },
+  'ephemeral-storage': { unit: 'GiB', bg: '#7A8BEA', icon: StorageIcon },
   gpu: { unit: 'GPU Unit', bg: '#6FCA88', icon: GpuIcon },
   pods: { unit: 'pod_unit', bg: '#2EB67D', icon: NodeIcon },
   'services.nodeports': { unit: 'port_unit', bg: '#8774EE', icon: PortIcon },

--- a/frontend/providers/costcenter/src/constants/payment.ts
+++ b/frontend/providers/costcenter/src/constants/payment.ts
@@ -89,8 +89,8 @@ export const START_TIME = new Date(2023, 0, 1);
 export const END_TIME = endOfDay(new Date());
 export const valuationMap = new Map([
   ['cpu', { unit: 'Core', scale: 1000, bg: '#33BABB' }],
-  ['memory', { unit: 'GB', scale: 1024, bg: '#36ADEF' }],
-  ['storage', { unit: 'GB', scale: 1024, bg: '#9A8EE0' }],
+  ['memory', { unit: 'GiB', scale: 1024, bg: '#36ADEF' }],
+  ['storage', { unit: 'GiB', scale: 1024, bg: '#9A8EE0' }],
   ['gpu', { unit: 'GPU Unit', scale: 1000, bg: '#6FCA88' }],
   ['network', { unit: 'M', scale: 1, bg: '#F182AA' }],
   ['services.nodeports', { unit: 'port_unit', scale: 1000, bg: '#F182AA' }]


### PR DESCRIPTION
<!--
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR,
because it will be placed in the release note.
-->

## Summary

- Fix resource unit inconsistency on the `release-v5.1` frontend by displaying memory, persistent storage, and ephemeral storage as `GiB`.
- Update Applaunchpad app list/detail renderers and Costcenter valuation, quota, and billing mappings; Kubernetes and API quantities remain unchanged.
- Verified on cluster 62 with both frontend endpoints returning HTTP 200.

## Sequence Diagram

```mermaid
sequenceDiagram
    participant User
    participant Applaunchpad as Applaunchpad UI
    participant Costcenter as Costcenter UI
    participant API as Existing APIs

    User->>Applaunchpad: Open app list or app detail
    Applaunchpad->>API: Load resource quantities
    API-->>Applaunchpad: Return resource values
    Applaunchpad-->>User: Render memory and storage as GiB

    User->>Costcenter: Open valuation, quota, or billing view
    Costcenter->>API: Load pricing and quota data
    API-->>Costcenter: Return resource values
    Costcenter-->>User: Render memory and storage as GiB
```

## Verification

- `pnpm --filter applaunchpad lint`
- `pnpm --filter costcenter lint`
- `pnpm exec tsc -p providers/applaunchpad/tsconfig.json --noEmit`
- `pnpm exec tsc -p providers/costcenter/tsconfig.json --noEmit`
- Built and pushed both frontend images for `linux/amd64`.
- Cluster 62: Applaunchpad `/apps` and Costcenter `/valuation` returned HTTP 200; both Deployments were `1/1 Ready` with zero restarts.

## Notes

- Existing React Hook, Browserslist, and Next.js build warnings are unchanged.
- No API contract or Kubernetes resource quantity format was changed.
