### PR TITLE
fix(pay): use Alipay precreate QR codes

### DIFF
--- a/controllers/pkg/pay/alipay_payment.go
+++ b/controllers/pkg/pay/alipay_payment.go
@@ -14,7 +14,14 @@ import (
 )
 
 type AlipayPayment struct {
-	client *alipay.Client
+	client alipayClient
+}
+
+type alipayClient interface {
+	TradePreCreate(context.Context, alipay.TradePreCreate) (*alipay.TradePreCreateRsp, error)
+	TradeQuery(context.Context, alipay.TradeQuery) (*alipay.TradeQueryRsp, error)
+	TradeClose(context.Context, alipay.TradeClose) (*alipay.TradeCloseRsp, error)
+	TradeRefund(context.Context, alipay.TradeRefund) (*alipay.TradeRefundRsp, error)
 }
 
 func NewAlipayPayment() (*AlipayPayment, error) {
@@ -39,26 +46,28 @@ func NewAlipayPayment() (*AlipayPayment, error) {
 	if err = client.LoadAlipayCertPublicKey(os.Getenv(account.AlipayCertPublicKey)); err != nil {
 		return nil, fmt.Errorf("load alipayCertPublicKey failed: %w", err)
 	}
-	return &AlipayPayment{client}, nil
+	return &AlipayPayment{client: client}, nil
 }
 
-// CreatePayment Create a payment and return the payment URL and order number
+// CreatePayment creates a payment and returns the QR code content and order number.
 func (a *AlipayPayment) CreatePayment(amount int64, _, _ string) (string, string, error) {
-	p := alipay.TradePagePay{}
+	p := alipay.TradePreCreate{}
 	p.Subject = "sealos_cloud_pay"
 	p.OutTradeNo = uuid.NewString()
 	p.TotalAmount = fmt.Sprintf(
 		"%.2f",
 		float64(amount)/1_000_000,
 	) // the unit of the amount is converted to a dollar
-	p.ProductCode = "FAST_INSTANT_TRADE_PAY"
-	p.QRPayMode = "2"
+	p.ProductCode = "FACE_TO_FACE_PAYMENT"
 	p.TimeoutExpress = "10m"
-	url, err := a.client.TradePagePay(p)
+	response, err := a.client.TradePreCreate(context.Background(), p)
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("alipay precreate failed: %w", err)
 	}
-	return p.OutTradeNo, url.String(), nil
+	if response == nil || response.QRCode == "" {
+		return "", "", fmt.Errorf("alipay precreate returned an empty QR code")
+	}
+	return p.OutTradeNo, response.QRCode, nil
 }
 
 // GetPaymentDetails check the status of your payment

--- a/controllers/pkg/pay/alipay_payment_test.go
+++ b/controllers/pkg/pay/alipay_payment_test.go
@@ -1,12 +1,36 @@
 package pay
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/labring/sealos/controllers/pkg/account"
+	"github.com/smartwalle/alipay/v3"
 )
+
+type mockAlipayClient struct {
+	preCreateParam alipay.TradePreCreate
+	preCreateResp  *alipay.TradePreCreateRsp
+}
+
+func (m *mockAlipayClient) TradePreCreate(_ context.Context, param alipay.TradePreCreate) (*alipay.TradePreCreateRsp, error) {
+	m.preCreateParam = param
+	return m.preCreateResp, nil
+}
+
+func (m *mockAlipayClient) TradeQuery(context.Context, alipay.TradeQuery) (*alipay.TradeQueryRsp, error) {
+	return nil, nil
+}
+
+func (m *mockAlipayClient) TradeClose(context.Context, alipay.TradeClose) (*alipay.TradeCloseRsp, error) {
+	return nil, nil
+}
+
+func (m *mockAlipayClient) TradeRefund(context.Context, alipay.TradeRefund) (*alipay.TradeRefundRsp, error) {
+	return nil, nil
+}
 
 func setupenvAlipay() {
 	const (
@@ -52,6 +76,30 @@ func setupenvAlipay() {
 	err := os.Setenv(account.PayIsProduction, "true")
 	if err != nil {
 		return
+	}
+}
+
+func TestAlipayPaymentCreatePaymentUsesPrecreatedQRCode(t *testing.T) {
+	client := &mockAlipayClient{
+		preCreateResp: &alipay.TradePreCreateRsp{QRCode: "https://qr.alipay.com/example"},
+	}
+	payment := &AlipayPayment{client: client}
+
+	tradeNo, codeURL, err := payment.CreatePayment(1_000_000, "test-user", "test payment")
+	if err != nil {
+		t.Fatalf("CreatePayment() failed: %v", err)
+	}
+	if tradeNo == "" {
+		t.Fatal("CreatePayment() returned an empty trade number")
+	}
+	if codeURL != "https://qr.alipay.com/example" {
+		t.Fatalf("CreatePayment() codeURL = %q, want precreated QR code", codeURL)
+	}
+	if client.preCreateParam.ProductCode != "FACE_TO_FACE_PAYMENT" {
+		t.Fatalf("ProductCode = %q, want FACE_TO_FACE_PAYMENT", client.preCreateParam.ProductCode)
+	}
+	if client.preCreateParam.TotalAmount != "1.00" {
+		t.Fatalf("TotalAmount = %q, want 1.00", client.preCreateParam.TotalAmount)
 	}
 }
 

--- a/frontend/providers/costcenter/src/components/RechargeModal.tsx
+++ b/frontend/providers/costcenter/src/components/RechargeModal.tsx
@@ -149,7 +149,6 @@ function AlipayPayment(props: { complete: number; codeURL?: string; tradeNO?: st
             size={185}
             value={props.codeURL}
             level="Q"
-            minVersion={4}
             style={{ margin: '0 auto' }}
             imageSettings={{
               // 二维码中间的logo图片


### PR DESCRIPTION
## Background

Alipay payments currently use `alipay.trade.page.pay` with QR mode enabled. The returned value is a long signed gateway URL, which produces a dense QR code that is difficult to scan reliably.

## Changes

- Use `alipay.trade.precreate` for Alipay payments and return its `qr_code` value.
- Keep the existing merchant order number and payment query, expiration, and refund flows unchanged.
- Allow the frontend QR renderer to select a smaller QR version for the shorter Alipay code.
- Add a unit test covering precreate QR code handling.

## Risks / Notes

The Alipay application must have the `alipay.trade.precreate` or face-to-face payment capability enabled. The existing full payment package tests require external payment credentials and network access.
