### PR TITLE
perf(account): reduce controller cache memory usage

### DIFF
--- a/controllers/account/controllers/account_controller.go
+++ b/controllers/account/controllers/account_controller.go
@@ -144,7 +144,8 @@ type AccountReconciler struct {
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 
 func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	user := &userv1.User{}
+	user := &metav1.PartialObjectMetadata{}
+	user.SetGroupVersionKind(userv1.GroupVersion.WithKind("User"))
 	if err := r.Get(
 		ctx,
 		client.ObjectKey{Namespace: req.Namespace, Name: req.Name},
@@ -165,8 +166,12 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ctrl.Result{}, nil
 		}
 		if err == nil {
+			original := user.DeepCopy()
+			if user.Annotations == nil {
+				user.Annotations = make(map[string]string)
+			}
 			user.Annotations[InitAccountTimeAnnotation] = time.Now().Format(time.RFC3339)
-			return ctrl.Result{}, r.Update(ctx, user)
+			return ctrl.Result{}, r.Patch(ctx, user, client.MergeFrom(original))
 		}
 		return ctrl.Result{}, err
 	} else if client.IgnoreNotFound(
@@ -180,7 +185,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 func (r *AccountReconciler) syncAccount(
 	ctx context.Context,
-	userCr *userv1.User,
+	userCr *metav1.PartialObjectMetadata,
 ) (account *pkgtypes.Account, err error) {
 	owner := userCr.Annotations[userv1.UserAnnotationOwnerKey]
 	userNamespace := "ns-" + userCr.Name
@@ -473,7 +478,7 @@ func (r *AccountReconciler) SetupWithManager(mgr ctrl.Manager, rateOpts controll
 	}
 	// r.SyncNSQuotaFunc = r.syncResourceQuotaAndLimitRange
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&userv1.User{}, builder.WithPredicates(OnlyCreatePredicate{})).
+		For(&userv1.User{}, builder.WithPredicates(OnlyCreatePredicate{}), builder.OnlyMetadata).
 		WithOptions(rateOpts).
 		Complete(r)
 }

