### PR TITLE
perf(resources): reduce controller cache memory

### DIFF
--- a/controllers/resources/controllers/cache/cache.go
+++ b/controllers/resources/controllers/cache/cache.go
@@ -1,0 +1,358 @@
+// Copyright 2026 labring.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"context"
+	"fmt"
+
+	kbv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	appv1 "github.com/labring/sealos/controllers/app/api/v1"
+	"github.com/labring/sealos/controllers/pkg/gpu"
+	"github.com/labring/sealos/controllers/pkg/resources"
+	accounttypes "github.com/labring/sealos/controllers/pkg/types"
+	"github.com/labring/sealos/controllers/pkg/utils/label"
+	userv1 "github.com/labring/sealos/controllers/user/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	gpuAliasConfigKey             = "alias"
+	gpuInfoConfigKey              = "gpu"
+	backupRepositoryLabelKey      = "dataprotection.kubeblocks.io/backup-repo-name"
+	networkStatusAnnotationKey    = "network.sealos.io/status"
+	originalNodePortLabelKey      = "network.sealos.io/original-nodeport"
+	persistentVolumeClaimPhaseKey = "status.phase"
+	backupPhaseKey                = "status.phase"
+	serviceTypeKey                = "spec.type"
+)
+
+// Options retains only the Kubernetes fields used by resource monitoring.
+func Options() ctrlcache.Options {
+	return ctrlcache.Options{
+		ReaderFailOnMissingInformer: true,
+		DefaultTransform:            ctrlcache.TransformStripManagedFields(),
+		ByObject: map[client.Object]ctrlcache.ByObject{
+			&corev1.Namespace{}: {
+				Transform: transformNamespace,
+			},
+			&corev1.Pod{}: {
+				Transform: transformPod,
+			},
+			&corev1.PersistentVolumeClaim{}: {
+				Transform: transformPersistentVolumeClaim,
+			},
+			&kbv1alpha1.Backup{}: {
+				Transform: transformBackup,
+			},
+			&corev1.Service{}: {
+				Transform: transformService,
+			},
+			&appv1.Instance{}: {
+				Transform: transformInstance,
+			},
+			&corev1.ConfigMap{}: {
+				Namespaces: map[string]ctrlcache.Config{
+					gpu.NodeInfoConfigmapNamespace: {
+						FieldSelector: fields.OneTermEqualSelector(
+							"metadata.name",
+							gpu.NodeInfoConfigmapName,
+						),
+					},
+				},
+				Transform: transformGPUConfigMap,
+			},
+		},
+	}
+}
+
+// UncachedObjects keeps general controller reads and all writes on complete API objects.
+func UncachedObjects() []client.Object {
+	return []client.Object{
+		&corev1.Namespace{},
+		&corev1.Pod{},
+		&corev1.PersistentVolumeClaim{},
+		&kbv1alpha1.Backup{},
+		&corev1.Service{},
+		&appv1.Instance{},
+		&corev1.ConfigMap{},
+	}
+}
+
+// SetupInformers registers projected informers that are read only by the periodic monitor.
+func SetupInformers(mgr ctrl.Manager) error {
+	instanceMetadata := &metav1.PartialObjectMetadata{}
+	instanceMetadata.SetGroupVersionKind(appv1.GroupVersion.WithKind("Instance"))
+	objects := []client.Object{
+		&corev1.Namespace{},
+		&corev1.Pod{},
+		&corev1.ConfigMap{},
+		instanceMetadata,
+	}
+
+	for _, object := range objects {
+		if _, err := mgr.GetCache().GetInformer(context.Background(), object); err != nil {
+			return fmt.Errorf("register informer for %T: %w", object, err)
+		}
+	}
+	return nil
+}
+
+func transformNamespace(obj any) (any, error) {
+	ns, ok := obj.(*corev1.Namespace)
+	if !ok {
+		return obj, nil
+	}
+
+	metadata := projectObjectMeta(ns.ObjectMeta)
+	metadata.Labels = copyMapValues(ns.Labels, userv1.UserLabelOwnerKey)
+	metadata.Annotations = copyMapValues(
+		ns.Annotations,
+		accounttypes.DebtNamespaceAnnoStatusKey,
+		accounttypes.WorkspaceSubscriptionStatusAnnoKey,
+		networkStatusAnnotationKey,
+	)
+	return &corev1.Namespace{
+		TypeMeta:   ns.TypeMeta,
+		ObjectMeta: metadata,
+	}, nil
+}
+
+func transformPod(obj any) (any, error) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return obj, nil
+	}
+
+	containers := make([]corev1.Container, 0, len(pod.Spec.Containers))
+	for i := range pod.Spec.Containers {
+		container := &pod.Spec.Containers[i]
+		projected := corev1.Container{
+			Name: container.Name,
+			Resources: corev1.ResourceRequirements{
+				Limits:   copyResourceList(container.Resources.Limits),
+				Requests: copyResourceList(container.Resources.Requests),
+			},
+		}
+		if container.Name == "acmesolver" {
+			projected.Args = append([]string(nil), container.Args...)
+		}
+		containers = append(containers, projected)
+	}
+
+	metadata := projectObjectMeta(pod.ObjectMeta)
+	metadata.Labels = resourceLabels(pod.Labels)
+	projected := &corev1.Pod{
+		TypeMeta:   pod.TypeMeta,
+		ObjectMeta: metadata,
+		Spec: corev1.PodSpec{
+			NodeName:   pod.Spec.NodeName,
+			Containers: containers,
+		},
+		Status: corev1.PodStatus{
+			Phase: pod.Status.Phase,
+		},
+	}
+	if pod.Status.StartTime != nil {
+		projected.Status.StartTime = pod.Status.StartTime.DeepCopy()
+	}
+	return projected, nil
+}
+
+func transformPersistentVolumeClaim(obj any) (any, error) {
+	pvc, ok := obj.(*corev1.PersistentVolumeClaim)
+	if !ok {
+		return obj, nil
+	}
+
+	metadata := projectObjectMeta(pvc.ObjectMeta)
+	metadata.Labels = resourceLabels(pvc.Labels)
+	if len(pvc.OwnerReferences) > 0 {
+		metadata.OwnerReferences = []metav1.OwnerReference{{
+			Kind: pvc.OwnerReferences[0].Kind,
+		}}
+	}
+	requests := corev1.ResourceList{}
+	if storage, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]; ok {
+		requests[corev1.ResourceStorage] = storage.DeepCopy()
+	}
+	return &corev1.PersistentVolumeClaim{
+		TypeMeta:   pvc.TypeMeta,
+		ObjectMeta: metadata,
+		Spec: corev1.PersistentVolumeClaimSpec{
+			Resources: corev1.VolumeResourceRequirements{Requests: requests},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: pvc.Status.Phase,
+		},
+	}, nil
+}
+
+func transformBackup(obj any) (any, error) {
+	backup, ok := obj.(*kbv1alpha1.Backup)
+	if !ok {
+		return obj, nil
+	}
+
+	metadata := projectObjectMeta(backup.ObjectMeta)
+	metadata.Labels = resourceLabels(backup.Labels)
+	return &kbv1alpha1.Backup{
+		TypeMeta:   backup.TypeMeta,
+		ObjectMeta: metadata,
+		Status: kbv1alpha1.BackupStatus{
+			Phase:     backup.Status.Phase,
+			TotalSize: backup.Status.TotalSize,
+		},
+	}, nil
+}
+
+func transformService(obj any) (any, error) {
+	service, ok := obj.(*corev1.Service)
+	if !ok {
+		return obj, nil
+	}
+
+	ports := make([]corev1.ServicePort, len(service.Spec.Ports))
+	for i := range service.Spec.Ports {
+		ports[i].NodePort = service.Spec.Ports[i].NodePort
+	}
+	metadata := projectObjectMeta(service.ObjectMeta)
+	metadata.Labels = resourceLabels(service.Labels)
+	if value, ok := service.Labels[originalNodePortLabelKey]; ok {
+		if metadata.Labels == nil {
+			metadata.Labels = make(map[string]string)
+		}
+		metadata.Labels[originalNodePortLabelKey] = value
+	}
+	return &corev1.Service{
+		TypeMeta:   service.TypeMeta,
+		ObjectMeta: metadata,
+		Spec: corev1.ServiceSpec{
+			Type:  service.Spec.Type,
+			Ports: ports,
+		},
+	}, nil
+}
+
+func transformInstance(obj any) (any, error) {
+	switch instance := obj.(type) {
+	case *appv1.Instance:
+		metadata := projectObjectMeta(instance.ObjectMeta)
+		metadata.Labels = copyMapValues(instance.Labels, resources.AppStoreDeployLabelKey)
+		return &appv1.Instance{
+			TypeMeta:   instance.TypeMeta,
+			ObjectMeta: metadata,
+		}, nil
+	case *metav1.PartialObjectMetadata:
+		metadata := projectObjectMeta(instance.ObjectMeta)
+		metadata.Labels = copyMapValues(instance.Labels, resources.AppStoreDeployLabelKey)
+		return &metav1.PartialObjectMetadata{
+			TypeMeta:   instance.TypeMeta,
+			ObjectMeta: metadata,
+		}, nil
+	default:
+		return obj, nil
+	}
+}
+
+func transformGPUConfigMap(obj any) (any, error) {
+	configMap, ok := obj.(*corev1.ConfigMap)
+	if !ok {
+		return obj, nil
+	}
+
+	return &corev1.ConfigMap{
+		TypeMeta:   configMap.TypeMeta,
+		ObjectMeta: projectObjectMeta(configMap.ObjectMeta),
+		Data: copyMapValues(
+			configMap.Data,
+			gpuAliasConfigKey,
+			gpuInfoConfigKey,
+		),
+	}, nil
+}
+
+func resourceLabels(source map[string]string) map[string]string {
+	return copyMapValues(
+		source,
+		resources.DBPodLabelInstanceKey,
+		resources.DBPodLabelComponentNameKey,
+		resources.TerminalIDLabelKey,
+		label.AppManagedBy,
+		label.AppPartOf,
+		label.AppName,
+		resources.AppLabelKey,
+		resources.AppDeployLabelKey,
+		resources.JobNameLabelKey,
+		resources.ACMEChallengeKey,
+		backupRepositoryLabelKey,
+		resources.InstanceLabelKey,
+	)
+}
+
+func copyResourceList(source corev1.ResourceList) corev1.ResourceList {
+	if len(source) == 0 {
+		return nil
+	}
+	result := make(corev1.ResourceList, len(source))
+	for name, quantity := range source {
+		result[name] = quantity.DeepCopy()
+	}
+	return result
+}
+
+func projectObjectMeta(in metav1.ObjectMeta) metav1.ObjectMeta {
+	out := metav1.ObjectMeta{
+		Name:              in.Name,
+		Namespace:         in.Namespace,
+		UID:               in.UID,
+		ResourceVersion:   in.ResourceVersion,
+		Generation:        in.Generation,
+		CreationTimestamp: in.CreationTimestamp,
+	}
+	if in.DeletionTimestamp != nil {
+		out.DeletionTimestamp = in.DeletionTimestamp.DeepCopy()
+	}
+	if in.DeletionGracePeriodSeconds != nil {
+		gracePeriod := *in.DeletionGracePeriodSeconds
+		out.DeletionGracePeriodSeconds = &gracePeriod
+	}
+	return out
+}
+
+func copyMapValues(source map[string]string, keys ...string) map[string]string {
+	var result map[string]string
+	for _, key := range keys {
+		if value, ok := source[key]; ok {
+			if result == nil {
+				result = make(map[string]string)
+			}
+			result[key] = value
+		}
+	}
+	return result
+}
+
+// Index field names shared with the monitor reconciler.
+const (
+	PersistentVolumeClaimPhaseKey = persistentVolumeClaimPhaseKey
+	BackupPhaseKey                = backupPhaseKey
+	ServiceTypeKey                = serviceTypeKey
+)

