### PR TITLE
feat(account): expose per-grant credit details in credits/info

### DIFF
--- a/service/account/api/admin_workspace_subscription.go
+++ b/service/account/api/admin_workspace_subscription.go
@@ -69,8 +69,8 @@ func AdminAddWorkspaceSubscription(c *gin.Context) {
 // @Tags WorkspaceSubscription
 // @Accept json
 // @Produce json
-// @Param req body AdminWorkspaceSubscriptionListReq true "AdminWorkspaceSubscriptionListReq"
-// @Success 200 {object} AdminWorkspaceSubscriptionListResp
+// @Param req body helper.AdminWorkspaceSubscriptionListReq true "AdminWorkspaceSubscriptionListReq"
+// @Success 200 {object} gin.H
 // @Router /admin/v1alpha1/workspace-subscription/list [post]
 func AdminWorkspaceSubscriptionList(c *gin.Context) {
 	// Authenticate admin request
@@ -189,8 +189,8 @@ func AdminWorkspaceSubscriptionList(c *gin.Context) {
 // @Tags WorkspaceSubscription
 // @Accept json
 // @Produce json
-// @Param req body AdminSubscriptionPlansReq true "AdminSubscriptionPlansReq"
-// @Success 200 {object} AdminSubscriptionPlansResp
+// @Param req body helper.AdminSubscriptionPlansReq true "AdminSubscriptionPlansReq"
+// @Success 200 {object} gin.H
 // @Router /admin/v1alpha1/subscription-plans [post]
 func AdminSubscriptionPlans(c *gin.Context) {
 	// Authenticate admin request
@@ -310,7 +310,7 @@ func AdminSubscriptionPlans(c *gin.Context) {
 // @Param planName query string false "Filter by plan name" example("Hobby")
 // @Param status query string false "Filter by subscription status" example("NORMAL")
 // @Param regionDomain query string false "Filter by region domain" example("192.168.10.35.nip.io")
-// @Success 200 {object} AdminWorkspaceSubscriptionListResp
+// @Success 200 {object} gin.H
 // @Router /admin/v1alpha1/workspace-subscription/list [get]
 func AdminWorkspaceSubscriptionListGET(c *gin.Context) {
 	// Authenticate admin request
@@ -459,7 +459,7 @@ func AdminWorkspaceSubscriptionListGET(c *gin.Context) {
 // @Produce json
 // @Param includeInactive query bool false "Include inactive plans" example(false)
 // @Param planType query string false "Filter by plan type" example("workspace")
-// @Success 200 {object} AdminSubscriptionPlansResp
+// @Success 200 {object} gin.H
 // @Router /admin/v1alpha1/subscription-plans [get]
 func AdminSubscriptionPlansGET(c *gin.Context) {
 	// Authenticate admin request

--- a/service/account/api/api.go
+++ b/service/account/api/api.go
@@ -777,7 +777,7 @@ func GetAPPCosts(c *gin.Context) {
 // @Tags WorkspaceAppCosts
 // @Accept json
 // @Produce json
-// @Param request body helper.WorkspaceAppCostsReq true "Workspace app costs request"
+// @Param request body helper.AppCostsReq true "Workspace app costs request"
 // @Success 200 {object} map[string]interface{} "successfully retrieved workspace app costs"
 // @Failure 400 {object} map[string]interface{} "failed to parse get workspace app cost request"
 // @Failure 401 {object} map[string]interface{} "authenticate error"
@@ -1414,7 +1414,7 @@ func UserUsage(c *gin.Context) {
 // @Tags RechargeDiscount
 // @Accept json
 // @Produce json
-// @Param request body object true "Get recharge discount request"
+// @Param request body helper.AuthBase true "AuthBase"
 // @Success 200 {object} map[string]interface{} "successfully get recharge discount"
 // @Failure 400 {object} map[string]interface{} "failed to parse get recharge discount request"
 // @Failure 401 {object} map[string]interface{} "authenticate error"

--- a/service/account/api/card.go
+++ b/service/account/api/card.go
@@ -17,8 +17,8 @@ import (
 // @Tags Payment
 // @Accept json
 // @Produce json
-// @Param req body CardListReq true "CardListReq"
-// @Success 200 {object} CardListResp
+// @Param req body helper.AuthBase true "AuthBase"
+// @Success 200 {object} gin.H
 // @Router /payment/v1alpha1/card/list [post]
 func ListCard(c *gin.Context) {
 	req := &helper.AuthBase{}
@@ -69,8 +69,8 @@ func ListCard(c *gin.Context) {
 // @Tags Payment
 // @Accept json
 // @Produce json
-// @Param req body CardDeleteReq true "CardDeleteReq"
-// @Success 200 {object} CardDeleteResp
+// @Param req body helper.CardOperationReq true "CardOperationReq"
+// @Success 200 {object} gin.H
 // @Router /payment/v1alpha1/card/delete [post]
 func DeleteCard(c *gin.Context) {
 	req, err := helper.ParseCardOperationReq(c)
@@ -107,8 +107,8 @@ func DeleteCard(c *gin.Context) {
 // @Tags Payment
 // @Accept json
 // @Produce json
-// @Param req body CardOperationReq true "CardOperationReq"
-// @Success 200 {object} CardOperationResp
+// @Param req body helper.CardOperationReq true "CardOperationReq"
+// @Success 200 {object} gin.H
 // @Router /payment/v1alpha1/card/set-default [post]
 func SetDefaultCard(c *gin.Context) {
 	req, err := helper.ParseCardOperationReq(c)

--- a/service/account/api/credits.go
+++ b/service/account/api/credits.go
@@ -19,7 +19,7 @@ import (
 // @Tags Credits
 // @Accept json
 // @Produce json
-// @Param req body CreditsInfoReq true "CreditsInfoReq"
+// @Param req body helper.AuthBase true "AuthBase"
 // @Success 200 {object} CreditsInfoResp
 // @Router /payment/v1alpha1/credits/info [post]
 func GetCreditsInfo(c *gin.Context) {
@@ -40,12 +40,14 @@ func GetCreditsInfo(c *gin.Context) {
 		)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{
-		"credits": creditsInfo,
-	})
+	c.JSON(http.StatusOK, CreditsInfoResp{Credits: creditsInfo})
 }
 
-type CreditsInfoReq struct {
+type CreditsInfoResp struct {
+	Credits CreditsInfo `json:"credits"`
+}
+
+type CreditsInfo struct {
 	UserUID          uuid.UUID `json:"userUid"`
 	Balance          int64     `json:"balance"`
 	DeductionBalance int64     `json:"deductionBalance"`
@@ -72,9 +74,9 @@ type CreditsItem struct {
 	Status     types.CreditsStatus `json:"status"`
 }
 
-func getCreditsInfo(userUID uuid.UUID) (any, error) {
+func getCreditsInfo(userUID uuid.UUID) (CreditsInfo, error) {
 	var (
-		creditsInfo  CreditsInfoReq
+		creditsInfo  CreditsInfo
 		subscription *types.Subscription
 		account      *types.Account
 		err          error
@@ -107,7 +109,7 @@ func getCreditsInfo(userUID uuid.UUID) (any, error) {
 
 	for e := range errChan {
 		if e != nil {
-			return nil, e
+			return CreditsInfo{}, e
 		}
 	}
 
@@ -115,16 +117,16 @@ func getCreditsInfo(userUID uuid.UUID) (any, error) {
 	currentPlan, err := dao.DBClient.GetSubscriptionPlan(subscription.PlanName)
 	// logrus.Printf("[DB] GetSubscriptionPlan (%s) took %v", subscription.PlanName, time.Since(start))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get subscription plan info: %w", err)
+		return CreditsInfo{}, fmt.Errorf("failed to get subscription plan info: %w", err)
 	}
 	freePlan, err := dao.DBClient.GetSubscriptionPlan(types.FreeSubscriptionPlanName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get free plan info: %w", err)
+		return CreditsInfo{}, fmt.Errorf("failed to get free plan info: %w", err)
 	}
 
 	credits, err := dao.DBClient.GetAvailableCredits(&types.UserQueryOpts{UID: userUID})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get available credits: %w", err)
+		return CreditsInfo{}, fmt.Errorf("failed to get available credits: %w", err)
 	}
 
 	creditsInfo = buildCreditsInfo(
@@ -142,8 +144,8 @@ func getCreditsInfo(userUID uuid.UUID) (any, error) {
 func buildCreditsInfo(
 	credits []types.Credits,
 	currentPlanID, freePlanID, planName string,
-) CreditsInfoReq {
-	creditsInfo := CreditsInfoReq{CreditsList: make([]CreditsItem, 0, len(credits))}
+) CreditsInfo {
+	creditsInfo := CreditsInfo{CreditsList: make([]CreditsItem, 0, len(credits))}
 	for i := range credits {
 		switch credits[i].FromID {
 		case currentPlanID:

--- a/service/account/api/credits.go
+++ b/service/account/api/credits.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -20,7 +21,7 @@ import (
 // @Produce json
 // @Param req body CreditsInfoReq true "CreditsInfoReq"
 // @Success 200 {object} CreditsInfoResp
-// @Router /account/v1alpha1/credits/info [post]
+// @Router /payment/v1alpha1/credits/info [post]
 func GetCreditsInfo(c *gin.Context) {
 	req := &helper.AuthBase{}
 	if err := authenticateRequest(c, req); err != nil {
@@ -55,6 +56,20 @@ type CreditsInfoReq struct {
 	KYCDeductionCreditsBalance          int64 `json:"kycDeductionCreditsBalance"`
 	CurrentPlanCreditsBalance           int64 `json:"currentPlanCreditsBalance"`
 	CurrentPlanCreditsDeductionBalance  int64 `json:"currentPlanCreditsDeductionBalance"`
+
+	// CreditsList holds the same rows the aggregate fields above are summed
+	// from, so sum(amount) == Credits and sum(usedAmount) == DeductionCredits;
+	// exhausted rows stay in the list to keep that invariant. Callers filter
+	// for display (e.g. amount > usedAmount).
+	CreditsList []CreditsItem `json:"creditsList"`
+}
+
+type CreditsItem struct {
+	Amount     int64               `json:"amount"`
+	UsedAmount int64               `json:"usedAmount"`
+	StartAt    *time.Time          `json:"startAt"`
+	ExpireAt   *time.Time          `json:"expireAt"`
+	Status     types.CreditsStatus `json:"status"`
 }
 
 func getCreditsInfo(userUID uuid.UUID) (any, error) {
@@ -112,34 +127,55 @@ func getCreditsInfo(userUID uuid.UUID) (any, error) {
 		return nil, fmt.Errorf("failed to get available credits: %w", err)
 	}
 
-	var currentCredits, freeCredits types.Credits
+	creditsInfo = buildCreditsInfo(
+		credits,
+		currentPlan.ID.String(),
+		freePlan.ID.String(),
+		subscription.PlanName,
+	)
+	creditsInfo.UserUID = userUID
+	creditsInfo.Balance = account.Balance
+	creditsInfo.DeductionBalance = account.DeductionBalance
+	return creditsInfo, nil
+}
+
+func buildCreditsInfo(
+	credits []types.Credits,
+	currentPlanID, freePlanID, planName string,
+) CreditsInfoReq {
+	creditsInfo := CreditsInfoReq{CreditsList: make([]CreditsItem, 0, len(credits))}
 	for i := range credits {
 		switch credits[i].FromID {
-		case currentPlan.ID.String():
-			currentCredits = credits[i]
-			creditsInfo.CurrentPlanCreditsBalance = currentCredits.Amount
-			creditsInfo.CurrentPlanCreditsDeductionBalance = currentCredits.UsedAmount
-		case freePlan.ID.String():
-			freeCredits = credits[i]
-			creditsInfo.KYCDeductionCreditsBalance = freeCredits.Amount
-			creditsInfo.KYCDeductionCreditsDeductionBalance = freeCredits.UsedAmount
+		case currentPlanID:
+			creditsInfo.CurrentPlanCreditsBalance = credits[i].Amount
+			creditsInfo.CurrentPlanCreditsDeductionBalance = credits[i].UsedAmount
+		case freePlanID:
+			creditsInfo.KYCDeductionCreditsBalance = credits[i].Amount
+			creditsInfo.KYCDeductionCreditsDeductionBalance = credits[i].UsedAmount
 		}
 	}
-	if subscription.PlanName == types.FreeSubscriptionPlanName {
+	if planName == types.FreeSubscriptionPlanName {
 		creditsInfo.KYCDeductionCreditsBalance = creditsInfo.CurrentPlanCreditsBalance
 		creditsInfo.KYCDeductionCreditsDeductionBalance = creditsInfo.CurrentPlanCreditsDeductionBalance
 	}
 
-	var totalCredits, totalDeductionCredits int64
 	for _, c := range credits {
-		totalCredits += c.Amount
-		totalDeductionCredits += c.UsedAmount
+		creditsInfo.Credits += c.Amount
+		creditsInfo.DeductionCredits += c.UsedAmount
+		creditsInfo.CreditsList = append(creditsInfo.CreditsList, CreditsItem{
+			Amount:     c.Amount,
+			UsedAmount: c.UsedAmount,
+			StartAt:    nonZeroTime(c.StartAt),
+			ExpireAt:   nonZeroTime(c.ExpireAt),
+			Status:     c.Status,
+		})
 	}
+	return creditsInfo
+}
 
-	creditsInfo.UserUID = userUID
-	creditsInfo.Balance = account.Balance
-	creditsInfo.DeductionBalance = account.DeductionBalance
-	creditsInfo.Credits = totalCredits
-	creditsInfo.DeductionCredits = totalDeductionCredits
-	return creditsInfo, nil
+func nonZeroTime(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	return &t
 }

--- a/service/account/api/credits_test.go
+++ b/service/account/api/credits_test.go
@@ -1,10 +1,13 @@
 package api
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/labring/sealos/controllers/pkg/types"
 	"github.com/labring/sealos/service/account/dao"
 )
 
@@ -26,4 +29,105 @@ func Test_getCreditsInfo(t *testing.T) {
 	}
 
 	t.Logf("getCreditsInfo() userCreditsInfo = %#+v, %s", userCreditsInfo, time.Since(start))
+}
+
+func Test_buildCreditsInfo(t *testing.T) {
+	freePlanID := uuid.New().String()
+	paidPlanID := uuid.New().String()
+	expireAt := time.Date(2026, 9, 20, 0, 0, 0, 0, time.UTC)
+	startAt := expireAt.AddDate(0, -1, 0)
+
+	rows := []types.Credits{
+		{
+			Amount:     500000,
+			UsedAmount: 280000,
+			FromID:     freePlanID,
+			StartAt:    startAt,
+			ExpireAt:   expireAt,
+			Status:     types.CreditsStatusActive,
+		},
+		{
+			Amount:     220000,
+			UsedAmount: 220000,
+			FromID:     paidPlanID,
+			Status:     types.CreditsStatusUsedUp,
+		},
+	}
+
+	info := buildCreditsInfo(rows, paidPlanID, freePlanID, "pro")
+
+	if info.Credits != 720000 || info.DeductionCredits != 500000 {
+		t.Fatalf("totals = %d/%d, want 720000/500000", info.Credits, info.DeductionCredits)
+	}
+	if info.KYCDeductionCreditsBalance != 500000 ||
+		info.KYCDeductionCreditsDeductionBalance != 280000 {
+		t.Fatalf(
+			"kyc pair = %d/%d, want 500000/280000",
+			info.KYCDeductionCreditsBalance,
+			info.KYCDeductionCreditsDeductionBalance,
+		)
+	}
+
+	// The list must cover exactly the aggregated rows, exhausted ones included.
+	if len(info.CreditsList) != 2 {
+		t.Fatalf("len(CreditsList) = %d, want 2", len(info.CreditsList))
+	}
+	var listAmount, listUsed int64
+	for _, item := range info.CreditsList {
+		listAmount += item.Amount
+		listUsed += item.UsedAmount
+	}
+	if listAmount != info.Credits || listUsed != info.DeductionCredits {
+		t.Fatalf(
+			"list sums %d/%d do not match totals %d/%d",
+			listAmount, listUsed, info.Credits, info.DeductionCredits,
+		)
+	}
+
+	if info.CreditsList[0].ExpireAt == nil ||
+		!info.CreditsList[0].ExpireAt.Equal(expireAt) {
+		t.Fatalf("ExpireAt = %v, want %v", info.CreditsList[0].ExpireAt, expireAt)
+	}
+	if info.CreditsList[1].ExpireAt != nil || info.CreditsList[1].StartAt != nil {
+		t.Fatalf("zero times must serialize as nil, got %#v", info.CreditsList[1])
+	}
+	if info.CreditsList[1].Status != types.CreditsStatusUsedUp {
+		t.Fatalf("Status = %q, want %q", info.CreditsList[1].Status, types.CreditsStatusUsedUp)
+	}
+}
+
+func Test_buildCreditsInfo_FreePlanCopiesKYCPair(t *testing.T) {
+	freePlanID := uuid.New().String()
+	rows := []types.Credits{
+		{
+			Amount:     100000,
+			UsedAmount: 40000,
+			FromID:     freePlanID,
+			Status:     types.CreditsStatusActive,
+		},
+	}
+
+	// On the Free plan the current plan IS the free plan, so the row lands in
+	// the current-plan pair and must be copied to the KYC pair.
+	info := buildCreditsInfo(rows, freePlanID, freePlanID, types.FreeSubscriptionPlanName)
+
+	if info.KYCDeductionCreditsBalance != 100000 ||
+		info.KYCDeductionCreditsDeductionBalance != 40000 {
+		t.Fatalf(
+			"kyc pair = %d/%d, want 100000/40000",
+			info.KYCDeductionCreditsBalance,
+			info.KYCDeductionCreditsDeductionBalance,
+		)
+	}
+}
+
+func Test_buildCreditsInfo_EmptyListSerializesAsArray(t *testing.T) {
+	info := buildCreditsInfo(nil, uuid.New().String(), uuid.New().String(), "pro")
+	raw, err := json.Marshal(info)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(raw), `"creditsList":[]`) {
+		t.Fatalf(`want "creditsList":[] in output, got %s`, raw)
+	}
 }

--- a/service/account/api/credits_test.go
+++ b/service/account/api/credits_test.go
@@ -34,7 +34,7 @@ func Test_getCreditsInfo(t *testing.T) {
 func Test_buildCreditsInfo(t *testing.T) {
 	freePlanID := uuid.New().String()
 	paidPlanID := uuid.New().String()
-	expireAt := time.Date(2026, 9, 20, 0, 0, 0, 0, time.UTC)
+	expireAt := time.Date(2026, time.September, 20, 0, 0, 0, 0, time.UTC)
 	startAt := expireAt.AddDate(0, -1, 0)
 
 	rows := []types.Credits{

--- a/service/account/api/flush.go
+++ b/service/account/api/flush.go
@@ -513,7 +513,7 @@ func AdminFlushSubscriptionQuota(c *gin.Context) {
 // @Tags Subscription
 // @Accept json
 // @Produce json
-// @Success 200 {object} SubscriptionFlushQuotaResp
+// @Success 200 {object} gin.H
 // @Router /payment/v1alpha1/subscription/flush-quota [post]
 func FlushSubscriptionQuota(c *gin.Context) {
 	// 初始化日志前的时间点

--- a/service/account/api/pay.go
+++ b/service/account/api/pay.go
@@ -31,8 +31,8 @@ const (
 // @Tags account
 // @Accept json
 // @Produce json
-// @Param req body CreatePayReq true "CreatePayReq"
-// @Success 200 {object} CreatePayResp
+// @Param req body helper.CreatePayReq true "CreatePayReq"
+// @Success 200 {object} gin.H
 // @Router /account/v1alpha1/createPay [post]
 func CreateCardPay(c *gin.Context) {
 	req, err := helper.ParseCreatePayReq(c)

--- a/service/account/api/subscription.go
+++ b/service/account/api/subscription.go
@@ -36,8 +36,8 @@ import (
 // @Tags Subscription
 // @Accept json
 // @Produce json
-// @Param req body SubscriptionUserInfoReq true "SubscriptionUserInfoReq"
-// @Success 200 {object} SubscriptionUserInfoResp
+// @Param req body helper.AuthBase true "AuthBase"
+// @Success 200 {object} gin.H
 // @Router /payment/v1alpha1/subscription/user-info [post]
 func GetSubscriptionUserInfo(c *gin.Context) {
 	req := &helper.AuthBase{}
@@ -67,8 +67,8 @@ func GetSubscriptionUserInfo(c *gin.Context) {
 // @Tags Subscription
 // @Accept json
 // @Produce json
-// @Param req body SubscriptionPlanListReq true "SubscriptionPlanListReq"
-// @Success 200 {object} SubscriptionPlanListResp
+// @Param req body helper.AuthBase true "AuthBase"
+// @Success 200 {object} gin.H
 // @Router /payment/v1alpha1/subscription/plan-list [post]
 func GetSubscriptionPlanList(c *gin.Context) {
 	plans, err := dao.DBClient.GetSubscriptionPlanList()
@@ -92,8 +92,8 @@ func GetSubscriptionPlanList(c *gin.Context) {
 // @Tags Subscription
 // @Accept json
 // @Produce json
-// @Param req body SubscriptionLastTransactionReq true "SubscriptionLastTransactionReq"
-// @Success 200 {object} SubscriptionLastTransactionResp
+// @Param req body helper.AuthBase true "AuthBase"
+// @Success 200 {object} gin.H
 // @Router /payment/v1alpha1/subscription/last-transaction [post]
 func GetLastSubscriptionTransaction(c *gin.Context) {
 	req := &helper.AuthBase{}
@@ -128,8 +128,8 @@ func GetLastSubscriptionTransaction(c *gin.Context) {
 // @Tags Subscription
 // @Accept json
 // @Produce json
-// @Param req body SubscriptionUpgradeAmountReq true "SubscriptionUpgradeAmountReq"
-// @Success 200 {object} SubscriptionUpgradeAmountResp
+// @Param req body helper.SubscriptionOperatorReq true "SubscriptionOperatorReq"
+// @Success 200 {object} gin.H
 // @Router /payment/v1alpha1/subscription/upgrade-amount [post]
 func GetSubscriptionUpgradeAmount(c *gin.Context) {
 	req, err := helper.ParseSubscriptionOperatorReq(c)
@@ -203,8 +203,8 @@ func GetSubscriptionUpgradeAmount(c *gin.Context) {
 // @Tags Subscription
 // @Accept json
 // @Produce json
-// @Param req body SubscriptionQuotaCheckReq true "SubscriptionQuotaCheckReq"
-// @Success 200 {object} SubscriptionQuotaCheckResp
+// @Param req body helper.SubscriptionQuotaCheckReq true "SubscriptionQuotaCheckReq"
+// @Success 200 {object} helper.SubscriptionQuotaCheckResp
 // @Router /payment/v1alpha1/subscription/quota-check [post]
 func CheckSubscriptionQuota(c *gin.Context) {
 	req, err := helper.ParseSubscriptionQuotaCheckReq(c)
@@ -433,8 +433,8 @@ func getDefaultResourceQuota(ns, name string, hard corev1.ResourceList) *corev1.
 // @Tags Subscription
 // @Accept json
 // @Produce json
-// @Param req body SubscriptionPayReq true "SubscriptionPayReq"
-// @Success 200 {object} SubscriptionPayResp
+// @Param req body helper.SubscriptionOperatorReq true "SubscriptionOperatorReq"
+// @Success 200 {object} gin.H
 // @Router /payment/v1alpha1/subscription/pay [post]
 func CreateSubscriptionPay(c *gin.Context) {
 	req, err := helper.ParseSubscriptionOperatorReq(c)

--- a/service/account/api/workspace.go
+++ b/service/account/api/workspace.go
@@ -74,8 +74,8 @@ type CustomResourceQuotaStatus struct {
 // @Tags WorkspaceSubscription
 // @Accept json
 // @Produce json
-// @Param req body WorkspaceResourceQuotaReq true "WorkspaceResourceQuotaReq"
-// @Success 200 {object} WorkspaceResourceQuotaResp
+// @Param req body helper.WorkspaceInfoReq true "WorkspaceInfoReq"
+// @Success 200 {object} gin.H
 // @Router /workspace/v1alpha1/resource-quota [post]
 func GetWorkspaceResourceQuota(c *gin.Context) {
 	req, err := helper.ParseWorkspaceInfoReq(c)

--- a/service/account/api/workspace_subscription.go
+++ b/service/account/api/workspace_subscription.go
@@ -36,8 +36,8 @@ import (
 // @Tags WorkspaceSubscription
 // @Accept json
 // @Produce json
-// @Param req body WorkspaceSubscriptionInfoReq true "WorkspaceSubscriptionInfoReq"
-// @Success 200 {object} WorkspaceSubscriptionInfoResp
+// @Param req body helper.WorkspaceSubscriptionInfoReq true "WorkspaceSubscriptionInfoReq"
+// @Success 200 {object} gin.H
 // @Router /payment/v1alpha1/workspace-subscription/info [post]
 func GetWorkspaceSubscriptionInfo(c *gin.Context) {
 	req, err := helper.ParseWorkspaceSubscriptionInfoReq(c)
@@ -459,8 +459,8 @@ func DeleteAccount(c *gin.Context) {
 // @Tags WorkspaceSubscription
 // @Accept json
 // @Produce json
-// @Param req body WorkspaceSubscriptionListReq true "WorkspaceSubscriptionListReq"
-// @Success 200 {object} WorkspaceSubscriptionListResp
+// @Param req body helper.AuthBase true "AuthBase"
+// @Success 200 {object} gin.H
 // @Router /payment/v1alpha1/workspace-subscription/list [post]
 func GetWorkspaceSubscriptionList(c *gin.Context) {
 	req := &helper.AuthBase{}
@@ -518,8 +518,8 @@ func GetWorkspaceSubscriptionList(c *gin.Context) {
 // @Tags WorkspaceSubscription
 // @Accept json
 // @Produce json
-// @Param req body WorkspaceSubscriptionInfoReq true "WorkspaceSubscriptionInfoReq"
-// @Success 200 {object} WorkspaceSubscriptionPaymentListResp
+// @Param req body helper.UserTimeRangeReq true "UserTimeRangeReq"
+// @Success 200 {object} gin.H
 // @Router /payment/v1alpha1/workspace-subscription/payment-list [post]
 func GetWorkspaceSubscriptionPaymentList(c *gin.Context) {
 	req, err := helper.ParseUserTimeRangeReq(c)
@@ -594,7 +594,7 @@ func GetWorkspaceSubscriptionPaymentList(c *gin.Context) {
 // @Tags WorkspaceSubscription
 // @Accept json
 // @Produce json
-// @Success 200 {object} WorkspaceSubscriptionPlanListResp
+// @Success 200 {object} gin.H
 // @Router /payment/v1alpha1/workspace-subscription/plan-list [post]
 func GetWorkspaceSubscriptionPlanList(c *gin.Context) {
 	plans, err := dao.DBClient.GetWorkspaceSubscriptionPlanList()
@@ -618,8 +618,8 @@ func GetWorkspaceSubscriptionPlanList(c *gin.Context) {
 // @Tags WorkspaceSubscription
 // @Accept json
 // @Produce json
-// @Param req body WorkspaceSubscriptionInfoReq true "WorkspaceSubscriptionInfoReq"
-// @Success 200 {object} WorkspaceSubscriptionLastTransactionResp
+// @Param req body helper.WorkspaceSubscriptionInfoReq true "WorkspaceSubscriptionInfoReq"
+// @Success 200 {object} gin.H
 // @Router /payment/v1alpha1/workspace-subscription/last-transaction [post]
 func GetLastWorkspaceSubscriptionTransaction(c *gin.Context) {
 	req, err := helper.ParseWorkspaceSubscriptionInfoReq(c)
@@ -668,8 +668,8 @@ func GetLastWorkspaceSubscriptionTransaction(c *gin.Context) {
 // @Tags WorkspaceSubscription
 // @Accept json
 // @Produce json
-// @Param req body WorkspaceSubscriptionUpgradeAmountReq true "WorkspaceSubscriptionUpgradeAmountReq"
-// @Success 200 {object} WorkspaceSubscriptionUpgradeAmountResp
+// @Param req body helper.WorkspaceSubscriptionOperatorReq true "WorkspaceSubscriptionOperatorReq"
+// @Success 200 {object} gin.H
 // @Router /payment/v1alpha1/workspace-subscription/upgrade-amount [post]
 func GetWorkspaceSubscriptionUpgradeAmount(c *gin.Context) {
 	req, err := helper.ParseWorkspaceSubscriptionOperatorReq(c)
@@ -1159,8 +1159,8 @@ func handleCalculatedUpgrade(
 // @Tags WorkspaceSubscription
 // @Accept json
 // @Produce json
-// @Param req body WorkspaceSubscriptionOperatorReq true "WorkspaceSubscriptionOperatorReq"
-// @Success 200 {object} WorkspaceSubscriptionPayResp
+// @Param req body helper.WorkspaceSubscriptionOperatorReq true "WorkspaceSubscriptionOperatorReq"
+// @Success 200 {object} gin.H
 // @Router /payment/v1alpha1/workspace-subscription/pay [post]
 func parseWorkspaceSubscriptionPayReq(
 	c *gin.Context,
@@ -4077,7 +4077,7 @@ func CreateWorkspaceSubscriptionSetupIntent(c *gin.Context) {
 // @Accept json
 // @Produce json
 // @Param req body helper.WorkspaceSubscriptionCardInfoReq true "WorkspaceSubscriptionCardInfoReq"
-// @Success 200 {object} gin.H{payment_method:interface{},success:bool}
+// @Success 200 {object} gin.H
 // @Router /payment/v1alpha1/workspace-subscription/card-info [post]
 
 func GetWorkspaceSubscriptionCardInfo(c *gin.Context) {
@@ -4238,7 +4238,7 @@ func AdminProcessExpiredWorkspaceSubscriptions(c *gin.Context) {
 // @Tags WorkspaceSubscription
 // @Accept json
 // @Produce json
-// @Param req body AdminWorkspaceSubscriptionAddReq true "AdminWorkspaceSubscriptionAddReq"
+// @Param req body helper.AdminWorkspaceSubscriptionAddReq true "AdminWorkspaceSubscriptionAddReq"
 // @Success 200 {object} gin.H
 // @Router /admin/v1alpha1/workspace-subscription/add [post]
 
@@ -4758,7 +4758,7 @@ func processSubscriptionTransaction(
 // @Accept json
 // @Produce json
 // @Param req body helper.WorkspaceSubscriptionPlansReq true "WorkspaceSubscriptionPlansReq"
-// @Success 200 {object} WorkspaceSubscriptionPlansResp
+// @Success 200 {object} gin.H
 // @Router /account/v1alpha1/workspace-subscription/plans [post]
 func GetWorkspaceSubscriptionPlans(c *gin.Context) {
 	req, err := helper.ParseWorkspaceSubscriptionPlansReq(c)
@@ -4834,7 +4834,7 @@ func GetWorkspaceSubscriptionPlans(c *gin.Context) {
 // @Accept json
 // @Produce json
 // @Param req body helper.WorkspaceSubscriptionInvoiceCancelReq true "WorkspaceSubscriptionInvoiceCancelReq"
-// @Success 200 {object} gin.H{success:bool,message:string}
+// @Success 200 {object} gin.H
 // @Router /account/v1alpha1/workspace-subscription/invoice-cancel [post]
 func CancelWorkspaceSubscriptionInvoice(c *gin.Context) {
 	req, err := helper.ParseWorkspaceSubscriptionInvoiceCancelReq(c)

--- a/service/account/docs/docs.go
+++ b/service/account/docs/docs.go
@@ -522,6 +522,62 @@ const docTemplate = `{
                 }
             }
         },
+        "/account/v1alpha1/costs/app-type": {
+            "post": {
+                "description": "Get app type costs within a specified time range",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AppTypeCosts"
+                ],
+                "summary": "Get app type costs",
+                "parameters": [
+                    {
+                        "description": "App type costs request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.AppCostsReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successfully retrieved app type costs",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "failed to parse get app type cost request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "authenticate error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "failed to get app type cost",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/account/v1alpha1/costs/consumption": {
             "post": {
                 "description": "Get user consumption amount within a specified time range",
@@ -741,6 +797,152 @@ const docTemplate = `{
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/account/v1alpha1/costs/workspace-app": {
+            "post": {
+                "description": "Get workspace app costs within a specified time range",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceAppCosts"
+                ],
+                "summary": "Get workspace app costs",
+                "parameters": [
+                    {
+                        "description": "Workspace app costs request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.AppCostsReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successfully retrieved workspace app costs",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "failed to parse get workspace app cost request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "authenticate error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "failed to get workspace app cost",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/account/v1alpha1/costs/workspace-consumption": {
+            "post": {
+                "description": "Get workspace consumption amount within a specified time range",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ConsumptionAmount"
+                ],
+                "summary": "Get workspace consumption amount",
+                "parameters": [
+                    {
+                        "description": "Workspace consumption amount request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.ConsumptionRecordReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successfully retrieved workspace consumption amount",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "failed to parse workspace consumption amount request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "authenticate error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "failed to get workspace consumption amount",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/account/v1alpha1/createPay": {
+            "post": {
+                "description": "Create a payment",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "account"
+                ],
+                "summary": "Create a payment",
+                "parameters": [
+                    {
+                        "description": "CreatePayReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.CreatePayReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
                         }
                     }
                 }
@@ -1288,12 +1490,12 @@ const docTemplate = `{
                 "summary": "Get recharge discount",
                 "parameters": [
                     {
-                        "description": "Get recharge discount request",
+                        "description": "AuthBase",
                         "name": "request",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "object"
+                            "$ref": "#/definitions/helper.AuthBase"
                         }
                     }
                 ],
@@ -1416,6 +1618,214 @@ const docTemplate = `{
                 }
             }
         },
+        "/account/v1alpha1/user-alert-notification-account": {
+            "post": {
+                "description": "Create a new user alert notification account. Only EMAIL and PHONE provider types are supported.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "UserAlertNotificationAccount"
+                ],
+                "summary": "Create user alert notification account",
+                "parameters": [
+                    {
+                        "description": "Create user alert notification account request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.CreateUserAlertNotificationAccountReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully created user alert notification account",
+                        "schema": {
+                            "$ref": "#/definitions/helper.CreateUserAlertNotificationAccountResp"
+                        }
+                    },
+                    "400": {
+                        "description": "Failed to parse create user alert notification account request or unsupported provider type",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication error",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to create user alert notification account",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    }
+                }
+            }
+        },
+        "/account/v1alpha1/user-alert-notification-account/delete": {
+            "post": {
+                "description": "Delete multiple user alert notification accounts",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "UserAlertNotificationAccount"
+                ],
+                "summary": "Delete user alert notification accounts",
+                "parameters": [
+                    {
+                        "description": "Delete user alert notification accounts request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.DeleteUserAlertNotificationAccountReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted user alert notification accounts",
+                        "schema": {
+                            "$ref": "#/definitions/helper.DeleteUserAlertNotificationAccountResp"
+                        }
+                    },
+                    "400": {
+                        "description": "Failed to parse delete user alert notification accounts request",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication error",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to delete user alert notification accounts",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    }
+                }
+            }
+        },
+        "/account/v1alpha1/user-alert-notification-account/list": {
+            "post": {
+                "description": "List all user alert notification accounts for a user",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "UserAlertNotificationAccount"
+                ],
+                "summary": "List user alert notification accounts",
+                "parameters": [
+                    {
+                        "description": "List user alert notification accounts request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.ListUserAlertNotificationAccountsReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully listed user alert notification accounts",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ListUserAlertNotificationAccountsResp"
+                        }
+                    },
+                    "400": {
+                        "description": "Failed to parse list user alert notification accounts request",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication error",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to list user alert notification accounts",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    }
+                }
+            }
+        },
+        "/account/v1alpha1/user-alert-notification-account/toggle": {
+            "post": {
+                "description": "Enable or disable multiple user alert notification accounts",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "UserAlertNotificationAccount"
+                ],
+                "summary": "Toggle user alert notification accounts",
+                "parameters": [
+                    {
+                        "description": "Toggle user alert notification accounts request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.ToggleUserAlertNotificationAccountsReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully toggled user alert notification accounts",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ToggleUserAlertNotificationAccountsResp"
+                        }
+                    },
+                    "400": {
+                        "description": "Failed to parse toggle user alert notification accounts request",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication error",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to toggle user alert notification accounts",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    }
+                }
+            }
+        },
         "/account/v1alpha1/user-usage": {
             "post": {
                 "description": "Get user usage within a specified time range",
@@ -1467,6 +1877,74 @@ const docTemplate = `{
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/account/v1alpha1/workspace-subscription/invoice-cancel": {
+            "post": {
+                "description": "Cancel an unpaid Stripe invoice for workspace subscription upgrade",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Cancel workspace subscription invoice",
+                "parameters": [
+                    {
+                        "description": "WorkspaceSubscriptionInvoiceCancelReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.WorkspaceSubscriptionInvoiceCancelReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/account/v1alpha1/workspace-subscription/plans": {
+            "post": {
+                "description": "Get subscription plan names for multiple namespaces, returning \"PAYG\" for non-subscribed workspaces",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Get workspace subscription plans by namespaces",
+                "parameters": [
+                    {
+                        "description": "WorkspaceSubscriptionPlansReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.WorkspaceSubscriptionPlansReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
                         }
                     }
                 }
@@ -1548,6 +2026,100 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/v1alpha1/gift-codes": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AdminRead"
+                ],
+                "summary": "List gift codes for admin",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/helper.AdminGiftCodeListResp"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/gift-codes/usage": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AdminRead"
+                ],
+                "summary": "List user gift code usage for admin",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/helper.AdminGiftCodeUsageResp"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/invoice": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AdminRead"
+                ],
+                "summary": "Get invoice for admin",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Invoice ID",
+                        "name": "id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/helper.AdminInvoice"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/invoices": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AdminRead"
+                ],
+                "summary": "List invoices for admin",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/helper.AdminInvoiceListResp"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/v1alpha1/real-name-info": {
             "get": {
                 "description": "Get user real name info",
@@ -1585,15 +2157,1317 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/admin/v1alpha1/recharge-gift-policy": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AdminRead"
+                ],
+                "summary": "Get recharge gift policy for admin",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/helper.AdminRechargeGiftPolicy"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/refund-status": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AdminRead"
+                ],
+                "summary": "Get refund status for admin",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Payment ID or trade number",
+                        "name": "id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/helper.AdminRefundStatusResp"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/regions": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AdminRead"
+                ],
+                "summary": "List regions for admin",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/helper.AdminRegion"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/reload-property-types": {
+            "post": {
+                "description": "Reload property types from database and update the global DefaultPropertyTypeLS",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "Reload property types",
+                "responses": {
+                    "200": {
+                        "description": "successfully reloaded property types",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ReloadPropertyTypesResp"
+                        }
+                    },
+                    "401": {
+                        "description": "authenticate error",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "500": {
+                        "description": "failed to reload property types",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/subscription-plan/delete": {
+            "post": {
+                "description": "Delete a WorkspaceSubscriptionPlan by ID or name",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "Delete WorkspaceSubscriptionPlan",
+                "parameters": [
+                    {
+                        "description": "Delete request (id or name required)",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successfully deleted subscription plan",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "invalid request body",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "401": {
+                        "description": "authenticate error",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "404": {
+                        "description": "subscription plan not found",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "500": {
+                        "description": "failed to delete subscription plan",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/subscription-plan/manage": {
+            "post": {
+                "description": "Create a new WorkspaceSubscriptionPlan with prices or update existing one with prices. Manages plan and prices as a single unit.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "Create or update WorkspaceSubscriptionPlan with prices",
+                "parameters": [
+                    {
+                        "description": "Subscription plan with prices data",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.SubscriptionPlanManageRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successfully created/updated subscription plan with prices",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "invalid request body",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "401": {
+                        "description": "authenticate error",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "500": {
+                        "description": "failed to create/update subscription plan with prices",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/subscription-plans": {
+            "get": {
+                "description": "Admin interface to get all available subscription plans using GET method",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Admin get subscription plans (GET)",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "example": false,
+                        "description": "Include inactive plans",
+                        "name": "includeInactive",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "example": "\"workspace\"",
+                        "description": "Filter by plan type",
+                        "name": "planType",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Admin interface to get all available subscription plans",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Admin get subscription plans",
+                "parameters": [
+                    {
+                        "description": "AdminSubscriptionPlansReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.AdminSubscriptionPlansReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/user": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AdminRead"
+                ],
+                "summary": "Get user detail for admin",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/helper.AdminUserDetail"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/user/balance-adjust-records": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AdminRead"
+                ],
+                "summary": "List user balance adjustments for admin",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Zero-based page index",
+                        "name": "pageIndex",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1-100",
+                        "name": "pageSize",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/helper.AdminBalanceAdjustRecordsResp"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/user/recharge-records": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AdminRead"
+                ],
+                "summary": "List user recharge records for admin",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Zero-based page index",
+                        "name": "pageIndex",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1-100",
+                        "name": "pageSize",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/helper.AdminRechargeRecordsResp"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/users": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AdminRead"
+                ],
+                "summary": "List users for admin",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Zero-based page index",
+                        "name": "pageIndex",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1-100",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Password provider username",
+                        "name": "username",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Phone provider ID",
+                        "name": "phone",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "workspaceId",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Workspace display name",
+                        "name": "workspaceName",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/helper.AdminUserListResp"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/workspace-subscription/add": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/workspace-subscription/list": {
+            "get": {
+                "description": "Admin interface to get paginated workspace subscription list with filtering options using GET method",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Admin get workspace subscription list (GET)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "example": 0,
+                        "description": "Page index (0-based)",
+                        "name": "pageIndex",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "example": 10,
+                        "description": "Page size (optional, defaults to 10)",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "example": "\"ns-8gmgq0jn\"",
+                        "description": "Filter by workspace name",
+                        "name": "workspace",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "example": "\"36ca5ee6-7b6e-4c15-922b-e861b3fbc061\"",
+                        "description": "Filter by user ID",
+                        "name": "userUID",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "example": "\"Hobby\"",
+                        "description": "Filter by plan name",
+                        "name": "planName",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "example": "\"NORMAL\"",
+                        "description": "Filter by subscription status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "example": "\"192.168.10.35.nip.io\"",
+                        "description": "Filter by region domain",
+                        "name": "regionDomain",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Admin interface to get paginated workspace subscription list with filtering options",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Admin get workspace subscription list",
+                "parameters": [
+                    {
+                        "description": "AdminWorkspaceSubscriptionListReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.AdminWorkspaceSubscriptionListReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/card/delete": {
+            "post": {
+                "description": "Delete user card info",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Payment"
+                ],
+                "summary": "Delete user card info",
+                "parameters": [
+                    {
+                        "description": "CardOperationReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.CardOperationReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/card/list": {
+            "post": {
+                "description": "List user card info",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Payment"
+                ],
+                "summary": "List user card info",
+                "parameters": [
+                    {
+                        "description": "AuthBase",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.AuthBase"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/card/set-default": {
+            "post": {
+                "description": "Set default user card",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Payment"
+                ],
+                "summary": "Set default user card",
+                "parameters": [
+                    {
+                        "description": "CardOperationReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.CardOperationReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/credits/info": {
+            "post": {
+                "description": "Get credits info",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Credits"
+                ],
+                "summary": "Get credits info",
+                "parameters": [
+                    {
+                        "description": "AuthBase",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.AuthBase"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.CreditsInfoResp"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/subscription/flush-quota": {
+            "post": {
+                "description": "flush user quota with subscription",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Subscription"
+                ],
+                "summary": "flush user quota with subscription",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/subscription/last-transaction": {
+            "post": {
+                "description": "Get user last subscription transaction",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Subscription"
+                ],
+                "summary": "Get user last subscription transaction",
+                "parameters": [
+                    {
+                        "description": "AuthBase",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.AuthBase"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/subscription/pay": {
+            "post": {
+                "description": "Subscription pay",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Subscription"
+                ],
+                "summary": "Subscription pay",
+                "parameters": [
+                    {
+                        "description": "SubscriptionOperatorReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.SubscriptionOperatorReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/subscription/plan-list": {
+            "post": {
+                "description": "Get subscription plan list",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Subscription"
+                ],
+                "summary": "Get subscription plan list",
+                "parameters": [
+                    {
+                        "description": "AuthBase",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.AuthBase"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/subscription/quota-check": {
+            "post": {
+                "description": "Check user subscription quota",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Subscription"
+                ],
+                "summary": "Check user subscription quota",
+                "parameters": [
+                    {
+                        "description": "SubscriptionQuotaCheckReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.SubscriptionQuotaCheckReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/helper.SubscriptionQuotaCheckResp"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/subscription/upgrade-amount": {
+            "post": {
+                "description": "Get subscription upgrade amount",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Subscription"
+                ],
+                "summary": "Get subscription upgrade amount",
+                "parameters": [
+                    {
+                        "description": "SubscriptionOperatorReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.SubscriptionOperatorReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/subscription/user-info": {
+            "post": {
+                "description": "Get user subscription info",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Subscription"
+                ],
+                "summary": "Get user subscription info",
+                "parameters": [
+                    {
+                        "description": "AuthBase",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.AuthBase"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/workspace-subscription/info": {
+            "post": {
+                "description": "Get workspace subscription info",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Get workspace subscription info",
+                "parameters": [
+                    {
+                        "description": "WorkspaceSubscriptionInfoReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.WorkspaceSubscriptionInfoReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/workspace-subscription/last-transaction": {
+            "post": {
+                "description": "Get last workspace subscription transaction",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Get last workspace subscription transaction",
+                "parameters": [
+                    {
+                        "description": "WorkspaceSubscriptionInfoReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.WorkspaceSubscriptionInfoReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/workspace-subscription/list": {
+            "post": {
+                "description": "Get workspace subscription list",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Get workspace subscription list",
+                "parameters": [
+                    {
+                        "description": "AuthBase",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.AuthBase"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/workspace-subscription/notify": {
+            "post": {
+                "description": "Handle Stripe webhook notifications for workspace subscription events",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Handle Stripe webhook for workspace subscription",
+                "responses": {}
+            }
+        },
+        "/payment/v1alpha1/workspace-subscription/pay": {
+            "post": {
+                "description": "Create workspace subscription payment with Stripe",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Create workspace subscription payment",
+                "parameters": [
+                    {
+                        "description": "WorkspaceSubscriptionOperatorReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.WorkspaceSubscriptionOperatorReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/workspace-subscription/payment-list": {
+            "post": {
+                "description": "Get workspace subscription payment list",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Get workspace subscription payment list",
+                "parameters": [
+                    {
+                        "description": "UserTimeRangeReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.UserTimeRangeReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/workspace-subscription/plan-list": {
+            "post": {
+                "description": "Get workspace subscription plan list",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Get workspace subscription plan list",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/workspace-subscription/upgrade-amount": {
+            "post": {
+                "description": "Get workspace subscription upgrade amount",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Get workspace subscription upgrade amount",
+                "parameters": [
+                    {
+                        "description": "WorkspaceSubscriptionOperatorReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.WorkspaceSubscriptionOperatorReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspace/v1alpha1/resource-quota": {
+            "post": {
+                "description": "Get workspace resource quota",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Get workspace resource quota",
+                "parameters": [
+                    {
+                        "description": "WorkspaceInfoReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.WorkspaceInfoReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
+        "api.CreditsInfo": {
+            "type": "object",
+            "properties": {
+                "balance": {
+                    "type": "integer"
+                },
+                "credits": {
+                    "type": "integer"
+                },
+                "creditsList": {
+                    "description": "CreditsList holds the same rows the aggregate fields above are summed\nfrom, so sum(amount) == Credits and sum(usedAmount) == DeductionCredits;\nexhausted rows stay in the list to keep that invariant. Callers filter\nfor display (e.g. amount \u003e usedAmount).",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.CreditsItem"
+                    }
+                },
+                "currentPlanCreditsBalance": {
+                    "type": "integer"
+                },
+                "currentPlanCreditsDeductionBalance": {
+                    "type": "integer"
+                },
+                "deductionBalance": {
+                    "type": "integer"
+                },
+                "deductionCredits": {
+                    "type": "integer"
+                },
+                "kycDeductionCreditsBalance": {
+                    "type": "integer"
+                },
+                "kycDeductionCreditsDeductionBalance": {
+                    "type": "integer"
+                },
+                "userUid": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.CreditsInfoResp": {
+            "type": "object",
+            "properties": {
+                "credits": {
+                    "$ref": "#/definitions/api.CreditsInfo"
+                }
+            }
+        },
+        "api.CreditsItem": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "integer"
+                },
+                "expireAt": {
+                    "type": "string"
+                },
+                "startAt": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/types.CreditsStatus"
+                },
+                "usedAmount": {
+                    "type": "integer"
+                }
+            }
+        },
+        "api.SubscriptionPlanManageRequest": {
+            "type": "object",
+            "properties": {
+                "plan": {
+                    "$ref": "#/definitions/types.WorkspaceSubscriptionPlan"
+                },
+                "prices": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.ProductPrice"
+                    }
+                }
+            }
+        },
         "common.PropertyQuery": {
             "type": "object",
             "properties": {
                 "alias": {
                     "type": "string",
                     "example": "gpu-tesla-v100"
+                },
+                "enum": {
+                    "type": "integer",
+                    "example": 1
                 },
                 "name": {
                     "type": "string",
@@ -1606,6 +3480,587 @@ const docTemplate = `{
                 "unit_price": {
                     "type": "number",
                     "example": 10000
+                }
+            }
+        },
+        "gin.H": {
+            "type": "object",
+            "additionalProperties": {}
+        },
+        "helper.AdminBalanceAdjustRecord": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "integer"
+                },
+                "balanceAfter": {
+                    "type": "integer"
+                },
+                "balanceBefore": {
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.AdminBalanceAdjustRecordsResp": {
+            "type": "object",
+            "properties": {
+                "list": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/helper.AdminBalanceAdjustRecord"
+                    }
+                },
+                "pageIndex": {
+                    "type": "integer"
+                },
+                "pageSize": {
+                    "type": "integer"
+                },
+                "totalItems": {
+                    "type": "integer"
+                },
+                "totalPages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "helper.AdminGiftCode": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "comment": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "createdBy": {
+                    "type": "string"
+                },
+                "createdById": {
+                    "type": "string"
+                },
+                "creditAmount": {
+                    "type": "integer"
+                },
+                "expiredAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "rechargeType": {
+                    "type": "string"
+                },
+                "used": {
+                    "type": "boolean"
+                },
+                "usedAt": {
+                    "type": "string"
+                },
+                "usedBy": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.AdminGiftCodeListResp": {
+            "type": "object",
+            "properties": {
+                "list": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/helper.AdminGiftCode"
+                    }
+                },
+                "pageIndex": {
+                    "type": "integer"
+                },
+                "pageSize": {
+                    "type": "integer"
+                },
+                "totalItems": {
+                    "type": "integer"
+                },
+                "totalPages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "helper.AdminGiftCodeUsage": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "comment": {
+                    "type": "string"
+                },
+                "creditAmount": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "rechargeType": {
+                    "type": "string"
+                },
+                "usedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.AdminGiftCodeUsageResp": {
+            "type": "object",
+            "properties": {
+                "list": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/helper.AdminGiftCodeUsage"
+                    }
+                },
+                "pageIndex": {
+                    "type": "integer"
+                },
+                "pageSize": {
+                    "type": "integer"
+                },
+                "totalItems": {
+                    "type": "integer"
+                },
+                "totalPages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "helper.AdminInvoice": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "detail": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "remark": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "totalAmount": {
+                    "type": "integer"
+                },
+                "updatedAt": {
+                    "type": "string"
+                },
+                "userID": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.AdminInvoiceListResp": {
+            "type": "object",
+            "properties": {
+                "list": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/helper.AdminInvoice"
+                    }
+                },
+                "pageIndex": {
+                    "type": "integer"
+                },
+                "pageSize": {
+                    "type": "integer"
+                },
+                "totalItems": {
+                    "type": "integer"
+                },
+                "totalPages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "helper.AdminRechargeGiftPolicy": {
+            "type": "object",
+            "properties": {
+                "defaultDiscountSteps": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    }
+                },
+                "firstRechargeDiscountSteps": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    }
+                }
+            }
+        },
+        "helper.AdminRechargeRecord": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "integer"
+                },
+                "chargeSource": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "gift": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "latestRefund": {
+                    "$ref": "#/definitions/helper.AdminRefund"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "refundCount": {
+                    "type": "integer"
+                },
+                "refunded": {
+                    "type": "boolean"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "tradeNo": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.AdminRechargeRecordsResp": {
+            "type": "object",
+            "properties": {
+                "list": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/helper.AdminRechargeRecord"
+                    }
+                },
+                "pageIndex": {
+                    "type": "integer"
+                },
+                "pageSize": {
+                    "type": "integer"
+                },
+                "totalItems": {
+                    "type": "integer"
+                },
+                "totalPages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "helper.AdminRefund": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "deductAmount": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "refundAmount": {
+                    "type": "integer"
+                },
+                "refundNo": {
+                    "type": "string"
+                },
+                "refundReason": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.AdminRefundStatusResp": {
+            "type": "object",
+            "properties": {
+                "latestRefund": {
+                    "$ref": "#/definitions/helper.AdminRefund"
+                },
+                "refundCount": {
+                    "type": "integer"
+                },
+                "refunded": {
+                    "type": "boolean"
+                },
+                "tradeNo": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.AdminRegion": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "displayName": {
+                    "type": "string"
+                },
+                "domain": {
+                    "type": "string"
+                },
+                "location": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.AdminSubscriptionPlansReq": {
+            "type": "object",
+            "properties": {
+                "includeInactive": {
+                    "description": "@Summary Include inactive plans\n@Description Include inactive plans in the response (optional, defaults to false)\n@JSONSchema",
+                    "type": "boolean",
+                    "example": false
+                },
+                "planType": {
+                    "description": "@Summary Plan type filter\n@Description Filter by plan type (optional)\n@JSONSchema",
+                    "type": "string",
+                    "example": "workspace"
+                }
+            }
+        },
+        "helper.AdminUser": {
+            "type": "object",
+            "properties": {
+                "availableBalance": {
+                    "type": "integer"
+                },
+                "balance": {
+                    "type": "integer"
+                },
+                "billingStatus": {
+                    "type": "string"
+                },
+                "deductionBalance": {
+                    "type": "integer"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "nickname": {
+                    "type": "string"
+                },
+                "phone": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "sourceProviderTypes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sourceType": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.AdminUserDetail": {
+            "type": "object",
+            "properties": {
+                "availableBalance": {
+                    "type": "integer"
+                },
+                "balance": {
+                    "type": "integer"
+                },
+                "billingStatus": {
+                    "type": "string"
+                },
+                "deductionBalance": {
+                    "type": "integer"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "idCard": {
+                    "type": "string"
+                },
+                "nickname": {
+                    "type": "string"
+                },
+                "phone": {
+                    "type": "string"
+                },
+                "productSeries": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "realName": {
+                    "type": "string"
+                },
+                "rechargeAmount": {
+                    "type": "integer"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "sourceProviderTypes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sourceType": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "string"
+                },
+                "userType": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                },
+                "workspaces": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/helper.AdminWorkspace"
+                    }
+                }
+            }
+        },
+        "helper.AdminUserListResp": {
+            "type": "object",
+            "properties": {
+                "list": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/helper.AdminUser"
+                    }
+                },
+                "pageIndex": {
+                    "type": "integer"
+                },
+                "pageSize": {
+                    "type": "integer"
+                },
+                "totalItems": {
+                    "type": "integer"
+                },
+                "totalPages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "helper.AdminWorkspace": {
+            "type": "object",
+            "properties": {
+                "displayName": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isPrivate": {
+                    "type": "boolean"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.AdminWorkspaceSubscriptionListReq": {
+            "type": "object",
+            "properties": {
+                "pageIndex": {
+                    "description": "@Summary Page index\n@Description Page index (0-based)\n@JSONSchema",
+                    "type": "integer",
+                    "example": 0
+                },
+                "pageSize": {
+                    "description": "@Summary Page size\n@Description Page size (optional, defaults to 10)\n@JSONSchema",
+                    "type": "integer",
+                    "example": 10
+                },
+                "planName": {
+                    "description": "@Summary Plan name filter\n@Description Filter by plan name (optional)\n@JSONSchema",
+                    "type": "string",
+                    "example": "premium"
+                },
+                "regionDomain": {
+                    "description": "@Summary Region domain filter\n@Description Filter by region domain (optional)\n@JSONSchema",
+                    "type": "string",
+                    "example": "example.com"
+                },
+                "status": {
+                    "description": "@Summary Status filter\n@Description Filter by subscription status (optional)\n@JSONSchema",
+                    "type": "string",
+                    "example": "normal"
+                },
+                "userUID": {
+                    "description": "@Summary User filter\n@Description Filter by user ID (optional)\n@JSONSchema",
+                    "type": "string",
+                    "example": "user-123"
+                },
+                "workspace": {
+                    "description": "@Summary Workspace filter\n@Description Filter by workspace name (optional)\n@JSONSchema",
+                    "type": "string",
+                    "example": "my-workspace"
                 }
             }
         },
@@ -1680,8 +4135,7 @@ const docTemplate = `{
             "properties": {
                 "detail": {
                     "description": "invoice detail information json\n@Summary Invoice detail information\n@Description Invoice detail information\n@JSONSchema required",
-                    "type": "string",
-                    "example": "{\"title\":\"title\",\"amount\":100,\"taxRate\":0.06,\"tax\":6,\"total\":106,\"invoiceType\":1,\"invoiceContent\":1,\"invoiceStatus\":1,\"invoiceTime\":\"2021-01-01T00:00:00Z\",\"invoiceNumber\":\"invoice-number-1\",\"invoiceCode\":\"invoice-code-1\",\"invoiceFile\":\"invoice-file-1\"}"
+                    "type": "string"
                 },
                 "kubeConfig": {
                     "type": "string"
@@ -1697,8 +4151,8 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "example": [
-                        "[\"payment-id-1\"",
-                        "\"payment-id-2\"]"
+                        "[payment-id-1",
+                        " payment-id-2]"
                     ]
                 },
                 "token": {
@@ -1718,6 +4172,69 @@ const docTemplate = `{
         "helper.Auth": {
             "type": "object",
             "properties": {
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                }
+            }
+        },
+        "helper.AuthBase": {
+            "type": "object",
+            "properties": {
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                }
+            }
+        },
+        "helper.CardOperationReq": {
+            "type": "object",
+            "properties": {
+                "cardBrand": {
+                    "description": "@Summary CardBrand\n@Description CardBrand",
+                    "type": "string",
+                    "example": "VISA"
+                },
+                "cardID": {
+                    "description": "@Summary CardID\n@Description CardID",
+                    "type": "string",
+                    "example": "123e4567-e89b-12d3-a456-426614174000"
+                },
+                "cardNo": {
+                    "description": "@Summary CardNo\n@Description CardNo",
+                    "type": "string",
+                    "example": "1234567890"
+                },
                 "kubeConfig": {
                     "type": "string"
                 },
@@ -1865,6 +4382,204 @@ const docTemplate = `{
                 "totalPage": {
                     "description": "@Summary Total page\n@Description Total page",
                     "type": "integer"
+                }
+            }
+        },
+        "helper.CreatePayReq": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "description": "@Summary Amount\n@Description Amount\n@JSONSchema required",
+                    "type": "integer",
+                    "example": 100000000
+                },
+                "cardBrand": {
+                    "description": "@Summary CardBrand\n@Description CardBrand",
+                    "type": "string",
+                    "example": "VISA"
+                },
+                "cardID": {
+                    "description": "@Summary CardID\n@Description CardID",
+                    "type": "string",
+                    "example": "123e4567-e89b-12d3-a456-426614174000"
+                },
+                "cardNo": {
+                    "description": "@Summary CardNo\n@Description CardNo",
+                    "type": "string",
+                    "example": "1234567890"
+                },
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "method": {
+                    "description": "@Summary Method\n@Description Method\n@JSONSchema required",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.PaymentMethod"
+                        }
+                    ],
+                    "example": "CARD"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                }
+            }
+        },
+        "helper.CreateUserAlertNotificationAccountReq": {
+            "type": "object",
+            "required": [
+                "providerId",
+                "providerType",
+                "userUid"
+            ],
+            "properties": {
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "providerId": {
+                    "description": "@Summary Provider ID\n@Description Provider ID (email address, phone number, etc.)\n@JSONSchema required",
+                    "type": "string",
+                    "example": "user@example.com"
+                },
+                "providerType": {
+                    "description": "@Summary Provider type\n@Description Provider type (Only EMAIL and PHONE are supported)\n@JSONSchema required",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.OauthProviderType"
+                        }
+                    ],
+                    "example": "EMAIL"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                },
+                "userUid": {
+                    "description": "@Summary User UUID\n@Description User UUID\n@JSONSchema required",
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                }
+            }
+        },
+        "helper.CreateUserAlertNotificationAccountResp": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/helper.CreateUserAlertNotificationAccountRespData"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.CreateUserAlertNotificationAccountRespData": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "providerId": {
+                    "type": "string"
+                },
+                "providerType": {
+                    "$ref": "#/definitions/types.OauthProviderType"
+                },
+                "userUid": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.DeleteUserAlertNotificationAccountReq": {
+            "type": "object",
+            "required": [
+                "ids",
+                "userUid"
+            ],
+            "properties": {
+                "ids": {
+                    "description": "@Summary Account IDs\n@Description List of account IDs to delete\n@JSONSchema required",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "[550e8400-e29b-41d4-a716-446655440000",
+                        " 550e8400-e29b-41d4-a716-446655440001]"
+                    ]
+                },
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                },
+                "userUid": {
+                    "description": "@Summary User UUID\n@Description User UUID\n@JSONSchema required",
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                }
+            }
+        },
+        "helper.DeleteUserAlertNotificationAccountResp": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/helper.DeleteUserAlertNotificationAccountRespData"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.DeleteUserAlertNotificationAccountRespData": {
+            "type": "object",
+            "properties": {
+                "deletedCount": {
+                    "type": "integer"
+                },
+                "deletedIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },
@@ -2124,6 +4839,44 @@ const docTemplate = `{
                 }
             }
         },
+        "helper.ListUserAlertNotificationAccountsReq": {
+            "type": "object",
+            "properties": {
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                }
+            }
+        },
+        "helper.ListUserAlertNotificationAccountsResp": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/helper.UserAlertNotificationAccountData"
+                    }
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
         "helper.NamespaceBillingHistoryReq": {
             "type": "object",
             "properties": {
@@ -2169,9 +4922,44 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "example": [
-                        "[\"ns-admin\"",
-                        "\"ns-test1\"]"
+                        "[ns-admin",
+                        "ns-test1]"
                     ]
+                }
+            }
+        },
+        "helper.PlanType": {
+            "type": "string",
+            "enum": [
+                "upgrade",
+                "downgrade",
+                "renewal"
+            ],
+            "x-enum-varnames": [
+                "Upgrade",
+                "Downgrade",
+                "Renewal"
+            ]
+        },
+        "helper.ReloadPropertyTypesResp": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/helper.ReloadPropertyTypesRespData"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.ReloadPropertyTypesRespData": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "status": {
+                    "type": "string"
                 }
             }
         },
@@ -2189,8 +4977,8 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "example": [
-                        "[\"invoice-id-1\"",
-                        "\"invoice-id-2\"]"
+                        "[invoice-id-1",
+                        " invoice-id-2]"
                     ]
                 },
                 "kubeConfig": {
@@ -2239,8 +5027,8 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "example": [
-                        "[\"payment-id-1\"",
-                        "\"payment-id-2\"]"
+                        "[payment-id-1",
+                        " payment-id-2]"
                     ]
                 },
                 "token": {
@@ -2254,6 +5042,196 @@ const docTemplate = `{
                 "userUID": {
                     "type": "string",
                     "example": "user-123"
+                }
+            }
+        },
+        "helper.SubscriptionOperatorReq": {
+            "type": "object",
+            "properties": {
+                "cardID": {
+                    "description": "@Summary CardID\n@Description CardID",
+                    "type": "string",
+                    "example": "123e4567-e89b-12d3-a456-426614174000"
+                },
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "payMethod": {
+                    "description": "@Summary PayMethod\n@Description PayMethod",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.PaymentMethod"
+                        }
+                    ],
+                    "example": "CARD"
+                },
+                "planID": {
+                    "description": "@Summary PlanID\n@Description PlanID",
+                    "type": "string",
+                    "example": "123e4567-e89b-12d3-a456-426614174000"
+                },
+                "planName": {
+                    "description": "@Summary PlanName\n@Description PlanName",
+                    "type": "string",
+                    "example": "planName"
+                },
+                "planType": {
+                    "description": "@Summary PlanType\n@Description PlanType",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/helper.PlanType"
+                        }
+                    ],
+                    "example": "upgrade;downgrade;renewal"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                }
+            }
+        },
+        "helper.SubscriptionQuotaCheckReq": {
+            "type": "object",
+            "properties": {
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "planID": {
+                    "description": "@Summary PlanID\n@Description PlanID",
+                    "type": "string",
+                    "example": "123e4567-e89b-12d3-a456-426614174000"
+                },
+                "planName": {
+                    "description": "@Summary PlanName\n@Description PlanName",
+                    "type": "string",
+                    "example": "planName"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                }
+            }
+        },
+        "helper.SubscriptionQuotaCheckResp": {
+            "type": "object",
+            "properties": {
+                "allWorkspaceReady": {
+                    "description": "allWorkspaceReady",
+                    "type": "boolean",
+                    "example": true
+                },
+                "readyWorkspace": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "workspace1",
+                        "workspace2"
+                    ]
+                },
+                "unReadyWorkspace": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "workspace3",
+                        "workspace4"
+                    ]
+                }
+            }
+        },
+        "helper.ToggleUserAlertNotificationAccountsReq": {
+            "type": "object",
+            "required": [
+                "ids",
+                "isEnabled"
+            ],
+            "properties": {
+                "ids": {
+                    "description": "@Summary Account IDs\n@Description List of account IDs to toggle\n@JSONSchema required",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "[550e8400-e29b-41d4-a716-446655440000",
+                        " 550e8400-e29b-41d4-a716-446655440001]"
+                    ]
+                },
+                "isEnabled": {
+                    "description": "@Summary Enable flag\n@Description Set to true to enable, false to disable\n@JSONSchema required",
+                    "type": "boolean",
+                    "example": true
+                },
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                }
+            }
+        },
+        "helper.ToggleUserAlertNotificationAccountsResp": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/helper.ToggleUserAlertNotificationAccountsRespData"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.ToggleUserAlertNotificationAccountsRespData": {
+            "type": "object",
+            "properties": {
+                "updatedCount": {
+                    "type": "integer"
+                },
+                "updatedIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },
@@ -2351,6 +5329,32 @@ const docTemplate = `{
                 }
             }
         },
+        "helper.UserAlertNotificationAccountData": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isEnabled": {
+                    "type": "boolean"
+                },
+                "providerId": {
+                    "type": "string"
+                },
+                "providerType": {
+                    "$ref": "#/definitions/types.OauthProviderType"
+                },
+                "updatedAt": {
+                    "type": "string"
+                },
+                "userUid": {
+                    "type": "string"
+                }
+            }
+        },
         "helper.UserTimeRangeReq": {
             "type": "object",
             "properties": {
@@ -2400,8 +5404,8 @@ const docTemplate = `{
                         "type": "string"
                     },
                     "example": [
-                        "[\"ns-admin\"",
-                        "\"ns-test1\"]"
+                        "[ns-admin",
+                        "ns-test1]"
                     ]
                 },
                 "owner": {
@@ -2423,6 +5427,463 @@ const docTemplate = `{
                 "userUID": {
                     "type": "string",
                     "example": "user-123"
+                }
+            }
+        },
+        "helper.WorkspaceInfoReq": {
+            "type": "object",
+            "required": [
+                "workspace"
+            ],
+            "properties": {
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                },
+                "workspace": {
+                    "description": "@Summary Workspace name\n@Description Workspace name",
+                    "type": "string",
+                    "example": "my-workspace"
+                }
+            }
+        },
+        "helper.WorkspaceSubscriptionInfoReq": {
+            "type": "object",
+            "required": [
+                "regionDomain",
+                "workspace"
+            ],
+            "properties": {
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "redirectUrl": {
+                    "description": "@Summary Redirect Url\n@Description Redirect Url for create session",
+                    "type": "string",
+                    "example": "https://example.com"
+                },
+                "regionDomain": {
+                    "description": "@Summary Region domain\n@Description Region domain\n@JSONSchema required",
+                    "type": "string",
+                    "example": "example.com"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                },
+                "workspace": {
+                    "description": "@Summary Workspace name\n@Description Workspace name\n@JSONSchema required",
+                    "type": "string",
+                    "example": "my-workspace"
+                }
+            }
+        },
+        "helper.WorkspaceSubscriptionInvoiceCancelReq": {
+            "type": "object",
+            "required": [
+                "invoiceID",
+                "regionDomain",
+                "workspace"
+            ],
+            "properties": {
+                "invoiceID": {
+                    "description": "@Summary Invoice ID\n@Description The Stripe invoice ID to cancel\n@JSONSchema required",
+                    "type": "string",
+                    "example": "in_1234567890"
+                },
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "regionDomain": {
+                    "description": "@Summary Region domain\n@Description Region domain (for authorization)\n@JSONSchema required",
+                    "type": "string",
+                    "example": "example.com"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                },
+                "workspace": {
+                    "description": "@Summary Workspace name\n@Description Workspace name (for authorization)\n@JSONSchema required",
+                    "type": "string",
+                    "example": "my-workspace"
+                }
+            }
+        },
+        "helper.WorkspaceSubscriptionOperatorReq": {
+            "type": "object",
+            "required": [
+                "operator",
+                "payMethod",
+                "planName",
+                "regionDomain"
+            ],
+            "properties": {
+                "cardId": {
+                    "description": "@Summary Card ID (optional for stripe payments)\n@Description Card ID for stripe payments",
+                    "type": "string"
+                },
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "operator": {
+                    "description": "@Summary Subscription operator (created/upgraded/downgraded/canceled/renewed)\n@Description Subscription operator type",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SubscriptionOperator"
+                        }
+                    ],
+                    "example": "created"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "payApp": {
+                    "description": "@Summary Stripe return app\n@Description Desktop app opened after returning from Stripe Checkout\n@JSONSchema optional",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.PayApp"
+                        }
+                    ],
+                    "example": "system-costcenter"
+                },
+                "payMethod": {
+                    "description": "@Summary Payment method\n@Description Payment method (STRIPE, BALANCE)\n@JSONSchema required",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.PaymentMethod"
+                        }
+                    ],
+                    "example": "STRIPE"
+                },
+                "period": {
+                    "description": "@Summary Subscription period\n@Description Subscription period (1m for monthly, 1y for yearly)\n@JSONSchema required",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SubscriptionPeriod"
+                        }
+                    ],
+                    "example": "1m"
+                },
+                "planName": {
+                    "description": "@Summary Plan name\n@Description Plan name\n@JSONSchema required",
+                    "type": "string",
+                    "example": "premium"
+                },
+                "promotionCode": {
+                    "description": "@Summary Promotion code\n@Description Promotion code for applying discount to the upgrade payment\n@JSONSchema optional",
+                    "type": "string",
+                    "example": "SAVE20"
+                },
+                "regionDomain": {
+                    "description": "@Summary Region domain\n@Description Region domain\n@JSONSchema required",
+                    "type": "string",
+                    "example": "example.com"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                },
+                "workspace": {
+                    "description": "@Summary Workspace name\n@Description Workspace name (optional for price preview, required for actual subscription)\n@JSONSchema optional",
+                    "type": "string",
+                    "example": "my-workspace"
+                }
+            }
+        },
+        "helper.WorkspaceSubscriptionPlansReq": {
+            "type": "object",
+            "required": [
+                "namespaces"
+            ],
+            "properties": {
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "namespaces": {
+                    "description": "@Summary Namespace list\n@Description List of workspace namespaces to query subscription plans for\n@JSONSchema required",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "[ns-admin",
+                        " ns-test1",
+                        " ns-dev]"
+                    ]
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                }
+            }
+        },
+        "types.CreditsStatus": {
+            "type": "string",
+            "enum": [
+                "active",
+                "expired",
+                "used_up"
+            ],
+            "x-enum-varnames": [
+                "CreditsStatusActive",
+                "CreditsStatusExpired",
+                "CreditsStatusUsedUp"
+            ]
+        },
+        "types.OauthProviderType": {
+            "type": "string",
+            "enum": [
+                "PHONE",
+                "EMAIL",
+                "PASSWORD",
+                "GITHUB"
+            ],
+            "x-enum-varnames": [
+                "OauthProviderTypePhone",
+                "OauthProviderTypeEmail",
+                "OauthProviderTypePassword",
+                "OauthProviderTypeGithub"
+            ]
+        },
+        "types.PayApp": {
+            "type": "string",
+            "enum": [
+                "system-costcenter",
+                "system-brain"
+            ],
+            "x-enum-varnames": [
+                "PayAppCostcenter",
+                "PayAppBrain"
+            ]
+        },
+        "types.PaymentMethod": {
+            "type": "string",
+            "enum": [
+                "err_and_use_balance",
+                "corporate",
+                "balance",
+                "stripe"
+            ],
+            "x-enum-comments": {
+                "PaymentMethodBalance": "余额支付",
+                "PaymentMethodCorporate": "企业转账支付",
+                "PaymentMethodErrAndUseBalance": "支付失败转余额支付",
+                "PaymentMethodStripe": "Stripe 支付"
+            },
+            "x-enum-varnames": [
+                "PaymentMethodErrAndUseBalance",
+                "PaymentMethodCorporate",
+                "PaymentMethodBalance",
+                "PaymentMethodStripe"
+            ]
+        },
+        "types.ProductPrice": {
+            "type": "object",
+            "properties": {
+                "billingCycle": {
+                    "description": "计费周期, 年/季/月/周/天/次",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SubscriptionPeriod"
+                        }
+                    ]
+                },
+                "createdAt": {
+                    "description": "Currency  string    ` + "`" + `gorm:\"type:varchar(10);not null;column:currency\"` + "`" + `  // 货币",
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "originalPrice": {
+                    "type": "integer"
+                },
+                "price": {
+                    "description": "价格",
+                    "type": "integer"
+                },
+                "productID": {
+                    "type": "string"
+                },
+                "stripePrice": {
+                    "description": "Stripe 价格 ID",
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "description": "更新时间",
+                    "type": "string"
+                }
+            }
+        },
+        "types.SubscriptionOperator": {
+            "type": "string",
+            "enum": [
+                "created",
+                "upgraded",
+                "downgraded",
+                "canceled",
+                "deleted",
+                "renewed",
+                "resumed",
+                "renew_failed",
+                "debt",
+                "other"
+            ],
+            "x-enum-varnames": [
+                "SubscriptionTransactionTypeCreated",
+                "SubscriptionTransactionTypeUpgraded",
+                "SubscriptionTransactionTypeDowngraded",
+                "SubscriptionTransactionTypeCanceled",
+                "SubscriptionTransactionTypeDeleted",
+                "SubscriptionTransactionTypeRenewed",
+                "SubscriptionTransactionTypeResumed",
+                "SubscriptionTransactionTypeRenewFailed",
+                "SubscriptionTransactionTypeDebt",
+                "SubscriptionTransactionTypeOther"
+            ]
+        },
+        "types.SubscriptionPeriod": {
+            "type": "string",
+            "enum": [
+                "1m",
+                "1y"
+            ],
+            "x-enum-varnames": [
+                "SubscriptionPeriodMonthly",
+                "SubscriptionPeriodYearly"
+            ]
+        },
+        "types.WorkspaceSubscriptionPlan": {
+            "type": "object",
+            "properties": {
+                "aiquota": {
+                    "description": "包含AI配额大小",
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "description": "创建时间",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "描述",
+                    "type": "string"
+                },
+                "downgradePlanList": {
+                    "description": "可降级的计划列表",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "id": {
+                    "description": "计划 ID",
+                    "type": "string"
+                },
+                "maxResources": {
+                    "description": "最大资源数: map[string]string: {\"cpu\": \"4\", \"memory\": \"8Gi\", \"storage\": \"100Gi\"}",
+                    "type": "string"
+                },
+                "maxSeats": {
+                    "description": "最大席位数",
+                    "type": "integer"
+                },
+                "name": {
+                    "description": "计划名称",
+                    "type": "string"
+                },
+                "order": {
+                    "description": "排序号",
+                    "type": "integer"
+                },
+                "prices": {
+                    "description": "一对多关联",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.ProductPrice"
+                    }
+                },
+                "tags": {
+                    "description": "标签分类",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "traffic": {
+                    "description": "包含流量包大小, 单位: MB",
+                    "type": "integer"
+                },
+                "updatedAt": {
+                    "description": "更新时间",
+                    "type": "string"
+                },
+                "upgradePlanList": {
+                    "description": "可升级的计划列表",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         }

--- a/service/account/docs/swagger.json
+++ b/service/account/docs/swagger.json
@@ -515,6 +515,62 @@
                 }
             }
         },
+        "/account/v1alpha1/costs/app-type": {
+            "post": {
+                "description": "Get app type costs within a specified time range",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AppTypeCosts"
+                ],
+                "summary": "Get app type costs",
+                "parameters": [
+                    {
+                        "description": "App type costs request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.AppCostsReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successfully retrieved app type costs",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "failed to parse get app type cost request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "authenticate error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "failed to get app type cost",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/account/v1alpha1/costs/consumption": {
             "post": {
                 "description": "Get user consumption amount within a specified time range",
@@ -734,6 +790,152 @@
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/account/v1alpha1/costs/workspace-app": {
+            "post": {
+                "description": "Get workspace app costs within a specified time range",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceAppCosts"
+                ],
+                "summary": "Get workspace app costs",
+                "parameters": [
+                    {
+                        "description": "Workspace app costs request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.AppCostsReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successfully retrieved workspace app costs",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "failed to parse get workspace app cost request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "authenticate error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "failed to get workspace app cost",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/account/v1alpha1/costs/workspace-consumption": {
+            "post": {
+                "description": "Get workspace consumption amount within a specified time range",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ConsumptionAmount"
+                ],
+                "summary": "Get workspace consumption amount",
+                "parameters": [
+                    {
+                        "description": "Workspace consumption amount request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.ConsumptionRecordReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successfully retrieved workspace consumption amount",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "failed to parse workspace consumption amount request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "authenticate error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "failed to get workspace consumption amount",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/account/v1alpha1/createPay": {
+            "post": {
+                "description": "Create a payment",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "account"
+                ],
+                "summary": "Create a payment",
+                "parameters": [
+                    {
+                        "description": "CreatePayReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.CreatePayReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
                         }
                     }
                 }
@@ -1281,12 +1483,12 @@
                 "summary": "Get recharge discount",
                 "parameters": [
                     {
-                        "description": "Get recharge discount request",
+                        "description": "AuthBase",
                         "name": "request",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "object"
+                            "$ref": "#/definitions/helper.AuthBase"
                         }
                     }
                 ],
@@ -1409,6 +1611,214 @@
                 }
             }
         },
+        "/account/v1alpha1/user-alert-notification-account": {
+            "post": {
+                "description": "Create a new user alert notification account. Only EMAIL and PHONE provider types are supported.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "UserAlertNotificationAccount"
+                ],
+                "summary": "Create user alert notification account",
+                "parameters": [
+                    {
+                        "description": "Create user alert notification account request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.CreateUserAlertNotificationAccountReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully created user alert notification account",
+                        "schema": {
+                            "$ref": "#/definitions/helper.CreateUserAlertNotificationAccountResp"
+                        }
+                    },
+                    "400": {
+                        "description": "Failed to parse create user alert notification account request or unsupported provider type",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication error",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to create user alert notification account",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    }
+                }
+            }
+        },
+        "/account/v1alpha1/user-alert-notification-account/delete": {
+            "post": {
+                "description": "Delete multiple user alert notification accounts",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "UserAlertNotificationAccount"
+                ],
+                "summary": "Delete user alert notification accounts",
+                "parameters": [
+                    {
+                        "description": "Delete user alert notification accounts request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.DeleteUserAlertNotificationAccountReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted user alert notification accounts",
+                        "schema": {
+                            "$ref": "#/definitions/helper.DeleteUserAlertNotificationAccountResp"
+                        }
+                    },
+                    "400": {
+                        "description": "Failed to parse delete user alert notification accounts request",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication error",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to delete user alert notification accounts",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    }
+                }
+            }
+        },
+        "/account/v1alpha1/user-alert-notification-account/list": {
+            "post": {
+                "description": "List all user alert notification accounts for a user",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "UserAlertNotificationAccount"
+                ],
+                "summary": "List user alert notification accounts",
+                "parameters": [
+                    {
+                        "description": "List user alert notification accounts request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.ListUserAlertNotificationAccountsReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully listed user alert notification accounts",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ListUserAlertNotificationAccountsResp"
+                        }
+                    },
+                    "400": {
+                        "description": "Failed to parse list user alert notification accounts request",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication error",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to list user alert notification accounts",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    }
+                }
+            }
+        },
+        "/account/v1alpha1/user-alert-notification-account/toggle": {
+            "post": {
+                "description": "Enable or disable multiple user alert notification accounts",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "UserAlertNotificationAccount"
+                ],
+                "summary": "Toggle user alert notification accounts",
+                "parameters": [
+                    {
+                        "description": "Toggle user alert notification accounts request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.ToggleUserAlertNotificationAccountsReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully toggled user alert notification accounts",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ToggleUserAlertNotificationAccountsResp"
+                        }
+                    },
+                    "400": {
+                        "description": "Failed to parse toggle user alert notification accounts request",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication error",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to toggle user alert notification accounts",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    }
+                }
+            }
+        },
         "/account/v1alpha1/user-usage": {
             "post": {
                 "description": "Get user usage within a specified time range",
@@ -1460,6 +1870,74 @@
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/account/v1alpha1/workspace-subscription/invoice-cancel": {
+            "post": {
+                "description": "Cancel an unpaid Stripe invoice for workspace subscription upgrade",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Cancel workspace subscription invoice",
+                "parameters": [
+                    {
+                        "description": "WorkspaceSubscriptionInvoiceCancelReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.WorkspaceSubscriptionInvoiceCancelReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/account/v1alpha1/workspace-subscription/plans": {
+            "post": {
+                "description": "Get subscription plan names for multiple namespaces, returning \"PAYG\" for non-subscribed workspaces",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Get workspace subscription plans by namespaces",
+                "parameters": [
+                    {
+                        "description": "WorkspaceSubscriptionPlansReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.WorkspaceSubscriptionPlansReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
                         }
                     }
                 }
@@ -1541,6 +2019,100 @@
                 }
             }
         },
+        "/admin/v1alpha1/gift-codes": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AdminRead"
+                ],
+                "summary": "List gift codes for admin",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/helper.AdminGiftCodeListResp"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/gift-codes/usage": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AdminRead"
+                ],
+                "summary": "List user gift code usage for admin",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/helper.AdminGiftCodeUsageResp"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/invoice": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AdminRead"
+                ],
+                "summary": "Get invoice for admin",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Invoice ID",
+                        "name": "id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/helper.AdminInvoice"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/invoices": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AdminRead"
+                ],
+                "summary": "List invoices for admin",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/helper.AdminInvoiceListResp"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/v1alpha1/real-name-info": {
             "get": {
                 "description": "Get user real name info",
@@ -1578,15 +2150,1317 @@
                     }
                 }
             }
+        },
+        "/admin/v1alpha1/recharge-gift-policy": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AdminRead"
+                ],
+                "summary": "Get recharge gift policy for admin",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/helper.AdminRechargeGiftPolicy"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/refund-status": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AdminRead"
+                ],
+                "summary": "Get refund status for admin",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Payment ID or trade number",
+                        "name": "id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/helper.AdminRefundStatusResp"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/regions": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AdminRead"
+                ],
+                "summary": "List regions for admin",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/helper.AdminRegion"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/reload-property-types": {
+            "post": {
+                "description": "Reload property types from database and update the global DefaultPropertyTypeLS",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "Reload property types",
+                "responses": {
+                    "200": {
+                        "description": "successfully reloaded property types",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ReloadPropertyTypesResp"
+                        }
+                    },
+                    "401": {
+                        "description": "authenticate error",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "500": {
+                        "description": "failed to reload property types",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/subscription-plan/delete": {
+            "post": {
+                "description": "Delete a WorkspaceSubscriptionPlan by ID or name",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "Delete WorkspaceSubscriptionPlan",
+                "parameters": [
+                    {
+                        "description": "Delete request (id or name required)",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successfully deleted subscription plan",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "invalid request body",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "401": {
+                        "description": "authenticate error",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "404": {
+                        "description": "subscription plan not found",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "500": {
+                        "description": "failed to delete subscription plan",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/subscription-plan/manage": {
+            "post": {
+                "description": "Create a new WorkspaceSubscriptionPlan with prices or update existing one with prices. Manages plan and prices as a single unit.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "Create or update WorkspaceSubscriptionPlan with prices",
+                "parameters": [
+                    {
+                        "description": "Subscription plan with prices data",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.SubscriptionPlanManageRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successfully created/updated subscription plan with prices",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "invalid request body",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "401": {
+                        "description": "authenticate error",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    },
+                    "500": {
+                        "description": "failed to create/update subscription plan with prices",
+                        "schema": {
+                            "$ref": "#/definitions/helper.ErrorMessage"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/subscription-plans": {
+            "get": {
+                "description": "Admin interface to get all available subscription plans using GET method",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Admin get subscription plans (GET)",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "example": false,
+                        "description": "Include inactive plans",
+                        "name": "includeInactive",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "example": "\"workspace\"",
+                        "description": "Filter by plan type",
+                        "name": "planType",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Admin interface to get all available subscription plans",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Admin get subscription plans",
+                "parameters": [
+                    {
+                        "description": "AdminSubscriptionPlansReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.AdminSubscriptionPlansReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/user": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AdminRead"
+                ],
+                "summary": "Get user detail for admin",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/helper.AdminUserDetail"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/user/balance-adjust-records": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AdminRead"
+                ],
+                "summary": "List user balance adjustments for admin",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Zero-based page index",
+                        "name": "pageIndex",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1-100",
+                        "name": "pageSize",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/helper.AdminBalanceAdjustRecordsResp"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/user/recharge-records": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AdminRead"
+                ],
+                "summary": "List user recharge records for admin",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Zero-based page index",
+                        "name": "pageIndex",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1-100",
+                        "name": "pageSize",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/helper.AdminRechargeRecordsResp"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/users": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "AdminRead"
+                ],
+                "summary": "List users for admin",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Zero-based page index",
+                        "name": "pageIndex",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size, 1-100",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Password provider username",
+                        "name": "username",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Phone provider ID",
+                        "name": "phone",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "workspaceId",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Workspace display name",
+                        "name": "workspaceName",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/helper.AdminUserListResp"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/workspace-subscription/add": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/v1alpha1/workspace-subscription/list": {
+            "get": {
+                "description": "Admin interface to get paginated workspace subscription list with filtering options using GET method",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Admin get workspace subscription list (GET)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "example": 0,
+                        "description": "Page index (0-based)",
+                        "name": "pageIndex",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "example": 10,
+                        "description": "Page size (optional, defaults to 10)",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "example": "\"ns-8gmgq0jn\"",
+                        "description": "Filter by workspace name",
+                        "name": "workspace",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "example": "\"36ca5ee6-7b6e-4c15-922b-e861b3fbc061\"",
+                        "description": "Filter by user ID",
+                        "name": "userUID",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "example": "\"Hobby\"",
+                        "description": "Filter by plan name",
+                        "name": "planName",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "example": "\"NORMAL\"",
+                        "description": "Filter by subscription status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "example": "\"192.168.10.35.nip.io\"",
+                        "description": "Filter by region domain",
+                        "name": "regionDomain",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Admin interface to get paginated workspace subscription list with filtering options",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Admin get workspace subscription list",
+                "parameters": [
+                    {
+                        "description": "AdminWorkspaceSubscriptionListReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.AdminWorkspaceSubscriptionListReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/card/delete": {
+            "post": {
+                "description": "Delete user card info",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Payment"
+                ],
+                "summary": "Delete user card info",
+                "parameters": [
+                    {
+                        "description": "CardOperationReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.CardOperationReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/card/list": {
+            "post": {
+                "description": "List user card info",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Payment"
+                ],
+                "summary": "List user card info",
+                "parameters": [
+                    {
+                        "description": "AuthBase",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.AuthBase"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/card/set-default": {
+            "post": {
+                "description": "Set default user card",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Payment"
+                ],
+                "summary": "Set default user card",
+                "parameters": [
+                    {
+                        "description": "CardOperationReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.CardOperationReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/credits/info": {
+            "post": {
+                "description": "Get credits info",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Credits"
+                ],
+                "summary": "Get credits info",
+                "parameters": [
+                    {
+                        "description": "AuthBase",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.AuthBase"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.CreditsInfoResp"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/subscription/flush-quota": {
+            "post": {
+                "description": "flush user quota with subscription",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Subscription"
+                ],
+                "summary": "flush user quota with subscription",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/subscription/last-transaction": {
+            "post": {
+                "description": "Get user last subscription transaction",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Subscription"
+                ],
+                "summary": "Get user last subscription transaction",
+                "parameters": [
+                    {
+                        "description": "AuthBase",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.AuthBase"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/subscription/pay": {
+            "post": {
+                "description": "Subscription pay",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Subscription"
+                ],
+                "summary": "Subscription pay",
+                "parameters": [
+                    {
+                        "description": "SubscriptionOperatorReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.SubscriptionOperatorReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/subscription/plan-list": {
+            "post": {
+                "description": "Get subscription plan list",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Subscription"
+                ],
+                "summary": "Get subscription plan list",
+                "parameters": [
+                    {
+                        "description": "AuthBase",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.AuthBase"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/subscription/quota-check": {
+            "post": {
+                "description": "Check user subscription quota",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Subscription"
+                ],
+                "summary": "Check user subscription quota",
+                "parameters": [
+                    {
+                        "description": "SubscriptionQuotaCheckReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.SubscriptionQuotaCheckReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/helper.SubscriptionQuotaCheckResp"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/subscription/upgrade-amount": {
+            "post": {
+                "description": "Get subscription upgrade amount",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Subscription"
+                ],
+                "summary": "Get subscription upgrade amount",
+                "parameters": [
+                    {
+                        "description": "SubscriptionOperatorReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.SubscriptionOperatorReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/subscription/user-info": {
+            "post": {
+                "description": "Get user subscription info",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Subscription"
+                ],
+                "summary": "Get user subscription info",
+                "parameters": [
+                    {
+                        "description": "AuthBase",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.AuthBase"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/workspace-subscription/info": {
+            "post": {
+                "description": "Get workspace subscription info",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Get workspace subscription info",
+                "parameters": [
+                    {
+                        "description": "WorkspaceSubscriptionInfoReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.WorkspaceSubscriptionInfoReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/workspace-subscription/last-transaction": {
+            "post": {
+                "description": "Get last workspace subscription transaction",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Get last workspace subscription transaction",
+                "parameters": [
+                    {
+                        "description": "WorkspaceSubscriptionInfoReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.WorkspaceSubscriptionInfoReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/workspace-subscription/list": {
+            "post": {
+                "description": "Get workspace subscription list",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Get workspace subscription list",
+                "parameters": [
+                    {
+                        "description": "AuthBase",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.AuthBase"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/workspace-subscription/notify": {
+            "post": {
+                "description": "Handle Stripe webhook notifications for workspace subscription events",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Handle Stripe webhook for workspace subscription",
+                "responses": {}
+            }
+        },
+        "/payment/v1alpha1/workspace-subscription/pay": {
+            "post": {
+                "description": "Create workspace subscription payment with Stripe",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Create workspace subscription payment",
+                "parameters": [
+                    {
+                        "description": "WorkspaceSubscriptionOperatorReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.WorkspaceSubscriptionOperatorReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/workspace-subscription/payment-list": {
+            "post": {
+                "description": "Get workspace subscription payment list",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Get workspace subscription payment list",
+                "parameters": [
+                    {
+                        "description": "UserTimeRangeReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.UserTimeRangeReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/workspace-subscription/plan-list": {
+            "post": {
+                "description": "Get workspace subscription plan list",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Get workspace subscription plan list",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/payment/v1alpha1/workspace-subscription/upgrade-amount": {
+            "post": {
+                "description": "Get workspace subscription upgrade amount",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Get workspace subscription upgrade amount",
+                "parameters": [
+                    {
+                        "description": "WorkspaceSubscriptionOperatorReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.WorkspaceSubscriptionOperatorReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspace/v1alpha1/resource-quota": {
+            "post": {
+                "description": "Get workspace resource quota",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "WorkspaceSubscription"
+                ],
+                "summary": "Get workspace resource quota",
+                "parameters": [
+                    {
+                        "description": "WorkspaceInfoReq",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/helper.WorkspaceInfoReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
+        "api.CreditsInfo": {
+            "type": "object",
+            "properties": {
+                "balance": {
+                    "type": "integer"
+                },
+                "credits": {
+                    "type": "integer"
+                },
+                "creditsList": {
+                    "description": "CreditsList holds the same rows the aggregate fields above are summed\nfrom, so sum(amount) == Credits and sum(usedAmount) == DeductionCredits;\nexhausted rows stay in the list to keep that invariant. Callers filter\nfor display (e.g. amount \u003e usedAmount).",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.CreditsItem"
+                    }
+                },
+                "currentPlanCreditsBalance": {
+                    "type": "integer"
+                },
+                "currentPlanCreditsDeductionBalance": {
+                    "type": "integer"
+                },
+                "deductionBalance": {
+                    "type": "integer"
+                },
+                "deductionCredits": {
+                    "type": "integer"
+                },
+                "kycDeductionCreditsBalance": {
+                    "type": "integer"
+                },
+                "kycDeductionCreditsDeductionBalance": {
+                    "type": "integer"
+                },
+                "userUid": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.CreditsInfoResp": {
+            "type": "object",
+            "properties": {
+                "credits": {
+                    "$ref": "#/definitions/api.CreditsInfo"
+                }
+            }
+        },
+        "api.CreditsItem": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "integer"
+                },
+                "expireAt": {
+                    "type": "string"
+                },
+                "startAt": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/types.CreditsStatus"
+                },
+                "usedAmount": {
+                    "type": "integer"
+                }
+            }
+        },
+        "api.SubscriptionPlanManageRequest": {
+            "type": "object",
+            "properties": {
+                "plan": {
+                    "$ref": "#/definitions/types.WorkspaceSubscriptionPlan"
+                },
+                "prices": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.ProductPrice"
+                    }
+                }
+            }
+        },
         "common.PropertyQuery": {
             "type": "object",
             "properties": {
                 "alias": {
                     "type": "string",
                     "example": "gpu-tesla-v100"
+                },
+                "enum": {
+                    "type": "integer",
+                    "example": 1
                 },
                 "name": {
                     "type": "string",
@@ -1599,6 +3473,587 @@
                 "unit_price": {
                     "type": "number",
                     "example": 10000
+                }
+            }
+        },
+        "gin.H": {
+            "type": "object",
+            "additionalProperties": {}
+        },
+        "helper.AdminBalanceAdjustRecord": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "integer"
+                },
+                "balanceAfter": {
+                    "type": "integer"
+                },
+                "balanceBefore": {
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.AdminBalanceAdjustRecordsResp": {
+            "type": "object",
+            "properties": {
+                "list": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/helper.AdminBalanceAdjustRecord"
+                    }
+                },
+                "pageIndex": {
+                    "type": "integer"
+                },
+                "pageSize": {
+                    "type": "integer"
+                },
+                "totalItems": {
+                    "type": "integer"
+                },
+                "totalPages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "helper.AdminGiftCode": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "comment": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "createdBy": {
+                    "type": "string"
+                },
+                "createdById": {
+                    "type": "string"
+                },
+                "creditAmount": {
+                    "type": "integer"
+                },
+                "expiredAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "rechargeType": {
+                    "type": "string"
+                },
+                "used": {
+                    "type": "boolean"
+                },
+                "usedAt": {
+                    "type": "string"
+                },
+                "usedBy": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.AdminGiftCodeListResp": {
+            "type": "object",
+            "properties": {
+                "list": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/helper.AdminGiftCode"
+                    }
+                },
+                "pageIndex": {
+                    "type": "integer"
+                },
+                "pageSize": {
+                    "type": "integer"
+                },
+                "totalItems": {
+                    "type": "integer"
+                },
+                "totalPages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "helper.AdminGiftCodeUsage": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "comment": {
+                    "type": "string"
+                },
+                "creditAmount": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "rechargeType": {
+                    "type": "string"
+                },
+                "usedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.AdminGiftCodeUsageResp": {
+            "type": "object",
+            "properties": {
+                "list": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/helper.AdminGiftCodeUsage"
+                    }
+                },
+                "pageIndex": {
+                    "type": "integer"
+                },
+                "pageSize": {
+                    "type": "integer"
+                },
+                "totalItems": {
+                    "type": "integer"
+                },
+                "totalPages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "helper.AdminInvoice": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "detail": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "remark": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "totalAmount": {
+                    "type": "integer"
+                },
+                "updatedAt": {
+                    "type": "string"
+                },
+                "userID": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.AdminInvoiceListResp": {
+            "type": "object",
+            "properties": {
+                "list": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/helper.AdminInvoice"
+                    }
+                },
+                "pageIndex": {
+                    "type": "integer"
+                },
+                "pageSize": {
+                    "type": "integer"
+                },
+                "totalItems": {
+                    "type": "integer"
+                },
+                "totalPages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "helper.AdminRechargeGiftPolicy": {
+            "type": "object",
+            "properties": {
+                "defaultDiscountSteps": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    }
+                },
+                "firstRechargeDiscountSteps": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    }
+                }
+            }
+        },
+        "helper.AdminRechargeRecord": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "integer"
+                },
+                "chargeSource": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "gift": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "latestRefund": {
+                    "$ref": "#/definitions/helper.AdminRefund"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "refundCount": {
+                    "type": "integer"
+                },
+                "refunded": {
+                    "type": "boolean"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "tradeNo": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.AdminRechargeRecordsResp": {
+            "type": "object",
+            "properties": {
+                "list": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/helper.AdminRechargeRecord"
+                    }
+                },
+                "pageIndex": {
+                    "type": "integer"
+                },
+                "pageSize": {
+                    "type": "integer"
+                },
+                "totalItems": {
+                    "type": "integer"
+                },
+                "totalPages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "helper.AdminRefund": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "deductAmount": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "refundAmount": {
+                    "type": "integer"
+                },
+                "refundNo": {
+                    "type": "string"
+                },
+                "refundReason": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.AdminRefundStatusResp": {
+            "type": "object",
+            "properties": {
+                "latestRefund": {
+                    "$ref": "#/definitions/helper.AdminRefund"
+                },
+                "refundCount": {
+                    "type": "integer"
+                },
+                "refunded": {
+                    "type": "boolean"
+                },
+                "tradeNo": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.AdminRegion": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "displayName": {
+                    "type": "string"
+                },
+                "domain": {
+                    "type": "string"
+                },
+                "location": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.AdminSubscriptionPlansReq": {
+            "type": "object",
+            "properties": {
+                "includeInactive": {
+                    "description": "@Summary Include inactive plans\n@Description Include inactive plans in the response (optional, defaults to false)\n@JSONSchema",
+                    "type": "boolean",
+                    "example": false
+                },
+                "planType": {
+                    "description": "@Summary Plan type filter\n@Description Filter by plan type (optional)\n@JSONSchema",
+                    "type": "string",
+                    "example": "workspace"
+                }
+            }
+        },
+        "helper.AdminUser": {
+            "type": "object",
+            "properties": {
+                "availableBalance": {
+                    "type": "integer"
+                },
+                "balance": {
+                    "type": "integer"
+                },
+                "billingStatus": {
+                    "type": "string"
+                },
+                "deductionBalance": {
+                    "type": "integer"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "nickname": {
+                    "type": "string"
+                },
+                "phone": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "sourceProviderTypes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sourceType": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.AdminUserDetail": {
+            "type": "object",
+            "properties": {
+                "availableBalance": {
+                    "type": "integer"
+                },
+                "balance": {
+                    "type": "integer"
+                },
+                "billingStatus": {
+                    "type": "string"
+                },
+                "deductionBalance": {
+                    "type": "integer"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "idCard": {
+                    "type": "string"
+                },
+                "nickname": {
+                    "type": "string"
+                },
+                "phone": {
+                    "type": "string"
+                },
+                "productSeries": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "realName": {
+                    "type": "string"
+                },
+                "rechargeAmount": {
+                    "type": "integer"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "sourceProviderTypes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sourceType": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "string"
+                },
+                "userType": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                },
+                "workspaces": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/helper.AdminWorkspace"
+                    }
+                }
+            }
+        },
+        "helper.AdminUserListResp": {
+            "type": "object",
+            "properties": {
+                "list": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/helper.AdminUser"
+                    }
+                },
+                "pageIndex": {
+                    "type": "integer"
+                },
+                "pageSize": {
+                    "type": "integer"
+                },
+                "totalItems": {
+                    "type": "integer"
+                },
+                "totalPages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "helper.AdminWorkspace": {
+            "type": "object",
+            "properties": {
+                "displayName": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isPrivate": {
+                    "type": "boolean"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.AdminWorkspaceSubscriptionListReq": {
+            "type": "object",
+            "properties": {
+                "pageIndex": {
+                    "description": "@Summary Page index\n@Description Page index (0-based)\n@JSONSchema",
+                    "type": "integer",
+                    "example": 0
+                },
+                "pageSize": {
+                    "description": "@Summary Page size\n@Description Page size (optional, defaults to 10)\n@JSONSchema",
+                    "type": "integer",
+                    "example": 10
+                },
+                "planName": {
+                    "description": "@Summary Plan name filter\n@Description Filter by plan name (optional)\n@JSONSchema",
+                    "type": "string",
+                    "example": "premium"
+                },
+                "regionDomain": {
+                    "description": "@Summary Region domain filter\n@Description Filter by region domain (optional)\n@JSONSchema",
+                    "type": "string",
+                    "example": "example.com"
+                },
+                "status": {
+                    "description": "@Summary Status filter\n@Description Filter by subscription status (optional)\n@JSONSchema",
+                    "type": "string",
+                    "example": "normal"
+                },
+                "userUID": {
+                    "description": "@Summary User filter\n@Description Filter by user ID (optional)\n@JSONSchema",
+                    "type": "string",
+                    "example": "user-123"
+                },
+                "workspace": {
+                    "description": "@Summary Workspace filter\n@Description Filter by workspace name (optional)\n@JSONSchema",
+                    "type": "string",
+                    "example": "my-workspace"
                 }
             }
         },
@@ -1673,8 +4128,7 @@
             "properties": {
                 "detail": {
                     "description": "invoice detail information json\n@Summary Invoice detail information\n@Description Invoice detail information\n@JSONSchema required",
-                    "type": "string",
-                    "example": "{\"title\":\"title\",\"amount\":100,\"taxRate\":0.06,\"tax\":6,\"total\":106,\"invoiceType\":1,\"invoiceContent\":1,\"invoiceStatus\":1,\"invoiceTime\":\"2021-01-01T00:00:00Z\",\"invoiceNumber\":\"invoice-number-1\",\"invoiceCode\":\"invoice-code-1\",\"invoiceFile\":\"invoice-file-1\"}"
+                    "type": "string"
                 },
                 "kubeConfig": {
                     "type": "string"
@@ -1690,8 +4144,8 @@
                         "type": "string"
                     },
                     "example": [
-                        "[\"payment-id-1\"",
-                        "\"payment-id-2\"]"
+                        "[payment-id-1",
+                        " payment-id-2]"
                     ]
                 },
                 "token": {
@@ -1711,6 +4165,69 @@
         "helper.Auth": {
             "type": "object",
             "properties": {
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                }
+            }
+        },
+        "helper.AuthBase": {
+            "type": "object",
+            "properties": {
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                }
+            }
+        },
+        "helper.CardOperationReq": {
+            "type": "object",
+            "properties": {
+                "cardBrand": {
+                    "description": "@Summary CardBrand\n@Description CardBrand",
+                    "type": "string",
+                    "example": "VISA"
+                },
+                "cardID": {
+                    "description": "@Summary CardID\n@Description CardID",
+                    "type": "string",
+                    "example": "123e4567-e89b-12d3-a456-426614174000"
+                },
+                "cardNo": {
+                    "description": "@Summary CardNo\n@Description CardNo",
+                    "type": "string",
+                    "example": "1234567890"
+                },
                 "kubeConfig": {
                     "type": "string"
                 },
@@ -1858,6 +4375,204 @@
                 "totalPage": {
                     "description": "@Summary Total page\n@Description Total page",
                     "type": "integer"
+                }
+            }
+        },
+        "helper.CreatePayReq": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "description": "@Summary Amount\n@Description Amount\n@JSONSchema required",
+                    "type": "integer",
+                    "example": 100000000
+                },
+                "cardBrand": {
+                    "description": "@Summary CardBrand\n@Description CardBrand",
+                    "type": "string",
+                    "example": "VISA"
+                },
+                "cardID": {
+                    "description": "@Summary CardID\n@Description CardID",
+                    "type": "string",
+                    "example": "123e4567-e89b-12d3-a456-426614174000"
+                },
+                "cardNo": {
+                    "description": "@Summary CardNo\n@Description CardNo",
+                    "type": "string",
+                    "example": "1234567890"
+                },
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "method": {
+                    "description": "@Summary Method\n@Description Method\n@JSONSchema required",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.PaymentMethod"
+                        }
+                    ],
+                    "example": "CARD"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                }
+            }
+        },
+        "helper.CreateUserAlertNotificationAccountReq": {
+            "type": "object",
+            "required": [
+                "providerId",
+                "providerType",
+                "userUid"
+            ],
+            "properties": {
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "providerId": {
+                    "description": "@Summary Provider ID\n@Description Provider ID (email address, phone number, etc.)\n@JSONSchema required",
+                    "type": "string",
+                    "example": "user@example.com"
+                },
+                "providerType": {
+                    "description": "@Summary Provider type\n@Description Provider type (Only EMAIL and PHONE are supported)\n@JSONSchema required",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.OauthProviderType"
+                        }
+                    ],
+                    "example": "EMAIL"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                },
+                "userUid": {
+                    "description": "@Summary User UUID\n@Description User UUID\n@JSONSchema required",
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                }
+            }
+        },
+        "helper.CreateUserAlertNotificationAccountResp": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/helper.CreateUserAlertNotificationAccountRespData"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.CreateUserAlertNotificationAccountRespData": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "providerId": {
+                    "type": "string"
+                },
+                "providerType": {
+                    "$ref": "#/definitions/types.OauthProviderType"
+                },
+                "userUid": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.DeleteUserAlertNotificationAccountReq": {
+            "type": "object",
+            "required": [
+                "ids",
+                "userUid"
+            ],
+            "properties": {
+                "ids": {
+                    "description": "@Summary Account IDs\n@Description List of account IDs to delete\n@JSONSchema required",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "[550e8400-e29b-41d4-a716-446655440000",
+                        " 550e8400-e29b-41d4-a716-446655440001]"
+                    ]
+                },
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                },
+                "userUid": {
+                    "description": "@Summary User UUID\n@Description User UUID\n@JSONSchema required",
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                }
+            }
+        },
+        "helper.DeleteUserAlertNotificationAccountResp": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/helper.DeleteUserAlertNotificationAccountRespData"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.DeleteUserAlertNotificationAccountRespData": {
+            "type": "object",
+            "properties": {
+                "deletedCount": {
+                    "type": "integer"
+                },
+                "deletedIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },
@@ -2117,6 +4832,44 @@
                 }
             }
         },
+        "helper.ListUserAlertNotificationAccountsReq": {
+            "type": "object",
+            "properties": {
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                }
+            }
+        },
+        "helper.ListUserAlertNotificationAccountsResp": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/helper.UserAlertNotificationAccountData"
+                    }
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
         "helper.NamespaceBillingHistoryReq": {
             "type": "object",
             "properties": {
@@ -2162,9 +4915,44 @@
                         "type": "string"
                     },
                     "example": [
-                        "[\"ns-admin\"",
-                        "\"ns-test1\"]"
+                        "[ns-admin",
+                        "ns-test1]"
                     ]
+                }
+            }
+        },
+        "helper.PlanType": {
+            "type": "string",
+            "enum": [
+                "upgrade",
+                "downgrade",
+                "renewal"
+            ],
+            "x-enum-varnames": [
+                "Upgrade",
+                "Downgrade",
+                "Renewal"
+            ]
+        },
+        "helper.ReloadPropertyTypesResp": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/helper.ReloadPropertyTypesRespData"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.ReloadPropertyTypesRespData": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "status": {
+                    "type": "string"
                 }
             }
         },
@@ -2182,8 +4970,8 @@
                         "type": "string"
                     },
                     "example": [
-                        "[\"invoice-id-1\"",
-                        "\"invoice-id-2\"]"
+                        "[invoice-id-1",
+                        " invoice-id-2]"
                     ]
                 },
                 "kubeConfig": {
@@ -2232,8 +5020,8 @@
                         "type": "string"
                     },
                     "example": [
-                        "[\"payment-id-1\"",
-                        "\"payment-id-2\"]"
+                        "[payment-id-1",
+                        " payment-id-2]"
                     ]
                 },
                 "token": {
@@ -2247,6 +5035,196 @@
                 "userUID": {
                     "type": "string",
                     "example": "user-123"
+                }
+            }
+        },
+        "helper.SubscriptionOperatorReq": {
+            "type": "object",
+            "properties": {
+                "cardID": {
+                    "description": "@Summary CardID\n@Description CardID",
+                    "type": "string",
+                    "example": "123e4567-e89b-12d3-a456-426614174000"
+                },
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "payMethod": {
+                    "description": "@Summary PayMethod\n@Description PayMethod",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.PaymentMethod"
+                        }
+                    ],
+                    "example": "CARD"
+                },
+                "planID": {
+                    "description": "@Summary PlanID\n@Description PlanID",
+                    "type": "string",
+                    "example": "123e4567-e89b-12d3-a456-426614174000"
+                },
+                "planName": {
+                    "description": "@Summary PlanName\n@Description PlanName",
+                    "type": "string",
+                    "example": "planName"
+                },
+                "planType": {
+                    "description": "@Summary PlanType\n@Description PlanType",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/helper.PlanType"
+                        }
+                    ],
+                    "example": "upgrade;downgrade;renewal"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                }
+            }
+        },
+        "helper.SubscriptionQuotaCheckReq": {
+            "type": "object",
+            "properties": {
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "planID": {
+                    "description": "@Summary PlanID\n@Description PlanID",
+                    "type": "string",
+                    "example": "123e4567-e89b-12d3-a456-426614174000"
+                },
+                "planName": {
+                    "description": "@Summary PlanName\n@Description PlanName",
+                    "type": "string",
+                    "example": "planName"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                }
+            }
+        },
+        "helper.SubscriptionQuotaCheckResp": {
+            "type": "object",
+            "properties": {
+                "allWorkspaceReady": {
+                    "description": "allWorkspaceReady",
+                    "type": "boolean",
+                    "example": true
+                },
+                "readyWorkspace": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "workspace1",
+                        "workspace2"
+                    ]
+                },
+                "unReadyWorkspace": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "workspace3",
+                        "workspace4"
+                    ]
+                }
+            }
+        },
+        "helper.ToggleUserAlertNotificationAccountsReq": {
+            "type": "object",
+            "required": [
+                "ids",
+                "isEnabled"
+            ],
+            "properties": {
+                "ids": {
+                    "description": "@Summary Account IDs\n@Description List of account IDs to toggle\n@JSONSchema required",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "[550e8400-e29b-41d4-a716-446655440000",
+                        " 550e8400-e29b-41d4-a716-446655440001]"
+                    ]
+                },
+                "isEnabled": {
+                    "description": "@Summary Enable flag\n@Description Set to true to enable, false to disable\n@JSONSchema required",
+                    "type": "boolean",
+                    "example": true
+                },
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                }
+            }
+        },
+        "helper.ToggleUserAlertNotificationAccountsResp": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/helper.ToggleUserAlertNotificationAccountsRespData"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "helper.ToggleUserAlertNotificationAccountsRespData": {
+            "type": "object",
+            "properties": {
+                "updatedCount": {
+                    "type": "integer"
+                },
+                "updatedIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },
@@ -2344,6 +5322,32 @@
                 }
             }
         },
+        "helper.UserAlertNotificationAccountData": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isEnabled": {
+                    "type": "boolean"
+                },
+                "providerId": {
+                    "type": "string"
+                },
+                "providerType": {
+                    "$ref": "#/definitions/types.OauthProviderType"
+                },
+                "updatedAt": {
+                    "type": "string"
+                },
+                "userUid": {
+                    "type": "string"
+                }
+            }
+        },
         "helper.UserTimeRangeReq": {
             "type": "object",
             "properties": {
@@ -2393,8 +5397,8 @@
                         "type": "string"
                     },
                     "example": [
-                        "[\"ns-admin\"",
-                        "\"ns-test1\"]"
+                        "[ns-admin",
+                        "ns-test1]"
                     ]
                 },
                 "owner": {
@@ -2416,6 +5420,463 @@
                 "userUID": {
                     "type": "string",
                     "example": "user-123"
+                }
+            }
+        },
+        "helper.WorkspaceInfoReq": {
+            "type": "object",
+            "required": [
+                "workspace"
+            ],
+            "properties": {
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                },
+                "workspace": {
+                    "description": "@Summary Workspace name\n@Description Workspace name",
+                    "type": "string",
+                    "example": "my-workspace"
+                }
+            }
+        },
+        "helper.WorkspaceSubscriptionInfoReq": {
+            "type": "object",
+            "required": [
+                "regionDomain",
+                "workspace"
+            ],
+            "properties": {
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "redirectUrl": {
+                    "description": "@Summary Redirect Url\n@Description Redirect Url for create session",
+                    "type": "string",
+                    "example": "https://example.com"
+                },
+                "regionDomain": {
+                    "description": "@Summary Region domain\n@Description Region domain\n@JSONSchema required",
+                    "type": "string",
+                    "example": "example.com"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                },
+                "workspace": {
+                    "description": "@Summary Workspace name\n@Description Workspace name\n@JSONSchema required",
+                    "type": "string",
+                    "example": "my-workspace"
+                }
+            }
+        },
+        "helper.WorkspaceSubscriptionInvoiceCancelReq": {
+            "type": "object",
+            "required": [
+                "invoiceID",
+                "regionDomain",
+                "workspace"
+            ],
+            "properties": {
+                "invoiceID": {
+                    "description": "@Summary Invoice ID\n@Description The Stripe invoice ID to cancel\n@JSONSchema required",
+                    "type": "string",
+                    "example": "in_1234567890"
+                },
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "regionDomain": {
+                    "description": "@Summary Region domain\n@Description Region domain (for authorization)\n@JSONSchema required",
+                    "type": "string",
+                    "example": "example.com"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                },
+                "workspace": {
+                    "description": "@Summary Workspace name\n@Description Workspace name (for authorization)\n@JSONSchema required",
+                    "type": "string",
+                    "example": "my-workspace"
+                }
+            }
+        },
+        "helper.WorkspaceSubscriptionOperatorReq": {
+            "type": "object",
+            "required": [
+                "operator",
+                "payMethod",
+                "planName",
+                "regionDomain"
+            ],
+            "properties": {
+                "cardId": {
+                    "description": "@Summary Card ID (optional for stripe payments)\n@Description Card ID for stripe payments",
+                    "type": "string"
+                },
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "operator": {
+                    "description": "@Summary Subscription operator (created/upgraded/downgraded/canceled/renewed)\n@Description Subscription operator type",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SubscriptionOperator"
+                        }
+                    ],
+                    "example": "created"
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "payApp": {
+                    "description": "@Summary Stripe return app\n@Description Desktop app opened after returning from Stripe Checkout\n@JSONSchema optional",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.PayApp"
+                        }
+                    ],
+                    "example": "system-costcenter"
+                },
+                "payMethod": {
+                    "description": "@Summary Payment method\n@Description Payment method (STRIPE, BALANCE)\n@JSONSchema required",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.PaymentMethod"
+                        }
+                    ],
+                    "example": "STRIPE"
+                },
+                "period": {
+                    "description": "@Summary Subscription period\n@Description Subscription period (1m for monthly, 1y for yearly)\n@JSONSchema required",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SubscriptionPeriod"
+                        }
+                    ],
+                    "example": "1m"
+                },
+                "planName": {
+                    "description": "@Summary Plan name\n@Description Plan name\n@JSONSchema required",
+                    "type": "string",
+                    "example": "premium"
+                },
+                "promotionCode": {
+                    "description": "@Summary Promotion code\n@Description Promotion code for applying discount to the upgrade payment\n@JSONSchema optional",
+                    "type": "string",
+                    "example": "SAVE20"
+                },
+                "regionDomain": {
+                    "description": "@Summary Region domain\n@Description Region domain\n@JSONSchema required",
+                    "type": "string",
+                    "example": "example.com"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                },
+                "workspace": {
+                    "description": "@Summary Workspace name\n@Description Workspace name (optional for price preview, required for actual subscription)\n@JSONSchema optional",
+                    "type": "string",
+                    "example": "my-workspace"
+                }
+            }
+        },
+        "helper.WorkspaceSubscriptionPlansReq": {
+            "type": "object",
+            "required": [
+                "namespaces"
+            ],
+            "properties": {
+                "kubeConfig": {
+                    "type": "string"
+                },
+                "namespaces": {
+                    "description": "@Summary Namespace list\n@Description List of workspace namespaces to query subscription plans for\n@JSONSchema required",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "[ns-admin",
+                        " ns-test1",
+                        " ns-dev]"
+                    ]
+                },
+                "owner": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "token": {
+                    "type": "string",
+                    "example": "token"
+                },
+                "userID": {
+                    "type": "string",
+                    "example": "admin"
+                },
+                "userUID": {
+                    "type": "string",
+                    "example": "user-123"
+                }
+            }
+        },
+        "types.CreditsStatus": {
+            "type": "string",
+            "enum": [
+                "active",
+                "expired",
+                "used_up"
+            ],
+            "x-enum-varnames": [
+                "CreditsStatusActive",
+                "CreditsStatusExpired",
+                "CreditsStatusUsedUp"
+            ]
+        },
+        "types.OauthProviderType": {
+            "type": "string",
+            "enum": [
+                "PHONE",
+                "EMAIL",
+                "PASSWORD",
+                "GITHUB"
+            ],
+            "x-enum-varnames": [
+                "OauthProviderTypePhone",
+                "OauthProviderTypeEmail",
+                "OauthProviderTypePassword",
+                "OauthProviderTypeGithub"
+            ]
+        },
+        "types.PayApp": {
+            "type": "string",
+            "enum": [
+                "system-costcenter",
+                "system-brain"
+            ],
+            "x-enum-varnames": [
+                "PayAppCostcenter",
+                "PayAppBrain"
+            ]
+        },
+        "types.PaymentMethod": {
+            "type": "string",
+            "enum": [
+                "err_and_use_balance",
+                "corporate",
+                "balance",
+                "stripe"
+            ],
+            "x-enum-comments": {
+                "PaymentMethodBalance": "余额支付",
+                "PaymentMethodCorporate": "企业转账支付",
+                "PaymentMethodErrAndUseBalance": "支付失败转余额支付",
+                "PaymentMethodStripe": "Stripe 支付"
+            },
+            "x-enum-varnames": [
+                "PaymentMethodErrAndUseBalance",
+                "PaymentMethodCorporate",
+                "PaymentMethodBalance",
+                "PaymentMethodStripe"
+            ]
+        },
+        "types.ProductPrice": {
+            "type": "object",
+            "properties": {
+                "billingCycle": {
+                    "description": "计费周期, 年/季/月/周/天/次",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SubscriptionPeriod"
+                        }
+                    ]
+                },
+                "createdAt": {
+                    "description": "Currency  string    `gorm:\"type:varchar(10);not null;column:currency\"`  // 货币",
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "originalPrice": {
+                    "type": "integer"
+                },
+                "price": {
+                    "description": "价格",
+                    "type": "integer"
+                },
+                "productID": {
+                    "type": "string"
+                },
+                "stripePrice": {
+                    "description": "Stripe 价格 ID",
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "description": "更新时间",
+                    "type": "string"
+                }
+            }
+        },
+        "types.SubscriptionOperator": {
+            "type": "string",
+            "enum": [
+                "created",
+                "upgraded",
+                "downgraded",
+                "canceled",
+                "deleted",
+                "renewed",
+                "resumed",
+                "renew_failed",
+                "debt",
+                "other"
+            ],
+            "x-enum-varnames": [
+                "SubscriptionTransactionTypeCreated",
+                "SubscriptionTransactionTypeUpgraded",
+                "SubscriptionTransactionTypeDowngraded",
+                "SubscriptionTransactionTypeCanceled",
+                "SubscriptionTransactionTypeDeleted",
+                "SubscriptionTransactionTypeRenewed",
+                "SubscriptionTransactionTypeResumed",
+                "SubscriptionTransactionTypeRenewFailed",
+                "SubscriptionTransactionTypeDebt",
+                "SubscriptionTransactionTypeOther"
+            ]
+        },
+        "types.SubscriptionPeriod": {
+            "type": "string",
+            "enum": [
+                "1m",
+                "1y"
+            ],
+            "x-enum-varnames": [
+                "SubscriptionPeriodMonthly",
+                "SubscriptionPeriodYearly"
+            ]
+        },
+        "types.WorkspaceSubscriptionPlan": {
+            "type": "object",
+            "properties": {
+                "aiquota": {
+                    "description": "包含AI配额大小",
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "description": "创建时间",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "描述",
+                    "type": "string"
+                },
+                "downgradePlanList": {
+                    "description": "可降级的计划列表",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "id": {
+                    "description": "计划 ID",
+                    "type": "string"
+                },
+                "maxResources": {
+                    "description": "最大资源数: map[string]string: {\"cpu\": \"4\", \"memory\": \"8Gi\", \"storage\": \"100Gi\"}",
+                    "type": "string"
+                },
+                "maxSeats": {
+                    "description": "最大席位数",
+                    "type": "integer"
+                },
+                "name": {
+                    "description": "计划名称",
+                    "type": "string"
+                },
+                "order": {
+                    "description": "排序号",
+                    "type": "integer"
+                },
+                "prices": {
+                    "description": "一对多关联",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.ProductPrice"
+                    }
+                },
+                "tags": {
+                    "description": "标签分类",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "traffic": {
+                    "description": "包含流量包大小, 单位: MB",
+                    "type": "integer"
+                },
+                "updatedAt": {
+                    "description": "更新时间",
+                    "type": "string"
+                },
+                "upgradePlanList": {
+                    "description": "可升级的计划列表",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         }

--- a/service/account/docs/swagger.yaml
+++ b/service/account/docs/swagger.yaml
@@ -1,9 +1,69 @@
 definitions:
+  api.CreditsInfo:
+    properties:
+      balance:
+        type: integer
+      credits:
+        type: integer
+      creditsList:
+        description: |-
+          CreditsList holds the same rows the aggregate fields above are summed
+          from, so sum(amount) == Credits and sum(usedAmount) == DeductionCredits;
+          exhausted rows stay in the list to keep that invariant. Callers filter
+          for display (e.g. amount > usedAmount).
+        items:
+          $ref: '#/definitions/api.CreditsItem'
+        type: array
+      currentPlanCreditsBalance:
+        type: integer
+      currentPlanCreditsDeductionBalance:
+        type: integer
+      deductionBalance:
+        type: integer
+      deductionCredits:
+        type: integer
+      kycDeductionCreditsBalance:
+        type: integer
+      kycDeductionCreditsDeductionBalance:
+        type: integer
+      userUid:
+        type: string
+    type: object
+  api.CreditsInfoResp:
+    properties:
+      credits:
+        $ref: '#/definitions/api.CreditsInfo'
+    type: object
+  api.CreditsItem:
+    properties:
+      amount:
+        type: integer
+      expireAt:
+        type: string
+      startAt:
+        type: string
+      status:
+        $ref: '#/definitions/types.CreditsStatus'
+      usedAmount:
+        type: integer
+    type: object
+  api.SubscriptionPlanManageRequest:
+    properties:
+      plan:
+        $ref: '#/definitions/types.WorkspaceSubscriptionPlan'
+      prices:
+        items:
+          $ref: '#/definitions/types.ProductPrice'
+        type: array
+    type: object
   common.PropertyQuery:
     properties:
       alias:
         example: gpu-tesla-v100
         type: string
+      enum:
+        example: 1
+        type: integer
       name:
         example: cpu
         type: string
@@ -13,6 +73,420 @@ definitions:
       unit_price:
         example: 10000
         type: number
+    type: object
+  gin.H:
+    additionalProperties: {}
+    type: object
+  helper.AdminBalanceAdjustRecord:
+    properties:
+      amount:
+        type: integer
+      balanceAfter:
+        type: integer
+      balanceBefore:
+        type: integer
+      createdAt:
+        type: string
+      id:
+        type: string
+      message:
+        type: string
+      type:
+        type: string
+    type: object
+  helper.AdminBalanceAdjustRecordsResp:
+    properties:
+      list:
+        items:
+          $ref: '#/definitions/helper.AdminBalanceAdjustRecord'
+        type: array
+      pageIndex:
+        type: integer
+      pageSize:
+        type: integer
+      totalItems:
+        type: integer
+      totalPages:
+        type: integer
+    type: object
+  helper.AdminGiftCode:
+    properties:
+      code:
+        type: string
+      comment:
+        type: string
+      createdAt:
+        type: string
+      createdBy:
+        type: string
+      createdById:
+        type: string
+      creditAmount:
+        type: integer
+      expiredAt:
+        type: string
+      id:
+        type: string
+      rechargeType:
+        type: string
+      used:
+        type: boolean
+      usedAt:
+        type: string
+      usedBy:
+        type: string
+    type: object
+  helper.AdminGiftCodeListResp:
+    properties:
+      list:
+        items:
+          $ref: '#/definitions/helper.AdminGiftCode'
+        type: array
+      pageIndex:
+        type: integer
+      pageSize:
+        type: integer
+      totalItems:
+        type: integer
+      totalPages:
+        type: integer
+    type: object
+  helper.AdminGiftCodeUsage:
+    properties:
+      code:
+        type: string
+      comment:
+        type: string
+      creditAmount:
+        type: integer
+      id:
+        type: string
+      rechargeType:
+        type: string
+      usedAt:
+        type: string
+    type: object
+  helper.AdminGiftCodeUsageResp:
+    properties:
+      list:
+        items:
+          $ref: '#/definitions/helper.AdminGiftCodeUsage'
+        type: array
+      pageIndex:
+        type: integer
+      pageSize:
+        type: integer
+      totalItems:
+        type: integer
+      totalPages:
+        type: integer
+    type: object
+  helper.AdminInvoice:
+    properties:
+      createdAt:
+        type: string
+      detail:
+        type: string
+      id:
+        type: string
+      remark:
+        type: string
+      status:
+        type: string
+      totalAmount:
+        type: integer
+      updatedAt:
+        type: string
+      userID:
+        type: string
+    type: object
+  helper.AdminInvoiceListResp:
+    properties:
+      list:
+        items:
+          $ref: '#/definitions/helper.AdminInvoice'
+        type: array
+      pageIndex:
+        type: integer
+      pageSize:
+        type: integer
+      totalItems:
+        type: integer
+      totalPages:
+        type: integer
+    type: object
+  helper.AdminRechargeGiftPolicy:
+    properties:
+      defaultDiscountSteps:
+        additionalProperties:
+          type: integer
+        type: object
+      firstRechargeDiscountSteps:
+        additionalProperties:
+          type: integer
+        type: object
+    type: object
+  helper.AdminRechargeRecord:
+    properties:
+      amount:
+        type: integer
+      chargeSource:
+        type: string
+      createdAt:
+        type: string
+      gift:
+        type: integer
+      id:
+        type: string
+      latestRefund:
+        $ref: '#/definitions/helper.AdminRefund'
+      method:
+        type: string
+      refundCount:
+        type: integer
+      refunded:
+        type: boolean
+      status:
+        type: string
+      tradeNo:
+        type: string
+      type:
+        type: string
+    type: object
+  helper.AdminRechargeRecordsResp:
+    properties:
+      list:
+        items:
+          $ref: '#/definitions/helper.AdminRechargeRecord'
+        type: array
+      pageIndex:
+        type: integer
+      pageSize:
+        type: integer
+      totalItems:
+        type: integer
+      totalPages:
+        type: integer
+    type: object
+  helper.AdminRefund:
+    properties:
+      createdAt:
+        type: string
+      deductAmount:
+        type: integer
+      id:
+        type: string
+      refundAmount:
+        type: integer
+      refundNo:
+        type: string
+      refundReason:
+        type: string
+    type: object
+  helper.AdminRefundStatusResp:
+    properties:
+      latestRefund:
+        $ref: '#/definitions/helper.AdminRefund'
+      refundCount:
+        type: integer
+      refunded:
+        type: boolean
+      tradeNo:
+        type: string
+    type: object
+  helper.AdminRegion:
+    properties:
+      description:
+        type: string
+      displayName:
+        type: string
+      domain:
+        type: string
+      location:
+        type: string
+      uid:
+        type: string
+    type: object
+  helper.AdminSubscriptionPlansReq:
+    properties:
+      includeInactive:
+        description: |-
+          @Summary Include inactive plans
+          @Description Include inactive plans in the response (optional, defaults to false)
+          @JSONSchema
+        example: false
+        type: boolean
+      planType:
+        description: |-
+          @Summary Plan type filter
+          @Description Filter by plan type (optional)
+          @JSONSchema
+        example: workspace
+        type: string
+    type: object
+  helper.AdminUser:
+    properties:
+      availableBalance:
+        type: integer
+      balance:
+        type: integer
+      billingStatus:
+        type: string
+      deductionBalance:
+        type: integer
+      email:
+        type: string
+      id:
+        type: string
+      nickname:
+        type: string
+      phone:
+        type: string
+      role:
+        type: string
+      sourceProviderTypes:
+        items:
+          type: string
+        type: array
+      sourceType:
+        type: string
+      status:
+        type: string
+      uid:
+        type: string
+      username:
+        type: string
+    type: object
+  helper.AdminUserDetail:
+    properties:
+      availableBalance:
+        type: integer
+      balance:
+        type: integer
+      billingStatus:
+        type: string
+      deductionBalance:
+        type: integer
+      email:
+        type: string
+      id:
+        type: string
+      idCard:
+        type: string
+      nickname:
+        type: string
+      phone:
+        type: string
+      productSeries:
+        items:
+          type: string
+        type: array
+      realName:
+        type: string
+      rechargeAmount:
+        type: integer
+      role:
+        type: string
+      sourceProviderTypes:
+        items:
+          type: string
+        type: array
+      sourceType:
+        type: string
+      status:
+        type: string
+      uid:
+        type: string
+      userType:
+        type: string
+      username:
+        type: string
+      workspaces:
+        items:
+          $ref: '#/definitions/helper.AdminWorkspace'
+        type: array
+    type: object
+  helper.AdminUserListResp:
+    properties:
+      list:
+        items:
+          $ref: '#/definitions/helper.AdminUser'
+        type: array
+      pageIndex:
+        type: integer
+      pageSize:
+        type: integer
+      totalItems:
+        type: integer
+      totalPages:
+        type: integer
+    type: object
+  helper.AdminWorkspace:
+    properties:
+      displayName:
+        type: string
+      id:
+        type: string
+      isPrivate:
+        type: boolean
+      role:
+        type: string
+      status:
+        type: string
+      uid:
+        type: string
+    type: object
+  helper.AdminWorkspaceSubscriptionListReq:
+    properties:
+      pageIndex:
+        description: |-
+          @Summary Page index
+          @Description Page index (0-based)
+          @JSONSchema
+        example: 0
+        type: integer
+      pageSize:
+        description: |-
+          @Summary Page size
+          @Description Page size (optional, defaults to 10)
+          @JSONSchema
+        example: 10
+        type: integer
+      planName:
+        description: |-
+          @Summary Plan name filter
+          @Description Filter by plan name (optional)
+          @JSONSchema
+        example: premium
+        type: string
+      regionDomain:
+        description: |-
+          @Summary Region domain filter
+          @Description Filter by region domain (optional)
+          @JSONSchema
+        example: example.com
+        type: string
+      status:
+        description: |-
+          @Summary Status filter
+          @Description Filter by subscription status (optional)
+          @JSONSchema
+        example: normal
+        type: string
+      userUID:
+        description: |-
+          @Summary User filter
+          @Description Filter by user ID (optional)
+          @JSONSchema
+        example: user-123
+        type: string
+      workspace:
+        description: |-
+          @Summary Workspace filter
+          @Description Filter by workspace name (optional)
+          @JSONSchema
+        example: my-workspace
+        type: string
     type: object
   helper.AppCostsReq:
     properties:
@@ -82,7 +556,6 @@ definitions:
           @Summary Invoice detail information
           @Description Invoice detail information
           @JSONSchema required
-        example: '{"title":"title","amount":100,"taxRate":0.06,"tax":6,"total":106,"invoiceType":1,"invoiceContent":1,"invoiceStatus":1,"invoiceTime":"2021-01-01T00:00:00Z","invoiceNumber":"invoice-number-1","invoiceCode":"invoice-code-1","invoiceFile":"invoice-file-1"}'
         type: string
       kubeConfig:
         type: string
@@ -96,8 +569,8 @@ definitions:
           @Description Payment ID list
           @JSONSchema required
         example:
-        - '["payment-id-1"'
-        - '"payment-id-2"]'
+        - '[payment-id-1'
+        - ' payment-id-2]'
         items:
           type: string
         type: array
@@ -116,6 +589,58 @@ definitions:
     type: object
   helper.Auth:
     properties:
+      kubeConfig:
+        type: string
+      owner:
+        example: admin
+        type: string
+      token:
+        example: token
+        type: string
+      userID:
+        example: admin
+        type: string
+      userUID:
+        example: user-123
+        type: string
+    type: object
+  helper.AuthBase:
+    properties:
+      kubeConfig:
+        type: string
+      owner:
+        example: admin
+        type: string
+      token:
+        example: token
+        type: string
+      userID:
+        example: admin
+        type: string
+      userUID:
+        example: user-123
+        type: string
+    type: object
+  helper.CardOperationReq:
+    properties:
+      cardBrand:
+        description: |-
+          @Summary CardBrand
+          @Description CardBrand
+        example: VISA
+        type: string
+      cardID:
+        description: |-
+          @Summary CardID
+          @Description CardID
+        example: 123e4567-e89b-12d3-a456-426614174000
+        type: string
+      cardNo:
+        description: |-
+          @Summary CardNo
+          @Description CardNo
+        example: "1234567890"
+        type: string
       kubeConfig:
         type: string
       owner:
@@ -255,6 +780,171 @@ definitions:
           @Summary Total page
           @Description Total page
         type: integer
+    type: object
+  helper.CreatePayReq:
+    properties:
+      amount:
+        description: |-
+          @Summary Amount
+          @Description Amount
+          @JSONSchema required
+        example: 100000000
+        type: integer
+      cardBrand:
+        description: |-
+          @Summary CardBrand
+          @Description CardBrand
+        example: VISA
+        type: string
+      cardID:
+        description: |-
+          @Summary CardID
+          @Description CardID
+        example: 123e4567-e89b-12d3-a456-426614174000
+        type: string
+      cardNo:
+        description: |-
+          @Summary CardNo
+          @Description CardNo
+        example: "1234567890"
+        type: string
+      kubeConfig:
+        type: string
+      method:
+        allOf:
+        - $ref: '#/definitions/types.PaymentMethod'
+        description: |-
+          @Summary Method
+          @Description Method
+          @JSONSchema required
+        example: CARD
+      owner:
+        example: admin
+        type: string
+      token:
+        example: token
+        type: string
+      userID:
+        example: admin
+        type: string
+      userUID:
+        example: user-123
+        type: string
+    type: object
+  helper.CreateUserAlertNotificationAccountReq:
+    properties:
+      kubeConfig:
+        type: string
+      owner:
+        example: admin
+        type: string
+      providerId:
+        description: |-
+          @Summary Provider ID
+          @Description Provider ID (email address, phone number, etc.)
+          @JSONSchema required
+        example: user@example.com
+        type: string
+      providerType:
+        allOf:
+        - $ref: '#/definitions/types.OauthProviderType'
+        description: |-
+          @Summary Provider type
+          @Description Provider type (Only EMAIL and PHONE are supported)
+          @JSONSchema required
+        example: EMAIL
+      token:
+        example: token
+        type: string
+      userID:
+        example: admin
+        type: string
+      userUID:
+        example: user-123
+        type: string
+      userUid:
+        description: |-
+          @Summary User UUID
+          @Description User UUID
+          @JSONSchema required
+        example: 550e8400-e29b-41d4-a716-446655440000
+        type: string
+    required:
+    - providerId
+    - providerType
+    - userUid
+    type: object
+  helper.CreateUserAlertNotificationAccountResp:
+    properties:
+      data:
+        $ref: '#/definitions/helper.CreateUserAlertNotificationAccountRespData'
+      message:
+        type: string
+    type: object
+  helper.CreateUserAlertNotificationAccountRespData:
+    properties:
+      id:
+        type: string
+      providerId:
+        type: string
+      providerType:
+        $ref: '#/definitions/types.OauthProviderType'
+      userUid:
+        type: string
+    type: object
+  helper.DeleteUserAlertNotificationAccountReq:
+    properties:
+      ids:
+        description: |-
+          @Summary Account IDs
+          @Description List of account IDs to delete
+          @JSONSchema required
+        example:
+        - '[550e8400-e29b-41d4-a716-446655440000'
+        - ' 550e8400-e29b-41d4-a716-446655440001]'
+        items:
+          type: string
+        type: array
+      kubeConfig:
+        type: string
+      owner:
+        example: admin
+        type: string
+      token:
+        example: token
+        type: string
+      userID:
+        example: admin
+        type: string
+      userUID:
+        example: user-123
+        type: string
+      userUid:
+        description: |-
+          @Summary User UUID
+          @Description User UUID
+          @JSONSchema required
+        example: 550e8400-e29b-41d4-a716-446655440000
+        type: string
+    required:
+    - ids
+    - userUid
+    type: object
+  helper.DeleteUserAlertNotificationAccountResp:
+    properties:
+      data:
+        $ref: '#/definitions/helper.DeleteUserAlertNotificationAccountRespData'
+      message:
+        type: string
+    type: object
+  helper.DeleteUserAlertNotificationAccountRespData:
+    properties:
+      deletedCount:
+        type: integer
+      deletedIds:
+        items:
+          type: string
+        type: array
     type: object
   helper.ErrorMessage:
     properties:
@@ -477,6 +1167,32 @@ definitions:
         example: user-123
         type: string
     type: object
+  helper.ListUserAlertNotificationAccountsReq:
+    properties:
+      kubeConfig:
+        type: string
+      owner:
+        example: admin
+        type: string
+      token:
+        example: token
+        type: string
+      userID:
+        example: admin
+        type: string
+      userUID:
+        example: user-123
+        type: string
+    type: object
+  helper.ListUserAlertNotificationAccountsResp:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/helper.UserAlertNotificationAccountData'
+        type: array
+      message:
+        type: string
+    type: object
   helper.NamespaceBillingHistoryReq:
     properties:
       endTime:
@@ -510,11 +1226,35 @@ definitions:
     properties:
       list:
         example:
-        - '["ns-admin"'
-        - '"ns-test1"]'
+        - '[ns-admin'
+        - ns-test1]
         items:
           type: string
         type: array
+    type: object
+  helper.PlanType:
+    enum:
+    - upgrade
+    - downgrade
+    - renewal
+    type: string
+    x-enum-varnames:
+    - Upgrade
+    - Downgrade
+    - Renewal
+  helper.ReloadPropertyTypesResp:
+    properties:
+      data:
+        $ref: '#/definitions/helper.ReloadPropertyTypesRespData'
+      message:
+        type: string
+    type: object
+  helper.ReloadPropertyTypesRespData:
+    properties:
+      count:
+        type: integer
+      status:
+        type: string
     type: object
   helper.SetInvoiceStatusReq:
     properties:
@@ -525,8 +1265,8 @@ definitions:
           @Description Invoice ID list
           @JSONSchema required
         example:
-        - '["invoice-id-1"'
-        - '"invoice-id-2"]'
+        - '[invoice-id-1'
+        - ' invoice-id-2]'
         items:
           type: string
         type: array
@@ -569,8 +1309,8 @@ definitions:
           @Description Payment ID list
           @JSONSchema required
         example:
-        - '["payment-id-1"'
-        - '"payment-id-2"]'
+        - '[payment-id-1'
+        - ' payment-id-2]'
         items:
           type: string
         type: array
@@ -585,6 +1325,159 @@ definitions:
         type: string
     required:
     - paymentIDList
+    type: object
+  helper.SubscriptionOperatorReq:
+    properties:
+      cardID:
+        description: |-
+          @Summary CardID
+          @Description CardID
+        example: 123e4567-e89b-12d3-a456-426614174000
+        type: string
+      kubeConfig:
+        type: string
+      owner:
+        example: admin
+        type: string
+      payMethod:
+        allOf:
+        - $ref: '#/definitions/types.PaymentMethod'
+        description: |-
+          @Summary PayMethod
+          @Description PayMethod
+        example: CARD
+      planID:
+        description: |-
+          @Summary PlanID
+          @Description PlanID
+        example: 123e4567-e89b-12d3-a456-426614174000
+        type: string
+      planName:
+        description: |-
+          @Summary PlanName
+          @Description PlanName
+        example: planName
+        type: string
+      planType:
+        allOf:
+        - $ref: '#/definitions/helper.PlanType'
+        description: |-
+          @Summary PlanType
+          @Description PlanType
+        example: upgrade;downgrade;renewal
+      token:
+        example: token
+        type: string
+      userID:
+        example: admin
+        type: string
+      userUID:
+        example: user-123
+        type: string
+    type: object
+  helper.SubscriptionQuotaCheckReq:
+    properties:
+      kubeConfig:
+        type: string
+      owner:
+        example: admin
+        type: string
+      planID:
+        description: |-
+          @Summary PlanID
+          @Description PlanID
+        example: 123e4567-e89b-12d3-a456-426614174000
+        type: string
+      planName:
+        description: |-
+          @Summary PlanName
+          @Description PlanName
+        example: planName
+        type: string
+      token:
+        example: token
+        type: string
+      userID:
+        example: admin
+        type: string
+      userUID:
+        example: user-123
+        type: string
+    type: object
+  helper.SubscriptionQuotaCheckResp:
+    properties:
+      allWorkspaceReady:
+        description: allWorkspaceReady
+        example: true
+        type: boolean
+      readyWorkspace:
+        example:
+        - workspace1
+        - workspace2
+        items:
+          type: string
+        type: array
+      unReadyWorkspace:
+        example:
+        - workspace3
+        - workspace4
+        items:
+          type: string
+        type: array
+    type: object
+  helper.ToggleUserAlertNotificationAccountsReq:
+    properties:
+      ids:
+        description: |-
+          @Summary Account IDs
+          @Description List of account IDs to toggle
+          @JSONSchema required
+        example:
+        - '[550e8400-e29b-41d4-a716-446655440000'
+        - ' 550e8400-e29b-41d4-a716-446655440001]'
+        items:
+          type: string
+        type: array
+      isEnabled:
+        description: |-
+          @Summary Enable flag
+          @Description Set to true to enable, false to disable
+          @JSONSchema required
+        example: true
+        type: boolean
+      kubeConfig:
+        type: string
+      owner:
+        example: admin
+        type: string
+      token:
+        example: token
+        type: string
+      userID:
+        example: admin
+        type: string
+      userUID:
+        example: user-123
+        type: string
+    required:
+    - ids
+    - isEnabled
+    type: object
+  helper.ToggleUserAlertNotificationAccountsResp:
+    properties:
+      data:
+        $ref: '#/definitions/helper.ToggleUserAlertNotificationAccountsRespData'
+      message:
+        type: string
+    type: object
+  helper.ToggleUserAlertNotificationAccountsRespData:
+    properties:
+      updatedCount:
+        type: integer
+      updatedIds:
+        items:
+          type: string
+        type: array
     type: object
   helper.TransferAmountReq:
     properties:
@@ -664,6 +1557,23 @@ definitions:
         example: user-123
         type: string
     type: object
+  helper.UserAlertNotificationAccountData:
+    properties:
+      createdAt:
+        type: string
+      id:
+        type: string
+      isEnabled:
+        type: boolean
+      providerId:
+        type: string
+      providerType:
+        $ref: '#/definitions/types.OauthProviderType'
+      updatedAt:
+        type: string
+      userUid:
+        type: string
+    type: object
   helper.UserTimeRangeReq:
     properties:
       endTime:
@@ -701,8 +1611,8 @@ definitions:
           @Description Namespace list
           @JSONSchema
         example:
-        - '["ns-admin"'
-        - '"ns-test1"]'
+        - '[ns-admin'
+        - ns-test1]
         items:
           type: string
         type: array
@@ -721,6 +1631,389 @@ definitions:
       userUID:
         example: user-123
         type: string
+    type: object
+  helper.WorkspaceInfoReq:
+    properties:
+      kubeConfig:
+        type: string
+      owner:
+        example: admin
+        type: string
+      token:
+        example: token
+        type: string
+      userID:
+        example: admin
+        type: string
+      userUID:
+        example: user-123
+        type: string
+      workspace:
+        description: |-
+          @Summary Workspace name
+          @Description Workspace name
+        example: my-workspace
+        type: string
+    required:
+    - workspace
+    type: object
+  helper.WorkspaceSubscriptionInfoReq:
+    properties:
+      kubeConfig:
+        type: string
+      owner:
+        example: admin
+        type: string
+      redirectUrl:
+        description: |-
+          @Summary Redirect Url
+          @Description Redirect Url for create session
+        example: https://example.com
+        type: string
+      regionDomain:
+        description: |-
+          @Summary Region domain
+          @Description Region domain
+          @JSONSchema required
+        example: example.com
+        type: string
+      token:
+        example: token
+        type: string
+      userID:
+        example: admin
+        type: string
+      userUID:
+        example: user-123
+        type: string
+      workspace:
+        description: |-
+          @Summary Workspace name
+          @Description Workspace name
+          @JSONSchema required
+        example: my-workspace
+        type: string
+    required:
+    - regionDomain
+    - workspace
+    type: object
+  helper.WorkspaceSubscriptionInvoiceCancelReq:
+    properties:
+      invoiceID:
+        description: |-
+          @Summary Invoice ID
+          @Description The Stripe invoice ID to cancel
+          @JSONSchema required
+        example: in_1234567890
+        type: string
+      kubeConfig:
+        type: string
+      owner:
+        example: admin
+        type: string
+      regionDomain:
+        description: |-
+          @Summary Region domain
+          @Description Region domain (for authorization)
+          @JSONSchema required
+        example: example.com
+        type: string
+      token:
+        example: token
+        type: string
+      userID:
+        example: admin
+        type: string
+      userUID:
+        example: user-123
+        type: string
+      workspace:
+        description: |-
+          @Summary Workspace name
+          @Description Workspace name (for authorization)
+          @JSONSchema required
+        example: my-workspace
+        type: string
+    required:
+    - invoiceID
+    - regionDomain
+    - workspace
+    type: object
+  helper.WorkspaceSubscriptionOperatorReq:
+    properties:
+      cardId:
+        description: |-
+          @Summary Card ID (optional for stripe payments)
+          @Description Card ID for stripe payments
+        type: string
+      kubeConfig:
+        type: string
+      operator:
+        allOf:
+        - $ref: '#/definitions/types.SubscriptionOperator'
+        description: |-
+          @Summary Subscription operator (created/upgraded/downgraded/canceled/renewed)
+          @Description Subscription operator type
+        example: created
+      owner:
+        example: admin
+        type: string
+      payApp:
+        allOf:
+        - $ref: '#/definitions/types.PayApp'
+        description: |-
+          @Summary Stripe return app
+          @Description Desktop app opened after returning from Stripe Checkout
+          @JSONSchema optional
+        example: system-costcenter
+      payMethod:
+        allOf:
+        - $ref: '#/definitions/types.PaymentMethod'
+        description: |-
+          @Summary Payment method
+          @Description Payment method (STRIPE, BALANCE)
+          @JSONSchema required
+        example: STRIPE
+      period:
+        allOf:
+        - $ref: '#/definitions/types.SubscriptionPeriod'
+        description: |-
+          @Summary Subscription period
+          @Description Subscription period (1m for monthly, 1y for yearly)
+          @JSONSchema required
+        example: 1m
+      planName:
+        description: |-
+          @Summary Plan name
+          @Description Plan name
+          @JSONSchema required
+        example: premium
+        type: string
+      promotionCode:
+        description: |-
+          @Summary Promotion code
+          @Description Promotion code for applying discount to the upgrade payment
+          @JSONSchema optional
+        example: SAVE20
+        type: string
+      regionDomain:
+        description: |-
+          @Summary Region domain
+          @Description Region domain
+          @JSONSchema required
+        example: example.com
+        type: string
+      token:
+        example: token
+        type: string
+      userID:
+        example: admin
+        type: string
+      userUID:
+        example: user-123
+        type: string
+      workspace:
+        description: |-
+          @Summary Workspace name
+          @Description Workspace name (optional for price preview, required for actual subscription)
+          @JSONSchema optional
+        example: my-workspace
+        type: string
+    required:
+    - operator
+    - payMethod
+    - planName
+    - regionDomain
+    type: object
+  helper.WorkspaceSubscriptionPlansReq:
+    properties:
+      kubeConfig:
+        type: string
+      namespaces:
+        description: |-
+          @Summary Namespace list
+          @Description List of workspace namespaces to query subscription plans for
+          @JSONSchema required
+        example:
+        - '[ns-admin'
+        - ' ns-test1'
+        - ' ns-dev]'
+        items:
+          type: string
+        type: array
+      owner:
+        example: admin
+        type: string
+      token:
+        example: token
+        type: string
+      userID:
+        example: admin
+        type: string
+      userUID:
+        example: user-123
+        type: string
+    required:
+    - namespaces
+    type: object
+  types.CreditsStatus:
+    enum:
+    - active
+    - expired
+    - used_up
+    type: string
+    x-enum-varnames:
+    - CreditsStatusActive
+    - CreditsStatusExpired
+    - CreditsStatusUsedUp
+  types.OauthProviderType:
+    enum:
+    - PHONE
+    - EMAIL
+    - PASSWORD
+    - GITHUB
+    type: string
+    x-enum-varnames:
+    - OauthProviderTypePhone
+    - OauthProviderTypeEmail
+    - OauthProviderTypePassword
+    - OauthProviderTypeGithub
+  types.PayApp:
+    enum:
+    - system-costcenter
+    - system-brain
+    type: string
+    x-enum-varnames:
+    - PayAppCostcenter
+    - PayAppBrain
+  types.PaymentMethod:
+    enum:
+    - err_and_use_balance
+    - corporate
+    - balance
+    - stripe
+    type: string
+    x-enum-comments:
+      PaymentMethodBalance: 余额支付
+      PaymentMethodCorporate: 企业转账支付
+      PaymentMethodErrAndUseBalance: 支付失败转余额支付
+      PaymentMethodStripe: Stripe 支付
+    x-enum-varnames:
+    - PaymentMethodErrAndUseBalance
+    - PaymentMethodCorporate
+    - PaymentMethodBalance
+    - PaymentMethodStripe
+  types.ProductPrice:
+    properties:
+      billingCycle:
+        allOf:
+        - $ref: '#/definitions/types.SubscriptionPeriod'
+        description: 计费周期, 年/季/月/周/天/次
+      createdAt:
+        description: Currency  string    `gorm:"type:varchar(10);not null;column:currency"`  //
+          货币
+        type: string
+      id:
+        type: string
+      originalPrice:
+        type: integer
+      price:
+        description: 价格
+        type: integer
+      productID:
+        type: string
+      stripePrice:
+        description: Stripe 价格 ID
+        type: string
+      updatedAt:
+        description: 更新时间
+        type: string
+    type: object
+  types.SubscriptionOperator:
+    enum:
+    - created
+    - upgraded
+    - downgraded
+    - canceled
+    - deleted
+    - renewed
+    - resumed
+    - renew_failed
+    - debt
+    - other
+    type: string
+    x-enum-varnames:
+    - SubscriptionTransactionTypeCreated
+    - SubscriptionTransactionTypeUpgraded
+    - SubscriptionTransactionTypeDowngraded
+    - SubscriptionTransactionTypeCanceled
+    - SubscriptionTransactionTypeDeleted
+    - SubscriptionTransactionTypeRenewed
+    - SubscriptionTransactionTypeResumed
+    - SubscriptionTransactionTypeRenewFailed
+    - SubscriptionTransactionTypeDebt
+    - SubscriptionTransactionTypeOther
+  types.SubscriptionPeriod:
+    enum:
+    - 1m
+    - 1y
+    type: string
+    x-enum-varnames:
+    - SubscriptionPeriodMonthly
+    - SubscriptionPeriodYearly
+  types.WorkspaceSubscriptionPlan:
+    properties:
+      aiquota:
+        description: 包含AI配额大小
+        type: integer
+      createdAt:
+        description: 创建时间
+        type: string
+      description:
+        description: 描述
+        type: string
+      downgradePlanList:
+        description: 可降级的计划列表
+        items:
+          type: string
+        type: array
+      id:
+        description: 计划 ID
+        type: string
+      maxResources:
+        description: '最大资源数: map[string]string: {"cpu": "4", "memory": "8Gi", "storage":
+          "100Gi"}'
+        type: string
+      maxSeats:
+        description: 最大席位数
+        type: integer
+      name:
+        description: 计划名称
+        type: string
+      order:
+        description: 排序号
+        type: integer
+      prices:
+        description: 一对多关联
+        items:
+          $ref: '#/definitions/types.ProductPrice'
+        type: array
+      tags:
+        description: 标签分类
+        items:
+          type: string
+        type: array
+      traffic:
+        description: '包含流量包大小, 单位: MB'
+        type: integer
+      updatedAt:
+        description: 更新时间
+        type: string
+      upgradePlanList:
+        description: 可升级的计划列表
+        items:
+          type: string
+        type: array
     type: object
 host: localhost:2333
 info:
@@ -1073,6 +2366,44 @@ paths:
       summary: Get app costs
       tags:
       - AppCosts
+  /account/v1alpha1/costs/app-type:
+    post:
+      consumes:
+      - application/json
+      description: Get app type costs within a specified time range
+      parameters:
+      - description: App type costs request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/helper.AppCostsReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: successfully retrieved app type costs
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: failed to parse get app type cost request
+          schema:
+            additionalProperties: true
+            type: object
+        "401":
+          description: authenticate error
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: failed to get app type cost
+          schema:
+            additionalProperties: true
+            type: object
+      summary: Get app type costs
+      tags:
+      - AppTypeCosts
   /account/v1alpha1/costs/consumption:
     post:
       consumes:
@@ -1225,6 +2556,104 @@ paths:
       summary: Get user recharge amount
       tags:
       - RechargeAmount
+  /account/v1alpha1/costs/workspace-app:
+    post:
+      consumes:
+      - application/json
+      description: Get workspace app costs within a specified time range
+      parameters:
+      - description: Workspace app costs request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/helper.AppCostsReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: successfully retrieved workspace app costs
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: failed to parse get workspace app cost request
+          schema:
+            additionalProperties: true
+            type: object
+        "401":
+          description: authenticate error
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: failed to get workspace app cost
+          schema:
+            additionalProperties: true
+            type: object
+      summary: Get workspace app costs
+      tags:
+      - WorkspaceAppCosts
+  /account/v1alpha1/costs/workspace-consumption:
+    post:
+      consumes:
+      - application/json
+      description: Get workspace consumption amount within a specified time range
+      parameters:
+      - description: Workspace consumption amount request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/helper.ConsumptionRecordReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: successfully retrieved workspace consumption amount
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: failed to parse workspace consumption amount request
+          schema:
+            additionalProperties: true
+            type: object
+        "401":
+          description: authenticate error
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: failed to get workspace consumption amount
+          schema:
+            additionalProperties: true
+            type: object
+      summary: Get workspace consumption amount
+      tags:
+      - ConsumptionAmount
+  /account/v1alpha1/createPay:
+    post:
+      consumes:
+      - application/json
+      description: Create a payment
+      parameters:
+      - description: CreatePayReq
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/helper.CreatePayReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: Create a payment
+      tags:
+      - account
   /account/v1alpha1/get-transfer:
     post:
       consumes:
@@ -1584,12 +3013,12 @@ paths:
       - application/json
       description: Get recharge discount
       parameters:
-      - description: Get recharge discount request
+      - description: AuthBase
         in: body
         name: request
         required: true
         schema:
-          type: object
+          $ref: '#/definitions/helper.AuthBase'
       produces:
       - application/json
       responses:
@@ -1675,6 +3104,144 @@ paths:
       summary: Transfer amount
       tags:
       - TransferAmount
+  /account/v1alpha1/user-alert-notification-account:
+    post:
+      consumes:
+      - application/json
+      description: Create a new user alert notification account. Only EMAIL and PHONE
+        provider types are supported.
+      parameters:
+      - description: Create user alert notification account request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/helper.CreateUserAlertNotificationAccountReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully created user alert notification account
+          schema:
+            $ref: '#/definitions/helper.CreateUserAlertNotificationAccountResp'
+        "400":
+          description: Failed to parse create user alert notification account request
+            or unsupported provider type
+          schema:
+            $ref: '#/definitions/helper.ErrorMessage'
+        "401":
+          description: Authentication error
+          schema:
+            $ref: '#/definitions/helper.ErrorMessage'
+        "500":
+          description: Failed to create user alert notification account
+          schema:
+            $ref: '#/definitions/helper.ErrorMessage'
+      summary: Create user alert notification account
+      tags:
+      - UserAlertNotificationAccount
+  /account/v1alpha1/user-alert-notification-account/delete:
+    post:
+      consumes:
+      - application/json
+      description: Delete multiple user alert notification accounts
+      parameters:
+      - description: Delete user alert notification accounts request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/helper.DeleteUserAlertNotificationAccountReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully deleted user alert notification accounts
+          schema:
+            $ref: '#/definitions/helper.DeleteUserAlertNotificationAccountResp'
+        "400":
+          description: Failed to parse delete user alert notification accounts request
+          schema:
+            $ref: '#/definitions/helper.ErrorMessage'
+        "401":
+          description: Authentication error
+          schema:
+            $ref: '#/definitions/helper.ErrorMessage'
+        "500":
+          description: Failed to delete user alert notification accounts
+          schema:
+            $ref: '#/definitions/helper.ErrorMessage'
+      summary: Delete user alert notification accounts
+      tags:
+      - UserAlertNotificationAccount
+  /account/v1alpha1/user-alert-notification-account/list:
+    post:
+      consumes:
+      - application/json
+      description: List all user alert notification accounts for a user
+      parameters:
+      - description: List user alert notification accounts request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/helper.ListUserAlertNotificationAccountsReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully listed user alert notification accounts
+          schema:
+            $ref: '#/definitions/helper.ListUserAlertNotificationAccountsResp'
+        "400":
+          description: Failed to parse list user alert notification accounts request
+          schema:
+            $ref: '#/definitions/helper.ErrorMessage'
+        "401":
+          description: Authentication error
+          schema:
+            $ref: '#/definitions/helper.ErrorMessage'
+        "500":
+          description: Failed to list user alert notification accounts
+          schema:
+            $ref: '#/definitions/helper.ErrorMessage'
+      summary: List user alert notification accounts
+      tags:
+      - UserAlertNotificationAccount
+  /account/v1alpha1/user-alert-notification-account/toggle:
+    post:
+      consumes:
+      - application/json
+      description: Enable or disable multiple user alert notification accounts
+      parameters:
+      - description: Toggle user alert notification accounts request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/helper.ToggleUserAlertNotificationAccountsReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully toggled user alert notification accounts
+          schema:
+            $ref: '#/definitions/helper.ToggleUserAlertNotificationAccountsResp'
+        "400":
+          description: Failed to parse toggle user alert notification accounts request
+          schema:
+            $ref: '#/definitions/helper.ErrorMessage'
+        "401":
+          description: Authentication error
+          schema:
+            $ref: '#/definitions/helper.ErrorMessage'
+        "500":
+          description: Failed to toggle user alert notification accounts
+          schema:
+            $ref: '#/definitions/helper.ErrorMessage'
+      summary: Toggle user alert notification accounts
+      tags:
+      - UserAlertNotificationAccount
   /account/v1alpha1/user-usage:
     post:
       consumes:
@@ -1713,6 +3280,51 @@ paths:
       summary: Get user usage
       tags:
       - UserUsage
+  /account/v1alpha1/workspace-subscription/invoice-cancel:
+    post:
+      consumes:
+      - application/json
+      description: Cancel an unpaid Stripe invoice for workspace subscription upgrade
+      parameters:
+      - description: WorkspaceSubscriptionInvoiceCancelReq
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/helper.WorkspaceSubscriptionInvoiceCancelReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: Cancel workspace subscription invoice
+      tags:
+      - WorkspaceSubscription
+  /account/v1alpha1/workspace-subscription/plans:
+    post:
+      consumes:
+      - application/json
+      description: Get subscription plan names for multiple namespaces, returning
+        "PAYG" for non-subscribed workspaces
+      parameters:
+      - description: WorkspaceSubscriptionPlansReq
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/helper.WorkspaceSubscriptionPlansReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: Get workspace subscription plans by namespaces
+      tags:
+      - WorkspaceSubscription
   /admin/v1alpha1/account:
     get:
       consumes:
@@ -1765,6 +3377,66 @@ paths:
       summary: Charge billing
       tags:
       - Account
+  /admin/v1alpha1/gift-codes:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/helper.AdminGiftCodeListResp'
+      summary: List gift codes for admin
+      tags:
+      - AdminRead
+  /admin/v1alpha1/gift-codes/usage:
+    get:
+      parameters:
+      - description: User ID
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/helper.AdminGiftCodeUsageResp'
+      summary: List user gift code usage for admin
+      tags:
+      - AdminRead
+  /admin/v1alpha1/invoice:
+    get:
+      parameters:
+      - description: Invoice ID
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/helper.AdminInvoice'
+      summary: Get invoice for admin
+      tags:
+      - AdminRead
+  /admin/v1alpha1/invoices:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/helper.AdminInvoiceListResp'
+      summary: List invoices for admin
+      tags:
+      - AdminRead
   /admin/v1alpha1/real-name-info:
     get:
       consumes:
@@ -1791,4 +3463,803 @@ paths:
       summary: Get user real name info
       tags:
       - Account
+  /admin/v1alpha1/recharge-gift-policy:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/helper.AdminRechargeGiftPolicy'
+      summary: Get recharge gift policy for admin
+      tags:
+      - AdminRead
+  /admin/v1alpha1/refund-status:
+    get:
+      parameters:
+      - description: Payment ID or trade number
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/helper.AdminRefundStatusResp'
+      summary: Get refund status for admin
+      tags:
+      - AdminRead
+  /admin/v1alpha1/regions:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/helper.AdminRegion'
+            type: array
+      summary: List regions for admin
+      tags:
+      - AdminRead
+  /admin/v1alpha1/reload-property-types:
+    post:
+      consumes:
+      - application/json
+      description: Reload property types from database and update the global DefaultPropertyTypeLS
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: successfully reloaded property types
+          schema:
+            $ref: '#/definitions/helper.ReloadPropertyTypesResp'
+        "401":
+          description: authenticate error
+          schema:
+            $ref: '#/definitions/helper.ErrorMessage'
+        "500":
+          description: failed to reload property types
+          schema:
+            $ref: '#/definitions/helper.ErrorMessage'
+      summary: Reload property types
+      tags:
+      - Admin
+  /admin/v1alpha1/subscription-plan/delete:
+    post:
+      consumes:
+      - application/json
+      description: Delete a WorkspaceSubscriptionPlan by ID or name
+      parameters:
+      - description: Delete request (id or name required)
+        in: body
+        name: request
+        required: true
+        schema:
+          additionalProperties: true
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: successfully deleted subscription plan
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: invalid request body
+          schema:
+            $ref: '#/definitions/helper.ErrorMessage'
+        "401":
+          description: authenticate error
+          schema:
+            $ref: '#/definitions/helper.ErrorMessage'
+        "404":
+          description: subscription plan not found
+          schema:
+            $ref: '#/definitions/helper.ErrorMessage'
+        "500":
+          description: failed to delete subscription plan
+          schema:
+            $ref: '#/definitions/helper.ErrorMessage'
+      summary: Delete WorkspaceSubscriptionPlan
+      tags:
+      - Admin
+  /admin/v1alpha1/subscription-plan/manage:
+    post:
+      consumes:
+      - application/json
+      description: Create a new WorkspaceSubscriptionPlan with prices or update existing
+        one with prices. Manages plan and prices as a single unit.
+      parameters:
+      - description: Subscription plan with prices data
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/api.SubscriptionPlanManageRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: successfully created/updated subscription plan with prices
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: invalid request body
+          schema:
+            $ref: '#/definitions/helper.ErrorMessage'
+        "401":
+          description: authenticate error
+          schema:
+            $ref: '#/definitions/helper.ErrorMessage'
+        "500":
+          description: failed to create/update subscription plan with prices
+          schema:
+            $ref: '#/definitions/helper.ErrorMessage'
+      summary: Create or update WorkspaceSubscriptionPlan with prices
+      tags:
+      - Admin
+  /admin/v1alpha1/subscription-plans:
+    get:
+      consumes:
+      - application/json
+      description: Admin interface to get all available subscription plans using GET
+        method
+      parameters:
+      - description: Include inactive plans
+        example: false
+        in: query
+        name: includeInactive
+        type: boolean
+      - description: Filter by plan type
+        example: '"workspace"'
+        in: query
+        name: planType
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: Admin get subscription plans (GET)
+      tags:
+      - WorkspaceSubscription
+    post:
+      consumes:
+      - application/json
+      description: Admin interface to get all available subscription plans
+      parameters:
+      - description: AdminSubscriptionPlansReq
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/helper.AdminSubscriptionPlansReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: Admin get subscription plans
+      tags:
+      - WorkspaceSubscription
+  /admin/v1alpha1/user:
+    get:
+      parameters:
+      - description: User ID
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/helper.AdminUserDetail'
+      summary: Get user detail for admin
+      tags:
+      - AdminRead
+  /admin/v1alpha1/user/balance-adjust-records:
+    get:
+      parameters:
+      - description: User ID
+        in: query
+        name: id
+        required: true
+        type: string
+      - description: Zero-based page index
+        in: query
+        name: pageIndex
+        type: integer
+      - description: Page size, 1-100
+        in: query
+        name: pageSize
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/helper.AdminBalanceAdjustRecordsResp'
+      summary: List user balance adjustments for admin
+      tags:
+      - AdminRead
+  /admin/v1alpha1/user/recharge-records:
+    get:
+      parameters:
+      - description: User ID
+        in: query
+        name: id
+        required: true
+        type: string
+      - description: Zero-based page index
+        in: query
+        name: pageIndex
+        type: integer
+      - description: Page size, 1-100
+        in: query
+        name: pageSize
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/helper.AdminRechargeRecordsResp'
+      summary: List user recharge records for admin
+      tags:
+      - AdminRead
+  /admin/v1alpha1/users:
+    get:
+      parameters:
+      - description: Zero-based page index
+        in: query
+        name: pageIndex
+        type: integer
+      - description: Page size, 1-100
+        in: query
+        name: pageSize
+        type: integer
+      - description: User ID
+        in: query
+        name: id
+        type: string
+      - description: Password provider username
+        in: query
+        name: username
+        type: string
+      - description: Phone provider ID
+        in: query
+        name: phone
+        type: string
+      - description: Workspace ID
+        in: query
+        name: workspaceId
+        type: string
+      - description: Workspace display name
+        in: query
+        name: workspaceName
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/helper.AdminUserListResp'
+      summary: List users for admin
+      tags:
+      - AdminRead
+  /admin/v1alpha1/workspace-subscription/add:
+    post:
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+  /admin/v1alpha1/workspace-subscription/list:
+    get:
+      consumes:
+      - application/json
+      description: Admin interface to get paginated workspace subscription list with
+        filtering options using GET method
+      parameters:
+      - description: Page index (0-based)
+        example: 0
+        in: query
+        name: pageIndex
+        type: integer
+      - description: Page size (optional, defaults to 10)
+        example: 10
+        in: query
+        name: pageSize
+        type: integer
+      - description: Filter by workspace name
+        example: '"ns-8gmgq0jn"'
+        in: query
+        name: workspace
+        type: string
+      - description: Filter by user ID
+        example: '"36ca5ee6-7b6e-4c15-922b-e861b3fbc061"'
+        in: query
+        name: userUID
+        type: string
+      - description: Filter by plan name
+        example: '"Hobby"'
+        in: query
+        name: planName
+        type: string
+      - description: Filter by subscription status
+        example: '"NORMAL"'
+        in: query
+        name: status
+        type: string
+      - description: Filter by region domain
+        example: '"192.168.10.35.nip.io"'
+        in: query
+        name: regionDomain
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: Admin get workspace subscription list (GET)
+      tags:
+      - WorkspaceSubscription
+    post:
+      consumes:
+      - application/json
+      description: Admin interface to get paginated workspace subscription list with
+        filtering options
+      parameters:
+      - description: AdminWorkspaceSubscriptionListReq
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/helper.AdminWorkspaceSubscriptionListReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: Admin get workspace subscription list
+      tags:
+      - WorkspaceSubscription
+  /payment/v1alpha1/card/delete:
+    post:
+      consumes:
+      - application/json
+      description: Delete user card info
+      parameters:
+      - description: CardOperationReq
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/helper.CardOperationReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: Delete user card info
+      tags:
+      - Payment
+  /payment/v1alpha1/card/list:
+    post:
+      consumes:
+      - application/json
+      description: List user card info
+      parameters:
+      - description: AuthBase
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/helper.AuthBase'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: List user card info
+      tags:
+      - Payment
+  /payment/v1alpha1/card/set-default:
+    post:
+      consumes:
+      - application/json
+      description: Set default user card
+      parameters:
+      - description: CardOperationReq
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/helper.CardOperationReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: Set default user card
+      tags:
+      - Payment
+  /payment/v1alpha1/credits/info:
+    post:
+      consumes:
+      - application/json
+      description: Get credits info
+      parameters:
+      - description: AuthBase
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/helper.AuthBase'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.CreditsInfoResp'
+      summary: Get credits info
+      tags:
+      - Credits
+  /payment/v1alpha1/subscription/flush-quota:
+    post:
+      consumes:
+      - application/json
+      description: flush user quota with subscription
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: flush user quota with subscription
+      tags:
+      - Subscription
+  /payment/v1alpha1/subscription/last-transaction:
+    post:
+      consumes:
+      - application/json
+      description: Get user last subscription transaction
+      parameters:
+      - description: AuthBase
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/helper.AuthBase'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: Get user last subscription transaction
+      tags:
+      - Subscription
+  /payment/v1alpha1/subscription/pay:
+    post:
+      consumes:
+      - application/json
+      description: Subscription pay
+      parameters:
+      - description: SubscriptionOperatorReq
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/helper.SubscriptionOperatorReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: Subscription pay
+      tags:
+      - Subscription
+  /payment/v1alpha1/subscription/plan-list:
+    post:
+      consumes:
+      - application/json
+      description: Get subscription plan list
+      parameters:
+      - description: AuthBase
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/helper.AuthBase'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: Get subscription plan list
+      tags:
+      - Subscription
+  /payment/v1alpha1/subscription/quota-check:
+    post:
+      consumes:
+      - application/json
+      description: Check user subscription quota
+      parameters:
+      - description: SubscriptionQuotaCheckReq
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/helper.SubscriptionQuotaCheckReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/helper.SubscriptionQuotaCheckResp'
+      summary: Check user subscription quota
+      tags:
+      - Subscription
+  /payment/v1alpha1/subscription/upgrade-amount:
+    post:
+      consumes:
+      - application/json
+      description: Get subscription upgrade amount
+      parameters:
+      - description: SubscriptionOperatorReq
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/helper.SubscriptionOperatorReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: Get subscription upgrade amount
+      tags:
+      - Subscription
+  /payment/v1alpha1/subscription/user-info:
+    post:
+      consumes:
+      - application/json
+      description: Get user subscription info
+      parameters:
+      - description: AuthBase
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/helper.AuthBase'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: Get user subscription info
+      tags:
+      - Subscription
+  /payment/v1alpha1/workspace-subscription/info:
+    post:
+      consumes:
+      - application/json
+      description: Get workspace subscription info
+      parameters:
+      - description: WorkspaceSubscriptionInfoReq
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/helper.WorkspaceSubscriptionInfoReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: Get workspace subscription info
+      tags:
+      - WorkspaceSubscription
+  /payment/v1alpha1/workspace-subscription/last-transaction:
+    post:
+      consumes:
+      - application/json
+      description: Get last workspace subscription transaction
+      parameters:
+      - description: WorkspaceSubscriptionInfoReq
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/helper.WorkspaceSubscriptionInfoReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: Get last workspace subscription transaction
+      tags:
+      - WorkspaceSubscription
+  /payment/v1alpha1/workspace-subscription/list:
+    post:
+      consumes:
+      - application/json
+      description: Get workspace subscription list
+      parameters:
+      - description: AuthBase
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/helper.AuthBase'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: Get workspace subscription list
+      tags:
+      - WorkspaceSubscription
+  /payment/v1alpha1/workspace-subscription/notify:
+    post:
+      consumes:
+      - application/json
+      description: Handle Stripe webhook notifications for workspace subscription
+        events
+      produces:
+      - application/json
+      responses: {}
+      summary: Handle Stripe webhook for workspace subscription
+      tags:
+      - WorkspaceSubscription
+  /payment/v1alpha1/workspace-subscription/pay:
+    post:
+      consumes:
+      - application/json
+      description: Create workspace subscription payment with Stripe
+      parameters:
+      - description: WorkspaceSubscriptionOperatorReq
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/helper.WorkspaceSubscriptionOperatorReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: Create workspace subscription payment
+      tags:
+      - WorkspaceSubscription
+  /payment/v1alpha1/workspace-subscription/payment-list:
+    post:
+      consumes:
+      - application/json
+      description: Get workspace subscription payment list
+      parameters:
+      - description: UserTimeRangeReq
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/helper.UserTimeRangeReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: Get workspace subscription payment list
+      tags:
+      - WorkspaceSubscription
+  /payment/v1alpha1/workspace-subscription/plan-list:
+    post:
+      consumes:
+      - application/json
+      description: Get workspace subscription plan list
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: Get workspace subscription plan list
+      tags:
+      - WorkspaceSubscription
+  /payment/v1alpha1/workspace-subscription/upgrade-amount:
+    post:
+      consumes:
+      - application/json
+      description: Get workspace subscription upgrade amount
+      parameters:
+      - description: WorkspaceSubscriptionOperatorReq
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/helper.WorkspaceSubscriptionOperatorReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: Get workspace subscription upgrade amount
+      tags:
+      - WorkspaceSubscription
+  /workspace/v1alpha1/resource-quota:
+    post:
+      consumes:
+      - application/json
+      description: Get workspace resource quota
+      parameters:
+      - description: WorkspaceInfoReq
+        in: body
+        name: req
+        required: true
+        schema:
+          $ref: '#/definitions/helper.WorkspaceInfoReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: Get workspace resource quota
+      tags:
+      - WorkspaceSubscription
 swagger: "2.0"


### PR DESCRIPTION
## Problem

`POST /payment/v1alpha1/credits/info` only reports aggregate totals, so no user-facing endpoint exposes when a gift credit grant expires — even though every `Credits` row carries `expire_at`, and the handler already loads those rows before discarding the field during aggregation.

Ref: labring/sealos-private#117

## Change

Add a `creditsList` array to the `credits/info` response, carrying each available credit grant's `amount`, `usedAmount`, `startAt`, `expireAt`, and `status`:

- **Additive only** — all existing fields are unchanged; zero extra DB queries (the rows were already fetched).
- **Consistent with the aggregates** — the list holds exactly the rows the totals are summed from (exhausted rows included), so `sum(amount) == credits` and `sum(usedAmount) == deductionCredits` always hold. Display layers filter with `amount > usedAmount`.
- **Clean serialization** — zero times serialize as `null`, an empty result as `[]`; internal row IDs and plan UUIDs are not exposed.

Also:
- extracted the aggregation into a pure `buildCreditsInfo` function and added DB-free unit tests (multi-row accounting, the Free-plan KYC-pair copy, empty-list serialization);
- fixed the swagger route comment to the actually registered `/payment/v1alpha1` path.

## Testing

`go build ./...` and `go test ./api/ -run Test_buildCreditsInfo` pass; the pre-existing DB-backed integration test is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVAx6Vw5dDgMzxpaj82qV3