--- a/controllers/account/controllers/billing_controller.go
+++ b/controllers/account/controllers/billing_controller.go
@@ -36,6 +36,7 @@ import (
 	userv1 "github.com/labring/sealos/controllers/user/api/v1"
 	"gorm.io/gorm"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -887,7 +888,8 @@ func (r *BillingReconciler) getUsersForNamespaces(namespaces []string) (map[stri
 		if !strings.HasPrefix(namespace, UserNamespacePrefix) {
 			continue
 		}
-		user := &userv1.User{}
+		user := &metav1.PartialObjectMetadata{}
+		user.SetGroupVersionKind(userv1.GroupVersion.WithKind("User"))
 		if err := r.Get(
 			context.Background(),
 			client.ObjectKey{Name: strings.TrimPrefix(namespace, UserNamespacePrefix)},

--- a/controllers/account/controllers/cache/cache.go
+++ b/controllers/account/controllers/cache/cache.go
@@ -18,14 +18,18 @@ import (
 	"context"
 
 	accountv1 "github.com/labring/sealos/controllers/account/api/v1"
+	notificationv1 "github.com/labring/sealos/controllers/pkg/notification/api/v1"
 	accounttypes "github.com/labring/sealos/controllers/pkg/types"
 	userv1 "github.com/labring/sealos/controllers/user/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const podSchedulerNameField = "spec.schedulerName"
 
 // Options limits cached objects to the fields consumed by account controllers.
 func Options() ctrlcache.Options {
@@ -33,8 +37,27 @@ func Options() ctrlcache.Options {
 		DefaultTransform: ctrlcache.TransformStripManagedFields(),
 		ByObject: map[client.Object]ctrlcache.ByObject{
 			&corev1.Namespace{}: {Transform: transformNamespace},
-			&userv1.User{}:      {Transform: transformUser},
+			&corev1.Pod{}: {
+				Field: fields.OneTermEqualSelector(
+					podSchedulerNameField,
+					accountv1.DebtSchedulerName,
+				),
+				Transform: transformPod,
+			},
+			&userv1.User{}: {Transform: transformUser},
 		},
+	}
+}
+
+// UncachedObjects returns objects whose reads require complete, current API data.
+func UncachedObjects() []client.Object {
+	return []client.Object{
+		&corev1.LimitRange{},
+		// PodReconciler watches metadata only and fetches complete Pods during reconciliation.
+		&corev1.Pod{},
+		&corev1.ResourceQuota{},
+		&accountv1.Debt{},
+		&notificationv1.Notification{},
 	}
 }
 
@@ -63,6 +86,24 @@ func transformNamespace(obj any) (any, error) {
 		Status: corev1.NamespaceStatus{
 			Phase: ns.Status.Phase,
 		},
+	}, nil
+}
+
+func transformPod(obj any) (any, error) {
+	if metadata, ok := obj.(*metav1.PartialObjectMetadata); ok {
+		return &metav1.PartialObjectMetadata{
+			TypeMeta:   metadata.TypeMeta,
+			ObjectMeta: projectObjectMeta(metadata.ObjectMeta),
+		}, nil
+	}
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return obj, nil
+	}
+
+	return &corev1.Pod{
+		TypeMeta:   pod.TypeMeta,
+		ObjectMeta: projectObjectMeta(pod.ObjectMeta),
 	}, nil
 }
 

--- a/controllers/account/controllers/cache/cache.go
+++ b/controllers/account/controllers/cache/cache.go
@@ -53,7 +53,8 @@ func Options() ctrlcache.Options {
 func UncachedObjects() []client.Object {
 	return []client.Object{
 		&corev1.LimitRange{},
-		// PodReconciler watches metadata only and fetches complete Pods during reconciliation.
+		// Other controllers need complete Pods; PodReconciler reads its projection
+		// directly from the cache.
 		&corev1.Pod{},
 		&corev1.ResourceQuota{},
 		&accountv1.Debt{},
@@ -104,6 +105,12 @@ func transformPod(obj any) (any, error) {
 	return &corev1.Pod{
 		TypeMeta:   pod.TypeMeta,
 		ObjectMeta: projectObjectMeta(pod.ObjectMeta),
+		Spec: corev1.PodSpec{
+			SchedulerName: pod.Spec.SchedulerName,
+		},
+		Status: corev1.PodStatus{
+			Phase: pod.Status.Phase,
+		},
 	}, nil
 }
 

--- a/controllers/account/controllers/cache/cache.go
+++ b/controllers/account/controllers/cache/cache.go
@@ -18,11 +18,117 @@ import (
 	"context"
 
 	accountv1 "github.com/labring/sealos/controllers/account/api/v1"
-	v1 "github.com/labring/sealos/controllers/user/api/v1"
+	accounttypes "github.com/labring/sealos/controllers/pkg/types"
+	userv1 "github.com/labring/sealos/controllers/user/api/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// Options limits cached objects to the fields consumed by account controllers.
+func Options() ctrlcache.Options {
+	return ctrlcache.Options{
+		DefaultTransform: ctrlcache.TransformStripManagedFields(),
+		ByObject: map[client.Object]ctrlcache.ByObject{
+			&corev1.Namespace{}: {Transform: transformNamespace},
+			&userv1.User{}:      {Transform: transformUser},
+		},
+	}
+}
+
+func transformNamespace(obj any) (any, error) {
+	ns, ok := obj.(*corev1.Namespace)
+	if !ok {
+		return obj, nil
+	}
+
+	metadata := projectObjectMeta(ns.ObjectMeta)
+	metadata.Labels = copyMapValues(ns.Labels, userv1.UserLabelOwnerKey)
+	metadata.Annotations = copyMapValues(
+		ns.Annotations,
+		accounttypes.DebtNamespaceAnnoStatusKey,
+		accounttypes.FinalDeletionReplayAnnotationKey,
+		accounttypes.NetworkStatusAnnoKey,
+		accounttypes.WorkspaceSubscriptionStatusAnnoKey,
+		accounttypes.WorkspaceSubscriptionStatusUpdateTimeAnnoKey,
+	)
+	return &corev1.Namespace{
+		TypeMeta:   ns.TypeMeta,
+		ObjectMeta: metadata,
+		Spec: corev1.NamespaceSpec{
+			Finalizers: append([]corev1.FinalizerName(nil), ns.Spec.Finalizers...),
+		},
+		Status: corev1.NamespaceStatus{
+			Phase: ns.Status.Phase,
+		},
+	}, nil
+}
+
+func transformUser(obj any) (any, error) {
+	if metadata, ok := obj.(*metav1.PartialObjectMetadata); ok {
+		projected := &metav1.PartialObjectMetadata{
+			TypeMeta:   metadata.TypeMeta,
+			ObjectMeta: projectObjectMeta(metadata.ObjectMeta),
+		}
+		projected.Annotations = copyMapValues(
+			metadata.Annotations,
+			userv1.UserAnnotationOwnerKey,
+			"user.sealos.io/init-account-time",
+			"user.sealos.io/workspace-status",
+		)
+		return projected, nil
+	}
+	user, ok := obj.(*userv1.User)
+	if !ok {
+		return obj, nil
+	}
+
+	metadata := projectObjectMeta(user.ObjectMeta)
+	metadata.Annotations = copyMapValues(
+		user.Annotations,
+		userv1.UserAnnotationOwnerKey,
+		"user.sealos.io/init-account-time",
+		"user.sealos.io/workspace-status",
+	)
+	return &userv1.User{
+		TypeMeta:   user.TypeMeta,
+		ObjectMeta: metadata,
+	}, nil
+}
+
+func projectObjectMeta(in metav1.ObjectMeta) metav1.ObjectMeta {
+	out := metav1.ObjectMeta{
+		Name:              in.Name,
+		Namespace:         in.Namespace,
+		UID:               in.UID,
+		ResourceVersion:   in.ResourceVersion,
+		Generation:        in.Generation,
+		CreationTimestamp: in.CreationTimestamp,
+	}
+	if in.DeletionTimestamp != nil {
+		out.DeletionTimestamp = in.DeletionTimestamp.DeepCopy()
+	}
+	if in.DeletionGracePeriodSeconds != nil {
+		gracePeriod := *in.DeletionGracePeriodSeconds
+		out.DeletionGracePeriodSeconds = &gracePeriod
+	}
+	return out
+}
+
+func copyMapValues(source map[string]string, keys ...string) map[string]string {
+	var result map[string]string
+	for _, key := range keys {
+		if value, ok := source[key]; ok {
+			if result == nil {
+				result = make(map[string]string)
+			}
+			result[key] = value
+		}
+	}
+	return result
+}
 
 func SetupCache(mgr ctrl.Manager) error {
 	ns := &corev1.Namespace{}
@@ -38,7 +144,7 @@ func SetupCache(mgr ctrl.Manager) error {
 		if !ok {
 			return nil
 		}
-		return []string{_ns.Labels[v1.UserLabelOwnerKey]}
+		return []string{_ns.Labels[userv1.UserLabelOwnerKey]}
 	}
 
 	for _, idx := range []struct {

--- a/controllers/account/controllers/cache/cache_test.go
+++ b/controllers/account/controllers/cache/cache_test.go
@@ -63,7 +63,7 @@ func TestUncachedObjectsIncludesPod(t *testing.T) {
 	t.Fatal("pod reads are not configured to bypass the cache")
 }
 
-func TestTransformPodKeepsOnlyMetadata(t *testing.T) {
+func TestTransformPodKeepsOnlyReconcileFields(t *testing.T) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "pod-a",
@@ -93,9 +93,14 @@ func TestTransformPodKeepsOnlyMetadata(t *testing.T) {
 		got.ResourceVersion != pod.ResourceVersion {
 		t.Fatalf("metadata was not retained: %#v", got.ObjectMeta)
 	}
+	if got.Spec.SchedulerName != pod.Spec.SchedulerName || got.Status.Phase != pod.Status.Phase {
+		t.Fatalf("required pod fields were not retained: %#v", got)
+	}
+	got.Spec.SchedulerName = ""
+	got.Status.Phase = ""
 	if !reflect.DeepEqual(got.Spec, corev1.PodSpec{}) ||
 		!reflect.DeepEqual(got.Status, corev1.PodStatus{}) {
-		t.Fatalf("pod data was retained: %#v", got)
+		t.Fatalf("unused pod data was retained: %#v", got)
 	}
 	if len(got.Annotations) != 0 || len(got.ManagedFields) != 0 {
 		t.Fatalf("unused metadata was retained: %#v", got.ObjectMeta)

--- a/controllers/account/controllers/cache/cache_test.go
+++ b/controllers/account/controllers/cache/cache_test.go
@@ -20,10 +20,125 @@ import (
 	"reflect"
 	"testing"
 
+	accountv1 "github.com/labring/sealos/controllers/account/api/v1"
 	userv1 "github.com/labring/sealos/controllers/user/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 )
+
+func TestPodCacheOptions(t *testing.T) {
+	found := false
+	for obj, options := range Options().ByObject {
+		if _, ok := obj.(*corev1.Pod); !ok {
+			continue
+		}
+		found = true
+		if options.Field == nil {
+			t.Fatal("pod cache field selector is nil")
+		}
+		if !options.Field.Matches(fields.Set{
+			podSchedulerNameField: accountv1.DebtSchedulerName,
+		}) {
+			t.Fatal("pod cache selector excludes debt scheduler pods")
+		}
+		if options.Field.Matches(fields.Set{podSchedulerNameField: "default-scheduler"}) {
+			t.Fatal("pod cache selector includes regular pods")
+		}
+		if options.Transform == nil {
+			t.Fatal("pod cache transform is nil")
+		}
+	}
+	if !found {
+		t.Fatal("pod cache options not found")
+	}
+}
+
+func TestUncachedObjectsIncludesPod(t *testing.T) {
+	for _, obj := range UncachedObjects() {
+		if _, ok := obj.(*corev1.Pod); ok {
+			return
+		}
+	}
+	t.Fatal("pod reads are not configured to bypass the cache")
+}
+
+func TestTransformPodKeepsOnlyMetadata(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "pod-a",
+			Namespace:       "ns-a",
+			ResourceVersion: "42",
+			Annotations:     map[string]string{"unused.example/key": "large-value"},
+			ManagedFields:   []metav1.ManagedFieldsEntry{{Manager: "test"}},
+		},
+		Spec: corev1.PodSpec{
+			SchedulerName: accountv1.DebtSchedulerName,
+			Containers:    []corev1.Container{{Name: "app", Image: "example/app:latest"}},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+
+	transformed, err := transformPod(pod)
+	if err != nil {
+		t.Fatalf("transform pod: %v", err)
+	}
+	got, ok := transformed.(*corev1.Pod)
+	if !ok {
+		t.Fatalf("transformed type = %T, want *corev1.Pod", transformed)
+	}
+	if got.Name != pod.Name || got.Namespace != pod.Namespace ||
+		got.ResourceVersion != pod.ResourceVersion {
+		t.Fatalf("metadata was not retained: %#v", got.ObjectMeta)
+	}
+	if !reflect.DeepEqual(got.Spec, corev1.PodSpec{}) ||
+		!reflect.DeepEqual(got.Status, corev1.PodStatus{}) {
+		t.Fatalf("pod data was retained: %#v", got)
+	}
+	if len(got.Annotations) != 0 || len(got.ManagedFields) != 0 {
+		t.Fatalf("unused metadata was retained: %#v", got.ObjectMeta)
+	}
+	if len(pod.ManagedFields) == 0 || len(pod.Spec.Containers) == 0 {
+		t.Fatal("transform mutated the source object")
+	}
+}
+
+func TestTransformPartialPodKeepsOnlyMetadata(t *testing.T) {
+	pod := &metav1.PartialObjectMetadata{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "pod-a",
+			Namespace:       "ns-a",
+			ResourceVersion: "42",
+			Labels:          map[string]string{"unused.example/key": "large-value"},
+			ManagedFields:   []metav1.ManagedFieldsEntry{{Manager: "test"}},
+		},
+	}
+	pod.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
+
+	transformed, err := transformPod(pod)
+	if err != nil {
+		t.Fatalf("transform partial pod: %v", err)
+	}
+	got, ok := transformed.(*metav1.PartialObjectMetadata)
+	if !ok {
+		t.Fatalf("transformed type = %T, want *metav1.PartialObjectMetadata", transformed)
+	}
+	if got.Name != pod.Name || got.Namespace != pod.Namespace ||
+		got.ResourceVersion != pod.ResourceVersion {
+		t.Fatalf("metadata was not retained: %#v", got.ObjectMeta)
+	}
+	if got.GroupVersionKind() != pod.GroupVersionKind() {
+		t.Fatalf("GVK = %s, want %s", got.GroupVersionKind(), pod.GroupVersionKind())
+	}
+	if len(got.Labels) != 0 || len(got.ManagedFields) != 0 {
+		t.Fatalf("unused metadata was retained: %#v", got.ObjectMeta)
+	}
+	if len(pod.Labels) == 0 || len(pod.ManagedFields) == 0 {
+		t.Fatal("transform mutated the source object")
+	}
+}
 
 func TestTransformUserKeepsOnlyMetadata(t *testing.T) {
 	user := &userv1.User{

--- a/controllers/account/controllers/cache/cache_test.go
+++ b/controllers/account/controllers/cache/cache_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"reflect"
+	"testing"
+
+	userv1 "github.com/labring/sealos/controllers/user/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTransformUserKeepsOnlyMetadata(t *testing.T) {
+	user := &userv1.User{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "user-a",
+			ResourceVersion: "42",
+			Annotations: map[string]string{
+				"user.sealos.io/owner": "owner-a",
+				"unused.example/key":   "large-value",
+			},
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "test"}},
+		},
+		Spec: userv1.UserSpec{CSRExpirationSeconds: 600},
+		Status: userv1.UserStatus{
+			Phase:      userv1.UserActive,
+			KubeConfig: "large-kubeconfig",
+		},
+	}
+
+	transformed, err := transformUser(user)
+	if err != nil {
+		t.Fatalf("transform user: %v", err)
+	}
+	got := transformed.(*userv1.User)
+	if got.Name != user.Name || got.ResourceVersion != user.ResourceVersion {
+		t.Fatalf("metadata was not retained: %#v", got.ObjectMeta)
+	}
+	wantAnnotations := map[string]string{"user.sealos.io/owner": "owner-a"}
+	if !reflect.DeepEqual(got.Annotations, wantAnnotations) {
+		t.Fatalf("annotations = %#v, want %#v", got.Annotations, wantAnnotations)
+	}
+	if len(got.ManagedFields) != 0 {
+		t.Fatalf("managed fields were retained: %#v", got.ManagedFields)
+	}
+	if !reflect.DeepEqual(got.Spec, userv1.UserSpec{}) {
+		t.Fatalf("spec was retained: %#v", got.Spec)
+	}
+	if !reflect.DeepEqual(got.Status, userv1.UserStatus{}) {
+		t.Fatalf("status was retained: %#v", got.Status)
+	}
+	if len(user.ManagedFields) == 0 {
+		t.Fatal("transform mutated the source object")
+	}
+}
+
+func TestTransformPartialUserKeepsOnlyMetadata(t *testing.T) {
+	user := &metav1.PartialObjectMetadata{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "user-a",
+			Annotations:   map[string]string{"user.sealos.io/owner": "owner-a", "unused.example/key": "large-value"},
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "test"}},
+		},
+	}
+	user.SetGroupVersionKind(userv1.GroupVersion.WithKind("User"))
+
+	transformed, err := transformUser(user)
+	if err != nil {
+		t.Fatalf("transform partial user: %v", err)
+	}
+	got := transformed.(*metav1.PartialObjectMetadata)
+	if got.Name != user.Name || got.Annotations[userv1.UserAnnotationOwnerKey] != "owner-a" {
+		t.Fatalf("metadata was not retained: %#v", got.ObjectMeta)
+	}
+	if _, ok := got.Annotations["unused.example/key"]; ok || len(got.ManagedFields) != 0 {
+		t.Fatalf("unused metadata was retained: %#v", got.ObjectMeta)
+	}
+}
+
+func TestTransformNamespaceKeepsIndexedFields(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "ns-a",
+			Labels: map[string]string{"user.sealos.io/owner": "owner-a"},
+			Annotations: map[string]string{
+				"debt.sealos/status": "Normal",
+				"unused.example/key": "large-value",
+			},
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "test"}},
+		},
+		Spec: corev1.NamespaceSpec{Finalizers: []corev1.FinalizerName{"kubernetes"}},
+		Status: corev1.NamespaceStatus{
+			Phase:      corev1.NamespaceActive,
+			Conditions: []corev1.NamespaceCondition{{Type: corev1.NamespaceDeletionContentFailure}},
+		},
+	}
+
+	transformed, err := transformNamespace(ns)
+	if err != nil {
+		t.Fatalf("transform namespace: %v", err)
+	}
+	got := transformed.(*corev1.Namespace)
+	if got.Labels["user.sealos.io/owner"] != "owner-a" || got.Annotations["debt.sealos/status"] != "Normal" {
+		t.Fatalf("indexed metadata was not retained: %#v", got.ObjectMeta)
+	}
+	if _, ok := got.Annotations["unused.example/key"]; ok {
+		t.Fatalf("unused annotation was retained: %#v", got.Annotations)
+	}
+	if got.Status.Phase != corev1.NamespaceActive {
+		t.Fatalf("phase = %q, want %q", got.Status.Phase, corev1.NamespaceActive)
+	}
+	if len(got.Spec.Finalizers) != len(ns.Spec.Finalizers) || len(got.Status.Conditions) != 0 || len(got.ManagedFields) != 0 {
+		t.Fatalf("unused namespace fields were retained: %#v", got)
+	}
+}

--- a/controllers/account/controllers/cache/cache_test.go
+++ b/controllers/account/controllers/cache/cache_test.go
@@ -47,7 +47,10 @@ func TestTransformUserKeepsOnlyMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("transform user: %v", err)
 	}
-	got := transformed.(*userv1.User)
+	got, ok := transformed.(*userv1.User)
+	if !ok {
+		t.Fatalf("transformed type = %T, want *userv1.User", transformed)
+	}
 	if got.Name != user.Name || got.ResourceVersion != user.ResourceVersion {
 		t.Fatalf("metadata was not retained: %#v", got.ObjectMeta)
 	}
@@ -72,8 +75,11 @@ func TestTransformUserKeepsOnlyMetadata(t *testing.T) {
 func TestTransformPartialUserKeepsOnlyMetadata(t *testing.T) {
 	user := &metav1.PartialObjectMetadata{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:          "user-a",
-			Annotations:   map[string]string{"user.sealos.io/owner": "owner-a", "unused.example/key": "large-value"},
+			Name: "user-a",
+			Annotations: map[string]string{
+				"user.sealos.io/owner": "owner-a",
+				"unused.example/key":   "large-value",
+			},
 			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "test"}},
 		},
 	}
@@ -83,7 +89,10 @@ func TestTransformPartialUserKeepsOnlyMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("transform partial user: %v", err)
 	}