--- a/controllers/resources/controllers/cache/cache_test.go
+++ b/controllers/resources/controllers/cache/cache_test.go
@@ -1,0 +1,419 @@
+// Copyright 2026 labring.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"reflect"
+	"testing"
+
+	kbv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	appv1 "github.com/labring/sealos/controllers/app/api/v1"
+	"github.com/labring/sealos/controllers/pkg/gpu"
+	"github.com/labring/sealos/controllers/pkg/resources"
+	accounttypes "github.com/labring/sealos/controllers/pkg/types"
+	userv1 "github.com/labring/sealos/controllers/user/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestOptionsRegistersOnlyMonitorObjects(t *testing.T) {
+	options := Options()
+	if !options.ReaderFailOnMissingInformer {
+		t.Fatal("missing informer reads are allowed")
+	}
+	if options.DefaultTransform == nil {
+		t.Fatal("default managed fields transform is nil")
+	}
+
+	required := []client.Object{
+		&corev1.Namespace{},
+		&corev1.Pod{},
+		&corev1.PersistentVolumeClaim{},
+		&kbv1alpha1.Backup{},
+		&corev1.Service{},
+		&appv1.Instance{},
+		&corev1.ConfigMap{},
+	}
+	if len(options.ByObject) != len(required) {
+		t.Fatalf("cache object count = %d, want %d", len(options.ByObject), len(required))
+	}
+	for _, expected := range required {
+		found := false
+		for obj, byObject := range options.ByObject {
+			if reflect.TypeOf(obj) != reflect.TypeOf(expected) {
+				continue
+			}
+			found = true
+			if byObject.Transform == nil {
+				t.Fatalf("%T transform is nil", expected)
+			}
+		}
+		if !found {
+			t.Fatalf("%T cache options not found", expected)
+		}
+	}
+}
+
+func TestUncachedObjectsProtectProjectedWrites(t *testing.T) {
+	disabled := UncachedObjects()
+	if len(disabled) != len(Options().ByObject) {
+		t.Fatalf("uncached object count = %d, want %d", len(disabled), len(Options().ByObject))
+	}
+	for cached := range Options().ByObject {
+		found := false
+		for _, object := range disabled {
+			if reflect.TypeOf(cached) == reflect.TypeOf(object) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("projected %T is not disabled on the general client", cached)
+		}
+	}
+}
+
+func TestOptionsLimitsGPUConfigMapCache(t *testing.T) {
+	options := Options()
+	for obj, byObject := range options.ByObject {
+		if _, ok := obj.(*corev1.ConfigMap); !ok {
+			continue
+		}
+		if len(byObject.Namespaces) != 1 {
+			t.Fatalf("configmap cache namespaces = %d, want 1", len(byObject.Namespaces))
+		}
+		config, ok := byObject.Namespaces[gpu.NodeInfoConfigmapNamespace]
+		if !ok {
+			t.Fatalf("configmap cache does not include %q", gpu.NodeInfoConfigmapNamespace)
+		}
+		if got, want := config.FieldSelector.String(), "metadata.name="+gpu.NodeInfoConfigmapName; got != want {
+			t.Fatalf("configmap field selector = %q, want %q", got, want)
+		}
+		return
+	}
+	t.Fatal("configmap cache options not found")
+}
+
+func TestTransformNamespaceKeepsMonitorSelectionFields(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "ns-user-a",
+			ResourceVersion: "42",
+			Labels: map[string]string{
+				userv1.UserLabelOwnerKey: "user-a",
+				"unused":                 "large-value",
+			},
+			Annotations: map[string]string{
+				accounttypes.DebtNamespaceAnnoStatusKey:         accounttypes.SuspendDebtNamespaceAnnoStatus,
+				accounttypes.WorkspaceSubscriptionStatusAnnoKey: "active",
+				networkStatusAnnotationKey:                      "Suspend",
+				"unused":                                        "large-value",
+			},
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "test"}},
+		},
+		Spec: corev1.NamespaceSpec{Finalizers: []corev1.FinalizerName{"kubernetes"}},
+	}
+
+	transformed, err := transformNamespace(ns)
+	if err != nil {
+		t.Fatalf("transform namespace: %v", err)
+	}
+	got, ok := transformed.(*corev1.Namespace)
+	if !ok {
+		t.Fatalf("transformed type = %T, want *v1.Namespace", transformed)
+	}
+	if got.Name != ns.Name || got.ResourceVersion != ns.ResourceVersion {
+		t.Fatalf("required identity metadata was not retained: %#v", got.ObjectMeta)
+	}
+	if !reflect.DeepEqual(got.Labels, map[string]string{userv1.UserLabelOwnerKey: "user-a"}) {
+		t.Fatalf("namespace labels = %#v", got.Labels)
+	}
+	if !reflect.DeepEqual(got.Annotations, map[string]string{
+		accounttypes.DebtNamespaceAnnoStatusKey:         accounttypes.SuspendDebtNamespaceAnnoStatus,
+		accounttypes.WorkspaceSubscriptionStatusAnnoKey: "active",
+		networkStatusAnnotationKey:                      "Suspend",
+	}) {
+		t.Fatalf("namespace annotations = %#v", got.Annotations)
+	}
+	if len(got.ManagedFields) != 0 || len(got.Spec.Finalizers) != 0 {
+		t.Fatalf("unused namespace payload was retained: %#v", got)
+	}
+}
+
+func TestTransformPodKeepsResourceAccountingFields(t *testing.T) {
+	startTime := metav1.Now()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app-a-0",
+			Namespace: "ns-user-a",
+			Labels: map[string]string{
+				resources.AppLabelKey: "app-a",
+				"unused":              "large-value",
+			},
+			Annotations:   map[string]string{"unused": "large-value"},
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "test"}},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node-a",
+			Containers: []corev1.Container{
+				{
+					Name:  "app",
+					Image: "large-image-name",
+					Args:  []string{"unused", "arguments"},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("500m"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+						Claims: []corev1.ResourceClaim{{Name: "unused-claim"}},
+					},
+				},
+				{
+					Name: "acmesolver",
+					Args: []string{"--domain=example.test"},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase:     corev1.PodRunning,
+			StartTime: &startTime,
+			PodIP:     "10.0.0.1",
+		},
+	}
+
+	transformed, err := transformPod(pod)
+	if err != nil {
+		t.Fatalf("transform pod: %v", err)
+	}
+	got, ok := transformed.(*corev1.Pod)
+	if !ok {
+		t.Fatalf("transformed type = %T, want *v1.Pod", transformed)
+	}
+	if got.Spec.NodeName != pod.Spec.NodeName || got.Status.Phase != pod.Status.Phase ||
+		got.Status.StartTime == nil || !got.Status.StartTime.Equal(pod.Status.StartTime) {
+		t.Fatalf("pod scheduling fields were not retained: %#v", got)
+	}
+	if got.Spec.Containers[0].Resources.Requests.Cpu().String() != "500m" ||
+		got.Spec.Containers[0].Resources.Limits.Memory().String() != "1Gi" {
+		t.Fatalf("pod resources were not retained: %#v", got.Spec.Containers[0].Resources)
+	}
+	if len(got.Spec.Containers[0].Args) != 0 || got.Spec.Containers[0].Image != "" ||
+		len(got.Spec.Containers[0].Resources.Claims) != 0 ||
+		!reflect.DeepEqual(got.Spec.Containers[1].Args, []string{"--domain=example.test"}) {
+		t.Fatalf("pod container projection is incorrect: %#v", got.Spec.Containers)
+	}
+	if got.Status.PodIP != "" || len(got.Annotations) != 0 || len(got.ManagedFields) != 0 {
+		t.Fatalf("unused pod payload was retained: %#v", got)
+	}
+	if named := resources.NewResourceNamed(got); named.Name() != "app-a" {
+		t.Fatalf("resource name = %q, want app-a", named.Name())
+	}
+}
+
+func TestTransformPersistentVolumeClaimKeepsIndexAndStorage(t *testing.T) {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "data-app-a",
+			Namespace: "ns-user-a",
+			Labels:    map[string]string{resources.AppLabelKey: "app-a", "unused": "value"},
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "StatefulSet", Name: "app-a", UID: types.UID("owner-a")},
+				{Kind: "Other", Name: "unused"},
+			},
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "test"}},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: "large-volume-name",
+			Resources: corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("20Gi"),
+				corev1.ResourceCPU:     resource.MustParse("1"),
+			}},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase:    corev1.ClaimBound,
+			Capacity: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("20Gi")},
+		},
+	}
+
+	transformed, err := transformPersistentVolumeClaim(pvc)
+	if err != nil {
+		t.Fatalf("transform pvc: %v", err)
+	}
+	got, ok := transformed.(*corev1.PersistentVolumeClaim)
+	if !ok {
+		t.Fatalf("transformed type = %T, want *v1.PersistentVolumeClaim", transformed)
+	}
+	if got.Status.Phase != corev1.ClaimBound ||
+		got.Spec.Resources.Requests.Storage().String() != "20Gi" {
+		t.Fatalf("pvc accounting fields were not retained: %#v", got)
+	}
+	if len(got.OwnerReferences) != 1 || got.OwnerReferences[0].Kind != "StatefulSet" ||
+		got.OwnerReferences[0].Name != "" {
+		t.Fatalf("pvc owner projection = %#v", got.OwnerReferences)
+	}
+	if got.Spec.VolumeName != "" || len(got.Status.Capacity) != 0 ||
+		got.Spec.Resources.Requests.Cpu().Sign() != 0 || len(got.ManagedFields) != 0 {
+		t.Fatalf("unused pvc payload was retained: %#v", got)
+	}
+}
+
+func TestTransformBackupAndServiceKeepAccountingFields(t *testing.T) {
+	backup := &kbv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "backup-a",
+			Labels: map[string]string{
+				resources.InstanceLabelKey: "database-a",
+				"unused":                   "value",
+			},
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "test"}},
+		},
+		Status: kbv1alpha1.BackupStatus{
+			Phase:         kbv1alpha1.BackupPhaseCompleted,
+			TotalSize:     "2Gi",
+			FailureReason: "unused-large-value",
+		},
+	}
+	transformedBackup, err := transformBackup(backup)
+	if err != nil {
+		t.Fatalf("transform backup: %v", err)
+	}
+	gotBackup, ok := transformedBackup.(*kbv1alpha1.Backup)
+	if !ok {
+		t.Fatalf("transformed type = %T, want *v1alpha1.Backup", transformedBackup)
+	}
+	if gotBackup.Status.Phase != backup.Status.Phase || gotBackup.Status.TotalSize != "2Gi" ||
+		gotBackup.Status.FailureReason != "" || len(gotBackup.ManagedFields) != 0 {
+		t.Fatalf("backup projection is incorrect: %#v", gotBackup)
+	}
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "app-a",
+			Labels: map[string]string{
+				resources.AppLabelKey:    "app-a",
+				originalNodePortLabelKey: "true",
+				"unused":                 "value",
+			},
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "test"}},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:      corev1.ServiceTypeNodePort,
+			ClusterIP: "10.96.0.1",
+			Selector:  map[string]string{"large": "selector"},
+			Ports: []corev1.ServicePort{
+				{Name: "http", Port: 80, NodePort: 30080},
+				{Name: "https", Port: 443, NodePort: 30443},
+			},
+		},
+	}
+	transformedService, err := transformService(service)
+	if err != nil {
+		t.Fatalf("transform service: %v", err)
+	}
+	gotService, ok := transformedService.(*corev1.Service)
+	if !ok {
+		t.Fatalf("transformed type = %T, want *v1.Service", transformedService)
+	}
+	if gotService.Spec.Type != corev1.ServiceTypeNodePort ||
+		gotService.Spec.Ports[0].NodePort != 30080 || gotService.Spec.Ports[1].NodePort != 30443 {
+		t.Fatalf("service accounting fields were not retained: %#v", gotService.Spec)
+	}
+	if gotService.Labels[originalNodePortLabelKey] != "true" {
+		t.Fatalf("service network label was not retained: %#v", gotService.Labels)
+	}
+	if gotService.Spec.ClusterIP != "" || len(gotService.Spec.Selector) != 0 ||
+		gotService.Spec.Ports[0].Name != "" || gotService.Spec.Ports[0].Port != 0 ||
+		len(gotService.ManagedFields) != 0 {
+		t.Fatalf("unused service payload was retained: %#v", gotService)
+	}
+}
+
+func TestTransformInstanceAndGPUConfigMap(t *testing.T) {
+	instance := &appv1.Instance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "instance-a",
+			Labels: map[string]string{
+				resources.AppStoreDeployLabelKey: "store-a",
+				"unused":                         "value",
+			},
+			Annotations:   map[string]string{"unused": "value"},
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "test"}},
+		},
+	}
+	transformedInstance, err := transformInstance(instance)
+	if err != nil {
+		t.Fatalf("transform instance: %v", err)
+	}
+	gotInstance, ok := transformedInstance.(*appv1.Instance)
+	if !ok {
+		t.Fatalf("transformed type = %T, want *v1.Instance", transformedInstance)
+	}
+	if !reflect.DeepEqual(gotInstance.Labels, map[string]string{
+		resources.AppStoreDeployLabelKey: "store-a",
+	}) || len(gotInstance.Annotations) != 0 || len(gotInstance.ManagedFields) != 0 {
+		t.Fatalf("instance projection is incorrect: %#v", gotInstance)
+	}
+	instanceMetadata := &metav1.PartialObjectMetadata{
+		ObjectMeta: instance.ObjectMeta,
+	}
+	instanceMetadata.SetGroupVersionKind(appv1.GroupVersion.WithKind("Instance"))
+	transformedMetadata, err := transformInstance(instanceMetadata)
+	if err != nil {
+		t.Fatalf("transform instance metadata: %v", err)
+	}
+	gotMetadata, ok := transformedMetadata.(*metav1.PartialObjectMetadata)
+	if !ok {
+		t.Fatalf("transformed type = %T, want *metav1.PartialObjectMetadata", transformedMetadata)
+	}
+	if gotMetadata.GroupVersionKind() != instanceMetadata.GroupVersionKind() ||
+		!reflect.DeepEqual(gotMetadata.Labels, gotInstance.Labels) ||
+		len(gotMetadata.Annotations) != 0 || len(gotMetadata.ManagedFields) != 0 {
+		t.Fatalf("instance metadata projection is incorrect: %#v", gotMetadata)
+	}
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            gpu.NodeInfoConfigmapName,
+			Namespace:       gpu.NodeInfoConfigmapNamespace,
+			ManagedFields:   []metav1.ManagedFieldsEntry{{Manager: "test"}},
+			ResourceVersion: "42",
+		},
+		Data: map[string]string{
+			gpuAliasConfigKey: "alias-data",
+			gpuInfoConfigKey:  "gpu-data",
+			"unused":          "large-value",
+		},
+		BinaryData: map[string][]byte{"unused": []byte("large-value")},
+	}
+	transformedConfigMap, err := transformGPUConfigMap(configMap)
+	if err != nil {
+		t.Fatalf("transform configmap: %v", err)
+	}
+	gotConfigMap, ok := transformedConfigMap.(*corev1.ConfigMap)
+	if !ok {
+		t.Fatalf("transformed type = %T, want *v1.ConfigMap", transformedConfigMap)
+	}
+	if !reflect.DeepEqual(gotConfigMap.Data, map[string]string{
+		gpuAliasConfigKey: "alias-data",
+		gpuInfoConfigKey:  "gpu-data",
+	}) || len(gotConfigMap.BinaryData) != 0 || len(gotConfigMap.ManagedFields) != 0 {
+		t.Fatalf("configmap projection is incorrect: %#v", gotConfigMap)
+	}
+}

