### PR TITLE
fix(template): preserve separated manifests and assets

### DIFF
--- a/frontend/providers/template/README.md
+++ b/frontend/providers/template/README.md
@@ -74,3 +74,12 @@
 │       └── user.ts
 └── tsconfig.json
 ```
+
+## Template repository layout
+
+Each catalog template keeps its metadata in `index.yaml`. Optional Kubernetes
+resources can live under the same template directory in `manifests/**/*.yaml`;
+the template provider loads those files as the deployment source while keeping
+the `Template` document as catalog metadata. Repository-hosted icons are served
+through the provider asset proxy when the repository's raw response is not
+browser-renderable.

--- a/frontend/providers/template/__tests__/unit/pages/api/getTemplateSource.test.ts
+++ b/frontend/providers/template/__tests__/unit/pages/api/getTemplateSource.test.ts
@@ -1,0 +1,92 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { GetTemplateByName } from '@/pages/api/getTemplateSource';
+
+const originalWorkingDirectory = process.cwd();
+const originalTemplateRepoEnv = {
+  url: process.env.TEMPLATE_REPO_URL,
+  branch: process.env.TEMPLATE_REPO_BRANCH,
+  provider: process.env.TEMPLATE_REPO_PROVIDER
+};
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  process.chdir(originalWorkingDirectory);
+  temporaryDirectories.splice(0).forEach((directory) => fs.rmSync(directory, { recursive: true }));
+  if (originalTemplateRepoEnv.url === undefined) delete process.env.TEMPLATE_REPO_URL;
+  else process.env.TEMPLATE_REPO_URL = originalTemplateRepoEnv.url;
+  if (originalTemplateRepoEnv.branch === undefined) delete process.env.TEMPLATE_REPO_BRANCH;
+  else process.env.TEMPLATE_REPO_BRANCH = originalTemplateRepoEnv.branch;
+  if (originalTemplateRepoEnv.provider === undefined) delete process.env.TEMPLATE_REPO_PROVIDER;
+  else process.env.TEMPLATE_REPO_PROVIDER = originalTemplateRepoEnv.provider;
+});
+
+describe('GetTemplateByName', () => {
+  it('loads separated manifests and persists a browser-compatible instance icon', async () => {
+    const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'template-source-'));
+    temporaryDirectories.push(workingDirectory);
+    const templateRoot = path.join(workingDirectory, 'templates');
+    const templateDirectory = path.join(templateRoot, 'ace-step');
+    const manifestsDirectory = path.join(templateDirectory, 'manifests');
+    fs.mkdirSync(manifestsDirectory, { recursive: true });
+
+    const iconUrl =
+      'https://gogs.192.168.0.62.nip.io/sealos-admin/templates/raw/main/template/ace-step/logo.svg';
+    const indexPath = path.join(templateDirectory, 'index.yaml');
+    fs.writeFileSync(
+      indexPath,
+      [
+        'apiVersion: app.sealos.io/v1',
+        'kind: Template',
+        'metadata:',
+        '  name: ace-step',
+        'spec:',
+        '  title: Ace Step',
+        `  icon: ${iconUrl}`,
+        '  defaults:',
+        '    app_name:',
+        '      type: string',
+        '      value: ace-step',
+        ''
+      ].join('\n')
+    );
+    fs.writeFileSync(
+      path.join(manifestsDirectory, '001-app.yaml'),
+      'apiVersion: apps/v1\nkind: StatefulSet\nmetadata:\n  name: ace-step\n'
+    );
+    fs.writeFileSync(
+      path.join(workingDirectory, 'templates.json'),
+      JSON.stringify([
+        {
+          apiVersion: 'app.sealos.io/v1',
+          kind: 'Template',
+          metadata: { name: 'ace-step' },
+          spec: {
+            fileName: 'index.yaml',
+            filePath: indexPath,
+            deployCount: 1
+          }
+        }
+      ])
+    );
+
+    process.env.TEMPLATE_REPO_URL = 'https://gogs.192.168.0.62.nip.io/sealos-admin/templates';
+    process.env.TEMPLATE_REPO_BRANCH = 'main';
+    process.env.TEMPLATE_REPO_PROVIDER = 'gogs';
+    process.chdir(workingDirectory);
+
+    const result = await GetTemplateByName({
+      namespace: 'ns-admin',
+      templateName: 'ace-step'
+    });
+
+    expect(result.code).toBe(20000);
+    expect(result.appYaml).toContain('kind: StatefulSet');
+    expect(result.appYaml).toContain('/api/templateAsset?path=template%2Face-step%2Flogo.svg');
+    expect(result.templateYaml?.spec.icon).toBe(
+      '/api/templateAsset?path=template%2Face-step%2Flogo.svg'
+    );
+  });
+});

--- a/frontend/providers/template/__tests__/unit/services/backend/template-manifests.test.ts
+++ b/frontend/providers/template/__tests__/unit/services/backend/template-manifests.test.ts
@@ -1,0 +1,74 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  appendTemplateManifestSources,
+  getTemplateManifestFiles
+} from '@/services/backend/template-manifests';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  temporaryDirectories.splice(0).forEach((directory) => fs.rmSync(directory, { recursive: true }));
+});
+
+describe('template manifest sources', () => {
+  it('appends nested manifests next to the template index in stable order', () => {
+    const templateDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'template-manifests-'));
+    temporaryDirectories.push(templateDirectory);
+    const manifestsDirectory = path.join(templateDirectory, 'manifests', 'nested');
+    fs.mkdirSync(manifestsDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(templateDirectory, 'manifests', '002-service.yaml'),
+      'kind: Service\n'
+    );
+    fs.writeFileSync(path.join(manifestsDirectory, '001-deployment.yaml'), 'kind: Deployment\n');
+
+    const templateFilePath = path.join(templateDirectory, 'index.yaml');
+    const realManifestsDirectory = fs.realpathSync(path.join(templateDirectory, 'manifests'));
+    expect(getTemplateManifestFiles(templateFilePath)).toEqual([
+      path.join(realManifestsDirectory, '002-service.yaml'),
+      path.join(realManifestsDirectory, 'nested', '001-deployment.yaml')
+    ]);
+
+    expect(appendTemplateManifestSources('kind: Instance\n', templateFilePath)).toBe(
+      'kind: Instance\n\n---\nkind: Service\n\n---\nkind: Deployment\n'
+    );
+  });
+
+  it('keeps a template without manifests unchanged', () => {
+    const templateDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'template-manifests-'));
+    temporaryDirectories.push(templateDirectory);
+
+    expect(
+      appendTemplateManifestSources('kind: Instance\n', path.join(templateDirectory, 'index.yaml'))
+    ).toBe('kind: Instance\n');
+  });
+
+  it('does not follow manifests symlinks outside the template directory', () => {
+    const templateDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'template-manifests-'));
+    const outsideDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'template-manifests-outside-'));
+    temporaryDirectories.push(templateDirectory, outsideDirectory);
+    fs.mkdirSync(path.join(templateDirectory, 'manifests'));
+    fs.writeFileSync(path.join(outsideDirectory, 'secret.yaml'), 'kind: Secret\n');
+    fs.symlinkSync(outsideDirectory, path.join(templateDirectory, 'manifests', 'external'));
+
+    expect(getTemplateManifestFiles(path.join(templateDirectory, 'index.yaml'))).toEqual([]);
+  });
+
+  it('does not read a template directory outside the repository root', () => {
+    const repositoryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'template-repository-'));
+    const templateDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'template-outside-'));
+    temporaryDirectories.push(repositoryDirectory, templateDirectory);
+    fs.mkdirSync(path.join(templateDirectory, 'manifests'));
+    fs.writeFileSync(
+      path.join(templateDirectory, 'manifests', '001-app.yaml'),
+      'kind: Deployment\n'
+    );
+
+    expect(
+      getTemplateManifestFiles(path.join(templateDirectory, 'index.yaml'), repositoryDirectory)
+    ).toEqual([]);
+  });
+});

--- a/frontend/providers/template/__tests__/unit/services/backend/template-manifests.test.ts
+++ b/frontend/providers/template/__tests__/unit/services/backend/template-manifests.test.ts
@@ -57,6 +57,16 @@ describe('template manifest sources', () => {
     expect(getTemplateManifestFiles(path.join(templateDirectory, 'index.yaml'))).toEqual([]);
   });
 
+  it('does not recurse through a symlinked directory cycle', () => {
+    const templateDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'template-manifests-'));
+    temporaryDirectories.push(templateDirectory);
+    const manifestsDirectory = path.join(templateDirectory, 'manifests');
+    fs.mkdirSync(manifestsDirectory);
+    fs.symlinkSync(manifestsDirectory, path.join(manifestsDirectory, 'loop'));
+
+    expect(getTemplateManifestFiles(path.join(templateDirectory, 'index.yaml'))).toEqual([]);
+  });
+
   it('does not read a template directory outside the repository root', () => {
     const repositoryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'template-repository-'));
     const templateDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'template-outside-'));

--- a/frontend/providers/template/__tests__/unit/utils/templateAsset.test.ts
+++ b/frontend/providers/template/__tests__/unit/utils/templateAsset.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { getTemplateAssetProxyUrl, proxyTemplateIconUrls } from '@/utils/templateAsset';
+
+const repo = {
+  url: 'https://gogs.192.168.0.62.nip.io/sealos-admin/templates',
+  branch: 'main',
+  provider: 'gogs' as const
+};
+
+describe('template asset URLs', () => {
+  it('proxies repository icons so browsers receive the correct MIME type', () => {
+    expect(
+      getTemplateAssetProxyUrl(
+        'https://gogs.192.168.0.62.nip.io/sealos-admin/templates/raw/main/template/ace-step/logo.svg',
+        repo
+      )
+    ).toBe('/api/templateAsset?path=template%2Face-step%2Flogo.svg');
+  });
+
+  it('preserves already proxied and unrelated URLs', () => {
+    const proxied = '/api/templateAsset?path=template%2Face-step%2Flogo.svg';
+    const external = 'https://example.com/logo.svg';
+
+    expect(getTemplateAssetProxyUrl(proxied, repo)).toBe(proxied);
+    expect(getTemplateAssetProxyUrl(external, repo)).toBe(external);
+  });
+
+  it('supports instance resources as well as catalog templates', () => {
+    const instance = {
+      apiVersion: 'app.sealos.io/v1',
+      kind: 'Instance',
+      metadata: { name: 'ace-step' },
+      spec: {
+        icon: 'https://gogs.192.168.0.62.nip.io/sealos-admin/templates/raw/main/template/ace-step/logo.svg'
+      }
+    };
+
+    expect(proxyTemplateIconUrls(instance, repo).spec.icon).toBe(
+      '/api/templateAsset?path=template%2Face-step%2Flogo.svg'
+    );
+  });
+});

--- a/frontend/providers/template/src/pages/api/getTemplateSource.ts
+++ b/frontend/providers/template/src/pages/api/getTemplateSource.ts
@@ -18,6 +18,7 @@ import { getResourceUsage, ResourceUsage } from '@/utils/usage';
 import { generateYamlData, getTemplateDefaultValues } from '@/utils/template';
 import { readmeCache } from '@/utils/readmeCache';
 import { proxyTemplateIconUrls, resolveTemplateAssetUrls } from '@/utils/templateAsset';
+import { appendTemplateManifestSources } from '@/services/backend/template-manifests';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
@@ -132,7 +133,16 @@ export async function GetTemplateByName({
     };
   }
 
-  templateYaml = parseTemplateVariable(templateYaml, TemplateEnvs);
+  const templateRepo = {
+    url: TemplateEnvs.TEMPLATE_REPO_URL,
+    branch: TemplateEnvs.TEMPLATE_REPO_BRANCH,
+    provider: TemplateEnvs.TEMPLATE_REPO_PROVIDER
+  };
+
+  templateYaml = proxyTemplateIconUrls(
+    parseTemplateVariable(templateYaml, TemplateEnvs),
+    templateRepo
+  );
   const dataSource = getTemplateDataSource(templateYaml);
 
   const instanceName = dataSource?.defaults?.['app_name']?.value;
@@ -144,11 +154,6 @@ export async function GetTemplateByName({
   }
   const instanceYaml = handleTemplateToInstanceYaml(templateYaml, instanceName);
   appYaml = `${JsYaml.dump(instanceYaml)}\n---\n${appYaml}`;
-  const templateRepo = {
-    url: TemplateEnvs.TEMPLATE_REPO_URL,
-    branch: TemplateEnvs.TEMPLATE_REPO_BRANCH,
-    provider: TemplateEnvs.TEMPLATE_REPO_PROVIDER
-  };
   const responseTemplateYaml = proxyTemplateIconUrls(templateYaml, templateRepo);
 
   let readmeContent = '';
@@ -236,7 +241,8 @@ function getTemplateYamlByName(
   const templateFilePath = template?.spec?.filePath || `${targetPath}/${templateFileName}`;
   const yamlString = fs.readFileSync(templateFilePath, 'utf-8');
 
-  const { appYaml, templateYaml: rawTemplateYaml } = getYamlTemplate(yamlString);
+  let { appYaml, templateYaml: rawTemplateYaml } = getYamlTemplate(yamlString);
+  appYaml = appendTemplateManifestSources(appYaml, templateFilePath, repoRootPath);
   let templateYaml = rawTemplateYaml;
   templateYaml.spec.deployCount = template?.spec?.deployCount;
   const templateRepo = {

--- a/frontend/providers/template/src/pages/api/instance/getByName.ts
+++ b/frontend/providers/template/src/pages/api/instance/getByName.ts
@@ -6,6 +6,8 @@ import { jsonRes } from '@/services/backend/response';
 import { adaptInstanceListItem } from '@/utils/adapt';
 import { TemplateInstanceType } from '@/types/app';
 import { MockInstance } from '@/constants/mock';
+import { getTemplateEnvs } from '@/utils/tools';
+import { proxyTemplateIconUrls } from '@/utils/templateAsset';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
@@ -35,7 +37,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       body: TemplateInstanceType;
     };
 
-    jsonRes(res, { data: adaptInstanceListItem(result.body) });
+    const templateEnvs = getTemplateEnvs();
+    const templateRepo = {
+      url: templateEnvs.TEMPLATE_REPO_URL,
+      branch: templateEnvs.TEMPLATE_REPO_BRANCH,
+      provider: templateEnvs.TEMPLATE_REPO_PROVIDER
+    };
+
+    jsonRes(res, { data: adaptInstanceListItem(proxyTemplateIconUrls(result.body, templateRepo)) });
   } catch (err: any) {
     jsonRes(res, {
       code: 500,

--- a/frontend/providers/template/src/pages/api/instance/list.ts
+++ b/frontend/providers/template/src/pages/api/instance/list.ts
@@ -3,6 +3,9 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { authSession } from '@/services/backend/auth';
 import { CRDMeta, getK8s } from '@/services/backend/kubernetes';
 import { jsonRes } from '@/services/backend/response';
+import { getTemplateEnvs } from '@/utils/tools';
+import { proxyTemplateIconUrls } from '@/utils/templateAsset';
+import { TemplateInstanceType } from '@/types/app';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
@@ -24,7 +27,20 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       InstanceCRD.plural
     );
 
-    jsonRes(res, { data: result.body });
+    const templateEnvs = getTemplateEnvs();
+    const templateRepo = {
+      url: templateEnvs.TEMPLATE_REPO_URL,
+      branch: templateEnvs.TEMPLATE_REPO_BRANCH,
+      provider: templateEnvs.TEMPLATE_REPO_PROVIDER
+    };
+    const body = result.body as { items: TemplateInstanceType[]; [key: string]: unknown };
+
+    jsonRes(res, {
+      data: {
+        ...body,
+        items: (body.items || []).map((item) => proxyTemplateIconUrls(item, templateRepo))
+      }
+    });
   } catch (err: any) {
     jsonRes(res, {
       code: 500,

--- a/frontend/providers/template/src/pages/api/v1alpha/getInstanceByName.ts
+++ b/frontend/providers/template/src/pages/api/v1alpha/getInstanceByName.ts
@@ -4,6 +4,8 @@ import { jsonRes } from '@/services/backend/response';
 
 import { TemplateInstanceType } from '@/types/app';
 import { adaptInstanceListItem } from '@/utils/adapt';
+import { getTemplateEnvs } from '@/utils/tools';
+import { proxyTemplateIconUrls } from '@/utils/templateAsset';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -28,7 +30,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         InstanceCRD.plural,
         instanceName
       )
-      .then((r) => adaptInstanceListItem(r.body as TemplateInstanceType));
+      .then((r) => {
+        const templateEnvs = getTemplateEnvs();
+        const templateRepo = {
+          url: templateEnvs.TEMPLATE_REPO_URL,
+          branch: templateEnvs.TEMPLATE_REPO_BRANCH,
+          provider: templateEnvs.TEMPLATE_REPO_PROVIDER
+        };
+        return adaptInstanceListItem(
+          proxyTemplateIconUrls(r.body as TemplateInstanceType, templateRepo)
+        );
+      });
 
     jsonRes(res, { data: result });
   } catch (err: any) {

--- a/frontend/providers/template/src/services/backend/template-manifests.ts
+++ b/frontend/providers/template/src/services/backend/template-manifests.ts
@@ -1,0 +1,67 @@
+import fs from 'fs';
+import path from 'path';
+
+const YAML_EXTENSIONS = new Set(['.yaml', '.yml']);
+
+function isWithinDirectory(rootPath: string, candidatePath: string, allowSamePath = false) {
+  const relativePath = path.relative(rootPath, candidatePath);
+  return (
+    (allowSamePath && relativePath.length === 0) ||
+    (relativePath.length > 0 && !relativePath.startsWith('..') && !path.isAbsolute(relativePath))
+  );
+}
+
+function readYamlFiles(targetPath: string, rootPath: string, fileList: string[]) {
+  for (const item of fs.readdirSync(targetPath).sort()) {
+    const filePath = path.join(targetPath, item);
+    let realFilePath: string;
+    try {
+      realFilePath = fs.realpathSync(filePath);
+    } catch (error) {
+      continue;
+    }
+
+    if (!isWithinDirectory(rootPath, realFilePath)) continue;
+
+    const stats = fs.statSync(realFilePath);
+
+    if (stats.isDirectory()) {
+      readYamlFiles(realFilePath, rootPath, fileList);
+      continue;
+    }
+
+    if (stats.isFile() && YAML_EXTENSIONS.has(path.extname(item).toLowerCase())) {
+      fileList.push(realFilePath);
+    }
+  }
+}
+
+export function getTemplateManifestFiles(templateFilePath: string, repoRootPath?: string) {
+  const manifestsPath = path.join(path.dirname(templateFilePath), 'manifests');
+  if (!fs.existsSync(manifestsPath) || !fs.statSync(manifestsPath).isDirectory()) {
+    return [];
+  }
+
+  const repositoryRoot = fs.realpathSync(repoRootPath || path.dirname(templateFilePath));
+  const templateDirectory = fs.realpathSync(path.dirname(templateFilePath));
+  if (!isWithinDirectory(repositoryRoot, templateDirectory, true)) return [];
+
+  const realManifestsPath = fs.realpathSync(manifestsPath);
+  if (!isWithinDirectory(templateDirectory, realManifestsPath)) return [];
+
+  const fileList: string[] = [];
+  readYamlFiles(realManifestsPath, templateDirectory, fileList);
+  return fileList;
+}
+
+export function appendTemplateManifestSources(
+  appYaml: string,
+  templateFilePath: string,
+  repoRootPath?: string
+) {
+  const manifestSources = getTemplateManifestFiles(templateFilePath, repoRootPath).map((filePath) =>
+    fs.readFileSync(filePath, 'utf-8')
+  );
+
+  return [appYaml, ...manifestSources].filter((source) => source.trim()).join('\n---\n');
+}

--- a/frontend/providers/template/src/services/backend/template-manifests.ts
+++ b/frontend/providers/template/src/services/backend/template-manifests.ts
@@ -11,9 +11,24 @@ function isWithinDirectory(rootPath: string, candidatePath: string, allowSamePat
   );
 }
 
-function readYamlFiles(targetPath: string, rootPath: string, fileList: string[]) {
-  for (const item of fs.readdirSync(targetPath).sort()) {
-    const filePath = path.join(targetPath, item);
+function readYamlFiles(
+  targetPath: string,
+  rootPath: string,
+  fileList: string[],
+  visitedDirectories: Set<string>
+) {
+  let realTargetPath: string;
+  try {
+    realTargetPath = fs.realpathSync(targetPath);
+  } catch (error) {
+    return;
+  }
+
+  if (visitedDirectories.has(realTargetPath)) return;
+  visitedDirectories.add(realTargetPath);
+
+  for (const item of fs.readdirSync(realTargetPath).sort()) {
+    const filePath = `${realTargetPath}${path.sep}${item}`;
     let realFilePath: string;
     try {
       realFilePath = fs.realpathSync(filePath);
@@ -26,7 +41,7 @@ function readYamlFiles(targetPath: string, rootPath: string, fileList: string[])
     const stats = fs.statSync(realFilePath);
 
     if (stats.isDirectory()) {
-      readYamlFiles(realFilePath, rootPath, fileList);
+      readYamlFiles(realFilePath, rootPath, fileList, visitedDirectories);
       continue;
     }
 
@@ -37,20 +52,20 @@ function readYamlFiles(targetPath: string, rootPath: string, fileList: string[])
 }
 
 export function getTemplateManifestFiles(templateFilePath: string, repoRootPath?: string) {
-  const manifestsPath = path.join(path.dirname(templateFilePath), 'manifests');
-  if (!fs.existsSync(manifestsPath) || !fs.statSync(manifestsPath).isDirectory()) {
-    return [];
-  }
-
   const repositoryRoot = fs.realpathSync(repoRootPath || path.dirname(templateFilePath));
   const templateDirectory = fs.realpathSync(path.dirname(templateFilePath));
   if (!isWithinDirectory(repositoryRoot, templateDirectory, true)) return [];
+
+  const manifestsPath = `${templateDirectory}${path.sep}manifests`;
+  if (!fs.existsSync(manifestsPath) || !fs.statSync(manifestsPath).isDirectory()) {
+    return [];
+  }
 
   const realManifestsPath = fs.realpathSync(manifestsPath);
   if (!isWithinDirectory(templateDirectory, realManifestsPath)) return [];
 
   const fileList: string[] = [];
-  readYamlFiles(realManifestsPath, templateDirectory, fileList);
+  readYamlFiles(realManifestsPath, templateDirectory, fileList, new Set());
   return fileList;
 }
 

--- a/frontend/providers/template/src/services/backend/template-repo.ts
+++ b/frontend/providers/template/src/services/backend/template-repo.ts
@@ -101,36 +101,38 @@ export async function updateRepo() {
   const templateStaticMap: { [key: string]: number } = await GetTemplateStatic();
 
   let jsonObjArr: unknown[] = [];
-  fileList.forEach((item: any) => {
-    try {
-      if (!item) return;
-      const fileName = path.basename(item);
-      const content = fs.readFileSync(item, 'utf-8');
-      let { templateYaml } = getYamlTemplate(content);
-      if (!!templateYaml) {
-        templateYaml = resolveTemplateAssetUrls(templateYaml, {
-          repo: {
-            url: TemplateEnvs.TEMPLATE_REPO_URL,
-            branch: TemplateEnvs.TEMPLATE_REPO_BRANCH,
-            provider: TemplateEnvs.TEMPLATE_REPO_PROVIDER
-          },
-          templateFilePath: item,
-          repoRootPath: targetPath
-        });
-        const appTitle = templateYaml.spec.title.toUpperCase();
-        const currentCount = templateStaticMap[appTitle] || 0;
-        const randomFactor = 11 + Math.floor(Math.random() * 5); // [11,12,13,14,15]
-        const newCount = (currentCount + 1) * randomFactor;
+  fileList
+    .filter((item: any) => !path.relative(_targetPath, item).split(path.sep).includes('manifests'))
+    .forEach((item: any) => {
+      try {
+        if (!item) return;
+        const fileName = path.basename(item);
+        const content = fs.readFileSync(item, 'utf-8');
+        const { templateYaml } = getYamlTemplate(content);
+        if (!!templateYaml) {
+          const resolvedTemplateYaml = resolveTemplateAssetUrls(templateYaml, {
+            repo: {
+              url: TemplateEnvs.TEMPLATE_REPO_URL,
+              branch: TemplateEnvs.TEMPLATE_REPO_BRANCH,
+              provider: TemplateEnvs.TEMPLATE_REPO_PROVIDER
+            },
+            templateFilePath: item,
+            repoRootPath: targetPath
+          });
+          const appTitle = resolvedTemplateYaml.spec.title.toUpperCase();
+          const currentCount = templateStaticMap[appTitle] || 0;
+          const randomFactor = 11 + Math.floor(Math.random() * 5); // [11,12,13,14,15]
+          const newCount = (currentCount + 1) * randomFactor;
 
-        templateYaml.spec['deployCount'] = newCount;
-        templateYaml.spec['filePath'] = item;
-        templateYaml.spec['fileName'] = fileName;
-        jsonObjArr.push(templateYaml);
+          resolvedTemplateYaml.spec['deployCount'] = newCount;
+          resolvedTemplateYaml.spec['filePath'] = item;
+          resolvedTemplateYaml.spec['fileName'] = fileName;
+          jsonObjArr.push(resolvedTemplateYaml);
+        }
+      } catch (error) {
+        console.log(error, 'yaml parse error');
       }
-    } catch (error) {
-      console.log(error, 'yaml parse error');
-    }
-  });
+    });
 
   const jsonContent = JSON.stringify(jsonObjArr, null, 2);
   fs.writeFileSync(jsonPath, jsonContent, 'utf-8');

--- a/frontend/providers/template/src/utils/templateAsset.ts
+++ b/frontend/providers/template/src/utils/templateAsset.ts
@@ -195,7 +195,17 @@ export function getTemplateAssetProxyUrl(assetUrl: string, repo: TemplateRepo) {
   return `${TEMPLATE_ASSET_PROXY_PREFIX}${encodeURIComponent(proxyablePath)}`;
 }
 
-export function proxyTemplateIconUrls(template: TemplateType, repo: TemplateRepo) {
+type TemplateAssetResource = {
+  spec: {
+    icon?: string;
+    i18n?: Record<string, { icon?: string; [key: string]: string | undefined }>;
+  };
+};
+
+export function proxyTemplateIconUrls<T extends TemplateAssetResource>(
+  template: T,
+  repo: TemplateRepo
+): T {
   const spec = {
     ...template.spec,
     icon: getTemplateAssetProxyUrl(template.spec.icon || '', repo)
@@ -216,7 +226,7 @@ export function proxyTemplateIconUrls(template: TemplateType, repo: TemplateRepo
   return {
     ...template,
     spec
-  };
+  } as T;
 }
 
 export function resolveTemplateAssetUrl({

--- a/frontend/providers/template/vitest.config.ts
+++ b/frontend/providers/template/vitest.config.ts
@@ -1,0 +1,13 @@
+import { resolve } from 'path';
+
+export default {
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src')
+    }
+  },
+  test: {
+    environment: 'node',
+    pool: 'forks'
+  }
+};


### PR DESCRIPTION
<!--
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR,
because it will be placed in the release note.
-->

## Summary

Fix template deployments and catalog/instance asset responses for repositories that separate template metadata from Kubernetes manifests. The provider now loads nested `manifests/**/*.yaml` files, excludes them from catalog indexing, and proxies repository-hosted icons through a browser-compatible asset endpoint. The template repository layout is documented and focused unit coverage is included.

## Verification

- `git diff --check origin/release-v5.1...HEAD` passed.
- The template build could not run because the existing workspace dependency `@sealos/gtm` is unavailable, and Vitest is not declared or installed in the workspace.

## Sequence Diagram

```mermaid
sequenceDiagram
    participant Browser
    participant TemplateAPI
    participant Repo as Template Repository
    participant AssetAPI

    Browser->>TemplateAPI: Request template or instance data
    TemplateAPI->>Repo: Read index metadata and nested manifests
    Repo-->>TemplateAPI: Return deployment source and asset references
    TemplateAPI->>AssetAPI: Rewrite repository icon URL
    AssetAPI-->>Browser: Serve icon with browser-compatible response
    TemplateAPI-->>Browser: Return separated deployment source and metadata
```
