### PR TITLE
feat(desktop): suppress the dock while Brain is the topmost window

### DIFF
--- a/frontend/desktop/src/components/AppDock/index.tsx
+++ b/frontend/desktop/src/components/AppDock/index.tsx
@@ -1,4 +1,5 @@
 import { MoreAppsContext } from '@/pages/index';
+import { BRAIN_APP_KEY } from '@/constants/app';
 import useAppStore, { AppInfo } from '@/stores/app';
 import { useConfigStore } from '@/stores/config';
 import { useDesktopConfigStore } from '@/stores/desktopConfig';
@@ -323,6 +324,14 @@ export default function AppDock() {
       mouseX.set(e.clientX);
     }
   };
+
+  // Desktop Dock Suppression: while Brain is the topmost non-minimized window,
+  // the dock (toggle pill included) must not overlay it. It comes back as soon
+  // as Brain loses the top layer, is minimized, or is closed.
+  const topApp = runningInfo.find((item) => item.pid === currentAppPid);
+  if (topApp?.key === BRAIN_APP_KEY && topApp.size !== 'minimize') {
+    return null;
+  }
 
   return (
     <Flex


### PR DESCRIPTION
## Summary

While Brain (`system-brain`) is the topmost non-minimized window, `AppDock` (collapse pill included, `zIndex: 1000`) no longer renders, so nothing overlays the Brain iframe.

- The dock returns as soon as Brain loses the top layer, is minimized, or is closed (`currentAppPid` no longer resolves to Brain).
- Other apps are unaffected; the floating-button shape (`FloatButton`) is unaffected.
- Follows the existing `BRAIN_APP_KEY` special-casing precedent in `constants/app.ts`. If a second app ever needs this, the constant check can graduate to an App CR annotation (like `forcedIconStyle`).

## Why

The collapsed-dock pill sits at the bottom center with `zIndex: 1000` while app windows start at 11, so it permanently overlays a maximized Brain, and an iframe app cannot affect it from inside. Brain keeps its own exit to the platform layer (the Sealos Desktop menu entry), so no in-tab escape hatch is lost.

## Testing

- `tsc --noEmit -p frontend/desktop` passes (no new errors).
- Early return sits after all hooks, so hook order is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)