--- a/controllers/resources/controllers/monitor_controller.go
+++ b/controllers/resources/controllers/monitor_controller.go
@@ -38,6 +38,7 @@ import (
 	"github.com/labring/sealos/controllers/pkg/utils/env"
 	"github.com/labring/sealos/controllers/pkg/utils/logger"
 	"github.com/labring/sealos/controllers/pkg/utils/retry"
+	resourcecache "github.com/labring/sealos/controllers/resources/controllers/cache"
 	userv1 "github.com/labring/sealos/controllers/user/api/v1"
 	"github.com/labring/sealos/controllers/user/controllers/helper/config"
 	"github.com/minio/minio-go/v7"
@@ -57,6 +58,7 @@ import (
 // MonitorReconciler reconciles a Monitor object
 type MonitorReconciler struct {
 	client.Client
+	cache client.Reader
 	logr.Logger
 	Interval                 time.Duration
 	Scheme                   *runtime.Scheme
@@ -135,6 +137,7 @@ const (
 func NewMonitorReconciler(mgr ctrl.Manager) (*MonitorReconciler, error) {
 	r := &MonitorReconciler{
 		Client:                mgr.GetClient(),
+		cache:                 mgr.GetCache(),
 		Logger:                ctrl.Log.WithName("controllers").WithName("Monitor"),
 		stopCh:                make(chan struct{}),
 		periodicReconcile:     1 * time.Minute,
@@ -164,7 +167,7 @@ func NewMonitorReconciler(mgr ctrl.Manager) (*MonitorReconciler, error) {
 
 func InitIndexField(mgr ctrl.Manager) error {
 	if err := mgr.GetFieldIndexer().
-		IndexField(context.Background(), &corev1.PersistentVolumeClaim{}, "status.phase", func(rawObj client.Object) []string {
+		IndexField(context.Background(), &corev1.PersistentVolumeClaim{}, resourcecache.PersistentVolumeClaimPhaseKey, func(rawObj client.Object) []string {
 			pvc, ok := rawObj.(*corev1.PersistentVolumeClaim)
 			if !ok {
 				return nil
@@ -174,7 +177,7 @@ func InitIndexField(mgr ctrl.Manager) error {
 		return err
 	}
 	if err := mgr.GetFieldIndexer().
-		IndexField(context.Background(), &kbv1alpha1.Backup{}, "status.phase", func(rawObj client.Object) []string {
+		IndexField(context.Background(), &kbv1alpha1.Backup{}, resourcecache.BackupPhaseKey, func(rawObj client.Object) []string {
 			backup, ok := rawObj.(*kbv1alpha1.Backup)
 			if !ok {
 				return nil
@@ -184,7 +187,7 @@ func InitIndexField(mgr ctrl.Manager) error {
 		return err
 	}
 	return mgr.GetFieldIndexer().
-		IndexField(context.Background(), &corev1.Service{}, "spec.type", func(rawObj client.Object) []string {
+		IndexField(context.Background(), &corev1.Service{}, resourcecache.ServiceTypeKey, func(rawObj client.Object) []string {
 			svc, ok := rawObj.(*corev1.Service)
 			if !ok {
 				return nil
@@ -230,7 +233,7 @@ func (r *MonitorReconciler) getNamespaceList() (*corev1.NamespaceList, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create label requirement: %w", err)
 	}
-	return namespaceList, r.List(context.Background(), namespaceList, &client.ListOptions{
+	return namespaceList, r.cache.List(context.Background(), namespaceList, &client.ListOptions{
 		LabelSelector: labels.NewSelector().Add(*req),
 	})
 }
@@ -467,7 +470,11 @@ func (r *MonitorReconciler) getInstances(namespace string) (map[string]struct{},
 	instances := make(map[string]struct{})
 	insList := metav1.PartialObjectMetadataList{}
 	insList.SetGroupVersionKind(appv1.GroupVersion.WithKind("InstanceList"))
-	if err := r.List(context.Background(), &insList, client.InNamespace(namespace)); err != nil {
+	if err := r.cache.List(
+		context.Background(),
+		&insList,
+		client.InNamespace(namespace),
+	); err != nil {
 		return nil, fmt.Errorf("failed to list instances: %w", err)
 	}
 	for i := range insList.Items {
@@ -487,7 +494,7 @@ func (r *MonitorReconciler) monitorPodResourceUsage(
 	instances map[string]struct{},
 ) error {
 	podList := &corev1.PodList{}
-	if err := r.List(context.Background(), podList, &client.ListOptions{
+	if err := r.cache.List(context.Background(), podList, &client.ListOptions{
 		Namespace: namespace,
 	}); err != nil {
 		return fmt.Errorf("failed to list pods: %w", err)
@@ -584,9 +591,12 @@ func (r *MonitorReconciler) monitorPVCResourceUsage(
 	instances map[string]struct{},
 ) error {
 	pvcList := &corev1.PersistentVolumeClaimList{}
-	if err := r.List(context.Background(), pvcList, &client.ListOptions{
-		Namespace:     namespace,
-		FieldSelector: fields.OneTermEqualSelector("status.phase", string(corev1.ClaimBound)),
+	if err := r.cache.List(context.Background(), pvcList, &client.ListOptions{
+		Namespace: namespace,
+		FieldSelector: fields.OneTermEqualSelector(
+			resourcecache.PersistentVolumeClaimPhaseKey,
+			string(corev1.ClaimBound),
+		),
 	}); err != nil {
 		return fmt.Errorf("failed to list pvc: %w", err)
 	}
@@ -614,10 +624,10 @@ func (r *MonitorReconciler) monitorDatabaseBackupUsage(
 	resNamed map[string]*resources.ResourceNamed,
 ) error {
 	backupList := &kbv1alpha1.BackupList{}
-	if err := r.List(context.Background(), backupList, &client.ListOptions{
+	if err := r.cache.List(context.Background(), backupList, &client.ListOptions{
 		Namespace: namespace,
 		FieldSelector: fields.OneTermEqualSelector(
-			"status.phase",
+			resourcecache.BackupPhaseKey,
 			string(kbv1alpha1.BackupPhaseCompleted),
 		),
 	}); err != nil {
@@ -649,9 +659,12 @@ func (r *MonitorReconciler) monitorServiceResourceUsage(
 	instances map[string]struct{},
 ) error {
 	svcList := &corev1.ServiceList{}
-	if err := r.List(context.Background(), svcList, &client.ListOptions{
-		Namespace:     namespace,
-		FieldSelector: fields.OneTermEqualSelector("spec.type", string(corev1.ServiceTypeNodePort)),
+	if err := r.cache.List(context.Background(), svcList, &client.ListOptions{
+		Namespace: namespace,
+		FieldSelector: fields.OneTermEqualSelector(
+			resourcecache.ServiceTypeKey,
+			string(corev1.ServiceTypeNodePort),
+		),
 	}); err != nil {
 		return fmt.Errorf("failed to list svc: %w", err)
 	}
@@ -916,7 +929,7 @@ func (r *MonitorReconciler) handlerTrafficUsed(
 
 func (r *MonitorReconciler) refreshGPUConfig(ctx context.Context) error {
 	configmap := &corev1.ConfigMap{}
-	if err := r.Get(ctx, client.ObjectKey{
+	if err := r.cache.Get(ctx, client.ObjectKey{
 		Namespace: gpu.NodeInfoConfigmapNamespace,
 		Name:      gpu.NodeInfoConfigmapName,
 	}, configmap); err != nil {

--- a/controllers/resources/main.go
+++ b/controllers/resources/main.go
@@ -31,11 +31,13 @@ import (
 	"github.com/labring/sealos/controllers/pkg/resources"
 	"github.com/labring/sealos/controllers/pkg/utils/env"
 	"github.com/labring/sealos/controllers/resources/controllers"
+	resourcecache "github.com/labring/sealos/controllers/resources/controllers/cache"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -82,6 +84,10 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
+		Cache:  resourcecache.Options(),
+		Client: client.Options{Cache: &client.CacheOptions{
+			DisableFor: resourcecache.UncachedObjects(),
+		}},
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
 		},
@@ -107,6 +113,10 @@ func main() {
 
 	setupLog.Info("starting manager")
 
+	if err = resourcecache.SetupInformers(mgr); err != nil {
+		setupLog.Error(err, "failed to set up resource cache informers")
+		os.Exit(1)
+	}
 	err = controllers.InitIndexField(mgr)
 	if err != nil {
 		setupLog.Error(err, "failed to init index field")

--- a/controllers/resources/main.go
+++ b/controllers/resources/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -137,12 +138,22 @@ func main() {
 	//	os.Exit(1)
 	//}
 
+	managerCtx := ctrl.SetupSignalHandler()
 	go func() {
-		if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		if err := mgr.Start(managerCtx); err != nil {
 			setupLog.Error(err, "problem running manager")
 			os.Exit(1)
 		}
 	}()
+	// ReaderFailOnMissingInformer skips the per-read sync wait, so synchronize all
+	// explicitly registered informers before the monitor performs its first read.
+	if !mgr.GetCache().WaitForCacheSync(managerCtx) {
+		setupLog.Error(
+			errors.New("resource cache sync did not complete"),
+			"unable to start monitor",
+		)
+		os.Exit(1)
+	}
 
 	reconciler, err := controllers.NewMonitorReconciler(mgr)
 	if err != nil {


### PR DESCRIPTION
## What this PR does

- project cached Pods, PVCs, Backups, Services, Namespaces, Instances, and the GPU ConfigMap to fields used by the resource controller
- route monitor reads through the projected cache while keeping write paths on complete API server objects
- clear managed fields and fail fast when an informer was not explicitly registered
- add projection tests for every cached resource type

## Verification

- `go test ./...`
- envtest
- `go build ./...`
- `go vet ./...`
- `golangci-lint`
- `git diff --check`