### PR TITLE
fix(dbprovider): flatten reconfigure history parameters

### DIFF
--- a/frontend/providers/dbprovider/__tests__/unit/utils/reconfigureHistory.test.ts
+++ b/frontend/providers/dbprovider/__tests__/unit/utils/reconfigureHistory.test.ts
@@ -40,6 +40,39 @@ test('maps Reconfiguring OpsRequest values for the operation history', () => {
   );
 });
 
+test('maps parameters across every configuration and key', () => {
+  assert.deepEqual(
+    getReconfigureHistoryConfigurations(
+      {
+        metadata: {
+          annotations: {
+            [previousConfigKey]: JSON.stringify({ first: '1', second: '2' })
+          }
+        },
+        spec: {
+          reconfigure: {
+            configurations: [
+              { keys: [{ parameters: [] }] },
+              {
+                keys: [
+                  { parameters: [{ key: 'first', value: '10' }] },
+                  { parameters: [{ key: 'second', value: '20' }] }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      previousConfigKey,
+      '-'
+    ),
+    [
+      { parameterName: 'first', oldValue: '1', newValue: '10' },
+      { parameterName: 'second', oldValue: '2', newValue: '20' }
+    ]
+  );
+});
+
 test('uses the operation history placeholder when the previous value is unavailable', () => {
   assert.deepEqual(
     getReconfigureHistoryConfigurations(

--- a/frontend/providers/dbprovider/__tests__/unit/utils/reconfigureHistory.test.ts
+++ b/frontend/providers/dbprovider/__tests__/unit/utils/reconfigureHistory.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getReconfigureHistoryConfigurations } from '../../../src/utils/reconfigureHistory.ts';
+
+const previousConfigKey = 'cloud.sealos.io/previous-config';
+
+test('maps Reconfiguring OpsRequest values for the operation history', () => {
+  assert.deepEqual(
+    getReconfigureHistoryConfigurations(
+      {
+        metadata: {
+          annotations: {
+            [previousConfigKey]: JSON.stringify({ 'net.maxIncomingConnections': '700' })
+          }
+        },
+        spec: {
+          reconfigure: {
+            configurations: [
+              {
+                keys: [
+                  {
+                    parameters: [{ key: 'net.maxIncomingConnections', value: '900' }]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      previousConfigKey,
+      '-'
+    ),
+    [
+      {
+        parameterName: 'net.maxIncomingConnections',
+        oldValue: '700',
+        newValue: '900'
+      }
+    ]
+  );
+});
+
+test('uses the operation history placeholder when the previous value is unavailable', () => {
+  assert.deepEqual(
+    getReconfigureHistoryConfigurations(
+      {
+        spec: {
+          reconfigure: {
+            configurations: [
+              {
+                keys: [{ parameters: [{ key: 'max_connections', value: '900' }] }]
+              }
+            ]
+          }
+        }
+      },
+      previousConfigKey,
+      '-'
+    ),
+    [{ parameterName: 'max_connections', oldValue: '-', newValue: '900' }]
+  );
+});

--- a/frontend/providers/dbprovider/src/utils/adapt.ts
+++ b/frontend/providers/dbprovider/src/utils/adapt.ts
@@ -39,6 +39,7 @@ import {
   memoryFormatToMi,
   storageFormatToNum
 } from '@/utils/tools';
+import { getReconfigureHistoryConfigurations } from './reconfigureHistory';
 import type { CoreV1EventList, V1Pod } from '@kubernetes/client-node';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
@@ -443,6 +444,10 @@ const getOperationLogConfigurations = (
   item: KubeBlockOpsRequestType,
   dbType: DBType
 ): OpsRequestConfiguration[] => {
+  if (item.spec.type === 'Reconfiguring' && item.spec.reconfigure) {
+    return getReconfigureHistoryConfigurations(item, DBPreviousConfigKey, '-');
+  }
+
   if (simpleOperationTypes.includes(item.spec.type)) {
     return [{ parameterName: item.spec.type, newValue: '-', oldValue: '-' }];
   }
@@ -546,24 +551,6 @@ export const adaptOpsRequest = (
   item: KubeBlockOpsRequestType,
   type: 'Reconfiguring' | 'Switchover'
 ): OpsRequestItemType => {
-  const config = item.metadata.annotations?.[DBPreviousConfigKey];
-
-  let previousConfigurations: {
-    [key: string]: string;
-  } = {};
-
-  if (config) {
-    try {
-      const confObject = JSON.parse(config);
-      Object.entries(confObject).forEach(([key, value]) => {
-        previousConfigurations[key] =
-          typeof value === 'string' ? value.replace(/^['"](.*)['"]$/, '$1') : String(value);
-      });
-    } catch (error) {
-      console.error('Error parsing postgresql.conf annotation:', error);
-    }
-  }
-
   let result: OpsRequestItemType = {
     id: item.metadata.uid,
     name: item.metadata.name,
@@ -576,13 +563,7 @@ export const adaptOpsRequest = (
   };
 
   if (type === 'Reconfiguring') {
-    result.configurations = item.spec.reconfigure!.configurations[0].keys[0].parameters.map(
-      (param) => ({
-        parameterName: param.key,
-        newValue: param.value,
-        oldValue: previousConfigurations[param.key]
-      })
-    );
+    result.configurations = getReconfigureHistoryConfigurations(item, DBPreviousConfigKey);
   }
 
   if (type === 'Switchover') {

--- a/frontend/providers/dbprovider/src/utils/reconfigureHistory.ts
+++ b/frontend/providers/dbprovider/src/utils/reconfigureHistory.ts
@@ -1,0 +1,63 @@
+type ReconfigureParameter = {
+  key: string;
+  value: string;
+};
+
+type ReconfigureOpsRequest = {
+  metadata?: {
+    annotations?: Record<string, string>;
+  };
+  spec?: {
+    reconfigure?: {
+      configurations?: {
+        keys?: {
+          parameters?: ReconfigureParameter[];
+        }[];
+      }[];
+    };
+  };
+};
+
+export type ReconfigureHistoryConfiguration = {
+  parameterName: string;
+  newValue: string;
+  oldValue?: string;
+};
+
+const parsePreviousConfigurations = (annotation?: string) => {
+  if (!annotation) return {};
+
+  try {
+    const configurations = JSON.parse(annotation) as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.entries(configurations).map(([key, value]) => [
+        key,
+        typeof value === 'string' ? value.replace(/^['"](.*)['"]$/, '$1') : String(value)
+      ])
+    );
+  } catch {
+    return {};
+  }
+};
+
+export const getReconfigureHistoryConfigurations = (
+  item: ReconfigureOpsRequest,
+  previousConfigKey: string,
+  missingOldValue?: string
+): ReconfigureHistoryConfiguration[] => {
+  const previousConfigurations = parsePreviousConfigurations(
+    item.metadata?.annotations?.[previousConfigKey]
+  );
+
+  return (
+    item.spec?.reconfigure?.configurations?.[0]?.keys?.[0]?.parameters?.map((param) => ({
+      parameterName: param.key,
+      newValue: param.value,
+      ...(previousConfigurations[param.key] !== undefined
+        ? { oldValue: previousConfigurations[param.key] }
+        : missingOldValue !== undefined
+        ? { oldValue: missingOldValue }
+        : {})
+    })) || []
+  );
+};

--- a/frontend/providers/dbprovider/src/utils/reconfigureHistory.ts
+++ b/frontend/providers/dbprovider/src/utils/reconfigureHistory.ts
@@ -48,16 +48,18 @@ export const getReconfigureHistoryConfigurations = (
   const previousConfigurations = parsePreviousConfigurations(
     item.metadata?.annotations?.[previousConfigKey]
   );
+  const parameters =
+    item.spec?.reconfigure?.configurations?.flatMap(
+      (configuration) => configuration.keys?.flatMap((key) => key.parameters || []) || []
+    ) || [];
 
-  return (
-    item.spec?.reconfigure?.configurations?.[0]?.keys?.[0]?.parameters?.map((param) => ({
-      parameterName: param.key,
-      newValue: param.value,
-      ...(previousConfigurations[param.key] !== undefined
-        ? { oldValue: previousConfigurations[param.key] }
-        : missingOldValue !== undefined
-        ? { oldValue: missingOldValue }
-        : {})
-    })) || []
-  );
+  return parameters.map((param) => ({
+    parameterName: param.key,
+    newValue: param.value,
+    ...(previousConfigurations[param.key] !== undefined
+      ? { oldValue: previousConfigurations[param.key] }
+      : missingOldValue !== undefined
+      ? { oldValue: missingOldValue }
+      : {})
+  }));
 };


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->

## Summary

Fix DBProvider Reconfiguring history extraction so operation logs and history views include parameters from every configuration and key group, including when an earlier group is empty.

## Sequence Diagram

```mermaid
sequenceDiagram
    participant User
    participant DBProvider
    participant Kubernetes
    participant HistoryAdapter

    User->>DBProvider: Open operation log or change history
    DBProvider->>Kubernetes: List Reconfiguring OpsRequests
    Kubernetes-->>DBProvider: Return configuration and key groups
    DBProvider->>HistoryAdapter: Flatten all parameter groups
    HistoryAdapter-->>DBProvider: Map old and new values
    DBProvider-->>User: Render every parameter change
```

## Verification

- `node --experimental-strip-types --test frontend/providers/dbprovider/__tests__/unit/utils/reconfigureHistory.test.ts` (3/3 passed)
- `pnpm --dir frontend/providers/dbprovider typecheck`
- `pnpm --dir frontend/providers/dbprovider lint`
- `pnpm --dir frontend/providers/dbprovider build`
