### PR TITLE
fix(subscription): allow deleted plans to resubscribe

### DIFF
--- a/frontend/providers/costcenter/__tests__/unit/subscription-state.test.ts
+++ b/frontend/providers/costcenter/__tests__/unit/subscription-state.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canRecreateSubscription,
+  getSubscriptionOperator,
+  isSubscriptionExpired
+} from '@/utils/subscription';
+
+const currentPlan = {
+  UpgradePlanList: ['Pro'],
+  DowngradePlanList: ['Free']
+};
+
+describe('subscription state', () => {
+  it.each(['DEBT', 'deleted'])('allows %s subscriptions to be recreated', (status) => {
+    expect(canRecreateSubscription(status)).toBe(true);
+  });
+
+  it('does not recreate a normal subscription', () => {
+    expect(canRecreateSubscription('NORMAL')).toBe(false);
+  });
+
+  it('uses created for a deleted subscription even when the old plan still exists', () => {
+    expect(getSubscriptionOperator('DELETED', currentPlan, 'Starter')).toBe('created');
+  });
+
+  it('keeps normal plan transitions unchanged', () => {
+    expect(getSubscriptionOperator('NORMAL', currentPlan, 'Pro')).toBe('upgraded');
+    expect(getSubscriptionOperator('NORMAL', currentPlan, 'Free')).toBe('downgraded');
+  });
+
+  it('treats deleted subscriptions as expired and not resumable', () => {
+    expect(
+      isSubscriptionExpired({
+        status: 'DELETED',
+        currentPeriodEndAt: '2026-08-25T00:00:00.000Z'
+      })
+    ).toBe(true);
+  });
+});

--- a/frontend/providers/costcenter/src/components/plan/PlanHeader.tsx
+++ b/frontend/providers/costcenter/src/components/plan/PlanHeader.tsx
@@ -9,6 +9,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createSubscriptionPayment } from '@/api/plan';
 import { useCustomToast } from '@/hooks/useCustomToast';
 import { useState } from 'react';
