### PR TITLE
fix(frontend): guard unknown workspace quota types

### DIFF
--- a/frontend/packages/client-sdk/package.json
+++ b/frontend/packages/client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sealos-desktop-sdk",
-  "version": "0.1.20",
+  "version": "0.1.22",
   "description": "sealos desktop sdk",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/frontend/packages/shared/src/constants/resource.tsx
+++ b/frontend/packages/shared/src/constants/resource.tsx
@@ -74,7 +74,9 @@ export const resourcePropertyMap: Record<
 };
 
 export const formatResourceQuotaValue = (value: number, type: WorkspaceQuotaItemType) => {
-  const scale = resourcePropertyMap[type].scale;
+  const scale = resourcePropertyMap[type]?.scale;
+
+  if (scale === undefined) return '--';
 
   return (value / scale).toFixed(2);
 };

--- a/frontend/providers/applaunchpad/__tests__/unit/utils/resource.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/resource.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { formatResourceQuotaValue } from '@sealos/shared';
+
+describe('formatResourceQuotaValue', () => {
+  it('formats the pod quota exposed by the desktop quota API', () => {
+    expect(formatResourceQuotaValue(2, 'pod')).toBe('2.00');
+  });
+
+  it('does not crash when a newer quota type reaches the UI', () => {
+    const unknownType = 'unknown-resource' as Parameters<typeof formatResourceQuotaValue>[1];
+
+    expect(formatResourceQuotaValue(1024, unknownType)).toBe('--');
+  });
+});

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/QuotaBox.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/QuotaBox.tsx
@@ -8,7 +8,15 @@ import {
 } from '@sealos/shadcn-ui/tooltip';
 import { Progress } from '@sealos/shadcn-ui/progress';
 import { Card, CardContent, CardHeader, CardTitle } from '@sealos/shadcn-ui/card';
-import { Cpu, MemoryStick, HardDrive, CircuitBoard, HdmiPort, ArrowUpDown, Layers } from 'lucide-react';
+import {
+  Cpu,
+  MemoryStick,
+  HardDrive,
+  CircuitBoard,
+  HdmiPort,
+  ArrowUpDown,
+  Layers
+} from 'lucide-react';
 
 import { useUserQuota, resourcePropertyMap, formatResourceQuotaValue } from '@sealos/shared';
 
@@ -30,7 +38,7 @@ const QuotaBox = () => {
     if (!userQuota) return [];
 
     return userQuota
-      .filter((item) => item.limit > 0)
+      .filter((item) => item.limit > 0 && resourcePropertyMap[item.type])
       .map((item) => {
         const { limit, used, type } = item;
         const unit = resourcePropertyMap[type]?.unit;

--- a/frontend/providers/dbprovider/src/components/QuotaBox/index.tsx
+++ b/frontend/providers/dbprovider/src/components/QuotaBox/index.tsx
@@ -38,7 +38,7 @@ const QuotaBox = () => {
     if (!userQuota) return [];
 
     return userQuota
-      .filter((item) => item.limit > 0)
+      .filter((item) => item.limit > 0 && resourcePropertyMap[item.type])
       .map((item) => {
         const { limit, used, type } = item;
         const unit = resourcePropertyMap[type]?.unit;

--- a/frontend/providers/template/src/pages/deploy/components/QuotaBox.tsx
+++ b/frontend/providers/template/src/pages/deploy/components/QuotaBox.tsx
@@ -43,7 +43,7 @@ const QuotaBox = () => {
     if (!userQuota) return [];
 
     return userQuota
-      .filter((item) => item.limit > 0)
+      .filter((item) => item.limit > 0 && resourcePropertyMap[item.type])
       .map((item) => {
         const { limit, used, type } = item;
         const unit = resourcePropertyMap[type]?.unit;


### PR DESCRIPTION
Summary: prevent quota formatting from crashing when the SDK returns a resource type not known by the frontend bundle; skip unsupported quota rows in applaunchpad, dbprovider, and template; add regression coverage for pod and unknown quota types. Test: pnpm exec vitest run --config vitest.config.mts --project unit __tests__/unit/utils/resource.test.ts. This protects provider pages when SDK/desktop quota payloads evolve independently of frontend bundles.