### PR TITLE
fix(account): allow recoverable deleted workspaces to resubscribe

### DIFF
--- a/service/account/api/handler_stripe_event.go
+++ b/service/account/api/handler_stripe_event.go
@@ -621,22 +621,62 @@ func handleSubscriptionCreateOrRenew(
 
 		if ws != nil {
 			payment.WorkspaceSubscriptionID = &ws.ID
-			if isInitial && ws.Status == types.SubscriptionStatusDeleted {
-				if _, err := services.StripeServiceInstance.CancelSubscription(
-					subscription.ID,
-				); err != nil {
-					return fmt.Errorf(
-						"failed to cancel subscription for deleted workspace: %w",
-						err,
+			if ws.Status == types.SubscriptionStatusDeleted {
+				if !isDeletedWorkspaceSubscriptionResubscriptionPayment(
+					isInitial,
+					wsTransaction.Operator,
+				) {
+					return rejectDeletedWorkspaceSubscriptionPayment(
+						tx,
+						wsTransaction,
+						subscription.ID,
+						"deleted workspace only accepts an initial created subscription payment",
 					)
 				}
-				dao.Logger.Infof(
-					"subscription paid for deleted workspace %s/%s, subscription %s canceled",
-					meta.Workspace,
-					meta.RegionDomain,
+				validResubscription := isValidDeletedWorkspaceSubscriptionResubscription(
+					ws,
+					wsTransaction,
 					subscription.ID,
 				)
-				return nil
+				if !validResubscription {
+					return rejectDeletedWorkspaceSubscriptionPayment(
+						tx,
+						wsTransaction,
+						subscription.ID,
+						"stale or invalid deleted workspace subscription transaction",
+					)
+				}
+
+				if dao.K8sManager == nil {
+					return rejectDeletedWorkspaceSubscriptionPayment(
+						tx,
+						wsTransaction,
+						subscription.ID,
+						"kubernetes manager is not initialized",
+					)
+				}
+
+				recoverable, recoverErr := isWorkspaceSubscriptionNamespaceRecoverable(
+					context.Background(),
+					dao.K8sManager.GetClient(),
+					meta.Workspace,
+				)
+				if recoverErr != nil {
+					return rejectDeletedWorkspaceSubscriptionPayment(
+						tx,
+						wsTransaction,
+						subscription.ID,
+						fmt.Sprintf("failed to validate workspace namespace: %v", recoverErr),
+					)
+				}
+				if !recoverable {
+					return rejectDeletedWorkspaceSubscriptionPayment(
+						tx,
+						wsTransaction,
+						subscription.ID,
+						"workspace namespace is no longer recoverable",
+					)
+				}
 			}
 
 			ws.CurrentPeriodStartAt = time.Unix(subscription.Items.Data[len(subscription.Items.Data)-1].CurrentPeriodStart, 0).
@@ -705,6 +745,41 @@ func handleSubscriptionCreateOrRenew(
 		)
 		return nil
 	})
+}
+
+func rejectDeletedWorkspaceSubscriptionPayment(
+	tx *gorm.DB,
+	transaction *types.WorkspaceSubscriptionTransaction,
+	stripeSubscriptionID, reason string,
+) error {
+	isPending := transaction.Status == types.SubscriptionTransactionStatusProcessing ||
+		transaction.Status == types.SubscriptionTransactionStatusPending
+	if isPending {
+		transaction.Status = types.SubscriptionTransactionStatusFailed
+		transaction.StatusDesc = reason
+		transaction.PayStatus = types.SubscriptionPayStatusCanceled
+		if err := tx.Save(transaction).Error; err != nil {
+			return fmt.Errorf("failed to mark rejected subscription transaction: %w", err)
+		}
+		if err := tx.Model(&types.PaymentOrder{}).
+			Where("id = ?", transaction.PayID).
+			Update("status", types.PaymentOrderStatusFailed).
+			Error; err != nil {
+			return fmt.Errorf("failed to mark rejected payment order: %w", err)
+		}
+	}
+
+	if _, err := services.StripeServiceInstance.CancelSubscription(stripeSubscriptionID); err != nil {
+		return fmt.Errorf("failed to cancel invalid subscription %s: %w", stripeSubscriptionID, err)
+	}
+	dao.Logger.Infof(
+		"Canceled invalid Stripe subscription %s for deleted workspace %s/%s: %s",
+		stripeSubscriptionID,
+		transaction.Workspace,
+		transaction.RegionDomain,
+		reason,
+	)
+	return nil
 }
 
 // prepareCreateOrRenewTransactionAndPayment

--- a/service/account/api/handler_stripe_event.go
+++ b/service/account/api/handler_stripe_event.go
@@ -769,7 +769,9 @@ func rejectDeletedWorkspaceSubscriptionPayment(
 		}
 	}
 
-	if _, err := services.StripeServiceInstance.CancelSubscription(stripeSubscriptionID); err != nil {
+	if _, err := services.StripeServiceInstance.CancelSubscription(
+		stripeSubscriptionID,
+	); err != nil {
 		return fmt.Errorf("failed to cancel invalid subscription %s: %w", stripeSubscriptionID, err)
 	}
 	dao.Logger.Infof(

--- a/service/account/api/workspace_subscription.go
+++ b/service/account/api/workspace_subscription.go
@@ -1175,6 +1175,98 @@ func parseWorkspaceSubscriptionPayReq(
 	return req, nil
 }
 
+func validateDeletedWorkspaceSubscriptionPayment(
+	c *gin.Context,
+	req *helper.WorkspaceSubscriptionOperatorReq,
+	currentSubscription *types.WorkspaceSubscription,
+) bool {
+	if currentSubscription == nil || currentSubscription.Status != types.SubscriptionStatusDeleted {
+		return true
+	}
+	if req.Operator != types.SubscriptionTransactionTypeCreated {
+		SetErrorResp(
+			c,
+			http.StatusBadRequest,
+			gin.H{
+				"error": "deleted workspace subscription can only be recreated with a new subscription",
+			},
+		)
+		return false
+	}
+	if req.PayMethod != helper.STRIPE {
+		SetErrorResp(
+			c,
+			http.StatusBadRequest,
+			gin.H{"error": "deleted workspace subscription must be recreated with Stripe payment"},
+		)
+		return false
+	}
+	if dao.K8sManager == nil {
+		SetErrorResp(
+			c,
+			http.StatusInternalServerError,
+			gin.H{"error": "kubernetes manager is not initialized"},
+		)
+		return false
+	}
+	recoverable, err := isWorkspaceSubscriptionNamespaceRecoverable(
+		c.Request.Context(),
+		dao.K8sManager.GetClient(),
+		req.Workspace,
+	)
+	if err != nil {
+		SetErrorResp(
+			c,
+			http.StatusInternalServerError,
+			gin.H{"error": fmt.Sprintf("failed to validate workspace namespace: %v", err)},
+		)
+		return false
+	}
+	if !recoverable {
+		SetErrorResp(
+			c,
+			http.StatusBadRequest,
+			gin.H{"error": "workspace namespace is no longer recoverable"},
+		)
+		return false
+	}
+	return true
+}
+
+func validateWorkspaceSubscriptionCreation(
+	c *gin.Context,
+	req *helper.WorkspaceSubscriptionOperatorReq,
+	currentSubscription *types.WorkspaceSubscription,
+) bool {
+	if currentSubscription == nil ||
+		currentSubscription.PlanName == types.FreeSubscriptionPlanName {
+		return true
+	}
+	if currentSubscription.Status != types.SubscriptionStatusDebt &&
+		currentSubscription.Status != types.SubscriptionStatusDeleted {
+		SetErrorResp(
+			c,
+			http.StatusBadRequest,
+			gin.H{"error": "cannot create new subscription with existing active subscription"},
+		)
+		return false
+	}
+	if currentSubscription.Status == types.SubscriptionStatusDebt {
+		logrus.Infof(
+			"Allowing subscription creation for overdue workspace %s/%s, will cancel old subscription",
+			req.Workspace,
+			req.RegionDomain,
+		)
+	} else {
+		logrus.Infof(
+			"Allowing subscription recreation for recoverable deleted workspace %s/%s",
+			req.Workspace,
+			req.RegionDomain,
+		)
+	}
+	return true
+}
+
 func CreateWorkspaceSubscriptionPay(c *gin.Context) {
 	req, err := parseWorkspaceSubscriptionPayReq(c)
 	if err != nil {
@@ -1211,55 +1303,8 @@ func CreateWorkspaceSubscriptionPay(c *gin.Context) {
 		return
 	}
 
-	if currentSubscription != nil &&
-		currentSubscription.Status == types.SubscriptionStatusDeleted &&
-		req.Operator != types.SubscriptionTransactionTypeCreated {
-		SetErrorResp(
-			c,
-			http.StatusBadRequest,
-			gin.H{"error": "deleted workspace subscription can only be recreated with a new subscription"},
-		)
+	if !validateDeletedWorkspaceSubscriptionPayment(c, req, currentSubscription) {
 		return
-	}
-
-	if currentSubscription != nil && currentSubscription.Status == types.SubscriptionStatusDeleted {
-		if req.PayMethod != helper.STRIPE {
-			SetErrorResp(
-				c,
-				http.StatusBadRequest,
-				gin.H{"error": "deleted workspace subscription must be recreated with Stripe payment"},
-			)
-			return
-		}
-		if dao.K8sManager == nil {
-			SetErrorResp(
-				c,
-				http.StatusInternalServerError,
-				gin.H{"error": "kubernetes manager is not initialized"},
-			)
-			return
-		}
-		recoverable, err := isWorkspaceSubscriptionNamespaceRecoverable(
-			c.Request.Context(),
-			dao.K8sManager.GetClient(),
-			req.Workspace,
-		)
-		if err != nil {
-			SetErrorResp(
-				c,
-				http.StatusInternalServerError,
-				gin.H{"error": fmt.Sprintf("failed to validate workspace namespace: %v", err)},
-			)
-			return
-		}
-		if !recoverable {
-			SetErrorResp(
-				c,
-				http.StatusBadRequest,
-				gin.H{"error": "workspace namespace is no longer recoverable"},
-			)
-			return
-		}
 	}
 
 	// Validate plan changes
@@ -1352,36 +1397,8 @@ func CreateWorkspaceSubscriptionPay(c *gin.Context) {
 	// Validate plan transitions and calculate pricing based on operator
 	switch req.Operator {
 	case types.SubscriptionTransactionTypeCreated:
-		// No additional validation needed for creation
-		if currentSubscription != nil &&
-			currentSubscription.PlanName != types.FreeSubscriptionPlanName {
-			// Allow re-creation for overdue subscriptions
-			switch currentSubscription.Status {
-			case types.SubscriptionStatusDebt:
-				// Overdue status allowed, will cancel old subscription in payment flow
-				logrus.Infof(
-					"Allowing subscription creation for overdue workspace %s/%s, will cancel old subscription",
-					req.Workspace,
-					req.RegionDomain,
-				)
-			case types.SubscriptionStatusDeleted:
-				// Recoverable deleted subscriptions are recreated with a new Stripe subscription.
-				logrus.Infof(
-					"Allowing subscription recreation for recoverable deleted workspace %s/%s",
-					req.Workspace,
-					req.RegionDomain,
-				)
-			default:
-				// Normal active subscription, reject creation
-				SetErrorResp(
-					c,
-					http.StatusBadRequest,
-					gin.H{
-						"error": "cannot create new subscription with existing active subscription",
-					},
-				)
-				return
-			}
+		if !validateWorkspaceSubscriptionCreation(c, req, currentSubscription) {
+			return
 		}
 		transaction.Amount = planPrice.Price // Full price for new subscription
 	case types.SubscriptionTransactionTypeUpgraded:
@@ -3044,7 +3061,9 @@ func updateWorkspaceSubscriptionNamespaceStatus(workspace string) error {
 		ns.Annotations[types.WorkspaceSubscriptionStatusAnnoKey] = types.NormalDebtNamespaceAnnoStatus
 		ns.Annotations[DebtNamespaceAnnoStatusKey] = ResumeDebtNamespaceAnnoStatus
 		ns.Annotations[NetworkStatusAnnoKey] = ResumeDebtNamespaceAnnoStatus
-		ns.Annotations[types.WorkspaceSubscriptionStatusUpdateTimeAnnoKey] = time.Now().UTC().Format(time.RFC3339)
+		ns.Annotations[types.WorkspaceSubscriptionStatusUpdateTimeAnnoKey] = time.Now().
+			UTC().
+			Format(time.RFC3339)
 		if err := dao.K8sManager.GetClient().
 			Patch(ctx, ns, client.MergeFrom(original)); err != nil {
 			return fmt.Errorf("patch namespace annotation failed: %w", err)
@@ -3598,7 +3617,9 @@ func handleDeletedWorkspaceSubscriptionInitialPaymentFailure(
 			First(&wsTransaction).
 			Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
-				_, cancelErr := services.StripeServiceInstance.CancelSubscription(stripeSubscription.ID)
+				_, cancelErr := services.StripeServiceInstance.CancelSubscription(
+					stripeSubscription.ID,
+				)
 				return cancelErr
 			}
 			return fmt.Errorf("failed to get deleted workspace resubscription transaction: %w", err)
@@ -3613,7 +3634,7 @@ func handleDeletedWorkspaceSubscriptionInitialPaymentFailure(
 			return err
 		}
 
-		failureReason := fmt.Sprintf("Stripe payment failed for invoice %s", invoice.ID)
+		failureReason := "Stripe payment failed for invoice " + invoice.ID
 		if invoice.LastFinalizationError != nil {
 			failureReason = invoice.LastFinalizationError.Error()
 		}
@@ -3621,18 +3642,30 @@ func handleDeletedWorkspaceSubscriptionInitialPaymentFailure(
 		wsTransaction.PayStatus = types.SubscriptionPayStatusFailed
 		wsTransaction.StatusDesc = failureReason
 		if err := tx.Save(&wsTransaction).Error; err != nil {
-			return fmt.Errorf("failed to update deleted workspace resubscription transaction: %w", err)
+			return fmt.Errorf(
+				"failed to update deleted workspace resubscription transaction: %w",
+				err,
+			)
 		}
 
 		if err := tx.Model(&types.PaymentOrder{}).
 			Where("id = ?", metadata.paymentID).
 			Update("status", types.PaymentOrderStatusFailed).
 			Error; err != nil {
-			return fmt.Errorf("failed to update deleted workspace resubscription payment order: %w", err)
+			return fmt.Errorf(
+				"failed to update deleted workspace resubscription payment order: %w",
+				err,
+			)
 		}
 
-		if _, err := services.StripeServiceInstance.CancelSubscription(stripeSubscription.ID); err != nil {
-			return fmt.Errorf("failed to cancel failed resubscription %s: %w", stripeSubscription.ID, err)
+		if _, err := services.StripeServiceInstance.CancelSubscription(
+			stripeSubscription.ID,
+		); err != nil {
+			return fmt.Errorf(
+				"failed to cancel failed resubscription %s: %w",
+				stripeSubscription.ID,
+				err,
+			)
 		}
 		return nil
 	})

--- a/service/account/api/workspace_subscription.go
+++ b/service/account/api/workspace_subscription.go
@@ -1211,6 +1211,57 @@ func CreateWorkspaceSubscriptionPay(c *gin.Context) {
 		return
 	}
 
+	if currentSubscription != nil &&
+		currentSubscription.Status == types.SubscriptionStatusDeleted &&
+		req.Operator != types.SubscriptionTransactionTypeCreated {
+		SetErrorResp(
+			c,
+			http.StatusBadRequest,
+			gin.H{"error": "deleted workspace subscription can only be recreated with a new subscription"},
+		)
+		return
+	}
+
+	if currentSubscription != nil && currentSubscription.Status == types.SubscriptionStatusDeleted {
+		if req.PayMethod != helper.STRIPE {
+			SetErrorResp(
+				c,
+				http.StatusBadRequest,
+				gin.H{"error": "deleted workspace subscription must be recreated with Stripe payment"},
+			)
+			return
+		}
+		if dao.K8sManager == nil {
+			SetErrorResp(
+				c,
+				http.StatusInternalServerError,
+				gin.H{"error": "kubernetes manager is not initialized"},
+			)
+			return
+		}
+		recoverable, err := isWorkspaceSubscriptionNamespaceRecoverable(
+			c.Request.Context(),
+			dao.K8sManager.GetClient(),
+			req.Workspace,
+		)
+		if err != nil {
+			SetErrorResp(
+				c,
+				http.StatusInternalServerError,
+				gin.H{"error": fmt.Sprintf("failed to validate workspace namespace: %v", err)},
+			)
+			return
+		}
+		if !recoverable {
+			SetErrorResp(
+				c,
+				http.StatusBadRequest,
+				gin.H{"error": "workspace namespace is no longer recoverable"},
+			)
+			return
+		}
+	}
+
 	// Validate plan changes
 	// Allow recreating the same plan for debt status subscriptions
 	if currentSubscription != nil && currentSubscription.PlanName == req.PlanName &&
@@ -1305,14 +1356,22 @@ func CreateWorkspaceSubscriptionPay(c *gin.Context) {
 		if currentSubscription != nil &&
 			currentSubscription.PlanName != types.FreeSubscriptionPlanName {
 			// Allow re-creation for overdue subscriptions
-			if currentSubscription.Status == types.SubscriptionStatusDebt {
+			switch currentSubscription.Status {
+			case types.SubscriptionStatusDebt:
 				// Overdue status allowed, will cancel old subscription in payment flow
 				logrus.Infof(
 					"Allowing subscription creation for overdue workspace %s/%s, will cancel old subscription",
 					req.Workspace,
 					req.RegionDomain,
 				)
-			} else {
+			case types.SubscriptionStatusDeleted:
+				// Recoverable deleted subscriptions are recreated with a new Stripe subscription.
+				logrus.Infof(
+					"Allowing subscription recreation for recoverable deleted workspace %s/%s",
+					req.Workspace,
+					req.RegionDomain,
+				)
+			default:
 				// Normal active subscription, reject creation
 				SetErrorResp(
 					c,
@@ -1916,8 +1975,11 @@ func processNewSubscription(
 	transaction types.WorkspaceSubscriptionTransaction,
 ) error {
 	// Handle overdue subscription re-creation: cancel old subscription first
-	if transaction.OldPlanStatus == types.SubscriptionStatusDebt ||
-		(transaction.OldPlanName != "" && transaction.OldPlanName != types.FreeSubscriptionPlanName) {
+	isDeletedWorkspaceResubscription := transaction.Operator == types.SubscriptionTransactionTypeCreated &&
+		transaction.OldPlanStatus == types.SubscriptionStatusDeleted
+	if !isDeletedWorkspaceResubscription &&
+		(transaction.OldPlanStatus == types.SubscriptionStatusDebt ||
+			(transaction.OldPlanName != "" && transaction.OldPlanName != types.FreeSubscriptionPlanName)) {
 		if err := cancelOldSubscriptionInTransaction(
 			tx,
 			req.Workspace,
@@ -2754,6 +2816,8 @@ func finalizeWorkspaceSubscriptionSuccess(
 	if workspaceSubscription != nil {
 		workspaceSubscriptionID = workspaceSubscription.ID
 		workspaceSubscription.CancelAtPeriodEnd = false
+		workspaceSubscription.CancelAt = time.Time{}
+		workspaceSubscription.UpdateAt = time.Now().UTC()
 		wsTransaction.OldPlanStatus = workspaceSubscription.Status
 		workspaceSubscription.Status = types.SubscriptionStatusNormal
 	} else {
@@ -2980,6 +3044,7 @@ func updateWorkspaceSubscriptionNamespaceStatus(workspace string) error {
 		ns.Annotations[types.WorkspaceSubscriptionStatusAnnoKey] = types.NormalDebtNamespaceAnnoStatus
 		ns.Annotations[DebtNamespaceAnnoStatusKey] = ResumeDebtNamespaceAnnoStatus
 		ns.Annotations[NetworkStatusAnnoKey] = ResumeDebtNamespaceAnnoStatus
+		ns.Annotations[types.WorkspaceSubscriptionStatusUpdateTimeAnnoKey] = time.Now().UTC().Format(time.RFC3339)
 		if err := dao.K8sManager.GetClient().
 			Patch(ctx, ns, client.MergeFrom(original)); err != nil {
 			return fmt.Errorf("patch namespace annotation failed: %w", err)
@@ -3368,6 +3433,17 @@ func handleWorkspaceSubscriptionRenewalFailure(event *stripe.Event) error {
 	}
 
 	if workspaceSubscription.Status == types.SubscriptionStatusDeleted {
+		if isDeletedWorkspaceSubscriptionResubscriptionPayment(
+			metadata.isInitial,
+			types.SubscriptionOperator(metadata.operator),
+		) {
+			return handleDeletedWorkspaceSubscriptionInitialPaymentFailure(
+				invoice,
+				subscription,
+				metadata,
+				workspaceSubscription,
+			)
+		}
 		_, err := services.StripeServiceInstance.CancelSubscription(subscriptionID)
 		if err != nil {
 			return fmt.Errorf("failed to cancel subscription for deleted workspace: %w", err)
@@ -3502,6 +3578,62 @@ func handleWorkspaceSubscriptionRenewalFailure(event *stripe.Event) error {
 			// Don't return error for notification failure to avoid transaction rollback
 		}
 
+		return nil
+	})
+}
+
+func handleDeletedWorkspaceSubscriptionInitialPaymentFailure(
+	invoice *stripe.Invoice,
+	stripeSubscription *stripe.Subscription,
+	metadata *renewalFailureMetadata,
+	workspaceSubscription *types.WorkspaceSubscription,
+) error {
+	return dao.DBClient.GlobalTransactionHandler(func(tx *gorm.DB) error {
+		var wsTransaction types.WorkspaceSubscriptionTransaction
+		if metadata.paymentID == "" {
+			_, err := services.StripeServiceInstance.CancelSubscription(stripeSubscription.ID)
+			return err
+		}
+		if err := tx.Where("pay_id = ?", metadata.paymentID).
+			First(&wsTransaction).
+			Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				_, cancelErr := services.StripeServiceInstance.CancelSubscription(stripeSubscription.ID)
+				return cancelErr
+			}
+			return fmt.Errorf("failed to get deleted workspace resubscription transaction: %w", err)
+		}
+
+		if !isValidDeletedWorkspaceSubscriptionResubscription(
+			workspaceSubscription,
+			&wsTransaction,
+			stripeSubscription.ID,
+		) {
+			_, err := services.StripeServiceInstance.CancelSubscription(stripeSubscription.ID)
+			return err
+		}
+
+		failureReason := fmt.Sprintf("Stripe payment failed for invoice %s", invoice.ID)
+		if invoice.LastFinalizationError != nil {
+			failureReason = invoice.LastFinalizationError.Error()
+		}
+		wsTransaction.Status = types.SubscriptionTransactionStatusFailed
+		wsTransaction.PayStatus = types.SubscriptionPayStatusFailed
+		wsTransaction.StatusDesc = failureReason
+		if err := tx.Save(&wsTransaction).Error; err != nil {
+			return fmt.Errorf("failed to update deleted workspace resubscription transaction: %w", err)
+		}
+
+		if err := tx.Model(&types.PaymentOrder{}).
+			Where("id = ?", metadata.paymentID).
+			Update("status", types.PaymentOrderStatusFailed).
+			Error; err != nil {
+			return fmt.Errorf("failed to update deleted workspace resubscription payment order: %w", err)
+		}
+
+		if _, err := services.StripeServiceInstance.CancelSubscription(stripeSubscription.ID); err != nil {
+			return fmt.Errorf("failed to cancel failed resubscription %s: %w", stripeSubscription.ID, err)
+		}
 		return nil
 	})
 }

--- a/service/account/api/workspace_subscription_recovery.go
+++ b/service/account/api/workspace_subscription_recovery.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/labring/sealos/controllers/pkg/types"
@@ -20,7 +21,7 @@ func isWorkspaceSubscriptionNamespaceRecoverable(
 	workspace string,
 ) (bool, error) {
 	if clt == nil {
-		return false, fmt.Errorf("kubernetes client is not initialized")
+		return false, errors.New("kubernetes client is not initialized")
 	}
 
 	ns := &corev1.Namespace{}

--- a/service/account/api/workspace_subscription_recovery.go
+++ b/service/account/api/workspace_subscription_recovery.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/labring/sealos/controllers/pkg/types"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	types2 "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// isWorkspaceSubscriptionNamespaceRecoverable checks whether a deleted
+// workspace still has a namespace that can safely be resumed by a new
+// subscription.
+func isWorkspaceSubscriptionNamespaceRecoverable(
+	ctx context.Context,
+	clt client.Client,
+	workspace string,
+) (bool, error) {
+	if clt == nil {
+		return false, fmt.Errorf("kubernetes client is not initialized")
+	}
+
+	ns := &corev1.Namespace{}
+	if err := clt.Get(ctx, types2.NamespacedName{Name: workspace}, ns); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get namespace %s: %w", workspace, err)
+	}
+
+	if ns.DeletionTimestamp != nil || ns.Status.Phase != corev1.NamespaceActive {
+		return false, nil
+	}
+
+	switch ns.Annotations[types.DebtNamespaceAnnoStatusKey] {
+	case "",
+		types.NormalDebtNamespaceAnnoStatus,
+		types.SuspendDebtNamespaceAnnoStatus,
+		types.SuspendCompletedDebtNamespaceAnnoStatus,
+		types.ResumeDebtNamespaceAnnoStatus,
+		types.ResumeCompletedDebtNamespaceAnnoStatus:
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+// isValidDeletedWorkspaceSubscriptionResubscription distinguishes a current
+// resubscription payment from a late event belonging to an older transaction.
+func isValidDeletedWorkspaceSubscriptionResubscription(
+	workspaceSubscription *types.WorkspaceSubscription,
+	transaction *types.WorkspaceSubscriptionTransaction,
+	stripeSubscriptionID string,
+) bool {
+	if workspaceSubscription == nil || transaction == nil ||
+		workspaceSubscription.Status != types.SubscriptionStatusDeleted ||
+		transaction.Operator != types.SubscriptionTransactionTypeCreated ||
+		transaction.OldPlanStatus != types.SubscriptionStatusDeleted ||
+		transaction.Workspace != workspaceSubscription.Workspace ||
+		transaction.RegionDomain != workspaceSubscription.RegionDomain ||
+		transaction.UserUID != workspaceSubscription.UserUID ||
+		transaction.OldPlanName != workspaceSubscription.PlanName ||
+		stripeSubscriptionID == "" {
+		return false
+	}
+
+	if transaction.Status != types.SubscriptionTransactionStatusProcessing &&
+		transaction.Status != types.SubscriptionTransactionStatusPending {
+		return false
+	}
+	// prepareCreateOrRenewTransactionAndPayment marks the initial transaction
+	// paid in memory before finalization. The transaction status remains the
+	// source of truth for distinguishing an active payment from a stale event.
+	if transaction.PayStatus != types.SubscriptionPayStatusPending &&
+		transaction.PayStatus != types.SubscriptionPayStatusProcessing &&
+		transaction.PayStatus != types.SubscriptionPayStatusPaid {
+		return false
+	}
+
+	// A payment event for the subscription already stored in the deleted row is
+	// a late event from the old subscription, not a new subscription.
+	return workspaceSubscription.Stripe == nil ||
+		workspaceSubscription.Stripe.SubscriptionID == "" ||
+		workspaceSubscription.Stripe.SubscriptionID != stripeSubscriptionID
+}
+
+func isDeletedWorkspaceSubscriptionResubscriptionPayment(
+	isInitial bool,
+	operator types.SubscriptionOperator,
+) bool {
+	return isInitial && operator == types.SubscriptionTransactionTypeCreated
+}

--- a/service/account/api/workspace_subscription_recovery_test.go
+++ b/service/account/api/workspace_subscription_recovery_test.go
@@ -1,0 +1,245 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labring/sealos/controllers/pkg/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestIsWorkspaceSubscriptionNamespaceRecoverable(t *testing.T) {
+	cases := []struct {
+		name        string
+		phase       corev1.NamespacePhase
+		annotations map[string]string
+		deleting    bool
+		want        bool
+	}{
+		{
+			name:  "active namespace",
+			phase: corev1.NamespaceActive,
+			want:  true,
+		},
+		{
+			name:  "active suspended namespace can be resumed",
+			phase: corev1.NamespaceActive,
+			annotations: map[string]string{
+				types.DebtNamespaceAnnoStatusKey: types.SuspendCompletedDebtNamespaceAnnoStatus,
+			},
+			want: true,
+		},
+		{
+			name:  "final deletion in progress",
+			phase: corev1.NamespaceActive,
+			annotations: map[string]string{
+				types.DebtNamespaceAnnoStatusKey: types.FinalDeletionDebtNamespaceAnnoStatus,
+			},
+		},
+		{
+			name:  "final deletion completed",
+			phase: corev1.NamespaceActive,
+			annotations: map[string]string{
+				types.DebtNamespaceAnnoStatusKey: types.FinalDeletionCompletedDebtNamespaceAnnoStatus,
+			},
+		},
+		{
+			name:  "terminate suspend in progress",
+			phase: corev1.NamespaceActive,
+			annotations: map[string]string{
+				types.DebtNamespaceAnnoStatusKey: types.TerminateSuspendDebtNamespaceAnnoStatus,
+			},
+		},
+		{
+			name:  "terminate suspend completed",
+			phase: corev1.NamespaceActive,
+			annotations: map[string]string{
+				types.DebtNamespaceAnnoStatusKey: types.TerminateSuspendCompletedDebtNamespaceAnnoStatus,
+			},
+		},
+		{
+			name:  "unknown debt status",
+			phase: corev1.NamespaceActive,
+			annotations: map[string]string{
+				types.DebtNamespaceAnnoStatusKey: "Unknown",
+			},
+		},
+		{
+			name:     "namespace has deletion timestamp",
+			phase:    corev1.NamespaceActive,
+			deleting: true,
+		},
+		{
+			name:  "namespace is terminating",
+			phase: corev1.NamespaceTerminating,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			if err := corev1.AddToScheme(scheme); err != nil {
+				t.Fatalf("add core scheme: %v", err)
+			}
+
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "ns-test",
+					Annotations: tt.annotations,
+				},
+				Status: corev1.NamespaceStatus{Phase: tt.phase},
+			}
+			if tt.deleting {
+				ns.Finalizers = []string{"kubernetes"}
+				deletionTimestamp := metav1.NewTime(time.Now().UTC())
+				ns.DeletionTimestamp = &deletionTimestamp
+			}
+
+			clt := clientfake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(ns).
+				Build()
+			got, err := isWorkspaceSubscriptionNamespaceRecoverable(
+				context.Background(),
+				clt,
+				"ns-test",
+			)
+			if err != nil {
+				t.Fatalf("check namespace recoverability: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("recoverable = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	t.Run("missing namespace", func(t *testing.T) {
+		scheme := runtime.NewScheme()
+		if err := corev1.AddToScheme(scheme); err != nil {
+			t.Fatalf("add core scheme: %v", err)
+		}
+		clt := clientfake.NewClientBuilder().WithScheme(scheme).Build()
+		got, err := isWorkspaceSubscriptionNamespaceRecoverable(
+			context.Background(),
+			clt,
+			"missing",
+		)
+		if err != nil {
+			t.Fatalf("check missing namespace: %v", err)
+		}
+		if got {
+			t.Fatal("missing namespace must not be recoverable")
+		}
+	})
+}
+
+func TestIsValidDeletedWorkspaceSubscriptionResubscription(t *testing.T) {
+	workspaceSubscription := &types.WorkspaceSubscription{
+		ID:           uuid.New(),
+		Workspace:    "ns-test",
+		RegionDomain: "example.com",
+		PlanName:     "pro",
+		Status:       types.SubscriptionStatusDeleted,
+		Stripe: &types.StripePay{
+			SubscriptionID: "sub-old",
+		},
+	}
+	transaction := &types.WorkspaceSubscriptionTransaction{
+		Workspace:     "ns-test",
+		RegionDomain:  "example.com",
+		OldPlanName:   "pro",
+		OldPlanStatus: types.SubscriptionStatusDeleted,
+		Operator:      types.SubscriptionTransactionTypeCreated,
+		Status:        types.SubscriptionTransactionStatusProcessing,
+		PayStatus:     types.SubscriptionPayStatusPending,
+	}
+
+	if !isValidDeletedWorkspaceSubscriptionResubscription(
+		workspaceSubscription,
+		transaction,
+		"sub-new",
+	) {
+		t.Fatal("expected current deleted workspace resubscription to be valid")
+	}
+
+	cases := []struct {
+		name   string
+		mutate func(*types.WorkspaceSubscription, *types.WorkspaceSubscriptionTransaction)
+	}{
+		{
+			name: "old stripe subscription event",
+			mutate: func(ws *types.WorkspaceSubscription, _ *types.WorkspaceSubscriptionTransaction) {
+				ws.Stripe.SubscriptionID = "sub-new"
+			},
+		},
+		{
+			name: "completed transaction",
+			mutate: func(_ *types.WorkspaceSubscription, tx *types.WorkspaceSubscriptionTransaction) {
+				tx.Status = types.SubscriptionTransactionStatusCompleted
+			},
+		},
+		{
+			name: "wrong operator",
+			mutate: func(_ *types.WorkspaceSubscription, tx *types.WorkspaceSubscriptionTransaction) {
+				tx.Operator = types.SubscriptionTransactionTypeRenewed
+			},
+		},
+		{
+			name: "wrong old status",
+			mutate: func(_ *types.WorkspaceSubscription, tx *types.WorkspaceSubscriptionTransaction) {
+				tx.OldPlanStatus = types.SubscriptionStatusDebt
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := *workspaceSubscription
+			ws.Stripe = &types.StripePay{SubscriptionID: "sub-old"}
+			tx := *transaction
+			tt.mutate(&ws, &tx)
+			if isValidDeletedWorkspaceSubscriptionResubscription(&ws, &tx, "sub-new") {
+				t.Fatal("expected invalid deleted workspace resubscription")
+			}
+		})
+	}
+}
+
+func TestIsDeletedWorkspaceSubscriptionResubscriptionPayment(t *testing.T) {
+	if !isDeletedWorkspaceSubscriptionResubscriptionPayment(
+		true,
+		types.SubscriptionTransactionTypeCreated,
+	) {
+		t.Fatal("expected an initial created payment to be a deleted workspace resubscription")
+	}
+
+	cases := []struct {
+		name     string
+		initial  bool
+		operator types.SubscriptionOperator
+	}{
+		{
+			name:     "old subscription cycle with created metadata",
+			initial:  false,
+			operator: types.SubscriptionTransactionTypeCreated,
+		},
+		{
+			name:     "initial payment with renewal operator",
+			initial:  true,
+			operator: types.SubscriptionTransactionTypeRenewed,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if isDeletedWorkspaceSubscriptionResubscriptionPayment(tt.initial, tt.operator) {
+				t.Fatal("expected payment not to be treated as a deleted workspace resubscription")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Background

Some workspaces can still be recovered after their database subscription status becomes `DELETED`: the namespace remains active and its debt/network state can be resumed. The payment endpoint only allowed recreating `DEBT` subscriptions, so users could not resubscribe to these workspaces. Stripe events from an old subscription also must not restore a deleted workspace accidentally.

## Changes

- Allow a deleted workspace to start a new Stripe subscription only when its namespace is recoverable.
- Reuse the existing subscription record and restore `NORMAL` status, payment fields, Stripe metadata, and namespace annotations after payment succeeds.
- Reject stale or invalid Stripe payment events and cancel the corresponding Stripe subscription.
- Add tests for namespace recoverability and stale deleted-workspace payment events.

## Risks / Notes

- Namespaces that are terminating, being finally deleted, terminating suspension, or in an unknown debt state cannot be recovered through this flow.
- Resubscription creates a new Stripe subscription; it does not revive the old Stripe subscription.
