### PR TITLE
fix(user): avoid full User objects in webhook validation

### DIFF
--- a/controllers/user/api/v1/user_webhook.go
+++ b/controllers/user/api/v1/user_webhook.go
@@ -32,8 +32,8 @@ import (
 
 // log is for logging in this package.
 var (
-	userlog                   = logf.Log.WithName("user-webhook")
-	userWebhookMetadataReader usercount.MetadataReader
+	userlog          = logf.Log.WithName("user-webhook")
+	userWebhookCount *usercount.Counter
 )
 
 const (
@@ -57,12 +57,12 @@ func buildUserCountLimitErrorMessage() string {
 
 func (r *User) SetupWebhookWithManager(
 	mgr ctrl.Manager,
-	metadataReader usercount.MetadataReader,
+	userCounter *usercount.Counter,
 ) error {
-	if metadataReader == nil {
-		return errors.New("user webhook metadata reader is not initialized")
+	if userCounter == nil {
+		return errors.New("user webhook count cache is not initialized")
 	}
-	userWebhookMetadataReader = metadataReader
+	userWebhookCount = userCounter
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
 		WithDefaulter(r).
@@ -111,13 +111,10 @@ func (r *User) ValidateCreate(ctx context.Context, obj runtime.Object) (admissio
 	if err := user.validateCSRExpirationSeconds(); err != nil {
 		return admission.Warnings{}, err
 	}
-	if userWebhookMetadataReader == nil {
-		return admission.Warnings{}, errors.New("user webhook metadata reader is not initialized")
+	if userWebhookCount == nil || !userWebhookCount.Initialized() {
+		return admission.Warnings{}, errors.New("user count cache is not initialized")
 	}
-	currentCount, err := usercount.CountQuotaUsersMetadata(ctx, userWebhookMetadataReader)
-	if err != nil {
-		return admission.Warnings{}, err
-	}
+	currentCount := userWebhookCount.Count()
 	if !licensegate.AllowNewUser(currentCount) {
 		message := buildLicenseLimitErrorMessage()
 		if licensegate.HasActiveLicense() {

--- a/controllers/user/api/v1/user_webhook.go
+++ b/controllers/user/api/v1/user_webhook.go
@@ -25,7 +25,6 @@ import (
 	"github.com/labring/sealos/controllers/user/pkg/usercount"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -33,8 +32,8 @@ import (
 
 // log is for logging in this package.
 var (
-	userlog           = logf.Log.WithName("user-webhook")
-	userWebhookReader client.Reader
+	userlog                   = logf.Log.WithName("user-webhook")
+	userWebhookMetadataReader usercount.MetadataReader
 )
 
 const (
@@ -56,8 +55,14 @@ func buildUserCountLimitErrorMessage() string {
 	)
 }
 
-func (r *User) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	userWebhookReader = mgr.GetAPIReader()
+func (r *User) SetupWebhookWithManager(
+	mgr ctrl.Manager,
+	metadataReader usercount.MetadataReader,
+) error {
+	if metadataReader == nil {
+		return errors.New("user webhook metadata reader is not initialized")
+	}
+	userWebhookMetadataReader = metadataReader
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
 		WithDefaulter(r).
@@ -92,7 +97,7 @@ func (r *User) Default(ctx context.Context, obj runtime.Object) error {
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-//+kubebuilder:webhook:path=/validate-user-sealos-io-v1-user,mutating=false,failurePolicy=fail,sideEffects=None,groups=user.sealos.io,resources=users,verbs=create;update,versions=v1,name=vuser.kb.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-user-sealos-io-v1-user,mutating=false,failurePolicy=fail,sideEffects=None,groups=user.sealos.io,resources=users,verbs=create;update,versions=v1,name=vuser.kb.io,admissionReviewVersions=v1,timeoutSeconds=30
 
 var _ webhook.CustomValidator = &User{}
 
@@ -106,13 +111,10 @@ func (r *User) ValidateCreate(ctx context.Context, obj runtime.Object) (admissio
 	if err := user.validateCSRExpirationSeconds(); err != nil {
 		return admission.Warnings{}, err
 	}
-	if userWebhookReader == nil {
-		return admission.Warnings{}, errors.New("user webhook reader is not initialized")
+	if userWebhookMetadataReader == nil {
+		return admission.Warnings{}, errors.New("user webhook metadata reader is not initialized")
 	}
-	if err := usercount.Init(ctx, userWebhookReader); err != nil {
-		return admission.Warnings{}, err
-	}
-	currentCount, err := usercount.CountQuotaUsers(ctx, userWebhookReader)
+	currentCount, err := usercount.CountQuotaUsersMetadata(ctx, userWebhookMetadataReader)
 	if err != nil {
 		return admission.Warnings{}, err
 	}

--- a/controllers/user/api/v1/webhook_suite_test.go
+++ b/controllers/user/api/v1/webhook_suite_test.go
@@ -103,7 +103,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	userCounter := usercount.NewCounter()
-	userCounter.Initialize(nil)
+	userCounter.MarkInitialized()
 	err = (&User{}).SetupWebhookWithManager(mgr, userCounter)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/controllers/user/api/v1/webhook_suite_test.go
+++ b/controllers/user/api/v1/webhook_suite_test.go
@@ -25,13 +25,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/labring/sealos/controllers/user/pkg/usercount"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	//+kubebuilder:scaffold:imports
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/metadata"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -94,14 +93,6 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
-	metadataClient, err := metadata.NewForConfig(cfg)
-	Expect(err).NotTo(HaveOccurred())
-	userMetadataReader := metadataClient.Resource(schema.GroupVersionResource{
-		Group:    "user.sealos.io",
-		Version:  "v1",
-		Resource: "users",
-	})
-
 	// start webhook server using Manager
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
@@ -111,7 +102,9 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	err = (&User{}).SetupWebhookWithManager(mgr, userMetadataReader)
+	userCounter := usercount.NewCounter()
+	userCounter.Initialize(nil)
+	err = (&User{}).SetupWebhookWithManager(mgr, userCounter)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&Operationrequest{}).SetupWebhookWithManager(mgr)

--- a/controllers/user/api/v1/webhook_suite_test.go
+++ b/controllers/user/api/v1/webhook_suite_test.go
@@ -30,6 +30,8 @@ import (
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	//+kubebuilder:scaffold:imports
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/metadata"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -92,6 +94,13 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
+	metadataClient, err := metadata.NewForConfig(cfg)
+	Expect(err).NotTo(HaveOccurred())
+	userMetadataReader := metadataClient.Resource(schema.GroupVersionResource{
+		Group:    "user.sealos.io",
+		Version:  "v1",
+		Resource: "users",
+	})
 
 	// start webhook server using Manager
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
@@ -102,7 +111,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	err = (&User{}).SetupWebhookWithManager(mgr)
+	err = (&User{}).SetupWebhookWithManager(mgr, userMetadataReader)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&Operationrequest{}).SetupWebhookWithManager(mgr)

--- a/controllers/user/config/webhook/manifests.yaml
+++ b/controllers/user/config/webhook/manifests.yaml
@@ -91,6 +91,7 @@ webhooks:
       name: webhook-service
       namespace: system
       path: /validate-user-sealos-io-v1-user
+  timeoutSeconds: 30
   failurePolicy: Fail
   name: vuser.kb.io
   rules:

--- a/controllers/user/controllers/user_controller.go
+++ b/controllers/user/controllers/user_controller.go
@@ -66,12 +66,12 @@ const (
 
 // UserReconciler reconciles a User object
 type UserReconciler struct {
-	Logger         logr.Logger
-	Recorder       record.EventRecorder
-	cache          cache.Cache
-	apiReader      client.Reader
-	metadataReader usercount.MetadataReader
-	config         *rest.Config
+	Logger      logr.Logger
+	Recorder    record.EventRecorder
+	cache       cache.Cache
+	apiReader   client.Reader
+	userCounter *usercount.Counter
+	config      *rest.Config
 	*runtime.Scheme
 	client.Client
 	finalizer          *finalizer.Finalizer
@@ -148,7 +148,7 @@ func (p *ControllerRestartPredicate) Create(e event.CreateEvent) bool {
 // SetupWithManager sets up the controller with the Manager.
 func (r *UserReconciler) SetupWithManager(mgr ctrl.Manager, opts ratelimiter.RateLimiterOptions,
 	minRequeueDuration, maxRequeueDuration, restartPredicateDuration time.Duration,
-	metadataReader usercount.MetadataReader,
+	userCounter *usercount.Counter,
 ) error {
 	const controllerName = "user_controller"
 	if r.Client == nil {
@@ -164,7 +164,7 @@ func (r *UserReconciler) SetupWithManager(mgr ctrl.Manager, opts ratelimiter.Rat
 	r.Scheme = mgr.GetScheme()
 	r.cache = mgr.GetCache()
 	r.apiReader = mgr.GetAPIReader()
-	r.metadataReader = metadataReader
+	r.userCounter = userCounter
 	r.config = mgr.GetConfig()
 	r.Logger.V(1).Info("init reconcile controller user")
 	r.minRequeueDuration = minRequeueDuration
@@ -915,13 +915,10 @@ func (r *UserReconciler) handleLicenseLimit(ctx context.Context, user *userv1.Us
 		return false, nil
 	}
 
-	if r.metadataReader == nil {
-		return false, errors.New("user metadata reader is not initialized")
+	if r.userCounter == nil || !r.userCounter.Initialized() {
+		return false, errors.New("user count cache is not initialized")
 	}
-	userCount, err := usercount.CountQuotaUsersMetadataExcluding(ctx, r.metadataReader, user.Name)
-	if err != nil {
-		return false, err
-	}
+	userCount := r.userCounter.CountExcluding(user.Name)
 	if licensegate.AllowNewUser(userCount) {
 		user.Status.Conditions = helper.DeleteCondition(
 			user.Status.Conditions,

--- a/controllers/user/controllers/user_controller.go
+++ b/controllers/user/controllers/user_controller.go
@@ -66,11 +66,12 @@ const (
 
 // UserReconciler reconciles a User object
 type UserReconciler struct {
-	Logger    logr.Logger
-	Recorder  record.EventRecorder
-	cache     cache.Cache
-	apiReader client.Reader
-	config    *rest.Config
+	Logger         logr.Logger
+	Recorder       record.EventRecorder
+	cache          cache.Cache
+	apiReader      client.Reader
+	metadataReader usercount.MetadataReader
+	config         *rest.Config
 	*runtime.Scheme
 	client.Client
 	finalizer          *finalizer.Finalizer
@@ -147,6 +148,7 @@ func (p *ControllerRestartPredicate) Create(e event.CreateEvent) bool {
 // SetupWithManager sets up the controller with the Manager.
 func (r *UserReconciler) SetupWithManager(mgr ctrl.Manager, opts ratelimiter.RateLimiterOptions,
 	minRequeueDuration, maxRequeueDuration, restartPredicateDuration time.Duration,
+	metadataReader usercount.MetadataReader,
 ) error {
 	const controllerName = "user_controller"
 	if r.Client == nil {
@@ -162,6 +164,7 @@ func (r *UserReconciler) SetupWithManager(mgr ctrl.Manager, opts ratelimiter.Rat
 	r.Scheme = mgr.GetScheme()
 	r.cache = mgr.GetCache()
 	r.apiReader = mgr.GetAPIReader()
+	r.metadataReader = metadataReader
 	r.config = mgr.GetConfig()
 	r.Logger.V(1).Info("init reconcile controller user")
 	r.minRequeueDuration = minRequeueDuration
@@ -912,10 +915,10 @@ func (r *UserReconciler) handleLicenseLimit(ctx context.Context, user *userv1.Us
 		return false, nil
 	}
 
-	if err := usercount.Init(ctx, reader); err != nil {
-		return false, err
+	if r.metadataReader == nil {
+		return false, errors.New("user metadata reader is not initialized")
 	}
-	userCount, err := usercount.CountQuotaUsersExcluding(ctx, reader, user.Name)
+	userCount, err := usercount.CountQuotaUsersMetadataExcluding(ctx, r.metadataReader, user.Name)
 	if err != nil {
 		return false, err
 	}

--- a/controllers/user/controllers/user_count.go
+++ b/controllers/user/controllers/user_count.go
@@ -28,7 +28,7 @@ import (
 
 type userCountRunnable struct {
 	counter    *usercount.Counter
-	initialize func(context.Context) ([]interface{}, error)
+	initialize func(context.Context) ([]any, error)
 }
 
 func (r *userCountRunnable) Start(ctx context.Context) error {
@@ -59,7 +59,7 @@ func SetupUserCount(mgr ctrl.Manager) (*usercount.Counter, error) {
 		return nil, fmt.Errorf("add user count event handler: %w", err)
 	}
 
-	initialize := func(ctx context.Context) ([]interface{}, error) {
+	initialize := func(ctx context.Context) ([]any, error) {
 		if storeInformer, ok := informer.(interface{ GetStore() toolscache.Store }); ok {
 			return storeInformer.GetStore().List(), nil
 		}
@@ -68,7 +68,7 @@ func SetupUserCount(mgr ctrl.Manager) (*usercount.Counter, error) {
 		if err := mgr.GetClient().List(ctx, list); err != nil {
 			return nil, err
 		}
-		objects := make([]interface{}, len(list.Items))
+		objects := make([]any, len(list.Items))
 		for i := range list.Items {
 			objects[i] = &list.Items[i]
 		}

--- a/controllers/user/controllers/user_count.go
+++ b/controllers/user/controllers/user_count.go
@@ -16,15 +16,75 @@ package controllers
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"net/http"
 
+	userv1 "github.com/labring/sealos/controllers/user/api/v1"
 	"github.com/labring/sealos/controllers/user/pkg/usercount"
+	toolscache "k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func SetupUserCount(mgr ctrl.Manager) error {
-	logger := ctrl.Log.WithName("user-count")
-	if err := usercount.Init(context.Background(), mgr.GetAPIReader()); err != nil {
-		logger.Error(err, "initial user count init failed")
+type userCountRunnable struct {
+	counter    *usercount.Counter
+	initialize func(context.Context) ([]interface{}, error)
+}
+
+func (r *userCountRunnable) Start(ctx context.Context) error {
+	objects, err := r.initialize(ctx)
+	if err != nil {
+		return fmt.Errorf("initialize user count: %w", err)
 	}
+	r.counter.Initialize(objects)
+	<-ctx.Done()
 	return nil
+}
+
+func (r *userCountRunnable) NeedLeaderElection() bool {
+	return false
+}
+
+func SetupUserCount(mgr ctrl.Manager) (*usercount.Counter, error) {
+	counter := usercount.NewCounter()
+	informer, err := mgr.GetCache().GetInformer(context.Background(), &userv1.User{})
+	if err != nil {
+		return nil, fmt.Errorf("get user informer: %w", err)
+	}
+	if _, err := informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
+		AddFunc:    counter.Add,
+		UpdateFunc: counter.Update,
+		DeleteFunc: counter.Delete,
+	}); err != nil {
+		return nil, fmt.Errorf("add user count event handler: %w", err)
+	}
+
+	initialize := func(ctx context.Context) ([]interface{}, error) {
+		if storeInformer, ok := informer.(interface{ GetStore() toolscache.Store }); ok {
+			return storeInformer.GetStore().List(), nil
+		}
+
+		list := &userv1.UserList{}
+		if err := mgr.GetClient().List(ctx, list); err != nil {
+			return nil, err
+		}
+		objects := make([]interface{}, len(list.Items))
+		for i := range list.Items {
+			objects[i] = &list.Items[i]
+		}
+		return objects, nil
+	}
+
+	if err := mgr.Add(&userCountRunnable{counter: counter, initialize: initialize}); err != nil {
+		return nil, fmt.Errorf("add user count runnable: %w", err)
+	}
+	if err := mgr.AddReadyzCheck("user-count-cache", func(_ *http.Request) error {
+		if !counter.Initialized() {
+			return errors.New("user count cache is not initialized")
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("add user count readiness check: %w", err)
+	}
+	return counter, nil
 }

--- a/controllers/user/controllers/user_count.go
+++ b/controllers/user/controllers/user_count.go
@@ -27,16 +27,18 @@ import (
 )
 
 type userCountRunnable struct {
-	counter    *usercount.Counter
-	initialize func(context.Context) ([]any, error)
+	counter             *usercount.Counter
+	handlerRegistration toolscache.ResourceEventHandlerRegistration
 }
 
 func (r *userCountRunnable) Start(ctx context.Context) error {
-	objects, err := r.initialize(ctx)
-	if err != nil {
-		return fmt.Errorf("initialize user count: %w", err)
+	if !toolscache.WaitForCacheSync(ctx.Done(), r.handlerRegistration.HasSynced) {
+		if ctx.Err() != nil {
+			return nil
+		}
+		return errors.New("user count event handler failed to sync")
 	}
-	r.counter.Initialize(objects)
+	r.counter.MarkInitialized()
 	<-ctx.Done()
 	return nil
 }
@@ -51,31 +53,19 @@ func SetupUserCount(mgr ctrl.Manager) (*usercount.Counter, error) {
 	if err != nil {
 		return nil, fmt.Errorf("get user informer: %w", err)
 	}
-	if _, err := informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
+	registration, err := informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
 		AddFunc:    counter.Add,
 		UpdateFunc: counter.Update,
 		DeleteFunc: counter.Delete,
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, fmt.Errorf("add user count event handler: %w", err)
 	}
 
-	initialize := func(ctx context.Context) ([]any, error) {
-		if storeInformer, ok := informer.(interface{ GetStore() toolscache.Store }); ok {
-			return storeInformer.GetStore().List(), nil
-		}
-
-		list := &userv1.UserList{}
-		if err := mgr.GetClient().List(ctx, list); err != nil {
-			return nil, err
-		}
-		objects := make([]any, len(list.Items))
-		for i := range list.Items {
-			objects[i] = &list.Items[i]
-		}
-		return objects, nil
-	}
-
-	if err := mgr.Add(&userCountRunnable{counter: counter, initialize: initialize}); err != nil {
+	if err := mgr.Add(&userCountRunnable{
+		counter:             counter,
+		handlerRegistration: registration,
+	}); err != nil {
 		return nil, fmt.Errorf("add user count runnable: %w", err)
 	}
 	if err := mgr.AddReadyzCheck("user-count-cache", func(_ *http.Request) error {

--- a/controllers/user/deploy/charts/user-controller/templates/webhook.yaml
+++ b/controllers/user/deploy/charts/user-controller/templates/webhook.yaml
@@ -81,6 +81,7 @@ webhooks:
         name: {{ include "user.fullname" . }}-webhook-service
         namespace: {{ .Release.Namespace }}
         path: /validate-user-sealos-io-v1-user
+    timeoutSeconds: 30
     failurePolicy: Fail
     rules:
       - apiGroups:

--- a/controllers/user/deploy/drop/deploy.yaml
+++ b/controllers/user/deploy/drop/deploy.yaml
@@ -454,6 +454,7 @@ webhooks:
       name: user-webhook-service
       namespace: user-system
       path: /validate-user-sealos-io-v1-user
+  timeoutSeconds: 30
   failurePolicy: Fail
   name: vuser.kb.io
   rules:

--- a/controllers/user/main.go
+++ b/controllers/user/main.go
@@ -28,10 +28,8 @@ import (
 	"github.com/labring/sealos/controllers/user/controllers"
 	ratelimiter "github.com/labring/sealos/controllers/user/controllers/helper/ratelimiter"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/metadata"
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -230,19 +228,13 @@ func main() {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
-	metadataClient, err := metadata.NewForConfig(cfg)
-	if err != nil {
-		setupLog.Error(err, "unable to create metadata client")
-		os.Exit(1)
-	}
-	userMetadataReader := metadataClient.Resource(schema.GroupVersionResource{
-		Group:    "user.sealos.io",
-		Version:  "v1",
-		Resource: "users",
-	})
-
 	if err := controllers.SetupLicenseGate(mgr); err != nil {
 		setupLog.Error(err, "unable to set up license gate")
+		os.Exit(1)
+	}
+	userCounter, err := controllers.SetupUserCount(mgr)
+	if err != nil {
+		setupLog.Error(err, "unable to set up user count cache")
 		os.Exit(1)
 	}
 
@@ -252,7 +244,7 @@ func main() {
 		minRequeueDuration,
 		maxRequeueDuration,
 		restartPredicateDuration,
-		userMetadataReader,
+		userCounter,
 	); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "User")
 		os.Exit(1)
@@ -261,7 +253,7 @@ func main() {
 	if os.Getenv("DISABLE_WEBHOOKS") == "true" {
 		setupLog.Info("disable all webhooks")
 	} else {
-		if err = (&userv1.User{}).SetupWebhookWithManager(mgr, userMetadataReader); err != nil {
+		if err = (&userv1.User{}).SetupWebhookWithManager(mgr, userCounter); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "User")
 			os.Exit(1)
 		}

--- a/controllers/user/main.go
+++ b/controllers/user/main.go
@@ -28,8 +28,10 @@ import (
 	"github.com/labring/sealos/controllers/user/controllers"
 	ratelimiter "github.com/labring/sealos/controllers/user/controllers/helper/ratelimiter"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/metadata"
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -228,13 +230,19 @@ func main() {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
+	metadataClient, err := metadata.NewForConfig(cfg)
+	if err != nil {
+		setupLog.Error(err, "unable to create metadata client")
+		os.Exit(1)
+	}
+	userMetadataReader := metadataClient.Resource(schema.GroupVersionResource{
+		Group:    "user.sealos.io",
+		Version:  "v1",
+		Resource: "users",
+	})
 
 	if err := controllers.SetupLicenseGate(mgr); err != nil {
 		setupLog.Error(err, "unable to set up license gate")
-		os.Exit(1)
-	}
-	if err := controllers.SetupUserCount(mgr); err != nil {
-		setupLog.Error(err, "unable to set up user count cache")
 		os.Exit(1)
 	}
 
@@ -244,6 +252,7 @@ func main() {
 		minRequeueDuration,
 		maxRequeueDuration,
 		restartPredicateDuration,
+		userMetadataReader,
 	); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "User")
 		os.Exit(1)
@@ -252,7 +261,7 @@ func main() {
 	if os.Getenv("DISABLE_WEBHOOKS") == "true" {
 		setupLog.Info("disable all webhooks")
 	} else {
-		if err = (&userv1.User{}).SetupWebhookWithManager(mgr); err != nil {
+		if err = (&userv1.User{}).SetupWebhookWithManager(mgr, userMetadataReader); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "User")
 			os.Exit(1)
 		}

--- a/controllers/user/pkg/usercount/count.go
+++ b/controllers/user/pkg/usercount/count.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"sync/atomic"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -84,6 +85,45 @@ func CountQuotaUsersExcluding(
 	if err != nil {
 		return 0, fmt.Errorf("unable to get quota user count excluding %s: %w", excludeName, err)
 	}
+	return count, nil
+}
+
+// MetadataReader lists resources without fetching their full objects. User
+// objects contain kubeconfigs in status, so full lists are too expensive for
+// admission requests that only need metadata.
+type MetadataReader interface {
+	List(context.Context, metav1.ListOptions) (*metav1.PartialObjectMetadataList, error)
+}
+
+func CountQuotaUsersMetadata(ctx context.Context, reader MetadataReader) (int, error) {
+	return CountQuotaUsersMetadataExcluding(ctx, reader, "")
+}
+
+func CountQuotaUsersMetadataExcluding(
+	ctx context.Context,
+	reader MetadataReader,
+	excludeName string,
+) (int, error) {
+	if reader == nil {
+		return 0, errors.New("metadata reader is nil")
+	}
+
+	list, err := reader.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return 0, fmt.Errorf("failed to list user metadata: %w", err)
+	}
+
+	var count int
+	for _, item := range list.Items {
+		if excludeName != "" && item.Name == excludeName {
+			continue
+		}
+		if item.DeletionTimestamp != nil && !item.DeletionTimestamp.IsZero() {
+			continue
+		}
+		count++
+	}
+
 	return count, nil
 }
 

--- a/controllers/user/pkg/usercount/count.go
+++ b/controllers/user/pkg/usercount/count.go
@@ -63,7 +63,7 @@ func (c *Counter) CountExcluding(name string) int {
 
 // Initialize replaces the counter from objects already present in the local
 // informer store. Event handlers can run concurrently with initialization.
-func (c *Counter) Initialize(objects []interface{}) {
+func (c *Counter) Initialize(objects []any) {
 	if c == nil {
 		return
 	}
@@ -85,7 +85,7 @@ func (c *Counter) Initialize(objects []interface{}) {
 	c.initialized.Store(true)
 }
 
-func (c *Counter) Add(obj interface{}) {
+func (c *Counter) Add(obj any) {
 	metadata, ok := objectMetadata(obj)
 	if !ok {
 		return
@@ -93,7 +93,7 @@ func (c *Counter) Add(obj interface{}) {
 	c.set(metadata.GetName(), isQuotaUser(metadata))
 }
 
-func (c *Counter) Update(oldObj, newObj interface{}) {
+func (c *Counter) Update(oldObj, newObj any) {
 	oldMetadata, oldOK := objectMetadata(oldObj)
 	newMetadata, newOK := objectMetadata(newObj)
 	if oldOK && newOK && oldMetadata.GetName() != newMetadata.GetName() {
@@ -105,7 +105,7 @@ func (c *Counter) Update(oldObj, newObj interface{}) {
 	c.set(newMetadata.GetName(), isQuotaUser(newMetadata))
 }
 
-func (c *Counter) Delete(obj interface{}) {
+func (c *Counter) Delete(obj any) {
 	metadata, ok := objectMetadata(obj)
 	if !ok {
 		return
@@ -143,7 +143,7 @@ func isQuotaUser(obj metav1.Object) bool {
 		(obj.GetDeletionTimestamp() == nil || obj.GetDeletionTimestamp().IsZero())
 }
 
-func objectMetadata(obj interface{}) (metav1.Object, bool) {
+func objectMetadata(obj any) (metav1.Object, bool) {
 	switch tombstone := obj.(type) {
 	case toolscache.DeletedFinalStateUnknown:
 		obj = tombstone.Obj

--- a/controllers/user/pkg/usercount/count.go
+++ b/controllers/user/pkg/usercount/count.go
@@ -92,7 +92,7 @@ func CountQuotaUsersExcluding(
 // objects contain kubeconfigs in status, so full lists are too expensive for
 // admission requests that only need metadata.
 type MetadataReader interface {
-	List(context.Context, metav1.ListOptions) (*metav1.PartialObjectMetadataList, error)
+	List(ctx context.Context, opts metav1.ListOptions) (*metav1.PartialObjectMetadataList, error)
 }
 
 func CountQuotaUsersMetadata(ctx context.Context, reader MetadataReader) (int, error) {

--- a/controllers/user/pkg/usercount/count.go
+++ b/controllers/user/pkg/usercount/count.go
@@ -15,201 +15,161 @@
 package usercount
 
 import (
-	"context"
-	"errors"
-	"fmt"
+	"sync"
 	"sync/atomic"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	toolscache "k8s.io/client-go/tools/cache"
 )
 
-const (
-	UserPhaseActive = "Active"
-)
+// Counter tracks users that are present and not being deleted. It stores only
+// object names so quota checks do not retain or copy User status fields.
+type Counter struct {
+	mu          sync.RWMutex
+	users       map[string]struct{}
+	count       atomic.Int64
+	initialized atomic.Bool
+}
 
+func NewCounter() *Counter {
+	return &Counter{users: make(map[string]struct{})}
+}
+
+func (c *Counter) Initialized() bool {
+	return c != nil && c.initialized.Load()
+}
+
+func (c *Counter) Count() int {
+	if c == nil {
+		return 0
+	}
+	return int(c.count.Load())
+}
+
+func (c *Counter) CountExcluding(name string) int {
+	if c == nil {
+		return 0
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	count := int(c.count.Load())
+	if _, ok := c.users[name]; ok {
+		return count - 1
+	}
+	return count
+}
+
+// Initialize replaces the counter from objects already present in the local
+// informer store. Event handlers can run concurrently with initialization.
+func (c *Counter) Initialize(objects []interface{}) {
+	if c == nil {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.users = make(map[string]struct{}, len(objects))
+	var count int64
+	for _, obj := range objects {
+		metadata, ok := objectMetadata(obj)
+		if !ok || !isQuotaUser(metadata) {
+			continue
+		}
+		c.users[metadata.GetName()] = struct{}{}
+		count++
+	}
+	c.count.Store(count)
+	c.initialized.Store(true)
+}
+
+func (c *Counter) Add(obj interface{}) {
+	metadata, ok := objectMetadata(obj)
+	if !ok {
+		return
+	}
+	c.set(metadata.GetName(), isQuotaUser(metadata))
+}
+
+func (c *Counter) Update(oldObj, newObj interface{}) {
+	oldMetadata, oldOK := objectMetadata(oldObj)
+	newMetadata, newOK := objectMetadata(newObj)
+	if oldOK && newOK && oldMetadata.GetName() != newMetadata.GetName() {
+		c.set(oldMetadata.GetName(), false)
+	}
+	if !newOK {
+		return
+	}
+	c.set(newMetadata.GetName(), isQuotaUser(newMetadata))
+}
+
+func (c *Counter) Delete(obj interface{}) {
+	metadata, ok := objectMetadata(obj)
+	if !ok {
+		return
+	}
+	c.set(metadata.GetName(), false)
+}
+
+func (c *Counter) set(name string, present bool) {
+	if c == nil || name == "" {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.users == nil {
+		c.users = make(map[string]struct{})
+	}
+	if present {
+		if _, ok := c.users[name]; ok {
+			return
+		}
+		c.users[name] = struct{}{}
+		c.count.Add(1)
+		return
+	}
+	if _, ok := c.users[name]; !ok {
+		return
+	}
+	delete(c.users, name)
+	c.count.Add(-1)
+}
+
+func isQuotaUser(obj metav1.Object) bool {
+	return obj.GetName() != "" &&
+		(obj.GetDeletionTimestamp() == nil || obj.GetDeletionTimestamp().IsZero())
+}
+
+func objectMetadata(obj interface{}) (metav1.Object, bool) {
+	switch tombstone := obj.(type) {
+	case toolscache.DeletedFinalStateUnknown:
+		obj = tombstone.Obj
+	case *toolscache.DeletedFinalStateUnknown:
+		obj = tombstone.Obj
+	}
+	metadata, err := meta.Accessor(obj)
+	return metadata, err == nil && metadata != nil
+}
+
+// The following process-local functions are retained for the license
+// controller, which refreshes its own user count independently.
 var (
-	userCount       atomic.Int64
-	initializedFlag atomic.Uint32
+	processUserCount            atomic.Int64
+	processUserCountInitialized atomic.Uint32
 )
 
 func Initialized() bool {
-	return initializedFlag.Load() == 1
+	return processUserCountInitialized.Load() == 1
 }
 
 func Get() int {
-	return int(userCount.Load())
+	return int(processUserCount.Load())
 }
 
 func Set(count int) {
-	userCount.Store(int64(count))
-	initializedFlag.Store(1)
-}
-
-func Init(ctx context.Context, reader client.Reader) error {
-	if Initialized() {
-		return nil
-	}
-	count, err := countActiveUsersUnstructured(ctx, reader, &client.ListOptions{}, "")
-	if err != nil {
-		return fmt.Errorf("failed to count active users: %w", err)
-	}
-	Set(count)
-	return nil
-}
-
-func CountActiveUsers(ctx context.Context, reader client.Reader) (int, error) {
-	active, err := countActiveUsersUnstructured(ctx, reader, &client.ListOptions{}, "")
-	if err != nil {
-		return 0, fmt.Errorf("unable to get active user count: %w", err)
-	}
-	return active, nil
-}
-
-func CountQuotaUsers(ctx context.Context, reader client.Reader) (int, error) {
-	count, err := countQuotaUsersUnstructured(ctx, reader, &client.ListOptions{}, "")
-	if err != nil {
-		return 0, fmt.Errorf("unable to get quota user count: %w", err)
-	}
-	return count, nil
-}
-
-func CountQuotaUsersExcluding(
-	ctx context.Context,
-	reader client.Reader,
-	excludeName string,
-) (int, error) {
-	count, err := countQuotaUsersUnstructured(ctx, reader, &client.ListOptions{}, excludeName)
-	if err != nil {
-		return 0, fmt.Errorf("unable to get quota user count excluding %s: %w", excludeName, err)
-	}
-	return count, nil
-}
-
-// MetadataReader lists resources without fetching their full objects. User
-// objects contain kubeconfigs in status, so full lists are too expensive for
-// admission requests that only need metadata.
-type MetadataReader interface {
-	List(ctx context.Context, opts metav1.ListOptions) (*metav1.PartialObjectMetadataList, error)
-}
-
-func CountQuotaUsersMetadata(ctx context.Context, reader MetadataReader) (int, error) {
-	return CountQuotaUsersMetadataExcluding(ctx, reader, "")
-}
-
-func CountQuotaUsersMetadataExcluding(
-	ctx context.Context,
-	reader MetadataReader,
-	excludeName string,
-) (int, error) {
-	if reader == nil {
-		return 0, errors.New("metadata reader is nil")
-	}
-
-	list, err := reader.List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return 0, fmt.Errorf("failed to list user metadata: %w", err)
-	}
-
-	var count int
-	for _, item := range list.Items {
-		if excludeName != "" && item.Name == excludeName {
-			continue
-		}
-		if item.DeletionTimestamp != nil && !item.DeletionTimestamp.IsZero() {
-			continue
-		}
-		count++
-	}
-
-	return count, nil
-}
-
-func CountActiveUsersExcluding(
-	ctx context.Context,
-	reader client.Reader,
-	excludeName string,
-) (int, error) {
-	active, err := countActiveUsersUnstructured(ctx, reader, &client.ListOptions{}, excludeName)
-	if err != nil {
-		return 0, fmt.Errorf("unable to get active user count excluding %s: %w", excludeName, err)
-	}
-	return active, nil
-}
-
-func countActiveUsersUnstructured(
-	ctx context.Context,
-	reader client.Reader,
-	opts *client.ListOptions,
-	excludeName string,
-) (int, error) {
-	if reader == nil {
-		return 0, errors.New("client reader is nil")
-	}
-
-	list := &unstructured.UnstructuredList{}
-	list.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "user.sealos.io",
-		Version: "v1",
-		Kind:    "UserList",
-	})
-
-	if err := reader.List(ctx, list, opts); err != nil {
-		return 0, fmt.Errorf("failed to list users: %w", err)
-	}
-
-	var activeCount int
-	for _, item := range list.Items {
-		if excludeName != "" && item.GetName() == excludeName {
-			continue
-		}
-		phase, _, _ := unstructured.NestedString(item.Object, "status", "phase")
-		if phase == UserPhaseActive {
-			activeCount++
-		}
-	}
-
-	return activeCount, nil
-}
-
-func countQuotaUsersUnstructured(
-	ctx context.Context,
-	reader client.Reader,
-	opts *client.ListOptions,
-	excludeName string,
-) (int, error) {
-	if reader == nil {
-		return 0, errors.New("client reader is nil")
-	}
-
-	list := &unstructured.UnstructuredList{}
-	list.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "user.sealos.io",
-		Version: "v1",
-		Kind:    "UserList",
-	})
-
-	if err := reader.List(ctx, list, opts); err != nil {
-		return 0, fmt.Errorf("failed to list users: %w", err)
-	}
-
-	var count int
-	for _, item := range list.Items {
-		if excludeName != "" && item.GetName() == excludeName {
-			continue
-		}
-		if deletionTimestamp, found, _ := unstructured.NestedString(
-			item.Object,
-			"metadata",
-			"deletionTimestamp",
-		); found &&
-			deletionTimestamp != "" {
-			continue
-		}
-		count++
-	}
-
-	return count, nil
+	processUserCount.Store(int64(count))
+	processUserCountInitialized.Store(1)
 }

--- a/controllers/user/pkg/usercount/count.go
+++ b/controllers/user/pkg/usercount/count.go
@@ -61,27 +61,12 @@ func (c *Counter) CountExcluding(name string) int {
 	return count
 }
 
-// Initialize replaces the counter from objects already present in the local
-// informer store. Event handlers can run concurrently with initialization.
-func (c *Counter) Initialize(objects []any) {
+// MarkInitialized marks the counter ready after the informer's initial events
+// have been delivered to the counter's event handler.
+func (c *Counter) MarkInitialized() {
 	if c == nil {
 		return
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.users = make(map[string]struct{}, len(objects))
-	var count int64
-	for _, obj := range objects {
-		metadata, ok := objectMetadata(obj)
-		if !ok || !isQuotaUser(metadata) {
-			continue
-		}
-		c.users[metadata.GetName()] = struct{}{}
-		count++
-	}
-	c.count.Store(count)
 	c.initialized.Store(true)
 }
 

--- a/controllers/user/pkg/usercount/count_test.go
+++ b/controllers/user/pkg/usercount/count_test.go
@@ -32,9 +32,13 @@ func TestCounterTracksInformerEvents(t *testing.T) {
 		},
 	}
 
-	counter.Initialize([]interface{}{active})
+	counter.Initialize([]any{active})
 	if !counter.Initialized() || counter.Count() != 1 {
-		t.Fatalf("initialized counter = (%t, %d), want (true, 1)", counter.Initialized(), counter.Count())
+		t.Fatalf(
+			"initialized counter = (%t, %d), want (true, 1)",
+			counter.Initialized(),
+			counter.Count(),
+		)
 	}
 	if got := counter.CountExcluding("active-user"); got != 0 {
 		t.Fatalf("CountExcluding() = %d, want 0", got)
@@ -57,7 +61,7 @@ func TestCounterTracksInformerEvents(t *testing.T) {
 
 func TestCounterIgnoresDeletedFinalStateUnknown(t *testing.T) {
 	counter := NewCounter()
-	counter.Initialize([]interface{}{
+	counter.Initialize([]any{
 		&metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: "user"}},
 	})
 

--- a/controllers/user/pkg/usercount/count_test.go
+++ b/controllers/user/pkg/usercount/count_test.go
@@ -13,7 +13,10 @@ type fakeMetadataReader struct {
 	err  error
 }
 
-func (f fakeMetadataReader) List(context.Context, metav1.ListOptions) (*metav1.PartialObjectMetadataList, error) {
+func (f fakeMetadataReader) List(
+	context.Context,
+	metav1.ListOptions,
+) (*metav1.PartialObjectMetadataList, error) {
 	return f.list, f.err
 }
 
@@ -23,7 +26,12 @@ func TestCountQuotaUsersMetadataExcluding(t *testing.T) {
 		list: &metav1.PartialObjectMetadataList{
 			Items: []metav1.PartialObjectMetadata{
 				{ObjectMeta: metav1.ObjectMeta{Name: "active-user"}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "deleted-user", DeletionTimestamp: &deletionTimestamp}},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "deleted-user",
+						DeletionTimestamp: &deletionTimestamp,
+					},
+				},
 				{ObjectMeta: metav1.ObjectMeta{Name: "excluded-user"}},
 			},
 		},

--- a/controllers/user/pkg/usercount/count_test.go
+++ b/controllers/user/pkg/usercount/count_test.go
@@ -1,0 +1,51 @@
+package usercount
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type fakeMetadataReader struct {
+	list *metav1.PartialObjectMetadataList
+	err  error
+}
+
+func (f fakeMetadataReader) List(context.Context, metav1.ListOptions) (*metav1.PartialObjectMetadataList, error) {
+	return f.list, f.err
+}
+
+func TestCountQuotaUsersMetadataExcluding(t *testing.T) {
+	deletionTimestamp := metav1.Now()
+	reader := fakeMetadataReader{
+		list: &metav1.PartialObjectMetadataList{
+			Items: []metav1.PartialObjectMetadata{
+				{ObjectMeta: metav1.ObjectMeta{Name: "active-user"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "deleted-user", DeletionTimestamp: &deletionTimestamp}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "excluded-user"}},
+			},
+		},
+	}
+
+	count, err := CountQuotaUsersMetadataExcluding(context.Background(), reader, "excluded-user")
+	if err != nil {
+		t.Fatalf("CountQuotaUsersMetadataExcluding() error = %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("CountQuotaUsersMetadataExcluding() = %d, want 1", count)
+	}
+}
+
+func TestCountQuotaUsersMetadataErrors(t *testing.T) {
+	if _, err := CountQuotaUsersMetadata(context.Background(), nil); err == nil {
+		t.Fatal("CountQuotaUsersMetadata() with nil reader returned nil error")
+	}
+
+	wantErr := errors.New("list failed")
+	_, err := CountQuotaUsersMetadata(context.Background(), fakeMetadataReader{err: wantErr})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("CountQuotaUsersMetadata() error = %v, want wrapped %v", err, wantErr)
+	}
+}

--- a/controllers/user/pkg/usercount/count_test.go
+++ b/controllers/user/pkg/usercount/count_test.go
@@ -1,59 +1,71 @@
+// Copyright © 2026 sealos.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package usercount
 
 import (
-	"context"
-	"errors"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	toolscache "k8s.io/client-go/tools/cache"
 )
 
-type fakeMetadataReader struct {
-	list *metav1.PartialObjectMetadataList
-	err  error
-}
-
-func (f fakeMetadataReader) List(
-	context.Context,
-	metav1.ListOptions,
-) (*metav1.PartialObjectMetadataList, error) {
-	return f.list, f.err
-}
-
-func TestCountQuotaUsersMetadataExcluding(t *testing.T) {
+func TestCounterTracksInformerEvents(t *testing.T) {
+	counter := NewCounter()
 	deletionTimestamp := metav1.Now()
-	reader := fakeMetadataReader{
-		list: &metav1.PartialObjectMetadataList{
-			Items: []metav1.PartialObjectMetadata{
-				{ObjectMeta: metav1.ObjectMeta{Name: "active-user"}},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:              "deleted-user",
-						DeletionTimestamp: &deletionTimestamp,
-					},
-				},
-				{ObjectMeta: metav1.ObjectMeta{Name: "excluded-user"}},
-			},
+	active := &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: "active-user"}}
+	deleting := &metav1.PartialObjectMetadata{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "active-user",
+			DeletionTimestamp: &deletionTimestamp,
 		},
 	}
 
-	count, err := CountQuotaUsersMetadataExcluding(context.Background(), reader, "excluded-user")
-	if err != nil {
-		t.Fatalf("CountQuotaUsersMetadataExcluding() error = %v", err)
+	counter.Initialize([]interface{}{active})
+	if !counter.Initialized() || counter.Count() != 1 {
+		t.Fatalf("initialized counter = (%t, %d), want (true, 1)", counter.Initialized(), counter.Count())
 	}
-	if count != 1 {
-		t.Fatalf("CountQuotaUsersMetadataExcluding() = %d, want 1", count)
+	if got := counter.CountExcluding("active-user"); got != 0 {
+		t.Fatalf("CountExcluding() = %d, want 0", got)
+	}
+
+	counter.Update(active, deleting)
+	if got := counter.Count(); got != 0 {
+		t.Fatalf("count after deletion update = %d, want 0", got)
+	}
+
+	counter.Add(&metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: "new-user"}})
+	if got := counter.Count(); got != 1 {
+		t.Fatalf("count after add = %d, want 1", got)
+	}
+	counter.Delete(&metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: "new-user"}})
+	if got := counter.Count(); got != 0 {
+		t.Fatalf("count after delete = %d, want 0", got)
 	}
 }
 
-func TestCountQuotaUsersMetadataErrors(t *testing.T) {
-	if _, err := CountQuotaUsersMetadata(context.Background(), nil); err == nil {
-		t.Fatal("CountQuotaUsersMetadata() with nil reader returned nil error")
-	}
+func TestCounterIgnoresDeletedFinalStateUnknown(t *testing.T) {
+	counter := NewCounter()
+	counter.Initialize([]interface{}{
+		&metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: "user"}},
+	})
 
-	wantErr := errors.New("list failed")
-	_, err := CountQuotaUsersMetadata(context.Background(), fakeMetadataReader{err: wantErr})
-	if !errors.Is(err, wantErr) {
-		t.Fatalf("CountQuotaUsersMetadata() error = %v, want wrapped %v", err, wantErr)
+	counter.Delete(toolscache.DeletedFinalStateUnknown{
+		Key: "user",
+		Obj: &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: "user"}},
+	})
+	if got := counter.Count(); got != 0 {
+		t.Fatalf("count after tombstone delete = %d, want 0", got)
 	}
 }

--- a/controllers/user/pkg/usercount/count_test.go
+++ b/controllers/user/pkg/usercount/count_test.go
@@ -32,7 +32,8 @@ func TestCounterTracksInformerEvents(t *testing.T) {
 		},
 	}
 
-	counter.Initialize([]any{active})
+	counter.Add(active)
+	counter.MarkInitialized()
 	if !counter.Initialized() || counter.Count() != 1 {
 		t.Fatalf(
 			"initialized counter = (%t, %d), want (true, 1)",
@@ -61,9 +62,8 @@ func TestCounterTracksInformerEvents(t *testing.T) {
 
 func TestCounterIgnoresDeletedFinalStateUnknown(t *testing.T) {
 	counter := NewCounter()
-	counter.Initialize([]any{
-		&metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: "user"}},
-	})
+	counter.Add(&metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: "user"}})
+	counter.MarkInitialized()
 
 	counter.Delete(toolscache.DeletedFinalStateUnknown{
 		Key: "user",


### PR DESCRIPTION
## Background

Creating a User invokes the validating webhook. The webhook previously listed full User objects to calculate the user limit. User status can contain kubeconfig data, so the list response becomes very large and can exceed the Kubernetes admission webhook timeout.

## Changes

- Use the Kubernetes metadata client to count Users without fetching spec or status.
- Apply metadata-only counting in the User validating webhook and User reconciler license-limit check.
- Maintain the quota user count from User informer Add/Update/Delete events instead of manually listing all Users at controller startup.
- Wait for the registered informer event handler to sync before marking the counter initialized, ensuring initial Add events are applied before quota checks start.
- Remove the controller startup full User list used only to initialize the legacy count cache.
- Set the User validating webhook timeout to 30 seconds as a short-term fallback.
- Add unit coverage for metadata-based counting, event-driven counter updates, and webhook test setup.

## Risks / Notes

The quota counting behavior remains the same: deleting Users are excluded, and reconciliation excludes the current User. The counter is maintained by the existing informer event stream; no second full User cache or startup list is introduced. The timeout increase is only a fallback; the main fix is avoiding full User object retrieval.

## Verification

- `go test ./pkg/usercount`
- `go build -buildvcs=false ./...`
- `helm lint controllers/user/deploy/charts/user-controller`
- Helm template rendering confirms `vuser.kb.io` uses `timeoutSeconds: 30`.
- Envtest suites could not start in the restricted execution environment because local listener creation was denied.