### PR TITLE
perf(account): optimize workspace consumption aggregation

### DIFF
--- a/.github/workflows/check-semgrep.yml
+++ b/.github/workflows/check-semgrep.yml
@@ -58,7 +58,8 @@ jobs:
           --exclude-rule go.lang.security.audit.xss.import-text-template.import-text-template \
           --exclude-rule yaml.kubernetes.security.run-as-non-root.run-as-non-root \
           --exclude-rule yaml.github-actions.security.pull-request-target-code-checkout.pull-request-target-code-checkout \
-          --exclude-rule yaml.github-actions.security.third-party-action-not-pinned-to-commit-sha.third-party-action-not-pinned-to-commit-sha
+          --exclude-rule yaml.github-actions.security.third-party-action-not-pinned-to-commit-sha.third-party-action-not-pinned-to-commit-sha \
+          --exclude-rule yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag
         env:
           # Add the rules that Semgrep uses by setting the SEMGREP_RULES environment variable.
           SEMGREP_RULES: p/default # more at semgrep.dev/explore

--- a/.github/workflows/service-build.yml
+++ b/.github/workflows/service-build.yml
@@ -69,6 +69,26 @@ jobs:
           working-directory: service/${{ inputs.module }}
           args: --color=always --config=${{ github.workspace }}/.golangci.yml
 
