### PR TITLE
fix(desktop): restore balance label in resource header

### DIFF
--- a/frontend/desktop/README.md
+++ b/frontend/desktop/README.md
@@ -169,7 +169,7 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 ### Workspace 资源展示
 
-- 桌面右上角摘要展示当前 workspace 的可用 CPU 以及账号积分；积分复用 `/api/account/getAmount` 的余额净额口径，即 `balance - deductionBalance` 后保留两位小数展示，点击摘要进入费用中心。
+- 桌面右上角摘要展示当前 workspace 的可用 CPU 以及账号余额；余额复用 `/api/account/getAmount` 的余额净额口径，即 `balance - deductionBalance` 后保留两位小数展示，点击摘要进入费用中心。
 - 桌面右上角的资源入口通过 `src/pages/api/desktop/getResource.ts` 读取当前登录 workspace namespace 的 Kubernetes `ResourceQuota`，默认 quota 名称为 `quota-${namespace}`。
 - `/api/desktop/getResource` 保留原有 Pod/PVC 运行资源统计，同时返回 `workspaceQuota`，用于展示 CPU、内存、存储、NodePort 的总量、已用和可用量；GPU 仍在接口里返回，但右上角头部暂不展示。
 - `desktopConfig.workspaceResourceHeaderEnabled` 控制右上角头部使用资源模式还是旧余额模式，默认关闭，也就是默认显示余额。

--- a/frontend/desktop/src/__tests__/unit/workspaceResourceHeaderFlag.test.ts
+++ b/frontend/desktop/src/__tests__/unit/workspaceResourceHeaderFlag.test.ts
@@ -138,7 +138,8 @@ describe('workspace resource header flag', () => {
     renderSecondaryLinks(true);
 
     expect(await screen.findByText('common:resources')).not.toBeNull();
-    expect(screen.queryByText('common:balance')).toBeNull();
+    expect(await screen.findByText('common:balance')).not.toBeNull();
+    expect(screen.queryByText('common:credits')).toBeNull();
     await waitFor(() => expect(mockedGetResource).toHaveBeenCalledTimes(1));
   });
 });

--- a/frontend/desktop/src/components/SecondaryLinks/index.tsx
+++ b/frontend/desktop/src/components/SecondaryLinks/index.tsx
@@ -156,7 +156,7 @@ export default function SecondaryLinks() {
     <Flex alignItems="center" gap="8px" minW={0} flexWrap={allowWrap ? 'wrap' : 'nowrap'}>
       {renderHeaderMetric(t('common:resources'), resourceSummary)}
       <Divider orientation="vertical" h="16px" borderColor="rgba(37, 99, 235, 0.14)" />
-      {renderHeaderMetric(t('common:credits'), balanceSummary)}
+      {renderHeaderMetric(t('common:balance'), balanceSummary)}
     </Flex>
   );
 


### PR DESCRIPTION
## Summary

Restore the resource header label from "Credits" to "Balance" in the desktop frontend.

## Changes

- Update the resource header feature-flag copy to use the `common:balance` translation key.
- Update the unit test to assert the restored label.
- Document the user-visible copy change in the desktop README.

## Sequence Diagram

```mermaid
sequenceDiagram
    participant User
    participant Desktop as Desktop Frontend
    participant I18n as Translation Catalog

    User->>Desktop: Open the resource header
    Desktop->>I18n: Resolve the balance label
    I18n-->>Desktop: Return "Balance"
    Desktop-->>User: Display "Balance"
```

## Verification

- `pnpm jest frontend/desktop/src/__tests__/unit/workspaceResourceHeaderFlag.test.ts --runInBand` (4 tests passed)
- `pnpm lint` passed with existing hook warnings only
- `pnpm build` passed
- Deployed to cluster 62 with the amd64 image `crpi-7jr40k6elhldekqp.cn-hangzhou.personal.cr.aliyuncs.com/mlhiter/sealos-desktop-frontend:balance-header-47db2379-20260816`
- Verified the running pod and Ingress `/healthz` return 200, and the served bundle contains `common:balance` without `common:credits`
