### PR TITLE
feat(app): support version field in App CRD

### DIFF
--- a/controllers/app/api/v1/app_types.go
+++ b/controllers/app/api/v1/app_types.go
@@ -61,6 +61,9 @@ type AppSpec struct {
 	Position float64 `json:"position,omitempty"`
 
 	//+kubebuilder:validation:Optional
+	Version string `json:"version,omitempty"`
+
+	//+kubebuilder:validation:Optional
 	I18N *map[string]AppMeta `json:"i18n,omitempty"`
 }
 

--- a/controllers/app/config/crd/bases/app.sealos.io_apps.yaml
+++ b/controllers/app/config/crd/bases/app.sealos.io_apps.yaml
@@ -113,6 +113,8 @@ spec:
                 type: number
               type:
                 type: string
+              version:
+                type: string
             type: object
           status:
             description: AppStatus defines the observed state of App

--- a/controllers/app/deploy/manifests/deploy.yaml
+++ b/controllers/app/deploy/manifests/deploy.yaml
@@ -125,6 +125,8 @@ spec:
                 type: number
               type:
                 type: string
+              version:
+                type: string
             type: object
           status:
             description: AppStatus defines the observed state of App


### PR DESCRIPTION
<!--
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR,
because it will be placed in the release note.
-->

## Summary

- Add an optional `spec.version` string to the `app.sealos.io/v1` App CRD.
- Synchronize the generated base CRD and bundled deployment manifest.
- Keep existing App resources compatible; no SemVer restriction is introduced.

## Verification

- `go test ./...` (from `controllers/app`, Go 1.25.4)
- `go vet ./...` (from `controllers/app`, Go 1.25.4)
- YAML schema assertions and base/bundled schema consistency check
- `git diff --check`

The repository root has no `package.json`, so the prescribed `npm run preflight`
command is not available for this Go controller-only change.
