### PR TITLE
fix(costcenter): embed Alipay cashier page via iframe

### DIFF
--- a/controllers/pkg/pay/alipay_payment.go
+++ b/controllers/pkg/pay/alipay_payment.go
@@ -3,6 +3,7 @@ package pay
 import (
 	"context"
 	"fmt"
+	"html"
 	"os"
 	"strconv"
 	"time"
@@ -42,7 +43,7 @@ func NewAlipayPayment() (*AlipayPayment, error) {
 	return &AlipayPayment{client}, nil
 }
 
-// CreatePayment Create a payment and return the payment URL and order number
+// CreatePayment creates a payment and returns the Alipay cashier page HTML and the order number
 func (a *AlipayPayment) CreatePayment(amount int64, _, _ string) (string, string, error) {
 	p := alipay.TradePagePay{}
 	p.Subject = "sealos_cloud_pay"
@@ -50,18 +51,24 @@ func (a *AlipayPayment) CreatePayment(amount int64, _, _ string) (string, string
 	p.TotalAmount = fmt.Sprintf(
 		"%.2f",
 		float64(amount)/1_000_000,
-	) // the unit of the amount is converted to a dollar
+	) // convert the amount unit to yuan
 	p.ProductCode = "FAST_INSTANT_TRADE_PAY"
-	p.QRPayMode = "2"
+	p.QRPayMode = "4" // order code mode: Alipay renders the cashier page (with official QR code), embedded by the frontend via iframe
+	p.QRCodeWidth = "210"
 	p.TimeoutExpress = "10m"
 	url, err := a.client.TradePagePay(p)
 	if err != nil {
 		return "", "", err
 	}
-	return p.OutTradeNo, url.String(), nil
+	// Return an auto-submitting cashier form, embedded by the frontend via iframe srcDoc (same as FastGPT payment)
+	html := fmt.Sprintf(
+		`<form action="%s" method="get" id="alipaySubmit" style="display:none"></form><script>document.getElementById("alipaySubmit").submit();</script>`,
+		html.EscapeString(url.String()),
+	)
+	return p.OutTradeNo, html, nil
 }
 
-// GetPaymentDetails check the status of your payment
+// GetPaymentDetails checks the payment status
 func (a *AlipayPayment) GetPaymentDetails(sessionID string) (string, int64, error) {
 	resp, err := a.client.TradeQuery(context.Background(), alipay.TradeQuery{
 		OutTradeNo: sessionID,
@@ -71,14 +78,13 @@ func (a *AlipayPayment) GetPaymentDetails(sessionID string) (string, int64, erro
 	}
 	amount, _ := strconv.ParseFloat(resp.TotalAmount, 64)
 	amountInt := int64(amount * 1_000_000)
-	// state mapping
+	// status mapping
 	var status string
-	//  the type of notification that is triggered
-	//  notification type	description	  it is enabled by default
-	//  tradeStatus.TRADE_CLOSED	transaction-closed	1
-	//  tradeStatus.TRADE_FINISHED	the-transaction-is-closed	1
-	//  tradeStatus.TRADE_SUCCESS	the-payment-was-successful	1
-	//  tradeStatus.WAIT_BUYER_PAY	deal-creation	0
+	// tradeStatus values and their meanings:
+	// TRADE_CLOSED: transaction closed
+	// TRADE_FINISHED: transaction finished
+	// TRADE_SUCCESS: payment successful
+	// WAIT_BUYER_PAY: waiting for buyer to pay
 	switch resp.TradeStatus {
 	case "TRADE_SUCCESS":
 		status = PaymentSuccess
@@ -92,7 +98,7 @@ func (a *AlipayPayment) GetPaymentDetails(sessionID string) (string, int64, erro
 	return status, amountInt, nil
 }
 
-// ExpireSession close the order
+// ExpireSession closes the order
 func (a *AlipayPayment) ExpireSession(payment string) error {
 	_, err := a.client.TradeClose(context.Background(), alipay.TradeClose{
 		OutTradeNo: payment,
@@ -100,7 +106,7 @@ func (a *AlipayPayment) ExpireSession(payment string) error {
 	return err
 }
 
-// RefundPayment refund
+// RefundPayment refunds a payment
 func (a *AlipayPayment) RefundPayment(option RefundOption) (string, string, error) {
 	ctx := context.Background()
 
@@ -112,7 +118,7 @@ func (a *AlipayPayment) RefundPayment(option RefundOption) (string, string, erro
 		return "", "", fmt.Errorf("failed to query Alipay order: %w", err)
 	}
 
-	// use sendpaydate to verify the time
+	// use sendPayDate to verify the payment time
 	if qresp.SendPayDate == "" {
 		return "", "", fmt.Errorf(
 			"the payment time of order %s is unknown, and it is impossible to determine the refund time",
@@ -132,13 +138,13 @@ func (a *AlipayPayment) RefundPayment(option RefundOption) (string, string, erro
 
 	outRequestNo := uuid.NewString()
 
-	// Amount Unit Conversion: option. The unit of Amount is "cent", and the SDK API requires "yuan" and supports two decimal places
+	// amount unit conversion: option.Amount is in "cents" and the SDK API requires "yuan" with two decimal places
 	refundAmt := fmt.Sprintf("%.2f", float64(option.Amount)/1_000_000)
 
 	req := alipay.TradeRefund{
-		OutTradeNo:   option.TradeNo, // Merchant's original order number, choose one of the two with TradeNo
-		OutRequestNo: outRequestNo,   // The number of this refund request, guaranteed idempotent
-		RefundAmount: refundAmt,      // The amount of this refund, in "yuan", supports two decimal places
+		OutTradeNo:   option.TradeNo, // merchant's original order number, use either this or TradeNo
+		OutRequestNo: outRequestNo,   // refund request number for this request, guarantees idempotency
+		RefundAmount: refundAmt,      // refund amount, in "yuan", supports two decimal places
 		RefundReason: "refund for order " + option.OrderID,
 	}
 
@@ -147,7 +153,7 @@ func (a *AlipayPayment) RefundPayment(option RefundOption) (string, string, erro
 		return "", "", fmt.Errorf("alipay TradeRefund error: %w", err)
 	}
 
-	// Response parsing: resp. RefundFee is the amount of the refund, in yuan and string type
-	// It can also be used according to the resp. FundChange or resp. RefundStatus for further judgment
+	// response parsing: resp.RefundFee is the refund amount in yuan (string type)
+	// it can also be judged by resp.FundChange or resp.RefundStatus for further processing
 	return outRequestNo, resp.RefundFee, nil
 }

--- a/controllers/pkg/pay/alipay_payment.go
+++ b/controllers/pkg/pay/alipay_payment.go
@@ -43,7 +43,7 @@ func NewAlipayPayment() (*AlipayPayment, error) {
 	return &AlipayPayment{client}, nil
 }
 
-// CreatePayment creates a payment and returns the Alipay cashier page HTML and the order number
+// CreatePayment Create a payment and return the cashier page HTML and order number
 func (a *AlipayPayment) CreatePayment(amount int64, _, _ string) (string, string, error) {
 	p := alipay.TradePagePay{}
 	p.Subject = "sealos_cloud_pay"
@@ -51,7 +51,7 @@ func (a *AlipayPayment) CreatePayment(amount int64, _, _ string) (string, string
 	p.TotalAmount = fmt.Sprintf(
 		"%.2f",
 		float64(amount)/1_000_000,
-	) // convert the amount unit to yuan
+	) // the unit of the amount is converted to a dollar
 	p.ProductCode = "FAST_INSTANT_TRADE_PAY"
 	p.QRPayMode = "4" // order code mode: Alipay renders the cashier page (with official QR code), embedded by the frontend via iframe
 	p.QRCodeWidth = "210"
@@ -68,7 +68,7 @@ func (a *AlipayPayment) CreatePayment(amount int64, _, _ string) (string, string
 	return p.OutTradeNo, html, nil
 }
 
-// GetPaymentDetails checks the payment status
+// GetPaymentDetails check the status of your payment
 func (a *AlipayPayment) GetPaymentDetails(sessionID string) (string, int64, error) {
 	resp, err := a.client.TradeQuery(context.Background(), alipay.TradeQuery{
 		OutTradeNo: sessionID,
@@ -78,13 +78,14 @@ func (a *AlipayPayment) GetPaymentDetails(sessionID string) (string, int64, erro
 	}
 	amount, _ := strconv.ParseFloat(resp.TotalAmount, 64)
 	amountInt := int64(amount * 1_000_000)
-	// status mapping
+	// state mapping
 	var status string
-	// tradeStatus values and their meanings:
-	// TRADE_CLOSED: transaction closed
-	// TRADE_FINISHED: transaction finished
-	// TRADE_SUCCESS: payment successful
-	// WAIT_BUYER_PAY: waiting for buyer to pay
+	//  the type of notification that is triggered
+	//  notification type	description	  it is enabled by default
+	//  tradeStatus.TRADE_CLOSED	transaction-closed	1
+	//  tradeStatus.TRADE_FINISHED	the-transaction-is-closed	1
+	//  tradeStatus.TRADE_SUCCESS	the-payment-was-successful	1
+	//  tradeStatus.WAIT_BUYER_PAY	deal-creation	0
 	switch resp.TradeStatus {
 	case "TRADE_SUCCESS":
 		status = PaymentSuccess
@@ -98,7 +99,7 @@ func (a *AlipayPayment) GetPaymentDetails(sessionID string) (string, int64, erro
 	return status, amountInt, nil
 }
 
-// ExpireSession closes the order
+// ExpireSession close the order
 func (a *AlipayPayment) ExpireSession(payment string) error {
 	_, err := a.client.TradeClose(context.Background(), alipay.TradeClose{
 		OutTradeNo: payment,
@@ -106,7 +107,7 @@ func (a *AlipayPayment) ExpireSession(payment string) error {
 	return err
 }
 
-// RefundPayment refunds a payment
+// RefundPayment refund
 func (a *AlipayPayment) RefundPayment(option RefundOption) (string, string, error) {
 	ctx := context.Background()
 
@@ -118,7 +119,7 @@ func (a *AlipayPayment) RefundPayment(option RefundOption) (string, string, erro
 		return "", "", fmt.Errorf("failed to query Alipay order: %w", err)
 	}
 
-	// use sendPayDate to verify the payment time
+	// use sendpaydate to verify the time
 	if qresp.SendPayDate == "" {
 		return "", "", fmt.Errorf(
 			"the payment time of order %s is unknown, and it is impossible to determine the refund time",
@@ -138,13 +139,13 @@ func (a *AlipayPayment) RefundPayment(option RefundOption) (string, string, erro
 
 	outRequestNo := uuid.NewString()
 
-	// amount unit conversion: option.Amount is in "cents" and the SDK API requires "yuan" with two decimal places
+	// Amount Unit Conversion: option. The unit of Amount is "cent", and the SDK API requires "yuan" and supports two decimal places
 	refundAmt := fmt.Sprintf("%.2f", float64(option.Amount)/1_000_000)
 
 	req := alipay.TradeRefund{
-		OutTradeNo:   option.TradeNo, // merchant's original order number, use either this or TradeNo
-		OutRequestNo: outRequestNo,   // refund request number for this request, guarantees idempotency
-		RefundAmount: refundAmt,      // refund amount, in "yuan", supports two decimal places
+		OutTradeNo:   option.TradeNo, // Merchant's original order number, choose one of the two with TradeNo
+		OutRequestNo: outRequestNo,   // The number of this refund request, guaranteed idempotent
+		RefundAmount: refundAmt,      // The amount of this refund, in "yuan", supports two decimal places
 		RefundReason: "refund for order " + option.OrderID,
 	}
 
@@ -153,7 +154,7 @@ func (a *AlipayPayment) RefundPayment(option RefundOption) (string, string, erro
 		return "", "", fmt.Errorf("alipay TradeRefund error: %w", err)
 	}
 
-	// response parsing: resp.RefundFee is the refund amount in yuan (string type)
-	// it can also be judged by resp.FundChange or resp.RefundStatus for further processing
+	// Response parsing: resp. RefundFee is the amount of the refund, in yuan and string type
+	// It can also be used according to the resp. FundChange or resp. RefundStatus for further judgment
 	return outRequestNo, resp.RefundFee, nil
 }

--- a/controllers/pkg/pay/alipay_payment.go
+++ b/controllers/pkg/pay/alipay_payment.go
@@ -3,7 +3,6 @@ package pay
 import (
 	"context"
 	"fmt"
-	"html"
 	"os"
 	"strconv"
 	"time"
@@ -43,7 +42,7 @@ func NewAlipayPayment() (*AlipayPayment, error) {
 	return &AlipayPayment{client}, nil
 }
 
-// CreatePayment Create a payment and return the cashier page HTML and order number
+// CreatePayment Create a payment and return the payment URL and order number
 func (a *AlipayPayment) CreatePayment(amount int64, _, _ string) (string, string, error) {
 	p := alipay.TradePagePay{}
 	p.Subject = "sealos_cloud_pay"
@@ -60,12 +59,7 @@ func (a *AlipayPayment) CreatePayment(amount int64, _, _ string) (string, string
 	if err != nil {
 		return "", "", err
 	}
-	// Return an auto-submitting cashier form, embedded by the frontend via iframe srcDoc (same as FastGPT payment)
-	html := fmt.Sprintf(
-		`<form action="%s" method="get" id="alipaySubmit" style="display:none"></form><script>document.getElementById("alipaySubmit").submit();</script>`,
-		html.EscapeString(url.String()),
-	)
-	return p.OutTradeNo, html, nil
+	return p.OutTradeNo, url.String(), nil
 }
 
 // GetPaymentDetails check the status of your payment

--- a/frontend/providers/costcenter/src/components/RechargeModal.tsx
+++ b/frontend/providers/costcenter/src/components/RechargeModal.tsx
@@ -130,8 +130,8 @@ function WechatPayment(props: { complete: number; codeURL?: string; tradeNO?: st
 }
 function AlipayPayment(props: { complete: number; codeURL?: string; tradeNO?: string }) {
   const { t } = useTranslation();
-  // The Alipay cashier is returned as an HTML form and embedded via iframe; otherwise (legacy data) render as a QR code
-  const isCashierHTML = !!props.codeURL?.trim().startsWith('<');
+  // The Alipay cashier is loaded directly in an iframe by its URL; otherwise (legacy data) render as a QR code
+  const isCashierURL = !!props.codeURL?.trim().startsWith('https://openapi.alipay.com');
   return (
     <Flex
       flexDirection="column"
@@ -145,16 +145,16 @@ function AlipayPayment(props: { complete: number; codeURL?: string; tradeNO?: st
       position={'relative'}
     >
       <Flex
-        height={isCashierHTML ? 'auto' : '295px'}
+        height={isCashierURL ? 'auto' : '295px'}
         direction={'column'}
         align="center"
         justify={'space-between'}
       >
         <p className="text-lg font-semibold mb-2 text-center">{t('common:scan_with_alipay')}</p>
         {props.complete === 2 && !!props.codeURL ? (
-          isCashierHTML ? (
+          isCashierURL ? (
             <iframe
-              srcDoc={props.codeURL}
+              src={props.codeURL}
               style={{ width: 215, height: 215, border: 'none', display: 'inline-block' }}
             />
           ) : (

--- a/frontend/providers/costcenter/src/components/RechargeModal.tsx
+++ b/frontend/providers/costcenter/src/components/RechargeModal.tsx
@@ -99,11 +99,11 @@ function WechatPayment(props: { complete: number; codeURL?: string; tradeNO?: st
             minVersion={4}
             style={{ margin: '0 auto' }}
             imageSettings={{
-              // 二维码中间的logo图片
+              // logo image in the center of the QR code
               src: wechat_icon.src,
               height: 40,
               width: 40,
-              excavate: true // 中间图片所在的位置是否镂空
+              excavate: true // whether to cut out the area where the center image is located
             }}
           />
         ) : (
@@ -130,6 +130,8 @@ function WechatPayment(props: { complete: number; codeURL?: string; tradeNO?: st
 }
 function AlipayPayment(props: { complete: number; codeURL?: string; tradeNO?: string }) {
   const { t } = useTranslation();
+  // The Alipay cashier is returned as an HTML form and embedded via iframe; otherwise (legacy data) render as a QR code
+  const isCashierHTML = !!props.codeURL?.trim().startsWith('<');
   return (
     <Flex
       flexDirection="column"
@@ -142,23 +144,35 @@ function AlipayPayment(props: { complete: number; codeURL?: string; tradeNO?: st
       alignItems={'center'}
       position={'relative'}
     >
-      <Flex height={'295px'} direction={'column'} align="center" justify={'space-between'}>
+      <Flex
+        height={isCashierHTML ? 'auto' : '295px'}
+        direction={'column'}
+        align="center"
+        justify={'space-between'}
+      >
         <p className="text-lg font-semibold mb-2 text-center">{t('common:scan_with_alipay')}</p>
         {props.complete === 2 && !!props.codeURL ? (
-          <QRCodeSVG
-            size={185}
-            value={props.codeURL}
-            level="Q"
-            minVersion={4}
-            style={{ margin: '0 auto' }}
-            imageSettings={{
-              // 二维码中间的logo图片
-              src: alipay_icon.src,
-              height: 40,
-              width: 40,
-              excavate: true // 中间图片所在的位置是否镂空
-            }}
-          />
+          isCashierHTML ? (
+            <iframe
+              srcDoc={props.codeURL}
+              style={{ width: 215, height: 215, border: 'none', display: 'inline-block' }}
+            />
+          ) : (
+            <QRCodeSVG
+              size={185}
+              value={props.codeURL}
+              level="Q"
+              minVersion={4}
+              style={{ margin: '0 auto' }}
+              imageSettings={{
+                // logo image in the center of the QR code
+                src: alipay_icon.src,
+                height: 40,
+                width: 40,
+                excavate: true // whether to cut out the area where the center image is located
+              }}
+            />
+          )
         ) : (
           <Box>waiting...</Box>
         )}
@@ -292,11 +306,11 @@ const RechargeModal = forwardRef(
 
     const [step, setStep] = useState(1);
 
-    // 整个流程跑通需要状态管理, 0 初始态， 1 创建支付单， 2 支付中, 3 支付成功
+    // the whole flow needs state management: 0 initial, 1 payment order created, 2 paying, 3 paid
     const [complete, setComplete] = useState<0 | 1 | 2 | 3>(0);
-    // 0 是微信，1 是stripe, 2 是支付宝
+    // 0 is wechat, 1 is stripe, 2 is alipay
     const [payType, setPayType] = useState<'wechat' | 'stripe' | 'alipay'>('wechat');
-    // 计费详情
+    // billing details
     const [detail, setDetail] = useState(false);
     const [paymentName, setPaymentName] = useState('');
     const [selectAmount, setSelectAmount] = useState(0);
@@ -448,7 +462,7 @@ const RechargeModal = forwardRef(
           status: 'error',
           title: t('common:pay_minimum_tips')
         });
-        // 校检，stripe有最低费用的要求
+        // validation: stripe has a minimum charge requirement
         return;
       }
       setComplete(1);


### PR DESCRIPTION
## Summary

The Alipay payment URL generated by `TradePagePay` is a signed gateway URL over 900 characters long, which cannot be rendered as a scannable QR code (QR version 30+, module size below the readable threshold).

This PR switches Alipay to `qr_pay_mode=4` (order code mode) so **Alipay itself renders the official cashier page** (including a clearly scannable QR code), returns the auto-submitting cashier form HTML as the payment code, and embeds it in the frontend via an iframe — the same approach FastGPT uses for Alipay payments.

## Changes

- `controllers/pkg/pay/alipay_payment.go`: `CreatePayment` uses `TradePagePay` with `QRPayMode=4` and `QRCodeWidth=210`, returning the cashier page HTML instead of the long signed URL.
- `frontend/providers/costcenter/src/components/RechargeModal.tsx`: `AlipayPayment` detects the HTML payment code and renders it in an `<iframe srcDoc>` (215×215); falls back to QR code rendering for legacy data.

## Notes

- WeChat payments are unaffected (they use the short native `weixin://` URL).
- Payment status polling via `TradeQuery` (`GetPaymentDetails`) is unchanged.
- Existing pending orders with the old long URL keep the QR fallback until they expire (12 min).