+import { isSubscriptionExpired } from '@/utils/subscription';
 
 export function getPlanBackgroundClass(planName: string, isPayg: boolean, inDebt: boolean): string {
   if (inDebt) return 'bg-plan-debt';
@@ -61,6 +62,13 @@ export function PlanHeader({ children, onRenewSuccess }: PlanHeaderProps) {
   const isCancelled = !!subscription?.CancelAtPeriodEnd && !isFreePlan;
   const stateLower = subscription?.Status?.toLowerCase?.() || '';
   const isNormal = stateLower === 'normal';
+  const subscriptionExpired = subscription
+    ? isSubscriptionExpired({
+        status: subscription.Status,
+        currentPeriodEndAt: subscription.CurrentPeriodEndAt
+      })
+    : false;
+  const canResume = isCancelled && !subscriptionExpired;
   const [cancelModalOpen, setCancelModalOpen] = useState(false);
 
   const cancelPlanMutation = useMutation({
@@ -248,21 +256,19 @@ export function PlanHeader({ children, onRenewSuccess }: PlanHeaderProps) {
                     <span>{isCancelled ? t('common:cancelled') : t('common:cancel_plan')}</span>
                   </Button>
                 )}
-                {isCancelled && (
+                {canResume && (
                   <Button
                     size="lg"
                     disabled={resumePlanMutation.isLoading || !canManagePayment}
                     onClick={() => {
                       if (!subscription) return;
 
-                      const statusLower = subscription.Status?.toLowerCase?.() || '';
-                      const isDeleted = statusLower === 'deleted';
-                      const periodEndMs = subscription.CurrentPeriodEndAt
-                        ? new Date(subscription.CurrentPeriodEndAt).getTime()
-                        : 0;
-                      const isExpired = !periodEndMs || periodEndMs <= Date.now();
-
-                      if (isDeleted || isExpired) {
+                      if (
+                        isSubscriptionExpired({
+                          status: subscription.Status,
+                          currentPeriodEndAt: subscription.CurrentPeriodEndAt
+                        })
+                      ) {
                         toast({
                           title: t('common:resume_plan_expired_title'),
                           description: t('common:resume_plan_expired_desc'),
@@ -292,12 +298,18 @@ export function PlanHeader({ children, onRenewSuccess }: PlanHeaderProps) {
 
                 {/* Keep UpgradePlanDialog mounted even when cancelled, so message-driven open works */}
                 {children?.({
-                  trigger: isCancelled ? (
+                  trigger: canResume ? (
                     <span className="hidden" />
                   ) : (
                     <Button size="lg" disabled={!canManagePayment}>
                       <Sparkles />
-                      <span>{inDebt ? t('common:renew') : t('common:upgrade_plan')}</span>
+                      <span>
+                        {subscriptionExpired
+                          ? t('common:subscribe_plan')
+                          : inDebt
+                          ? t('common:renew')
+                          : t('common:upgrade_plan')}
+                      </span>
                     </Button>
                   )
                 })}

--- a/frontend/providers/costcenter/src/components/plan/UpgradePlanCard.tsx
+++ b/frontend/providers/costcenter/src/components/plan/UpgradePlanCard.tsx
@@ -6,6 +6,7 @@ import usePlanStore from '@/stores/plan';
 import { formatMoney, formatTrafficAuto } from '@/utils/format';
 import { useTranslation } from 'next-i18next';
 import CurrencySymbol from '../CurrencySymbol';
+import { canRecreateSubscription, getSubscriptionOperator } from '@/utils/subscription';
 
 interface UpgradePlanCardProps {
   plan: SubscriptionPlan;
@@ -39,6 +40,7 @@ export function UpgradePlanCard({
   const lastTransaction = lastTransactionData?.transaction;
   const currentPlan = getCurrentPlan() || undefined;
   const inDebt = subscription?.Status?.toLowerCase() === 'debt';
+  const canRecreate = canRecreateSubscription(subscription?.Status);
   const isCurrentPlan = !isCreateMode && plan.Name === subscription?.PlanName;
   const isNextPlan =
     !isCreateMode &&
@@ -61,22 +63,12 @@ export function UpgradePlanCard({
 
   const actionType = getActionType();
 
-  // Get operator for upgrade amount calculation
-  const getOperator = () => {
-    // If in debt state, always use 'created' operation
-    if (inDebt) return 'created';
-    if (!currentPlan) return 'created';
-    if (currentPlan.UpgradePlanList?.includes(plan.Name)) return 'upgraded';
-    if (currentPlan.DowngradePlanList?.includes(plan.Name)) return 'downgraded';
-    return 'upgraded';
-  };
-
   const handleSubscribeClick = () => {
-    // If in debt state, allow clicking on current plan (for renew)
-    if (!inDebt && (isCurrentPlan || isNextPlan || actionType === 'contact')) {
+    // Inactive subscriptions can select their previous plan again.
+    if (!canRecreate && (isCurrentPlan || isNextPlan || actionType === 'contact')) {
       return;
     }
-    const operator = getOperator();
+    const operator = getSubscriptionOperator(subscription?.Status, currentPlan, plan.Name);
     // Determine business operation for UI display
     let businessOperation: 'create' | 'upgrade' | 'downgrade' | 'renew' | undefined;
     if (inDebt) {
@@ -123,7 +115,8 @@ export function UpgradePlanCard({
     // If in debt state and is current plan, show Renew button
     if (inDebt && isCurrentPlan) return t('common:renew');
 
-    if (!inDebt && isCurrentPlan) return t('common:your_current_plan');
+    if (canRecreate && isCurrentPlan) return t('common:subscribe');
+    if (!canRecreate && isCurrentPlan) return t('common:your_current_plan');
     if (isNextPlan) return t('common:your_next_plan');
     if (isLoading) return t('common:processing');
 
@@ -180,15 +173,15 @@ export function UpgradePlanCard({
             className={cn(
               'w-full mb-6 font-medium',
               // If in debt state and is current plan, show enabled button
-              inDebt && isCurrentPlan
+              canRecreate && isCurrentPlan
                 ? 'bg-gray-900 text-white hover:bg-gray-800'
-                : !inDebt && (isCurrentPlan || isNextPlan)
+                : !canRecreate && (isCurrentPlan || isNextPlan)
                 ? 'bg-gray-200 text-gray-600 cursor-not-allowed hover:bg-gray-200'
                 : actionType === 'contact'
                 ? 'bg-blue-600 text-white hover:bg-blue-700'
                 : 'bg-gray-900 text-white hover:bg-gray-800'
             )}
-            disabled={(!inDebt && (isCurrentPlan || isNextPlan)) || isLoading}
+            disabled={(!canRecreate && (isCurrentPlan || isNextPlan)) || isLoading}
             onClick={handleSubscribeClick}
           >
             {getButtonText()}

--- a/frontend/providers/costcenter/src/components/plan/UpgradePlanDialogActions.tsx
+++ b/frontend/providers/costcenter/src/components/plan/UpgradePlanDialogActions.tsx
@@ -3,6 +3,7 @@ import { Checkbox } from '@sealos/shadcn-ui';
 import { SubscriptionPlan } from '@/types/plan';
 import usePlanStore from '@/stores/plan';
 import { useTranslation } from 'next-i18next';
+import { canRecreateSubscription, getSubscriptionOperator } from '@/utils/subscription';
 
 interface UpgradePlanDialogActionsProps {
   isCreateMode?: boolean;
@@ -169,21 +170,14 @@ export function UpgradeButton({
 
   const subscription = subscriptionData?.subscription;
   const inDebt = subscription?.Status?.toLowerCase() === 'debt';
+  const canRecreate = canRecreateSubscription(subscription?.Status);
 
   const handleUpgradeClick = () => {
     if (onUpgradeClick) {
       onUpgradeClick(plan);
     } else {
       // Fallback to default behavior
-      const getOperator = () => {
-        // If in debt state, always use 'created' operation
-        if (inDebt) return 'created';
-        if (!currentPlanObj) return 'created';
-        if (currentPlanObj.UpgradePlanList?.includes(plan.Name)) return 'upgraded';
-        if (currentPlanObj.DowngradePlanList?.includes(plan.Name)) return 'downgraded';
-        return 'upgraded';
-      };
-      const operator = getOperator();
+      const operator = getSubscriptionOperator(subscription?.Status, currentPlanObj, plan.Name);
       // Determine business operation for UI display
       let businessOperation: 'create' | 'upgrade' | 'downgrade' | 'renew' | undefined;
       if (inDebt) {
@@ -229,6 +223,7 @@ export function UpgradeButton({
 
   const getButtonText = () => {
     if (isSubscribing) return t('common:processing');
+    if (canRecreate && isCurrentPlan) return t('common:subscribe');
     if (isCurrentPlan) return t('common:your_current_plan');
     if (isNextPlan) return t('common:your_next_plan');
 
@@ -244,7 +239,7 @@ export function UpgradeButton({
 
   return (
     <Button
-      disabled={!selectedPlan || isSubscribing || isCurrentPlan || isNextPlan}
+      disabled={!selectedPlan || isSubscribing || (!canRecreate && (isCurrentPlan || isNextPlan))}
       onClick={handleUpgradeClick}
     >
       {getButtonText()}

--- a/frontend/providers/costcenter/src/pages/plan/index.tsx
+++ b/frontend/providers/costcenter/src/pages/plan/index.tsx
@@ -36,6 +36,7 @@ import { Skeleton } from '@sealos/shadcn-ui';
 import { UpgradePlanDialog } from '@/components/plan/UpgradePlanDialog';
 import { gtmSubscribeCheckout, gtmSubscribeSuccess } from '@/utils/gtm';
 import { openInNewWindow } from '@/utils/windowUtils';
+import { getSubscriptionOperator } from '@/utils/subscription';
 
 export default function Plan() {
   const router = useRouter();
@@ -594,17 +595,11 @@ export default function Plan() {
     const currentPlanObj = plansData?.plans?.find(
       (p) => p.Name === subscriptionData?.subscription?.PlanName
     );
-    const inDebt = subscriptionData?.subscription?.Status?.toLowerCase() === 'debt';
-    const getOperator = () => {
-      // If in debt state, always use 'created' operation
-      if (inDebt) return 'created';
-      if (!currentPlanObj) return 'created';
-      if (currentPlanObj.UpgradePlanList?.includes(plan.Name)) return 'upgraded';
-      if (currentPlanObj.DowngradePlanList?.includes(plan.Name)) return 'downgraded';
-      return 'upgraded';
-    };
-
-    const operator = getOperator();
+    const operator = getSubscriptionOperator(
+      subscriptionData?.subscription?.Status,
+      currentPlanObj,
+      plan.Name
+    );
     const subscriptionType: 'new' | 'upgrade' | 'downgrade' =
       operator === 'created' ? 'new' : operator === 'downgraded' ? 'downgrade' : 'upgrade';
 

--- a/frontend/providers/costcenter/src/utils/subscription.ts
+++ b/frontend/providers/costcenter/src/utils/subscription.ts
@@ -1,0 +1,38 @@
+type PlanTransition = {
+  UpgradePlanList?: string[] | null;
+  DowngradePlanList?: string[] | null;
+};
+
+type SubscriptionPeriod = {
+  status?: string;
+  currentPeriodEndAt?: string;
+};
+
+export type SubscriptionOperator = 'created' | 'upgraded' | 'downgraded';
+
+const normalizeStatus = (status?: string) => status?.toLowerCase() || '';
+
+export const canRecreateSubscription = (status?: string) => {
+  const normalizedStatus = normalizeStatus(status);
+  return normalizedStatus === 'debt' || normalizedStatus === 'deleted';
+};
+
+export const isSubscriptionExpired = (subscription: SubscriptionPeriod, now = Date.now()) => {
+  if (normalizeStatus(subscription.status) === 'deleted') return true;
+
+  const periodEnd = subscription.currentPeriodEndAt
+    ? new Date(subscription.currentPeriodEndAt).getTime()
+    : 0;
+  return !periodEnd || periodEnd <= now;
+};
+
+export const getSubscriptionOperator = (
+  status: string | undefined,
+  currentPlan: PlanTransition | undefined,
+  targetPlanName: string
+): SubscriptionOperator => {
+  if (canRecreateSubscription(status) || !currentPlan) return 'created';
+  if (currentPlan.UpgradePlanList?.includes(targetPlanName)) return 'upgraded';
+  if (currentPlan.DowngradePlanList?.includes(targetPlanName)) return 'downgraded';
+  return 'upgraded';
+};

--- a/service/account/api/workspace_subscription.go
+++ b/service/account/api/workspace_subscription.go
@@ -1217,8 +1217,7 @@ func CreateWorkspaceSubscriptionPay(c *gin.Context) {
 		req.Operator != types.SubscriptionTransactionTypeRenewed &&
 		req.Operator != types.SubscriptionTransactionTypeResumed &&
 		req.Operator != types.SubscriptionTransactionTypeCanceled &&
-		currentSubscription.Status != types.SubscriptionStatusDebt &&
-		currentSubscription.Status != types.SubscriptionStatusDeleted {
+		!canRecreateWorkspaceSubscription(currentSubscription.Status) {
 		SetErrorResp(c, http.StatusBadRequest, gin.H{"error": "plan name is same as current plan"})
 		return
 	}
@@ -1304,13 +1303,13 @@ func CreateWorkspaceSubscriptionPay(c *gin.Context) {
 		// No additional validation needed for creation
 		if currentSubscription != nil &&
 			currentSubscription.PlanName != types.FreeSubscriptionPlanName {
-			// Allow re-creation for overdue subscriptions
-			if currentSubscription.Status == types.SubscriptionStatusDebt {
-				// Overdue status allowed, will cancel old subscription in payment flow
+			// Allow re-creation for inactive subscriptions
+			if canRecreateWorkspaceSubscription(currentSubscription.Status) {
 				logrus.Infof(
-					"Allowing subscription creation for overdue workspace %s/%s, will cancel old subscription",
+					"Allowing subscription creation for inactive workspace %s/%s with status %s",
 					req.Workspace,
 					req.RegionDomain,
+					currentSubscription.Status,
 				)
 			} else {
 				// Normal active subscription, reject creation
@@ -1450,8 +1449,7 @@ func CreateWorkspaceSubscriptionPay(c *gin.Context) {
 			return
 		}
 		now := time.Now().UTC()
-		if currentSubscription.Status == types.SubscriptionStatusDeleted ||
-			!currentSubscription.CurrentPeriodEndAt.After(now) {
+		if isWorkspaceSubscriptionExpired(currentSubscription, now) {
 			SetErrorResp(
 				c,
 				http.StatusBadRequest,
@@ -1479,6 +1477,19 @@ func CreateWorkspaceSubscriptionPay(c *gin.Context) {
 }
 
 // Helper functions for workspace subscription payment logic
+
+func canRecreateWorkspaceSubscription(status types.SubscriptionStatus) bool {
+	return status == types.SubscriptionStatusDebt ||
+		status == types.SubscriptionStatusDeleted
+}
+
+func isWorkspaceSubscriptionExpired(
+	subscription *types.WorkspaceSubscription,
+	now time.Time,
+) bool {
+	return subscription.Status == types.SubscriptionStatusDeleted ||
+		!subscription.CurrentPeriodEndAt.After(now)
+}
 
 var ErrSamePendingOperation = errors.New("same pending operation exists")
 

--- a/service/account/api/workspace_subscription_pay_test.go
+++ b/service/account/api/workspace_subscription_pay_test.go
@@ -6,11 +6,56 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/labring/sealos/controllers/pkg/types"
 	"github.com/labring/sealos/service/account/helper"
 )
+
+func TestCanRecreateWorkspaceSubscription(t *testing.T) {
+	tests := []struct {
+		name   string
+		status types.SubscriptionStatus
+		want   bool
+	}{
+		{
+			name:   "debt subscription",
+			status: types.SubscriptionStatusDebt,
+			want:   true,
+		},
+		{
+			name:   "deleted subscription",
+			status: types.SubscriptionStatusDeleted,
+			want:   true,
+		},
+		{
+			name:   "normal subscription",
+			status: types.SubscriptionStatusNormal,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := canRecreateWorkspaceSubscription(tt.status); got != tt.want {
+				t.Fatalf("canRecreateWorkspaceSubscription(%q) = %v, want %v", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeletedWorkspaceSubscriptionIsExpired(t *testing.T) {
+	now := time.Date(2026, time.August, 24, 0, 0, 0, 0, time.UTC)
+	subscription := &types.WorkspaceSubscription{
+		Status:             types.SubscriptionStatusDeleted,
+		CurrentPeriodEndAt: now.Add(24 * time.Hour),
+	}
+
+	if !isWorkspaceSubscriptionExpired(subscription, now) {
+		t.Fatal("expected a deleted subscription to be ineligible for resume")
+	}
+}
 
 func TestParseWorkspaceSubscriptionPayReqRejectsInvalidPayApp(t *testing.T) {
 	gin.SetMode(gin.TestMode)


### PR DESCRIPTION
## Summary

- treat `DELETED` subscriptions as recreatable in the account service instead of rejecting them as active
- route expired CostCenter subscriptions to the resubscribe flow with the `created` operator
- keep canceled subscriptions resumable only before their current period expires
- add backend and frontend regression coverage for deleted, debt, and normal states

## Testing

- `go test ./api -run "TestCanRecreateWorkspaceSubscription|TestDeletedWorkspaceSubscriptionIsExpired|TestParseWorkspaceSubscriptionPayReqRejectsInvalidPayApp|TestSamePendingWorkspaceSubscriptionRequestIncludesPayApp" -count=1`
- `pnpm --filter costcenter test:ci` (23 tests passed)
- `pnpm --filter costcenter lint` (passed with existing warnings)

## Local baseline limitations

- full `go test ./api` requires configured database clients and currently panics in the existing credits tests when they are absent
- `pnpm --filter costcenter exec tsc --noEmit` is blocked by the existing mock typing error in `refetch-after-payment.test.ts`