-	got := transformed.(*metav1.PartialObjectMetadata)
+	got, ok := transformed.(*metav1.PartialObjectMetadata)
+	if !ok {
+		t.Fatalf("transformed type = %T, want *metav1.PartialObjectMetadata", transformed)
+	}
 	if got.Name != user.Name || got.Annotations[userv1.UserAnnotationOwnerKey] != "owner-a" {
 		t.Fatalf("metadata was not retained: %#v", got.ObjectMeta)
 	}
@@ -114,8 +123,12 @@ func TestTransformNamespaceKeepsIndexedFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("transform namespace: %v", err)
 	}
-	got := transformed.(*corev1.Namespace)
-	if got.Labels["user.sealos.io/owner"] != "owner-a" || got.Annotations["debt.sealos/status"] != "Normal" {
+	got, ok := transformed.(*corev1.Namespace)
+	if !ok {
+		t.Fatalf("transformed type = %T, want *corev1.Namespace", transformed)
+	}
+	if got.Labels["user.sealos.io/owner"] != "owner-a" ||
+		got.Annotations["debt.sealos/status"] != "Normal" {
 		t.Fatalf("indexed metadata was not retained: %#v", got.ObjectMeta)
 	}
 	if _, ok := got.Annotations["unused.example/key"]; ok {
@@ -124,7 +137,9 @@ func TestTransformNamespaceKeepsIndexedFields(t *testing.T) {
 	if got.Status.Phase != corev1.NamespaceActive {
 		t.Fatalf("phase = %q, want %q", got.Status.Phase, corev1.NamespaceActive)
 	}
-	if len(got.Spec.Finalizers) != len(ns.Spec.Finalizers) || len(got.Status.Conditions) != 0 || len(got.ManagedFields) != 0 {
+	if len(got.Spec.Finalizers) != len(ns.Spec.Finalizers) ||
+		len(got.Status.Conditions) != 0 ||
+		len(got.ManagedFields) != 0 {
 		t.Fatalf("unused namespace fields were retained: %#v", got)
 	}
 }

--- a/controllers/account/controllers/namespace_controller.go
+++ b/controllers/account/controllers/namespace_controller.go
@@ -132,13 +132,14 @@ func (r *NamespaceReconciler) Reconcile(
 
 	// auxiliary function update annotations
 	updateAnnotations := func(debtStatus, networkStatus string) (ctrl.Result, error) {
+		original := ns.DeepCopy()
 		if debtStatus != "" {
 			ns.Annotations[types.DebtNamespaceAnnoStatusKey] = debtStatus
 		}
 		if networkStatus != "" {
 			ns.Annotations[types.NetworkStatusAnnoKey] = networkStatus
 		}
-		if err := r.Client.Update(ctx, &ns); err != nil {
+		if err := r.Client.Patch(ctx, &ns, client.MergeFrom(original)); err != nil {
 			logger.Error(err, "failed to update namespace annotations")
 			return ctrl.Result{}, err
 		}

--- a/controllers/account/controllers/operationrequest_monitor_controller.go
+++ b/controllers/account/controllers/operationrequest_monitor_controller.go
@@ -213,11 +213,12 @@ func (r *OperationRequestMonitorReconciler) synchronizeNamespaceStatus(
 
 	// Check if owner debt status allows resuming and target is in suspended state
 	if isOwnerEligibleForResume(ownerDebtStatus) && isSuspendedDebtStatus(targetDebtStatus) {
+		original := targetNamespace.DeepCopy()
 		// Resume the target namespace
 		targetNamespace.Annotations[types.DebtNamespaceAnnoStatusKey] = types.ResumeDebtNamespaceAnnoStatus
 
 		// Update the target namespace
-		if err := r.Update(ctx, targetNamespace); err != nil {
+		if err := r.Patch(ctx, targetNamespace, client.MergeFrom(original)); err != nil {
 			return fmt.Errorf(
 				"failed to update target namespace %s annotations: %w",
 				targetNamespace.Name,

--- a/controllers/account/controllers/pod_controller.go
+++ b/controllers/account/controllers/pod_controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -102,7 +103,7 @@ func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 	r.Logger = ctrl.Log.WithName("controllers").WithName("Pod")
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&corev1.Pod{}).
+		For(&corev1.Pod{}, builder.OnlyMetadata).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(r)
 }

--- a/controllers/account/controllers/pod_controller.go
+++ b/controllers/account/controllers/pod_controller.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -36,6 +35,7 @@ import (
 // PodReconciler reconciles a Pod object
 type PodReconciler struct {
 	client.Client
+	CacheReader client.Reader
 	logr.Logger
 	Scheme *runtime.Scheme
 }
@@ -61,7 +61,11 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	// Fetch the pod
 	pod := corev1.Pod{}
 
-	err := r.Get(ctx, req.NamespacedName, &pod)
+	reader := r.CacheReader
+	if reader == nil {
+		reader = r.Client
+	}
+	err := reader.Get(ctx, req.NamespacedName, &pod)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -76,23 +80,21 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	if pod.Spec.SchedulerName != v1.DebtSchedulerName {
 		return reconcile.Result{}, nil
 	}
+	original := pod.DeepCopy()
 	pod.Status.Phase = v1.PodPhaseSuspended
 
 	// Update status after reconciliation.
-	if err = r.patchStatus(ctx, &pod); err != nil {
+	if err = r.patchStatus(ctx, &pod, original); err != nil {
 		return ctrl.Result{Requeue: true}, client.IgnoreNotFound(err)
 	}
 	return ctrl.Result{}, nil
 }
 
-func (r *PodReconciler) patchStatus(ctx context.Context, pod *corev1.Pod) error {
-	key := client.ObjectKeyFromObject(pod)
-	latest := &corev1.Pod{}
-	if err := r.Get(ctx, key, latest); err != nil {
-		return err
-	}
-
-	return r.Client.Status().Patch(ctx, pod, client.MergeFrom(latest))
+func (r *PodReconciler) patchStatus(
+	ctx context.Context,
+	pod, original *corev1.Pod,
+) error {
+	return r.Client.Status().Patch(ctx, pod, client.MergeFrom(original))
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -101,9 +103,12 @@ func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if maxConcurrentReconciles == 0 {
 		maxConcurrentReconciles = 2
 	}
+	if r.CacheReader == nil {
+		r.CacheReader = mgr.GetCache()
+	}
 	r.Logger = ctrl.Log.WithName("controllers").WithName("Pod")
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&corev1.Pod{}, builder.OnlyMetadata).
+		For(&corev1.Pod{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		Complete(r)
 }

--- a/controllers/account/controllers/pod_controller_cache_test.go
+++ b/controllers/account/controllers/pod_controller_cache_test.go
@@ -37,11 +37,15 @@ func TestPatchPodStatusPreservesUncachedFields(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "default"},
 		Spec: corev1.PodSpec{
 			SchedulerName: accountv1.DebtSchedulerName,
-			Containers:    []corev1.Container{{Name: "app", Image: "example/app:latest"}},
+			Containers: []corev1.Container{
+				{Name: "app", Image: "example/app:latest"},
+			},
 		},
 		Status: corev1.PodStatus{
-			Phase:      corev1.PodRunning,
-			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
 		},
 	}
 	cli := fake.NewClientBuilder().

--- a/controllers/account/controllers/pod_controller_cache_test.go
+++ b/controllers/account/controllers/pod_controller_cache_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 labring.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	accountv1 "github.com/labring/sealos/controllers/account/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestPatchPodStatusPreservesUncachedFields(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	stored := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			SchedulerName: accountv1.DebtSchedulerName,
+			Containers:    []corev1.Container{{Name: "app", Image: "example/app:latest"}},
+		},
+		Status: corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&corev1.Pod{}).
+		WithObjects(stored).
+		Build()
+
+	projected := &corev1.Pod{
+		ObjectMeta: stored.ObjectMeta,
+		Spec: corev1.PodSpec{
+			SchedulerName: stored.Spec.SchedulerName,
+		},
+		Status: corev1.PodStatus{Phase: stored.Status.Phase},
+	}
+	original := projected.DeepCopy()
+	projected.Status.Phase = accountv1.PodPhaseSuspended
+
+	reconciler := &PodReconciler{Client: cli}
+	if err := reconciler.patchStatus(context.Background(), projected, original); err != nil {
+		t.Fatalf("patch pod status: %v", err)
+	}
+
+	got := &corev1.Pod{}
+	if err := cli.Get(context.Background(), client.ObjectKeyFromObject(stored), got); err != nil {
+		t.Fatalf("get updated pod: %v", err)
+	}
+	if got.Status.Phase != accountv1.PodPhaseSuspended {
+		t.Fatalf("phase = %q, want %q", got.Status.Phase, accountv1.PodPhaseSuspended)
+	}
+	if len(got.Status.Conditions) != len(stored.Status.Conditions) {
+		t.Fatalf("conditions = %#v, want %#v", got.Status.Conditions, stored.Status.Conditions)
+	}
+}

--- a/controllers/account/controllers/workspace_traffic_controller.go
+++ b/controllers/account/controllers/workspace_traffic_controller.go
@@ -502,8 +502,12 @@ func updateNamespaceStatus(
 		if ns.Annotations[types.NetworkStatusAnnoKey] == status {
 			continue
 		}
+		original := ns.DeepCopy()
+		if ns.Annotations == nil {
+			ns.Annotations = make(map[string]string)
+		}
 		ns.Annotations[types.NetworkStatusAnnoKey] = status
-		if err := clt.Update(ctx, ns); err != nil {
+		if err := clt.Patch(ctx, ns, client.MergeFrom(original)); err != nil {
 			return err
 		}
 	}

--- a/controllers/account/main.go
+++ b/controllers/account/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/labring/sealos/controllers/pkg/utils/env"
 	"github.com/labring/sealos/controllers/pkg/utils/maps"
 	userv1 "github.com/labring/sealos/controllers/user/api/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -144,6 +145,13 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
+		Cache:  cache.Options(),
+		Client: client.Options{Cache: &client.CacheOptions{DisableFor: []client.Object{
+			&corev1.LimitRange{},
+			&corev1.ResourceQuota{},
+			&accountv1.Debt{},
+			&notificationv1.Notification{},
+		}}},
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
 		},

--- a/controllers/account/main.go
+++ b/controllers/account/main.go
@@ -37,7 +37,6 @@ import (
 	"github.com/labring/sealos/controllers/pkg/utils/env"
 	"github.com/labring/sealos/controllers/pkg/utils/maps"
 	userv1 "github.com/labring/sealos/controllers/user/api/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -146,12 +145,7 @@ func main() {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
 		Cache:  cache.Options(),
-		Client: client.Options{Cache: &client.CacheOptions{DisableFor: []client.Object{
-			&corev1.LimitRange{},
-			&corev1.ResourceQuota{},
-			&accountv1.Debt{},
-			&notificationv1.Notification{},
-		}}},
+		Client: client.Options{Cache: &client.CacheOptions{DisableFor: cache.UncachedObjects()}},
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
 		},
@@ -277,7 +271,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", controller)
 		os.Exit(1)
 	}
-	if err = (accountReconciler).SetupWithManager(mgr, rateOpts); err != nil {
+	if err = accountReconciler.SetupWithManager(mgr, rateOpts); err != nil {
 		setupManagerError(err, "Account")
 	}
 	debtUserMap := maps.NewConcurrentMap()

--- a/service/account/api/workspace_subscription.go
+++ b/service/account/api/workspace_subscription.go
@@ -2984,10 +2984,6 @@ func updateWorkspaceSubscriptionNamespaceStatus(workspace string) error {
 			Patch(ctx, ns, client.MergeFrom(original)); err != nil {
 			return fmt.Errorf("patch namespace annotation failed: %w", err)
 		}
-		// Attempt to update the namespace
-		if err := dao.K8sManager.GetClient().Update(ctx, ns); err != nil {
-			return fmt.Errorf("failed to update namespace annotation: %w", err)
-		}
 
 		logrus.Infof(
 			"Successfully updated workspace subscription status annotation for namespace %s",

--- a/service/account/dao/cache_test.go
+++ b/service/account/dao/cache_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dao
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTransformNamespaceKeepsServiceFields(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "ns-a",
+			Labels: map[string]string{UserOwnerLabel: "owner-a"},
+			Annotations: map[string]string{
+				"subscription.sealos.io/status": "Normal",
+				"unused.example/key":            "large-value",
+			},
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "test"}},
+		},
+		Spec: corev1.NamespaceSpec{Finalizers: []corev1.FinalizerName{"kubernetes"}},
+		Status: corev1.NamespaceStatus{
+			Phase:      corev1.NamespaceActive,
+			Conditions: []corev1.NamespaceCondition{{Type: corev1.NamespaceDeletionContentFailure}},
+		},
+	}
+
+	transformed, err := transformNamespace(ns)
+	if err != nil {
+		t.Fatalf("transform namespace: %v", err)
+	}
+	got := transformed.(*corev1.Namespace)
+	if got.Name != ns.Name || got.Labels[UserOwnerLabel] != "owner-a" || len(got.Annotations) == 0 {
+		t.Fatalf("service metadata was not retained: %#v", got.ObjectMeta)
+	}
+	if _, ok := got.Annotations["unused.example/key"]; ok {
+		t.Fatalf("unused annotation was retained: %#v", got.Annotations)
+	}
+	if got.Status.Phase != corev1.NamespaceActive {
+		t.Fatalf("phase = %q, want %q", got.Status.Phase, corev1.NamespaceActive)
+	}
+	if len(got.Spec.Finalizers) != len(ns.Spec.Finalizers) || len(got.Status.Conditions) != 0 || len(got.ManagedFields) != 0 {
+		t.Fatalf("unused namespace fields were retained: %#v", got)
+	}
+}

--- a/service/account/dao/cache_test.go
+++ b/service/account/dao/cache_test.go
@@ -45,8 +45,13 @@ func TestTransformNamespaceKeepsServiceFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("transform namespace: %v", err)
 	}
-	got := transformed.(*corev1.Namespace)
-	if got.Name != ns.Name || got.Labels[UserOwnerLabel] != "owner-a" || len(got.Annotations) == 0 {
+	got, ok := transformed.(*corev1.Namespace)
+	if !ok {
+		t.Fatalf("transformed type = %T, want *corev1.Namespace", transformed)
+	}
+	if got.Name != ns.Name ||
+		got.Labels[UserOwnerLabel] != "owner-a" ||
+		len(got.Annotations) == 0 {
 		t.Fatalf("service metadata was not retained: %#v", got.ObjectMeta)
 	}
 	if _, ok := got.Annotations["unused.example/key"]; ok {
@@ -55,7 +60,9 @@ func TestTransformNamespaceKeepsServiceFields(t *testing.T) {
 	if got.Status.Phase != corev1.NamespaceActive {
 		t.Fatalf("phase = %q, want %q", got.Status.Phase, corev1.NamespaceActive)
 	}
-	if len(got.Spec.Finalizers) != len(ns.Spec.Finalizers) || len(got.Status.Conditions) != 0 || len(got.ManagedFields) != 0 {
+	if len(got.Spec.Finalizers) != len(ns.Spec.Finalizers) ||
+		len(got.Status.Conditions) != 0 ||
+		len(got.ManagedFields) != 0 {
 		t.Fatalf("unused namespace fields were retained: %#v", got)
 	}
 }

--- a/service/account/dao/init.go
+++ b/service/account/dao/init.go
@@ -23,10 +23,12 @@ import (
 	services "github.com/labring/sealos/service/pkg/pay"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -265,6 +267,12 @@ func Init(ctx context.Context) error {
 
 	K8sManager, err = ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
+		Cache:  cacheOptions(),
+		Client: client.Options{Cache: &client.CacheOptions{DisableFor: []client.Object{
+			&corev1.Node{},
+			&corev1.ResourceQuota{},
+			&v1.Notification{},
+		}}},
 	})
 	if err != nil {
 		return fmt.Errorf("unable to start manager: %w", err)
@@ -298,6 +306,75 @@ func Init(ctx context.Context) error {
 }
 
 const UserOwnerLabel = "user.sealos.io/owner"
+
+func cacheOptions() ctrlcache.Options {
+	return ctrlcache.Options{
+		DefaultTransform: ctrlcache.TransformStripManagedFields(),
+		ByObject: map[client.Object]ctrlcache.ByObject{
+			&corev1.Namespace{}: {Transform: transformNamespace},
+		},
+	}
+}
+
+func transformNamespace(obj any) (any, error) {
+	ns, ok := obj.(*corev1.Namespace)
+	if !ok {
+		return obj, nil
+	}
+
+	metadata := projectObjectMeta(ns.ObjectMeta)
+	metadata.Labels = copyMapValues(ns.Labels, UserOwnerLabel)
+	metadata.Annotations = copyMapValues(
+		ns.Annotations,
+		types.DebtNamespaceAnnoStatusKey,
+		types.FinalDeletionReplayAnnotationKey,
+		types.NetworkStatusAnnoKey,
+		types.WorkspaceSubscriptionStatusAnnoKey,
+		types.WorkspaceSubscriptionStatusUpdateTimeAnnoKey,
+	)
+	return &corev1.Namespace{
+		TypeMeta:   ns.TypeMeta,
+		ObjectMeta: metadata,
+		Spec: corev1.NamespaceSpec{
+			Finalizers: append([]corev1.FinalizerName(nil), ns.Spec.Finalizers...),
+		},
+		Status: corev1.NamespaceStatus{
+			Phase: ns.Status.Phase,
+		},
+	}, nil
+}
+
+func projectObjectMeta(in metav1.ObjectMeta) metav1.ObjectMeta {
+	out := metav1.ObjectMeta{
+		Name:              in.Name,
+		Namespace:         in.Namespace,
+		UID:               in.UID,
+		ResourceVersion:   in.ResourceVersion,
+		Generation:        in.Generation,
+		CreationTimestamp: in.CreationTimestamp,
+	}
+	if in.DeletionTimestamp != nil {
+		out.DeletionTimestamp = in.DeletionTimestamp.DeepCopy()
+	}
+	if in.DeletionGracePeriodSeconds != nil {
+		gracePeriod := *in.DeletionGracePeriodSeconds
+		out.DeletionGracePeriodSeconds = &gracePeriod
+	}
+	return out
+}
+
+func copyMapValues(source map[string]string, keys ...string) map[string]string {
+	var result map[string]string
+	for _, key := range keys {
+		if value, ok := source[key]; ok {
+			if result == nil {
+				result = make(map[string]string)
+			}
+			result[key] = value
+		}
+	}
+	return result
+}
 
 func SetupCache(mgr ctrl.Manager) error {
 	ns := &corev1.Namespace{}

--- a/service/account/helper/workspace_subscription.go
+++ b/service/account/helper/workspace_subscription.go
@@ -166,11 +166,12 @@ func updateNamespaceStatus(
 				return nil
 			}
 
+			original := ns.DeepCopy()
 			// Update the annotation
 			ns.Annotations[types.NetworkStatusAnnoKey] = status
 
 			// Attempt to update the namespace
-			return clt.Update(ctx, ns)
+			return clt.Patch(ctx, ns, client.MergeFrom(original))
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
## What this PR does

- strips `managedFields` from account controller and service caches
- projects cached User and Namespace objects to the metadata and business fields their consumers use
- switches account reconciliation and billing lookups to metadata-only User informers
- bypasses the cache for low-frequency objects such as ResourceQuota, LimitRange, Debt, Notification, and Node
- uses merge patches for annotation updates so projected cache objects cannot overwrite omitted fields
- removes a redundant Namespace update after a successful patch

## Why

Account controller and account service retain Kubernetes objects in reflector/informer caches. User status data and unused object fields increase the long-lived heap even though these components only read a small subset of them.

## Testing

- `go test ./... -run ^'$' -count=0` in `controllers/account`
- `go test ./... -run ^'$' -count=0` in `service/account`
- targeted cache transform and controller tests
- `go vet ./...` in both modules\n- `git diff --check`