### PR TITLE
fix(account): allow patching user annotations

### DIFF
--- a/controllers/account/config/rbac/role.yaml
+++ b/controllers/account/config/rbac/role.yaml
@@ -352,4 +352,5 @@ rules:
   - create
   - get
   - list
+  - patch
   - watch

--- a/controllers/account/controllers/account_controller.go
+++ b/controllers/account/controllers/account_controller.go
@@ -138,7 +138,7 @@ type AccountReconciler struct {
 //+kubebuilder:rbac:groups=account.sealos.io,resources=accounts/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=resourcequotas,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=limitranges,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=user.sealos.io,resources=users,verbs=create;get;list;watch
+//+kubebuilder:rbac:groups=user.sealos.io,resources=users,verbs=create;get;list;patch;watch
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/account/deploy/charts/account-controller/templates/rbac.yaml
+++ b/controllers/account/deploy/charts/account-controller/templates/rbac.yaml
@@ -380,6 +380,7 @@ rules:
       - update
       - get
       - list
+      - patch
       - watch
   - apiGroups: [""]
     resources: ["persistentvolumeclaims", "services", "pods"]


### PR DESCRIPTION
The account cache memory optimization changed the User annotation write from `Update` to `Patch`, but the account controller RBAC still lacks the `patch` verb for `users.user.sealos.io`. New account initialization succeeds in storage and then repeatedly fails to persist `user.sealos.io/init-account-time` with `Forbidden`.

This adds the required `patch` permission to the kubebuilder marker, generated RBAC, and Helm chart.

Verification:
- `golangci-lint` on changed code
- account controller/cache compile checks