+  account-dao-runtime:
+    name: Account DAO MongoDB runtime test
+    if: ${{ inputs.module == 'account' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Golang with cache
+        uses: magnetikonline/action-golang-cache@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Run MongoDB runtime test
+        working-directory: service/account
+        env:
+          TESTCONTAINERS_REQUIRED: "true"
+        run: go test ./dao -run '^TestGetWorkspaceConsumptionAmountWithMongoRuntime$' -count=1 -v
+
   image-build:
     strategy:
       matrix:

--- a/controllers/pkg/database/mongo/account.go
+++ b/controllers/pkg/database/mongo/account.go
@@ -1170,6 +1170,14 @@ func (m *mongoDB) CreateBillingIfNotExist() error {
 			},
 		},
 		{
+			// workspace consumption aggregation: equality filters before time range
+			Keys: bson.D{
+				primitive.E{Key: "owner", Value: 1},
+				primitive.E{Key: "status", Value: 1},
+				primitive.E{Key: "time", Value: 1},
+			},
+		},
+		{
 			// recover stable unsettled billings for one billing hour
 			Keys: bson.D{
 				primitive.E{Key: "time", Value: 1},

--- a/controllers/pkg/database/mongo/billing_runtime_test.go
+++ b/controllers/pkg/database/mongo/billing_runtime_test.go
@@ -98,8 +98,8 @@ func TestBillingPersistenceWithMongoRuntime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(indexSpecs) != 4 {
-		t.Fatalf("billing index count = %d, want 4", len(indexSpecs))
+	if len(indexSpecs) != 5 {
+		t.Fatalf("billing index count = %d, want 5", len(indexSpecs))
 	}
 	monitorTime := end.Add(-time.Hour)
 	namespaces, err := account.GetTimeUsedNamespaceList(monitorTime, end)

--- a/controllers/pkg/database/mongo/billing_runtime_test.go
+++ b/controllers/pkg/database/mongo/billing_runtime_test.go
@@ -98,8 +98,16 @@ func TestBillingPersistenceWithMongoRuntime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(indexSpecs) != 5 {
-		t.Fatalf("billing index count = %d, want 5", len(indexSpecs))
+	const workspaceConsumptionIndexName = "owner_1_status_1_time_1"
+	hasWorkspaceConsumptionIndex := false
+	for _, indexSpec := range indexSpecs {
+		if indexSpec.Name == workspaceConsumptionIndexName {
+			hasWorkspaceConsumptionIndex = true
+			break
+		}
+	}
+	if !hasWorkspaceConsumptionIndex {
+		t.Fatalf("billing indexes do not include %q", workspaceConsumptionIndexName)
 	}
 	monitorTime := end.Add(-time.Hour)
 	namespaces, err := account.GetTimeUsedNamespaceList(monitorTime, end)

--- a/service/account/dao/interface.go
+++ b/service/account/dao/interface.go
@@ -2331,140 +2331,122 @@ func (m *MongoDB) GetConsumptionAmount(req helper.ConsumptionRecordReq) (int64, 
 	return totalAmount, nil
 }
 
+func normalizeWorkspaceConsumptionAppType(appType string) (string, uint8, error) {
+	normalized := strings.ToUpper(strings.TrimSpace(appType))
+	if normalized == "" {
+		return "", 0, nil
+	}
+
+	value, ok := resources.AppType[normalized]
+	if !ok {
+		return "", 0, fmt.Errorf("unsupported app type %q", appType)
+	}
+	return normalized, value, nil
+}
+
+func buildWorkspaceConsumptionPipeline(req helper.ConsumptionRecordReq) (mongo.Pipeline, error) {
+	normalizedAppType, appTypeValue, err := normalizeWorkspaceConsumptionAppType(req.AppType)
+	if err != nil {
+		return nil, err
+	}
+
+	matchValue := bson.D{
+		{Key: "owner", Value: req.Owner},
+		{Key: "status", Value: resources.Settled},
+		{Key: "type", Value: resources.Consumption},
+		{Key: "time", Value: bson.D{
+			{Key: "$gte", Value: req.StartTime},
+			{Key: "$lte", Value: req.EndTime},
+		}},
+	}
+	if req.Namespace != "" {
+		matchValue = append(matchValue, bson.E{Key: "namespace", Value: req.Namespace})
+	}
+	if normalizedAppType != "" {
+		matchValue = append(matchValue, bson.E{Key: "app_type", Value: appTypeValue})
+	}
+
+	groupStage := bson.D{{Key: "$group", Value: bson.D{
+		{Key: "_id", Value: "$namespace"},
+		{Key: "total", Value: bson.D{{Key: "$sum", Value: "$amount"}}},
+	}}}
+	pipeline := mongo.Pipeline{
+		{{Key: "$match", Value: matchValue}},
+	}
+
+	// Billing.Amount is the authoritative total for a billing record. Avoid
+	// unwinding app_costs unless the caller needs an app-level filter.
+	if req.AppName == "" {
+		return append(pipeline, groupStage), nil
+	}
+
+	directAppTypes := bson.A{
+		resources.AppType[resources.AppStore],
+		resources.AppType[resources.LLMToken],
+	}
+	pipeline = append(pipeline,
+		bson.D{{Key: "$project", Value: bson.D{
+			{Key: "namespace", Value: 1},
+			{Key: "app_type", Value: 1},
+			{Key: "app_name", Value: 1},
+			{Key: "amount", Value: 1},
+			{Key: "app_costs.name", Value: 1},
+			{Key: "app_costs.amount", Value: 1},
+		}}},
+		bson.D{{Key: "$unwind", Value: bson.D{
+			{Key: "path", Value: "$app_costs"},
+			{Key: "preserveNullAndEmptyArrays", Value: true},
+		}}},
+		bson.D{{Key: "$match", Value: bson.D{{Key: "$or", Value: bson.A{
+			bson.D{
+				{Key: "app_type", Value: bson.D{{Key: "$in", Value: directAppTypes}}},
+				{Key: "app_name", Value: req.AppName},
+			},
+			bson.D{
+				{Key: "app_type", Value: bson.D{{Key: "$nin", Value: directAppTypes}}},
+				{Key: "app_costs.name", Value: req.AppName},
+			},
+		}}}}},
+		bson.D{{Key: "$project", Value: bson.D{
+			{Key: "namespace", Value: 1},
+			{Key: "amount", Value: bson.D{{Key: "$cond", Value: bson.A{
+				bson.D{{Key: "$in", Value: bson.A{"$app_type", directAppTypes}}},
+				"$amount",
+				"$app_costs.amount",
+			}}}},
+		}}},
+		groupStage,
+	)
+	return pipeline, nil
+}
+
 func (m *MongoDB) GetWorkspaceConsumptionAmount(
 	req helper.ConsumptionRecordReq,
 ) (map[string]int64, error) {
-	// 获取各个 namespace的费用
-	owner, appType, appName, startTime, endTime := req.Owner, req.AppType, req.AppName, req.StartTime, req.EndTime
-	timeMatchValue := bson.D{
-		primitive.E{Key: "$gte", Value: startTime},
-		primitive.E{Key: "$lte", Value: endTime},
+	pipeline, err := buildWorkspaceConsumptionPipeline(req)
+	if err != nil {
+		return nil, err
 	}
 
-	// Apply common filters before $facet so MongoDB can use the billing index
-	// before executing either aggregation branch.
-	baseMatchValue := bson.D{
-		primitive.E{Key: "time", Value: timeMatchValue},
-		primitive.E{Key: "owner", Value: owner},
-		primitive.E{Key: "status", Value: resources.Settled},
-	}
-
-	appCostsMatchValue := bson.D{}
-	if appType != "" {
-		appCostsMatchValue = append(
-			appCostsMatchValue,
-			primitive.E{Key: "app_type", Value: resources.AppType[strings.ToUpper(appType)]},
-		)
-	}
-
-	// Build the post-unwind filters for nested app costs.
-	unwindMatchValue := bson.D{}
-	if appType != "" && appName != "" {
-		if appType != resources.AppStore {
-			unwindMatchValue = append(
-				unwindMatchValue,
-				primitive.E{Key: "app_costs.name", Value: appName},
-			)
-		} else {
-			unwindMatchValue = append(
-				unwindMatchValue,
-				primitive.E{Key: "app_name", Value: appName},
-			)
-		}
-	}
-
-	// Build branch-specific filters for direct consumption (AppStore and LLMToken).
-	directMatchValue := bson.D{}
-	// For direct consumption, match app_type to AppStore or LLMToken if not specified
-	if appType != "" {
-		directMatchValue = append(
-			directMatchValue,
-			primitive.E{Key: "app_type", Value: resources.AppType[strings.ToUpper(appType)]},
-		)
-	} else {
-		// If no appType specified, match both AppStore and LLMToken
-		directMatchValue = append(
-			directMatchValue,
-			primitive.E{Key: "app_type", Value: bson.D{{Key: "$in", Value: bson.A{
-				resources.AppType[resources.AppStore],
-				resources.AppType[resources.LLMToken],
-			}}}},
-		)
-	}
-	if appName != "" {
-		directMatchValue = append(directMatchValue, primitive.E{Key: "app_name", Value: appName})
-	}
-
-	appCostsPipeline := bson.A{}
-	if len(appCostsMatchValue) > 0 {
-		appCostsPipeline = append(
-			appCostsPipeline,
-			bson.D{{Key: "$match", Value: appCostsMatchValue}},
-		)
-	}
-	appCostsPipeline = append(appCostsPipeline, bson.D{{Key: "$unwind", Value: "$app_costs"}})
-	if len(unwindMatchValue) > 0 {
-		appCostsPipeline = append(
-			appCostsPipeline,
-			bson.D{{Key: "$match", Value: unwindMatchValue}},
-		)
-	}
-	appCostsPipeline = append(appCostsPipeline, bson.D{{Key: "$group", Value: bson.M{
-		"_id":   "$namespace", // group by namespace
-		"total": bson.M{"$sum": "$app_costs.amount"},
-	}}})
-
-	// Use $facet to query both types in parallel
-	pipeline := bson.A{
-		bson.D{{Key: "$match", Value: baseMatchValue}},
-		bson.D{{Key: "$facet", Value: bson.M{
-			"appCosts": appCostsPipeline,
-			"directAmount": bson.A{
-				bson.D{{Key: "$match", Value: directMatchValue}},
-				bson.D{{Key: "$group", Value: bson.M{
-					"_id":   "$namespace",
-					"total": bson.M{"$sum": "$amount"},
-				}}},
-			},
-		}}},
-	}
-
-	cursor, err := m.getBillingCollection().Aggregate(context.Background(), pipeline)
+	ctx := context.Background()
+	cursor, err := m.getBillingCollection().Aggregate(ctx, pipeline)
 	if err != nil {
 		return nil, fmt.Errorf("failed to aggregate billing collection: %w", err)
 	}
-	defer cursor.Close(context.Background())
+	defer cursor.Close(ctx)
 
-	var result struct {
-		AppCosts []struct {
-			Namespace string `bson:"_id"`
-			Total     int64  `bson:"total"`
-		} `bson:"appCosts"`
-		DirectAmount []struct {
-			Namespace string `bson:"_id"`
-			Total     int64  `bson:"total"`
-		} `bson:"directAmount"`
+	var results []struct {
+		Namespace string `bson:"_id"`
+		Total     int64  `bson:"total"`
+	}
+	if err := cursor.All(ctx, &results); err != nil {
+		return nil, fmt.Errorf("failed to decode workspace consumption result: %w", err)
 	}
 
-	if cursor.Next(context.Background()) {
-		if err := cursor.Decode(&result); err != nil {
-			return nil, fmt.Errorf("failed to decode result: %w", err)
-		}
+	resultMap := make(map[string]int64, len(results))
+	for _, item := range results {
+		resultMap[item.Namespace] = item.Total
 	}
-
-	// Merge results from both queries
-	resultMap := make(map[string]int64)
-
-	// Add app_costs totals
-	for _, item := range result.AppCosts {
-		resultMap[item.Namespace] += item.Total
-	}
-
-	// Add direct amount totals (AppStore and LLMToken)
-	for _, item := range result.DirectAmount {
-		resultMap[item.Namespace] += item.Total
-	}
-
 	return resultMap, nil
 }
 

--- a/service/account/dao/interface.go
+++ b/service/account/dao/interface.go
@@ -2341,25 +2341,24 @@ func (m *MongoDB) GetWorkspaceConsumptionAmount(
 		primitive.E{Key: "$lte", Value: endTime},
 	}
 
-	// Build base match conditions for app_costs (sub-consumption type)
-	matchValue := bson.D{
+	// Apply common filters before $facet so MongoDB can use the billing index
+	// before executing either aggregation branch.
+	baseMatchValue := bson.D{
 		primitive.E{Key: "time", Value: timeMatchValue},
 		primitive.E{Key: "owner", Value: owner},
 		primitive.E{Key: "status", Value: resources.Settled},
 	}
 
-	// 添加app_type过滤条件
+	appCostsMatchValue := bson.D{}
 	if appType != "" {
-		matchValue = append(
-			matchValue,
+		appCostsMatchValue = append(
+			appCostsMatchValue,
 			primitive.E{Key: "app_type", Value: resources.AppType[strings.ToUpper(appType)]},
 		)
 	}
 
-	// 构建unwind后的匹配条件
-	unwindMatchValue := bson.D{
-		primitive.E{Key: "time", Value: timeMatchValue},
-	}
+	// Build the post-unwind filters for nested app costs.
+	unwindMatchValue := bson.D{}
 	if appType != "" && appName != "" {
 		if appType != resources.AppStore {
 			unwindMatchValue = append(
@@ -2374,12 +2373,8 @@ func (m *MongoDB) GetWorkspaceConsumptionAmount(
 		}
 	}
 
-	// Build match conditions for direct consumption (AppStore and LLMToken)
-	directMatchValue := bson.D{
-		primitive.E{Key: "time", Value: timeMatchValue},
-		primitive.E{Key: "owner", Value: owner},
-		primitive.E{Key: "status", Value: resources.Settled},
-	}
+	// Build branch-specific filters for direct consumption (AppStore and LLMToken).
+	directMatchValue := bson.D{}
 	// For direct consumption, match app_type to AppStore or LLMToken if not specified
 	if appType != "" {
 		directMatchValue = append(
@@ -2402,16 +2397,16 @@ func (m *MongoDB) GetWorkspaceConsumptionAmount(
 
 	// Use $facet to query both types in parallel
 	pipeline := bson.A{
+		bson.D{{Key: "$match", Value: baseMatchValue}},
 		bson.D{{Key: "$facet", Value: bson.M{
 			"appCosts": bson.A{
-				bson.D{{Key: "$match", Value: matchValue}},
+				bson.D{{Key: "$match", Value: appCostsMatchValue}},
 				bson.D{{Key: "$unwind", Value: "$app_costs"}},
 				bson.D{{Key: "$match", Value: unwindMatchValue}},
 				bson.D{{Key: "$group", Value: bson.M{
 					"_id":   "$namespace", // group by namespace
 					"total": bson.M{"$sum": "$app_costs.amount"},
 				}}},
-				bson.D{{Key: "$sort", Value: bson.M{"_id": 1}}},
 			},
 			"directAmount": bson.A{
 				bson.D{{Key: "$match", Value: directMatchValue}},
@@ -2419,7 +2414,6 @@ func (m *MongoDB) GetWorkspaceConsumptionAmount(
 					"_id":   "$namespace",
 					"total": bson.M{"$sum": "$amount"},
 				}}},
-				bson.D{{Key: "$sort", Value: bson.M{"_id": 1}}},
 			},
 		}}},
 	}

--- a/service/account/dao/interface.go
+++ b/service/account/dao/interface.go
@@ -2397,11 +2397,17 @@ func (m *MongoDB) GetWorkspaceConsumptionAmount(
 
 	appCostsPipeline := bson.A{}
 	if len(appCostsMatchValue) > 0 {
-		appCostsPipeline = append(appCostsPipeline, bson.D{{Key: "$match", Value: appCostsMatchValue}})
+		appCostsPipeline = append(
+			appCostsPipeline,
+			bson.D{{Key: "$match", Value: appCostsMatchValue}},
+		)
 	}
 	appCostsPipeline = append(appCostsPipeline, bson.D{{Key: "$unwind", Value: "$app_costs"}})
 	if len(unwindMatchValue) > 0 {
-		appCostsPipeline = append(appCostsPipeline, bson.D{{Key: "$match", Value: unwindMatchValue}})
+		appCostsPipeline = append(
+			appCostsPipeline,
+			bson.D{{Key: "$match", Value: unwindMatchValue}},
+		)
 	}
 	appCostsPipeline = append(appCostsPipeline, bson.D{{Key: "$group", Value: bson.M{
 		"_id":   "$namespace", // group by namespace

--- a/service/account/dao/interface.go
+++ b/service/account/dao/interface.go
@@ -2384,36 +2384,41 @@ func buildWorkspaceConsumptionPipeline(req helper.ConsumptionRecordReq) (mongo.P
 		resources.AppType[resources.AppStore],
 		resources.AppType[resources.LLMToken],
 	}
-	pipeline = append(pipeline,
-		bson.D{{Key: "$project", Value: bson.D{
-			{Key: "namespace", Value: 1},
-			{Key: "app_type", Value: 1},
-			{Key: "app_name", Value: 1},
-			{Key: "amount", Value: 1},
-			{Key: "app_costs.name", Value: 1},
-			{Key: "app_costs.amount", Value: 1},
-		}}},
-		bson.D{{Key: "$unwind", Value: bson.D{
-			{Key: "path", Value: "$app_costs"},
-			{Key: "preserveNullAndEmptyArrays", Value: true},
-		}}},
-		bson.D{{Key: "$match", Value: bson.D{{Key: "$or", Value: bson.A{
-			bson.D{
-				{Key: "app_type", Value: bson.D{{Key: "$in", Value: directAppTypes}}},
-				{Key: "app_name", Value: req.AppName},
+	matchedNestedAmount := bson.M{
+		"$sum": bson.M{
+			"$map": bson.M{
+				"input": bson.M{
+					"$filter": bson.M{
+						"input": bson.M{"$ifNull": bson.A{"$app_costs", bson.A{}}},
+						"as":    "appCost",
+						"cond": bson.M{
+							"$eq": bson.A{"$$appCost.name", req.AppName},
+						},
+					},
+				},
+				"as": "appCost",
+				"in": "$$appCost.amount",
 			},
-			bson.D{
-				{Key: "app_type", Value: bson.D{{Key: "$nin", Value: directAppTypes}}},
-				{Key: "app_costs.name", Value: req.AppName},
-			},
-		}}}}},
+		},
+	}
+	pipeline = append(
+		pipeline,
 		bson.D{{Key: "$project", Value: bson.D{
 			{Key: "namespace", Value: 1},
 			{Key: "amount", Value: bson.D{{Key: "$cond", Value: bson.A{
 				bson.D{{Key: "$in", Value: bson.A{"$app_type", directAppTypes}}},
-				"$amount",
-				"$app_costs.amount",
+				bson.D{{Key: "$cond", Value: bson.A{
+					bson.D{{Key: "$eq", Value: bson.A{"$app_name", req.AppName}}},
+					"$amount",
+					int64(0),
+				}}},
+				matchedNestedAmount,
 			}}}},
+		}}},
+		bson.D{{Key: "$match", Value: bson.D{
+			{Key: "amount", Value: bson.D{
+				{Key: "$gt", Value: int64(0)},
+			}},
 		}}},
 		groupStage,
 	)

--- a/service/account/dao/interface.go
+++ b/service/account/dao/interface.go
@@ -2395,19 +2395,24 @@ func (m *MongoDB) GetWorkspaceConsumptionAmount(
 		directMatchValue = append(directMatchValue, primitive.E{Key: "app_name", Value: appName})
 	}
 
+	appCostsPipeline := bson.A{}
+	if len(appCostsMatchValue) > 0 {
+		appCostsPipeline = append(appCostsPipeline, bson.D{{Key: "$match", Value: appCostsMatchValue}})
+	}
+	appCostsPipeline = append(appCostsPipeline, bson.D{{Key: "$unwind", Value: "$app_costs"}})
+	if len(unwindMatchValue) > 0 {
+		appCostsPipeline = append(appCostsPipeline, bson.D{{Key: "$match", Value: unwindMatchValue}})
+	}
+	appCostsPipeline = append(appCostsPipeline, bson.D{{Key: "$group", Value: bson.M{
+		"_id":   "$namespace", // group by namespace
+		"total": bson.M{"$sum": "$app_costs.amount"},
+	}}})
+
 	// Use $facet to query both types in parallel
 	pipeline := bson.A{
 		bson.D{{Key: "$match", Value: baseMatchValue}},
 		bson.D{{Key: "$facet", Value: bson.M{
-			"appCosts": bson.A{
-				bson.D{{Key: "$match", Value: appCostsMatchValue}},
-				bson.D{{Key: "$unwind", Value: "$app_costs"}},
-				bson.D{{Key: "$match", Value: unwindMatchValue}},
-				bson.D{{Key: "$group", Value: bson.M{
-					"_id":   "$namespace", // group by namespace
-					"total": bson.M{"$sum": "$app_costs.amount"},
-				}}},
-			},
+			"appCosts": appCostsPipeline,
 			"directAmount": bson.A{
 				bson.D{{Key: "$match", Value: directMatchValue}},
 				bson.D{{Key: "$group", Value: bson.M{

--- a/service/account/dao/interface.go
+++ b/service/account/dao/interface.go
@@ -2353,7 +2353,6 @@ func buildWorkspaceConsumptionPipeline(req helper.ConsumptionRecordReq) (mongo.P
 	matchValue := bson.D{
 		{Key: "owner", Value: req.Owner},
 		{Key: "status", Value: resources.Settled},
-		{Key: "type", Value: resources.Consumption},
 		{Key: "time", Value: bson.D{
 			{Key: "$gte", Value: req.StartTime},
 			{Key: "$lte", Value: req.EndTime},

--- a/service/account/dao/workspace_consumption_runtime_test.go
+++ b/service/account/dao/workspace_consumption_runtime_test.go
@@ -1,0 +1,194 @@
+package dao
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/labring/sealos/controllers/pkg/resources"
+	"github.com/labring/sealos/service/account/helper"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const (
+	workspaceConsumptionTestOwner = "workspace-consumption-test-owner"
+	workspaceConsumptionTestDB    = "workspace-consumption-test"
+	workspaceConsumptionTestColl  = "billing"
+)
+
+func newWorkspaceConsumptionMongo(t *testing.T) (*MongoDB, context.Context) {
+	t.Helper()
+	testcontainers.SkipIfProviderIsNotHealthy(t)
+
+	ctx := context.Background()
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "mongo:7.0",
+			ExposedPorts: []string{"27017/tcp"},
+			WaitingFor: wait.ForListeningPort("27017/tcp").
+				WithStartupTimeout(2 * time.Minute),
+		},
+		Started: true,
+	})
+	if err != nil {
+		t.Fatalf("start MongoDB container: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := container.Terminate(ctx); err != nil {
+			t.Errorf("terminate MongoDB container: %v", err)
+		}
+	})
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatalf("get MongoDB container host: %v", err)
+	}
+	port, err := container.MappedPort(ctx, "27017/tcp")
+	if err != nil {
+		t.Fatalf("get MongoDB container port: %v", err)
+	}
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI("mongodb://"+net.JoinHostPort(host, port.Port())))
+	if err != nil {
+		t.Fatalf("connect MongoDB client: %v", err)
+	}
+	if err := client.Ping(ctx, nil); err != nil {
+		_ = client.Disconnect(ctx)
+		t.Fatalf("ping MongoDB: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := client.Disconnect(ctx); err != nil {
+			t.Errorf("disconnect MongoDB client: %v", err)
+		}
+	})
+
+	return &MongoDB{
+		Client:        client,
+		AccountDBName: workspaceConsumptionTestDB,
+		BillingConn:   workspaceConsumptionTestColl,
+	}, ctx
+}
+
+func TestGetWorkspaceConsumptionAmountWithMongoRuntime(t *testing.T) {
+	mongoDB, ctx := newWorkspaceConsumptionMongo(t)
+	startTime := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	endTime := time.Date(2026, time.January, 2, 0, 0, 0, 0, time.UTC)
+
+	appCosts := []resources.AppCost{
+		{Name: "app-a", Amount: 30},
+		{Name: "app-b", Amount: 5},
+	}
+	documents := []any{
+		resources.Billing{
+			Time: startTime, OrderID: "nested-at-start", Type: resources.Consumption,
+			Namespace: "ns-a", AppCosts: appCosts, AppType: resources.AppType[resources.APP],
+			Amount: 100, Owner: workspaceConsumptionTestOwner, Status: resources.Settled,
+		},
+		resources.Billing{
+			Time: endTime, OrderID: "nested-at-end", Type: resources.Consumption,
+			Namespace: "ns-a", AppType: resources.AppType[resources.APP], Amount: 50,
+			Owner: workspaceConsumptionTestOwner, Status: resources.Settled,
+		},
+		resources.Billing{
+			Time: endTime, OrderID: "llm-subconsumption", Type: resources.SubConsumption,
+			Namespace: "ns-b", AppName: "llm-a", AppType: resources.AppType[resources.LLMToken],
+			Amount: 20, Owner: workspaceConsumptionTestOwner, Status: resources.Settled,
+		},
+		resources.Billing{
+			Time: endTime, OrderID: "app-store-direct", Type: resources.Consumption,
+			Namespace: "ns-c", AppName: "store-a", AppType: resources.AppType[resources.AppStore],
+			Amount: 40, Owner: workspaceConsumptionTestOwner, Status: resources.Settled,
+		},
+		resources.Billing{
+			Time: endTime, OrderID: "unsettled", Type: resources.Consumption,
+			Namespace: "ns-ignored", AppType: resources.AppType[resources.APP], Amount: 1000,
+			Owner: workspaceConsumptionTestOwner, Status: resources.Unsettled,
+		},
+		resources.Billing{
+			Time: endTime, OrderID: "other-owner", Type: resources.Consumption,
+			Namespace: "ns-ignored", AppType: resources.AppType[resources.APP], Amount: 2000,
+			Owner: "other-owner", Status: resources.Settled,
+		},
+		resources.Billing{
+			Time: endTime.Add(time.Hour), OrderID: "outside-range", Type: resources.Consumption,
+			Namespace: "ns-ignored", AppType: resources.AppType[resources.APP], Amount: 3000,
+			Owner: workspaceConsumptionTestOwner, Status: resources.Settled,
+		},
+	}
+	collection := mongoDB.getBillingCollection()
+	if _, err := collection.InsertMany(ctx, documents); err != nil {
+		t.Fatalf("insert billing fixtures: %v", err)
+	}
+
+	baseRequest := helper.ConsumptionRecordReq{
+		TimeRange: helper.TimeRange{StartTime: startTime, EndTime: endTime},
+		AuthBase:  helper.AuthBase{Auth: &helper.Auth{Owner: workspaceConsumptionTestOwner}},
+	}
+	tests := []struct {
+		name string
+		req  helper.ConsumptionRecordReq
+		want map[string]int64
+	}{
+		{
+			name: "all settled consumption by namespace",
+			req:  baseRequest,
+			want: map[string]int64{"ns-a": 150, "ns-b": 20, "ns-c": 40},
+		},
+		{
+			name: "namespace filter",
+			req:  withWorkspaceConsumptionRequest(baseRequest, func(req *helper.ConsumptionRecordReq) { req.Namespace = "ns-a" }),
+			want: map[string]int64{"ns-a": 150},
+		},
+		{
+			name: "app type filter",
+			req:  withWorkspaceConsumptionRequest(baseRequest, func(req *helper.ConsumptionRecordReq) { req.AppType = " llm-token " }),
+			want: map[string]int64{"ns-b": 20},
+		},
+		{
+			name: "nested app name filter",
+			req:  withWorkspaceConsumptionRequest(baseRequest, func(req *helper.ConsumptionRecordReq) { req.AppName = "app-a" }),
+			want: map[string]int64{"ns-a": 30},
+		},
+		{
+			name: "direct app name filter",
+			req:  withWorkspaceConsumptionRequest(baseRequest, func(req *helper.ConsumptionRecordReq) { req.AppName = "store-a" }),
+			want: map[string]int64{"ns-c": 40},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := mongoDB.GetWorkspaceConsumptionAmount(test.req)
+			if err != nil {
+				t.Fatalf("get workspace consumption amount: %v", err)
+			}
+			if !mapsEqual(got, test.want) {
+				t.Fatalf("workspace consumption = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func withWorkspaceConsumptionRequest(
+	base helper.ConsumptionRecordReq,
+	update func(*helper.ConsumptionRecordReq),
+) helper.ConsumptionRecordReq {
+	request := base
+	update(&request)
+	return request
+}
+
+func mapsEqual(got, want map[string]int64) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for key, wantValue := range want {
+		if got[key] != wantValue {
+			return false
+		}
+	}
+	return true
+}

--- a/service/account/dao/workspace_consumption_runtime_test.go
+++ b/service/account/dao/workspace_consumption_runtime_test.go
@@ -27,7 +27,7 @@ func newWorkspaceConsumptionMongo(t *testing.T) (*MongoDB, context.Context) {
 	ctx := context.Background()
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "mongo:7.0",
+			Image:        "mongo:4.4.29",
 			ExposedPorts: []string{"27017/tcp"},
 			WaitingFor: wait.ForListeningPort("27017/tcp").
 				WithStartupTimeout(2 * time.Minute),

--- a/service/account/dao/workspace_consumption_runtime_test.go
+++ b/service/account/dao/workspace_consumption_runtime_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"testing"
 	"time"
 
@@ -20,6 +21,7 @@ const (
 	workspaceConsumptionTestDB           = "workspace-consumption-test"
 	workspaceConsumptionTestColl         = "billing"
 	workspaceConsumptionBenchmarkRecords = 10000
+	workspaceConsumptionRequiredEnv      = "TESTCONTAINERS_REQUIRED"
 )
 
 func newWorkspaceConsumptionMongo(t testing.TB) (*MongoDB, context.Context) {
@@ -78,19 +80,27 @@ func skipIfWorkspaceConsumptionDockerIsNotHealthy(t testing.TB) {
 	t.Helper()
 	defer func() {
 		if r := recover(); r != nil {
-			t.Skipf("recovered from panic: %v; Docker is not running", r)
+			skipOrFailWorkspaceConsumptionDocker(t, "recovered from panic: %v; Docker is not running", r)
 		}
 	}()
 
 	ctx := context.Background()
 	provider, err := testcontainers.ProviderDocker.GetProvider()
 	if err != nil {
-		t.Skipf("Docker is not running: %v", err)
+		skipOrFailWorkspaceConsumptionDocker(t, "Docker is not running: %v", err)
 	}
 	defer provider.Close()
 	if err := provider.Health(ctx); err != nil {
-		t.Skipf("Docker is not running: %v", err)
+		skipOrFailWorkspaceConsumptionDocker(t, "Docker is not running: %v", err)
 	}
+}
+
+func skipOrFailWorkspaceConsumptionDocker(t testing.TB, format string, args ...any) {
+	t.Helper()
+	if os.Getenv(workspaceConsumptionRequiredEnv) == "true" {
+		t.Fatalf(format, args...)
+	}
+	t.Skipf(format, args...)
 }
 
 func TestGetWorkspaceConsumptionAmountWithMongoRuntime(t *testing.T) {

--- a/service/account/dao/workspace_consumption_runtime_test.go
+++ b/service/account/dao/workspace_consumption_runtime_test.go
@@ -2,6 +2,7 @@ package dao
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -15,14 +16,15 @@ import (
 )
 
 const (
-	workspaceConsumptionTestOwner = "workspace-consumption-test-owner"
-	workspaceConsumptionTestDB    = "workspace-consumption-test"
-	workspaceConsumptionTestColl  = "billing"
+	workspaceConsumptionTestOwner        = "workspace-consumption-test-owner"
+	workspaceConsumptionTestDB           = "workspace-consumption-test"
+	workspaceConsumptionTestColl         = "billing"
+	workspaceConsumptionBenchmarkRecords = 10000
 )
 
-func newWorkspaceConsumptionMongo(t *testing.T) (*MongoDB, context.Context) {
+func newWorkspaceConsumptionMongo(t testing.TB) (*MongoDB, context.Context) {
 	t.Helper()
-	testcontainers.SkipIfProviderIsNotHealthy(t)
+	skipIfWorkspaceConsumptionDockerIsNotHealthy(t)
 
 	ctx := context.Background()
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
@@ -70,6 +72,25 @@ func newWorkspaceConsumptionMongo(t *testing.T) (*MongoDB, context.Context) {
 		AccountDBName: workspaceConsumptionTestDB,
 		BillingConn:   workspaceConsumptionTestColl,
 	}, ctx
+}
+
+func skipIfWorkspaceConsumptionDockerIsNotHealthy(t testing.TB) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Skipf("recovered from panic: %v; Docker is not running", r)
+		}
+	}()
+
+	ctx := context.Background()
+	provider, err := testcontainers.ProviderDocker.GetProvider()
+	if err != nil {
+		t.Skipf("Docker is not running: %v", err)
+	}
+	defer provider.Close()
+	if err := provider.Health(ctx); err != nil {
+		t.Skipf("Docker is not running: %v", err)
+	}
 }
 
 func TestGetWorkspaceConsumptionAmountWithMongoRuntime(t *testing.T) {
@@ -167,6 +188,67 @@ func TestGetWorkspaceConsumptionAmountWithMongoRuntime(t *testing.T) {
 			}
 			if !mapsEqual(got, test.want) {
 				t.Fatalf("workspace consumption = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func BenchmarkGetWorkspaceConsumptionAmountWithMongoRuntime(b *testing.B) {
+	mongoDB, ctx := newWorkspaceConsumptionMongo(b)
+	startTime := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	endTime := startTime.Add(24 * time.Hour)
+	documents := make([]any, 0, workspaceConsumptionBenchmarkRecords)
+	for i := 0; i < workspaceConsumptionBenchmarkRecords; i++ {
+		documents = append(documents, resources.Billing{
+			Time:      startTime.Add(time.Duration(i%24) * time.Hour),
+			OrderID:   fmt.Sprintf("benchmark-%d", i),
+			Type:      resources.Consumption,
+			Namespace: fmt.Sprintf("ns-%02d", i%32),
+			AppCosts: []resources.AppCost{{
+				Name:   "app-a",
+				Amount: int64(i%100 + 1),
+			}},
+			AppType: resources.AppType[resources.APP],
+			Amount:  int64(i%100 + 1),
+			Owner:   workspaceConsumptionTestOwner,
+			Status:  resources.Settled,
+		})
+	}
+	if _, err := mongoDB.getBillingCollection().InsertMany(ctx, documents); err != nil {
+		b.Fatalf("insert billing benchmark fixtures: %v", err)
+	}
+
+	baseRequest := helper.ConsumptionRecordReq{
+		TimeRange: helper.TimeRange{StartTime: startTime, EndTime: endTime},
+		AuthBase:  helper.AuthBase{Auth: &helper.Auth{Owner: workspaceConsumptionTestOwner}},
+	}
+	benchmarks := []struct {
+		name string
+		req  helper.ConsumptionRecordReq
+	}{
+		{name: "all", req: baseRequest},
+		{
+			name: "namespace",
+			req:  withWorkspaceConsumptionRequest(baseRequest, func(req *helper.ConsumptionRecordReq) { req.Namespace = "ns-07" }),
+		},
+		{
+			name: "app_type",
+			req:  withWorkspaceConsumptionRequest(baseRequest, func(req *helper.ConsumptionRecordReq) { req.AppType = "app" }),
+		},
+		{
+			name: "app_name",
+			req:  withWorkspaceConsumptionRequest(baseRequest, func(req *helper.ConsumptionRecordReq) { req.AppName = "app-a" }),
+		},
+	}
+
+	for _, benchmark := range benchmarks {
+		b.Run(benchmark.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := mongoDB.GetWorkspaceConsumptionAmount(benchmark.req); err != nil {
+					b.Fatalf("get workspace consumption amount: %v", err)
+				}
 			}
 		})
 	}

--- a/service/account/dao/workspace_consumption_runtime_test.go
+++ b/service/account/dao/workspace_consumption_runtime_test.go
@@ -24,9 +24,9 @@ const (
 	workspaceConsumptionRequiredEnv      = "TESTCONTAINERS_REQUIRED"
 )
 
-func newWorkspaceConsumptionMongo(t testing.TB) (*MongoDB, context.Context) {
-	t.Helper()
-	skipIfWorkspaceConsumptionDockerIsNotHealthy(t)
+func newWorkspaceConsumptionMongo(tb testing.TB) (*MongoDB, context.Context) {
+	tb.Helper()
+	skipIfWorkspaceConsumptionDockerIsNotHealthy(tb)
 
 	ctx := context.Background()
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
@@ -39,33 +39,36 @@ func newWorkspaceConsumptionMongo(t testing.TB) (*MongoDB, context.Context) {
 		Started: true,
 	})
 	if err != nil {
-		t.Fatalf("start MongoDB container: %v", err)
+		tb.Fatalf("start MongoDB container: %v", err)
 	}
-	t.Cleanup(func() {
+	tb.Cleanup(func() {
 		if err := container.Terminate(ctx); err != nil {
-			t.Errorf("terminate MongoDB container: %v", err)
+			tb.Errorf("terminate MongoDB container: %v", err)
 		}
 	})
 
 	host, err := container.Host(ctx)
 	if err != nil {
-		t.Fatalf("get MongoDB container host: %v", err)
+		tb.Fatalf("get MongoDB container host: %v", err)
 	}
 	port, err := container.MappedPort(ctx, "27017/tcp")
 	if err != nil {
-		t.Fatalf("get MongoDB container port: %v", err)
+		tb.Fatalf("get MongoDB container port: %v", err)
 	}
-	client, err := mongo.Connect(ctx, options.Client().ApplyURI("mongodb://"+net.JoinHostPort(host, port.Port())))
+	client, err := mongo.Connect(
+		ctx,
+		options.Client().ApplyURI("mongodb://"+net.JoinHostPort(host, port.Port())),
+	)
 	if err != nil {
-		t.Fatalf("connect MongoDB client: %v", err)
+		tb.Fatalf("connect MongoDB client: %v", err)
 	}
 	if err := client.Ping(ctx, nil); err != nil {
 		_ = client.Disconnect(ctx)
-		t.Fatalf("ping MongoDB: %v", err)
+		tb.Fatalf("ping MongoDB: %v", err)
 	}
-	t.Cleanup(func() {
+	tb.Cleanup(func() {
 		if err := client.Disconnect(ctx); err != nil {
-			t.Errorf("disconnect MongoDB client: %v", err)
+			tb.Errorf("disconnect MongoDB client: %v", err)
 		}
 	})
 
@@ -76,31 +79,35 @@ func newWorkspaceConsumptionMongo(t testing.TB) (*MongoDB, context.Context) {
 	}, ctx
 }
 
-func skipIfWorkspaceConsumptionDockerIsNotHealthy(t testing.TB) {
-	t.Helper()
+func skipIfWorkspaceConsumptionDockerIsNotHealthy(tb testing.TB) {
+	tb.Helper()
 	defer func() {
 		if r := recover(); r != nil {
-			skipOrFailWorkspaceConsumptionDocker(t, "recovered from panic: %v; Docker is not running", r)
+			skipOrFailWorkspaceConsumptionDockerf(
+				tb,
+				"recovered from panic: %v; Docker is not running",
+				r,
+			)
 		}
 	}()
 
 	ctx := context.Background()
 	provider, err := testcontainers.ProviderDocker.GetProvider()
 	if err != nil {
-		skipOrFailWorkspaceConsumptionDocker(t, "Docker is not running: %v", err)
+		skipOrFailWorkspaceConsumptionDockerf(tb, "Docker is not running: %v", err)
 	}
 	defer provider.Close()
 	if err := provider.Health(ctx); err != nil {
-		skipOrFailWorkspaceConsumptionDocker(t, "Docker is not running: %v", err)
+		skipOrFailWorkspaceConsumptionDockerf(tb, "Docker is not running: %v", err)
 	}
 }
 
-func skipOrFailWorkspaceConsumptionDocker(t testing.TB, format string, args ...any) {
-	t.Helper()
+func skipOrFailWorkspaceConsumptionDockerf(tb testing.TB, format string, args ...any) {
+	tb.Helper()
 	if os.Getenv(workspaceConsumptionRequiredEnv) == "true" {
-		t.Fatalf(format, args...)
+		tb.Fatalf(format, args...)
 	}
-	t.Skipf(format, args...)
+	tb.Skipf(format, args...)
 }
 
 func TestGetWorkspaceConsumptionAmountWithMongoRuntime(t *testing.T) {
@@ -170,22 +177,42 @@ func TestGetWorkspaceConsumptionAmountWithMongoRuntime(t *testing.T) {
 		},
 		{
 			name: "namespace filter",
-			req:  withWorkspaceConsumptionRequest(baseRequest, func(req *helper.ConsumptionRecordReq) { req.Namespace = "ns-a" }),
+			req: withWorkspaceConsumptionRequest(
+				baseRequest,
+				func(req *helper.ConsumptionRecordReq) {
+					req.Namespace = "ns-a"
+				},
+			),
 			want: map[string]int64{"ns-a": 150},
 		},
 		{
 			name: "app type filter",
-			req:  withWorkspaceConsumptionRequest(baseRequest, func(req *helper.ConsumptionRecordReq) { req.AppType = " llm-token " }),
+			req: withWorkspaceConsumptionRequest(
+				baseRequest,
+				func(req *helper.ConsumptionRecordReq) {
+					req.AppType = " llm-token "
+				},
+			),
 			want: map[string]int64{"ns-b": 20},
 		},
 		{
 			name: "nested app name filter",
-			req:  withWorkspaceConsumptionRequest(baseRequest, func(req *helper.ConsumptionRecordReq) { req.AppName = "app-a" }),
+			req: withWorkspaceConsumptionRequest(
+				baseRequest,
+				func(req *helper.ConsumptionRecordReq) {
+					req.AppName = "app-a"
+				},
+			),
 			want: map[string]int64{"ns-a": 30},
 		},
 		{
 			name: "direct app name filter",
-			req:  withWorkspaceConsumptionRequest(baseRequest, func(req *helper.ConsumptionRecordReq) { req.AppName = "store-a" }),
+			req: withWorkspaceConsumptionRequest(
+				baseRequest,
+				func(req *helper.ConsumptionRecordReq) {
+					req.AppName = "store-a"
+				},
+			),
 			want: map[string]int64{"ns-c": 40},
 		},
 	}
@@ -208,7 +235,7 @@ func BenchmarkGetWorkspaceConsumptionAmountWithMongoRuntime(b *testing.B) {
 	startTime := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
 	endTime := startTime.Add(24 * time.Hour)
 	documents := make([]any, 0, workspaceConsumptionBenchmarkRecords)
-	for i := 0; i < workspaceConsumptionBenchmarkRecords; i++ {
+	for i := range workspaceConsumptionBenchmarkRecords {
 		documents = append(documents, resources.Billing{
 			Time:      startTime.Add(time.Duration(i%24) * time.Hour),
 			OrderID:   fmt.Sprintf("benchmark-%d", i),
@@ -239,15 +266,30 @@ func BenchmarkGetWorkspaceConsumptionAmountWithMongoRuntime(b *testing.B) {
 		{name: "all", req: baseRequest},
 		{
 			name: "namespace",
-			req:  withWorkspaceConsumptionRequest(baseRequest, func(req *helper.ConsumptionRecordReq) { req.Namespace = "ns-07" }),
+			req: withWorkspaceConsumptionRequest(
+				baseRequest,
+				func(req *helper.ConsumptionRecordReq) {
+					req.Namespace = "ns-07"
+				},
+			),
 		},
 		{
 			name: "app_type",
-			req:  withWorkspaceConsumptionRequest(baseRequest, func(req *helper.ConsumptionRecordReq) { req.AppType = "app" }),
+			req: withWorkspaceConsumptionRequest(
+				baseRequest,
+				func(req *helper.ConsumptionRecordReq) {
+					req.AppType = "app"
+				},
+			),
 		},
 		{
 			name: "app_name",
-			req:  withWorkspaceConsumptionRequest(baseRequest, func(req *helper.ConsumptionRecordReq) { req.AppName = "app-a" }),
+			req: withWorkspaceConsumptionRequest(
+				baseRequest,
+				func(req *helper.ConsumptionRecordReq) {
+					req.AppName = "app-a"
+				},
+			),
 		},
 	}
 
@@ -255,7 +297,7 @@ func BenchmarkGetWorkspaceConsumptionAmountWithMongoRuntime(b *testing.B) {
 		b.Run(benchmark.name, func(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				if _, err := mongoDB.GetWorkspaceConsumptionAmount(benchmark.req); err != nil {
 					b.Fatalf("get workspace consumption amount: %v", err)
 				}

--- a/service/account/dao/workspace_consumption_test.go
+++ b/service/account/dao/workspace_consumption_test.go
@@ -1,0 +1,127 @@
+package dao
+
+import (
+	"testing"
+	"time"
+
+	"github.com/labring/sealos/controllers/pkg/resources"
+	"github.com/labring/sealos/service/account/helper"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func workspaceConsumptionRequest() helper.ConsumptionRecordReq {
+	return helper.ConsumptionRecordReq{
+		TimeRange: helper.TimeRange{
+			StartTime: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC),
+			EndTime:   time.Date(2026, time.January, 2, 0, 0, 0, 0, time.UTC),
+		},
+		Namespace: "ns-test",
+		AuthBase: helper.AuthBase{
+			Auth: &helper.Auth{Owner: "owner-test"},
+		},
+	}
+}
+
+func workspaceConsumptionStageValue(stage bson.D, key string) (any, bool) {
+	for _, element := range stage {
+		if element.Key == key {
+			return element.Value, true
+		}
+	}
+	return nil, false
+}
+
+func TestNormalizeWorkspaceConsumptionAppType(t *testing.T) {
+	normalized, value, err := normalizeWorkspaceConsumptionAppType(" app-store ")
+	if err != nil {
+		t.Fatalf("normalize app type: %v", err)
+	}
+	if normalized != resources.AppStore {
+		t.Fatalf("normalized app type = %q, want %q", normalized, resources.AppStore)
+	}
+	if value != resources.AppType[resources.AppStore] {
+		t.Fatalf("app type value = %d, want %d", value, resources.AppType[resources.AppStore])
+	}
+
+	if _, _, err := normalizeWorkspaceConsumptionAppType("unknown"); err == nil {
+		t.Fatal("expected an error for an unsupported app type")
+	}
+}
+
+func TestBuildWorkspaceConsumptionPipelineWithoutAppFilter(t *testing.T) {
+	pipeline, err := buildWorkspaceConsumptionPipeline(workspaceConsumptionRequest())
+	if err != nil {
+		t.Fatalf("build pipeline: %v", err)
+	}
+	if len(pipeline) != 2 {
+		t.Fatalf("pipeline stage count = %d, want 2", len(pipeline))
+	}
+
+	matchValue, ok := workspaceConsumptionStageValue(pipeline[0], "$match")
+	if !ok {
+		t.Fatal("pipeline does not start with $match")
+	}
+	match, ok := matchValue.(bson.D)
+	if !ok {
+		t.Fatalf("$match value type = %T, want bson.D", matchValue)
+	}
+	for key, want := range map[string]any{
+		"owner":     "owner-test",
+		"namespace": "ns-test",
+		"status":    resources.Settled,
+		"type":      resources.Consumption,
+	} {
+		got, ok := workspaceConsumptionStageValue(match, key)
+		if !ok || got != want {
+			t.Errorf("$match[%q] = %#v, want %#v", key, got, want)
+		}
+	}
+
+	if _, ok := workspaceConsumptionStageValue(pipeline[1], "$group"); !ok {
+		t.Fatal("pipeline does not end with $group")
+	}
+}
+
+func TestBuildWorkspaceConsumptionPipelineWithAppFilter(t *testing.T) {
+	req := workspaceConsumptionRequest()
+	req.AppType = " app "
+	req.AppName = "application"
+
+	pipeline, err := buildWorkspaceConsumptionPipeline(req)
+	if err != nil {
+		t.Fatalf("build pipeline: %v", err)
+	}
+	if len(pipeline) != 6 {
+		t.Fatalf("pipeline stage count = %d, want 6", len(pipeline))
+	}
+
+	matchValue, ok := workspaceConsumptionStageValue(pipeline[0], "$match")
+	if !ok {
+		t.Fatal("pipeline does not start with $match")
+	}
+	match, ok := matchValue.(bson.D)
+	if !ok {
+		t.Fatalf("$match value type = %T, want bson.D", matchValue)
+	}
+	appType, ok := workspaceConsumptionStageValue(match, "app_type")
+	if !ok || appType != resources.AppType[resources.APP] {
+		t.Fatalf("$match app_type = %#v, want %d", appType, resources.AppType[resources.APP])
+	}
+
+	unwindValue, ok := workspaceConsumptionStageValue(pipeline[2], "$unwind")
+	if !ok {
+		t.Fatal("app-filtered pipeline does not unwind app_costs")
+	}
+	unwind, ok := unwindValue.(bson.D)
+	if !ok {
+		t.Fatalf("$unwind value type = %T, want bson.D", unwindValue)
+	}
+	preserve, ok := workspaceConsumptionStageValue(unwind, "preserveNullAndEmptyArrays")
+	if !ok || preserve != true {
+		t.Fatalf("preserveNullAndEmptyArrays = %#v, want true", preserve)
+	}
+
+	if _, ok := workspaceConsumptionStageValue(pipeline[1], "$facet"); ok {
+		t.Fatal("app-filtered pipeline should not use $facet")
+	}
+}

--- a/service/account/dao/workspace_consumption_test.go
+++ b/service/account/dao/workspace_consumption_test.go
@@ -91,8 +91,8 @@ func TestBuildWorkspaceConsumptionPipelineWithAppFilter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build pipeline: %v", err)
 	}
-	if len(pipeline) != 6 {
-		t.Fatalf("pipeline stage count = %d, want 6", len(pipeline))
+	if len(pipeline) != 4 {
+		t.Fatalf("pipeline stage count = %d, want 4", len(pipeline))
 	}
 
 	matchValue, ok := workspaceConsumptionStageValue(pipeline[0], "$match")
@@ -108,20 +108,13 @@ func TestBuildWorkspaceConsumptionPipelineWithAppFilter(t *testing.T) {
 		t.Fatalf("$match app_type = %#v, want %d", appType, resources.AppType[resources.APP])
 	}
 
-	unwindValue, ok := workspaceConsumptionStageValue(pipeline[2], "$unwind")
-	if !ok {
-		t.Fatal("app-filtered pipeline does not unwind app_costs")
-	}
-	unwind, ok := unwindValue.(bson.D)
-	if !ok {
-		t.Fatalf("$unwind value type = %T, want bson.D", unwindValue)
-	}
-	preserve, ok := workspaceConsumptionStageValue(unwind, "preserveNullAndEmptyArrays")
-	if !ok || preserve != true {
-		t.Fatalf("preserveNullAndEmptyArrays = %#v, want true", preserve)
-	}
-
 	if _, ok := workspaceConsumptionStageValue(pipeline[1], "$facet"); ok {
 		t.Fatal("app-filtered pipeline should not use $facet")
+	}
+	if _, ok := workspaceConsumptionStageValue(pipeline[1], "$unwind"); ok {
+		t.Fatal("app-filtered pipeline should keep one row per billing record")
+	}
+	if _, ok := workspaceConsumptionStageValue(pipeline[2], "$match"); !ok {
+		t.Fatal("app-filtered pipeline should discard zero matched amounts")
 	}
 }

--- a/service/account/dao/workspace_consumption_test.go
+++ b/service/account/dao/workspace_consumption_test.go
@@ -69,7 +69,6 @@ func TestBuildWorkspaceConsumptionPipelineWithoutAppFilter(t *testing.T) {
 		"owner":     "owner-test",
 		"namespace": "ns-test",
 		"status":    resources.Settled,
-		"type":      resources.Consumption,
 	} {
 		got, ok := workspaceConsumptionStageValue(match, key)
 		if !ok || got != want {

--- a/service/account/go.mod
+++ b/service/account/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0
 	github.com/swaggo/swag v1.16.2
+	github.com/testcontainers/testcontainers-go v0.42.0
 	go.mongodb.org/mongo-driver v1.13.0
 	gorm.io/gorm v1.25.5
 )


### PR DESCRIPTION
## Background

The `/account/v1alpha1/costs/workspace/consumption` endpoint calculates settled consumption grouped by namespace. The previous pipeline used `$facet` to aggregate both `app_costs` and top-level `amount`, so the two branches reprocessed the same matched Billing documents and could double-count a record when it exposed both the authoritative top-level total and nested resource breakdown.

## Changes

- Add the common `owner`, `status`, `time`, and optional `namespace` filters before aggregation. No `type` filter is applied because settled LLM token records are stored as `SubConsumption` and must remain included alongside `Consumption` records.
- Use a single `$match` + `$group` pipeline over top-level `amount` for the normal workspace-total request, avoiding `$facet` and `$unwind` entirely.
- Only inspect `app_costs` when `appName` filtering is requested, using `$filter`/`$map`/`$sum` to keep one output row per Billing record.
- Make direct `APP-STORE`/`LLM-TOKEN` matching mutually exclusive from nested resource matching to prevent duplicate totals.
- Normalize and validate `appType`, handle cursor decoding errors, and add pipeline unit tests for the default and app-filtered paths.
- Add the `{owner: 1, status: 1, time: 1}` billing index for the common query path.

## Risks / Notes

`Billing.Amount` is treated as the authoritative total for a Billing record, consistent with the existing billing writers. App-level filtering still sums matching `app_costs.amount` for nested resource types and uses top-level `amount` once for direct application types. The API response shape is unchanged.

Validation completed locally:

- `cd service && go test ./account/dao -run 'Test(NormalizeWorkspaceConsumptionAppType|BuildWorkspaceConsumptionPipeline)' -count=1`
- `cd service && go test ./account/dao -run '^$' -count=1`
- `golangci-lint run --config=.golangci.yml` (from the repository root)
- `cd service/account && go test ./dao -run '^TestGetWorkspaceConsumptionAmountWithMongoRuntime$' -count=1 -v` (testcontainers with MongoDB `4.4.29`; 5 scenarios passed)
- `cd service/account && go test ./dao -run '^$' -bench '^BenchmarkGetWorkspaceConsumptionAmountWithMongoRuntime$' -benchtime=100ms -count=1 -benchmem`

  The benchmark uses 10,000 billing records and excludes container startup and fixture insertion from the timed section. The local reference results were:

  | Case | Result |
  | --- | ---: |
  | `all` | 16.7 ms/op, 28,916 B/op, 407 allocs/op |
  | `namespace` | 5.6 ms/op, 11,269 B/op, 133 allocs/op |
  | `app_type` | 19.2 ms/op, 29,008 B/op, 408 allocs/op |
  | `app_name` | 34.8 ms/op, 39,730 B/op, 512 allocs/op |

  These local benchmark values are for comparison and are not used as a CI pass/fail threshold.

## Benchmark

The endpoint was benchmarked against a Kubernetes deployment with 50,000 temporary settled `APP` billing records across 100 namespaces. Each record contained 50 `app_costs` entries. The same request was sent directly to account-service five times for each image, using a 90-second client timeout; the frontend's 40-second timeout was not used for measurement.

| Deployment | Image digest | Result |
| --- | --- | --- |
| Baseline | `sha256:b0f432707d718cdf2b5fa19e462ea37eb6da8a9b7f6a5652eb0d628a88cdc60e` | 1.397-1.603s, median 1.408s |
| Optimized | `sha256:8c754d77513e996c09ec04c59c60e1e5b42abb769213e2853c2af93ee120939c` | 0.142-0.172s, median 0.158s |

All 10 requests returned HTTP 200 with the expected result: 100 namespaces, 50,000 per namespace, and a 3,112-byte response. Average latency decreased from 1.445s to 0.157s, an 89% reduction and approximately 9.2x speedup. The benchmark cluster did not yet have the new `{owner: 1, status: 1, time: 1}` index, so these numbers measure the aggregation pipeline optimization without the index contribution. The temporary billing records were deleted after the test and the original deployment image was restored.

Build: [GitHub Actions run](https://github.com/dinoallo/sealos/actions/runs/33495282704) (lint, amd64/arm64 image builds, image release, and cluster image build all passed).