### PR TITLE
feat(desktop): route GitHub repo deep-links to Brain /deploy like templates

### DIFF
--- a/frontend/desktop/src/pages/oauth.tsx
+++ b/frontend/desktop/src/pages/oauth.tsx
@@ -74,6 +74,8 @@ export default function OAuth() {
       token,
       login,
       openapp,
+      githubRepo,
+      autoDeploy,
       templateName,
       templateForm,
       workspaceUid,
@@ -106,6 +108,28 @@ export default function OAuth() {
         raw: rawQuery
       });
       cancelAutoDeployTemplate();
+      await router.replace(appendMarketingQuery('/', activeMarketingQuery));
+
+      return true;
+    };
+
+    const openBrainGithubDeploy = async (activeMarketingQuery = marketingQuery) => {
+      if (openapp !== 'system-brain' || typeof githubRepo !== 'string') {
+        return false;
+      }
+
+      const brainDeployQuery = new URLSearchParams({
+        githubRepo
+      });
+      if (autoDeploy === '1') {
+        brainDeployQuery.set('autoDeploy', '1');
+      }
+      const rawQuery = mergeMarketingQuery(brainDeployQuery.toString(), activeMarketingQuery);
+
+      setAutoLaunch('system-brain', {
+        pathname: '/deploy',
+        raw: rawQuery
+      });
       await router.replace(appendMarketingQuery('/', activeMarketingQuery));
 
       return true;
@@ -163,7 +187,10 @@ export default function OAuth() {
           }
         }
 
-        if (await openBrainTemplateDeploy(marketingQuery)) {
+        if (
+          (await openBrainGithubDeploy(marketingQuery)) ||
+          (await openBrainTemplateDeploy(marketingQuery))
+        ) {
           return;
         }
 
@@ -414,7 +441,10 @@ export default function OAuth() {
       hasProcessedRef.current = true;
 
       (async () => {
-        if (await openBrainTemplateDeploy(marketingQuery)) {
+        if (
+          (await openBrainGithubDeploy(marketingQuery)) ||
+          (await openBrainTemplateDeploy(marketingQuery))
+        ) {
           return;
         }
 


### PR DESCRIPTION
## Summary

Brain's GitHub one-click deploy (labring/brain#283) needs the same desktop entry point the official template one-click deploy already uses, otherwise `githubRepo`/`autoDeploy` on an `/oauth?login=github&openapp=system-brain&…` link are silently dropped.

This mirrors the existing `openBrainTemplateDeploy` branch (`/oauth?…&templateName=…&templateForm=…` → autolaunch Brain `/deploy`) with a symmetric `openBrainGithubDeploy`:

- `openapp === 'system-brain'` + `githubRepo` (string) → `setAutoLaunch('system-brain', { pathname: '/deploy', raw: 'githubRepo=…&autoDeploy=1' })`
- `autoDeploy` only honored when exactly `'1'` (matches Brain's `githubDeployProjectPath`)
- Wired into **both** paths: token-login (`handleTokenLogin`) and already-logged-in direct visits
- Malformed/repeated params fail closed to normal openapp handling; template flow untouched

Resulting link (after deploy): `…/oauth?login=github&openapp=system-brain&githubRepo=https%3A%2F%2Fgithub.com%2Facme%2Fapi&autoDeploy=1` → Brain `/deploy` → `/project?side=project-creation:githubDirect:<repo>:auto` → GitHub deployer opens pre-filled and auto-deploys once.

## Verification

- `tsc --noEmit` (frontend/desktop): clean
- `next lint --file src/pages/oauth.tsx`: no warnings or errors
- `pnpm test:ci` (vitest unit): 23 files / 123 tests passed