### PR TITLE
fix(client-sdk): target direct parent frame

### DIFF
--- a/frontend/desktop/src/__tests__/unit/sdkParentBoundary.test.ts
+++ b/frontend/desktop/src/__tests__/unit/sdkParentBoundary.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createSealosApp, sealosApp } from '../../../../packages/client-sdk/src/app';
+
+describe('client SDK parent boundary', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('sends requests to the direct parent Desktop instead of the top-level host', async () => {
+    const parentPostMessage = vi.fn();
+    const topPostMessage = vi.fn();
+    let messageListener: ((event: MessageEvent) => void) | undefined;
+
+    vi.stubGlobal('window', {
+      location: { origin: 'https://app.example.com' },
+      parent: { postMessage: parentPostMessage },
+      top: { postMessage: topPostMessage },
+      addEventListener: vi.fn((type: string, listener: (event: MessageEvent) => void) => {
+        if (type === 'message') messageListener = listener;
+      }),
+      removeEventListener: vi.fn()
+    });
+
+    const cleanup = createSealosApp();
+    const sessionPromise = sealosApp.getSession();
+
+    expect(parentPostMessage).toHaveBeenCalledOnce();
+    expect(topPostMessage).not.toHaveBeenCalled();
+
+    const [request, targetOrigin] = parentPostMessage.mock.calls[0];
+    expect(targetOrigin).toBe('*');
+    expect(messageListener).toBeDefined();
+
+    messageListener?.({
+      data: {
+        messageId: request.messageId,
+        success: true,
+        data: { user: 'test-user' }
+      },
+      origin: 'https://desktop.example.com',
+      source: {}
+    } as MessageEvent);
+
+    await expect(sessionPromise).resolves.toEqual({ user: 'test-user' });
+    cleanup?.();
+  });
+});

--- a/frontend/packages/client-sdk/package.json
+++ b/frontend/packages/client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sealos-desktop-sdk",
-  "version": "0.1.21",
+  "version": "0.1.23",
   "description": "sealos desktop sdk",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/frontend/packages/client-sdk/package.json
+++ b/frontend/packages/client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sealos-desktop-sdk",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "sealos desktop sdk",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/frontend/packages/client-sdk/src/app.ts
+++ b/frontend/packages/client-sdk/src/app.ts
@@ -74,7 +74,8 @@ class ClientSDK {
       data
     };
 
-    window.top?.postMessage(sendMessage, this.desktopOrigin);
+    // Apps are direct children of Desktop. If Desktop is embedded, top belongs to the host page.
+    window.parent?.postMessage(sendMessage, this.desktopOrigin);
 
     return cb;
   }


### PR DESCRIPTION
## Summary

- send client SDK requests to the direct parent Desktop frame instead of the top-level window
- preserve existing behavior when Desktop is the top-level page
- add a regression test for Desktop embedded inside an external host page
- bump the SDK package version to 0.1.23 for the next `@labring/sealos-desktop-sdk` release

## Why

When Desktop is embedded, `window.top` points to the external host while `window.parent` still points to Desktop. Targeting the direct parent keeps the SDK request/reply flow inside the Desktop boundary.

## Testing

- `pnpm exec vitest run --project unit src/__tests__/unit/sdkParentBoundary.test.ts`
- `pnpm run build` in `frontend/packages/client-sdk`
- package dry-run verified as `@labring/sealos-desktop-sdk@0.1.23`
- Prettier check for changed files

## Compatibility

This is backward compatible for the current direct-child app model: when Desktop is top-level, `window.parent` and `window.top` are the same window.