### PR TITLE
fix(desktop): persist user language preference

### DIFF
--- a/frontend/desktop/data/config.yaml
+++ b/frontend/desktop/data/config.yaml
@@ -50,7 +50,6 @@ desktop:
       noscripts: []
     customerServiceURL: ""
     discordInviteLink: ""
-    forcedLanguage: "en"
     currencySymbol: "usd"
     protocol:
       enabled: true

--- a/frontend/desktop/deploy/HELM_VALUES_GUIDE.md
+++ b/frontend/desktop/deploy/HELM_VALUES_GUIDE.md
@@ -75,9 +75,9 @@ desktopConfig:
 ```yaml
 desktopConfig:
   version: 'en' # UI 版本: "cn" 或 "en"
-  # forcedLanguage 和 currencySymbol 会根据 version 自动配置:
-  # - version: "cn" → forcedLanguage: "zh", currencySymbol: "shellCoin"
-  # - version: "en" → forcedLanguage: "en", currencySymbol: "usd"
+  # currencySymbol 会根据 version 自动配置:
+  # - version: "cn" → currencySymbol: "shellCoin"
+  # - version: "en" → currencySymbol: "usd"
 ```
 
 ### 6. Google Tag Manager

--- a/frontend/desktop/deploy/HELM_VALUES_GUIDE_CN.md
+++ b/frontend/desktop/deploy/HELM_VALUES_GUIDE_CN.md
@@ -75,9 +75,9 @@ desktopConfig:
 ```yaml
 desktopConfig:
   version: "en"                               # UI 版本: "cn" 或 "en"
-  # forcedLanguage 和 currencySymbol 会根据 version 自动配置:
-  # - version: "cn" → forcedLanguage: "zh", currencySymbol: "shellCoin"
-  # - version: "en" → forcedLanguage: "en", currencySymbol: "usd"
+  # currencySymbol 会根据 version 自动配置:
+  # - version: "cn" → currencySymbol: "shellCoin"
+  # - version: "en" → currencySymbol: "usd"
 ```
 
 ### 6. Google Tag Manager

--- a/frontend/desktop/deploy/README.md
+++ b/frontend/desktop/deploy/README.md
@@ -207,7 +207,6 @@ desktop:
     title: 'Sealos Cloud'
     logo: '/logo.svg'
     backgroundImage: '/images/bg-light.svg'
-    forcedLanguage: 'en' # Auto-configured based on version: "cn"→"zh", "en"→"en"
     customerServiceURL: ''
     discordInviteLink: '' # Auto-configured: shown for "en", empty for "cn"
     gtmId: null

--- a/frontend/desktop/deploy/README_CN.md
+++ b/frontend/desktop/deploy/README_CN.md
@@ -207,7 +207,6 @@ desktop:
     title: 'Sealos Cloud'
     logo: '/logo.svg'
     backgroundImage: '/images/bg-light.svg'
-    forcedLanguage: 'en' # 自动根据 version 配置: "cn"→"zh", "en"→"en"
     customerServiceURL: ''
     discordInviteLink: '' # 自动根据 version 配置: "en"时显示, "cn"时为空
     gtmId: null

--- a/frontend/desktop/deploy/charts/desktop-frontend/desktop-frontend-values.yaml
+++ b/frontend/desktop/deploy/charts/desktop-frontend/desktop-frontend-values.yaml
@@ -35,9 +35,9 @@ desktopConfig:
 
   # Currency and language configuration
   # Options: "cn" (Chinese) or "en" (English)
-  # forcedLanguage and currencySymbol will be auto-configured based on version:
-  # - version: "cn" → forcedLanguage: "zh", currencySymbol: "shellCoin"
-  # - version: "en" → forcedLanguage: "en", currencySymbol: "usd"
+  # currencySymbol is auto-configured based on version:
+  # - version: "cn" → currencySymbol: "shellCoin"
+  # - version: "en" → currencySymbol: "usd"
   version: "cn"
 
   allowedAllOrigins: true

--- a/frontend/desktop/deploy/charts/desktop-frontend/templates/configmap.yaml
+++ b/frontend/desktop/deploy/charts/desktop-frontend/templates/configmap.yaml
@@ -50,7 +50,6 @@ data:
         logo: "{{ .Values.desktopConfig.layoutLogo }}"
         backgroundImage: "{{ .Values.desktopConfig.layoutBackgroundImage }}"
         workspaceResourceHeaderEnabled: {{ .Values.desktopConfig.workspaceResourceHeaderEnabled }}
-        forcedLanguage: {{ if eq .Values.desktopConfig.version "cn" }}"zh"{{ else }}"en"{{ end }}
         customerServiceURL: "{{ .Values.desktopConfig.customerServiceURL }}"
         discordInviteLink: {{ if eq .Values.desktopConfig.version "en" }}"{{ .Values.desktopConfig.discordInviteLink }}"{{ else }}""{{ end }}
         gtmId: {{ if .Values.desktopConfig.gtmId }}"{{ .Values.desktopConfig.gtmId }}"{{ else }}null{{ end }}

--- a/frontend/desktop/src/__tests__/unit/locale.test.ts
+++ b/frontend/desktop/src/__tests__/unit/locale.test.ts
@@ -1,0 +1,35 @@
+import {
+  getLocaleCookieHeader,
+  getPlatformDefaultLocale,
+  getRequestLocale,
+  localeCookieOptions,
+  normalizeLocale
+} from '@/utils/locale';
+
+describe('locale persistence', () => {
+  it('keeps the user-selected language over the platform default after a reload', () => {
+    expect(getRequestLocale('en', 'zh')).toBe('en');
+    expect(getRequestLocale('zh', 'en')).toBe('zh');
+  });
+
+  it('uses the platform version only when no valid user preference exists', () => {
+    expect(normalizeLocale('zh-Hans')).toBe('zh');
+    expect(normalizeLocale('en-US')).toBe('en');
+    expect(getPlatformDefaultLocale('cn')).toBe('zh');
+    expect(getPlatformDefaultLocale('en')).toBe('en');
+    expect(getRequestLocale('fr', getPlatformDefaultLocale('cn'))).toBe('zh');
+    expect(getRequestLocale(undefined, getPlatformDefaultLocale('en'))).toBe('en');
+  });
+
+  it('uses one root-scoped cookie contract for client and server navigation', () => {
+    expect(localeCookieOptions).toMatchObject({
+      expires: 30,
+      path: '/',
+      sameSite: 'None',
+      secure: true
+    });
+    expect(getLocaleCookieHeader('en')).toBe(
+      'NEXT_LOCALE=en; Path=/; Max-Age=2592000; Secure; SameSite=None'
+    );
+  });
+});

--- a/frontend/desktop/src/__tests__/unit/useLanguageSwitcher.test.ts
+++ b/frontend/desktop/src/__tests__/unit/useLanguageSwitcher.test.ts
@@ -1,0 +1,50 @@
+/** @jest-environment jsdom */
+
+import { renderHook } from '@testing-library/react';
+import { useLanguageSwitcher } from '@/hooks/useLanguageSwitcher';
+import { setCookie } from '@/utils/cookieUtils';
+import { LOCALE_COOKIE_NAME, localeCookieOptions } from '@/utils/locale';
+import { masterApp } from 'sealos-desktop-sdk/master';
+
+const mockChangeLanguage = jest.fn();
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({
+    i18n: {
+      language: 'zh',
+      changeLanguage: mockChangeLanguage
+    }
+  })
+}));
+
+jest.mock('@/utils/cookieUtils', () => ({
+  setCookie: jest.fn()
+}));
+
+jest.mock('sealos-desktop-sdk', () => ({
+  EVENT_NAME: { CHANGE_I18N: 'change_i18n' }
+}));
+
+jest.mock('sealos-desktop-sdk/master', () => ({
+  masterApp: { sendMessageToAll: jest.fn() }
+}));
+
+describe('useLanguageSwitcher', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('persists a user-selected language before navigation', () => {
+    const { result } = renderHook(() => useLanguageSwitcher());
+
+    result.current.switchLanguage('en');
+
+    expect(setCookie).toHaveBeenCalledWith(LOCALE_COOKIE_NAME, 'en', localeCookieOptions);
+    expect(mockChangeLanguage).toHaveBeenCalledWith('en');
+    expect(masterApp?.sendMessageToAll).toHaveBeenCalledWith({
+      apiName: 'event-bus',
+      eventName: 'change_i18n',
+      data: { currentLanguage: 'en' }
+    });
+  });
+});

--- a/frontend/desktop/src/components/LangSelect/index.tsx
+++ b/frontend/desktop/src/components/LangSelect/index.tsx
@@ -1,4 +1,5 @@
 import { setCookie } from '@/utils/cookieUtils';
+import { LOCALE_COOKIE_NAME, localeCookieOptions } from '@/utils/locale';
 import {
   Button,
   Flex,
@@ -58,11 +59,7 @@ export default function LangSelectList(props: MenuButtonProps) {
                   currentLanguage: lngKey
                 }
               });
-              setCookie('NEXT_LOCALE', lngKey, {
-                expires: 30,
-                sameSite: 'None',
-                secure: true
-              });
+              setCookie(LOCALE_COOKIE_NAME, lngKey, localeCookieOptions);
               i18n?.changeLanguage(lngKey);
             }}
             key={lngKey}

--- a/frontend/desktop/src/hooks/useLanguageSwitcher.ts
+++ b/frontend/desktop/src/hooks/useLanguageSwitcher.ts
@@ -1,13 +1,11 @@
-import { useConfigStore } from '@/stores/config';
 import { setCookie } from '@/utils/cookieUtils';
+import { LOCALE_COOKIE_NAME, localeCookieOptions } from '@/utils/locale';
 import { useTranslation } from 'next-i18next';
-import { useEffect } from 'react';
 import { EVENT_NAME } from 'sealos-desktop-sdk';
 import { masterApp } from 'sealos-desktop-sdk/master';
 
 export function useLanguageSwitcher() {
   const { i18n } = useTranslation();
-  const { layoutConfig } = useConfigStore();
 
   const switchLanguage = (targetLang: string) => {
     masterApp?.sendMessageToAll({
@@ -17,19 +15,9 @@ export function useLanguageSwitcher() {
         currentLanguage: targetLang
       }
     });
-    setCookie('NEXT_LOCALE', targetLang, {
-      expires: 30,
-      sameSite: 'None',
-      secure: true
-    });
+    setCookie(LOCALE_COOKIE_NAME, targetLang, localeCookieOptions);
     i18n?.changeLanguage(targetLang);
   };
-
-  useEffect(() => {
-    if (layoutConfig?.forcedLanguage && i18n?.language !== layoutConfig.forcedLanguage) {
-      switchLanguage(layoutConfig.forcedLanguage);
-    }
-  }, [layoutConfig?.forcedLanguage, i18n]);
 
   return {
     currentLanguage: i18n?.language || 'en',

--- a/frontend/desktop/src/pages/WorkspaceInvite.tsx
+++ b/frontend/desktop/src/pages/WorkspaceInvite.tsx
@@ -3,7 +3,8 @@ import useCallbackStore from '@/stores/callback';
 import { useConfigStore } from '@/stores/config';
 import useSessionStore from '@/stores/session';
 import { ROLE_LIST, UserRole } from '@/types/team';
-import { compareFirstLanguages } from '@/utils/tools';
+import { getLocaleCookieHeader, getPlatformDefaultLocale, getRequestLocale } from '@/utils/locale';
+import { getLayoutConfig } from './api/platform/getLayoutConfig';
 import { Button, Flex, Image, Text, VStack } from '@chakra-ui/react';
 import { track } from '@sealos/gtm';
 import { dehydrate, QueryClient, useMutation, useQuery } from '@tanstack/react-query';
@@ -166,9 +167,12 @@ const Callback: NextPage = () => {
   );
 };
 export async function getServerSideProps({ req, res, locales }: any) {
-  const local =
-    req?.cookies?.NEXT_LOCALE || compareFirstLanguages(req?.headers?.['accept-language'] || 'zh');
-  res.setHeader('Set-Cookie', `NEXT_LOCALE=${local}; Max-Age=2592000; Secure; SameSite=None`);
+  const layoutConfig = await getLayoutConfig();
+  const local = getRequestLocale(
+    req?.cookies?.NEXT_LOCALE,
+    getPlatformDefaultLocale(layoutConfig.version)
+  );
+  res.setHeader('Set-Cookie', getLocaleCookieHeader(local));
 
   const queryClient = new QueryClient();
   const props = {

--- a/frontend/desktop/src/pages/callback.tsx
+++ b/frontend/desktop/src/pages/callback.tsx
@@ -21,7 +21,8 @@ import {
 import { useCustomToast } from '@/hooks/useCustomToast';
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
-import { compareFirstLanguages } from '@/utils/tools';
+import { getLocaleCookieHeader, getPlatformDefaultLocale, getRequestLocale } from '@/utils/locale';
+import { getLayoutConfig } from './api/platform/getLayoutConfig';
 
 export default function Callback() {
   const router = useRouter();
@@ -204,9 +205,12 @@ export default function Callback() {
 }
 
 export async function getServerSideProps({ req, res, locales }: any) {
-  const local =
-    req?.cookies?.NEXT_LOCALE || compareFirstLanguages(req?.headers?.['accept-language'] || 'zh');
-  res.setHeader('Set-Cookie', `NEXT_LOCALE=${local}; Max-Age=2592000; Secure; SameSite=None`);
+  const layoutConfig = await getLayoutConfig();
+  const local = getRequestLocale(
+    req?.cookies?.NEXT_LOCALE,
+    getPlatformDefaultLocale(layoutConfig.version)
+  );
+  res.setHeader('Set-Cookie', getLocaleCookieHeader(local));
 
   return {
     props: {

--- a/frontend/desktop/src/pages/emailCheck.tsx
+++ b/frontend/desktop/src/pages/emailCheck.tsx
@@ -1,6 +1,7 @@
 import { EmailCheckForm } from '@/components/v2/EmailCheckForm';
 import SignLayout from '@/components/v2/SignLayout';
-import { compareFirstLanguages } from '@/utils/tools';
+import { getLocaleCookieHeader, getPlatformDefaultLocale, getRequestLocale } from '@/utils/locale';
+import { getLayoutConfig } from './api/platform/getLayoutConfig';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 
@@ -12,9 +13,12 @@ export default function PersonalInfoPage() {
   );
 }
 export async function getServerSideProps({ req, res, locales }: any) {
-  const local =
-    req?.cookies?.NEXT_LOCALE || compareFirstLanguages(req?.headers?.['accept-language'] || 'en');
-  res.setHeader('Set-Cookie', `NEXT_LOCALE=${local}; Max-Age=2592000; Secure; SameSite=None`);
+  const layoutConfig = await getLayoutConfig();
+  const local = getRequestLocale(
+    req?.cookies?.NEXT_LOCALE,
+    getPlatformDefaultLocale(layoutConfig.version)
+  );
+  res.setHeader('Set-Cookie', getLocaleCookieHeader(local));
 
   const queryClient = new QueryClient();
   const props = {

--- a/frontend/desktop/src/pages/index.tsx
+++ b/frontend/desktop/src/pages/index.tsx
@@ -13,7 +13,8 @@ import { AccessTokenPayload } from '@/types/token';
 import { parseOpenappQuery } from '@/utils/format';
 import { sessionConfig, setAdClickData, setInviterId, setUserSemData } from '@/utils/sessionConfig';
 import { switchKubeconfigNamespace } from '@/utils/switchKubeconfigNamespace';
-import { compareFirstLanguages } from '@/utils/tools';
+import { getLocaleCookieHeader, getPlatformDefaultLocale, getRequestLocale } from '@/utils/locale';
+import { getLayoutConfig } from './api/platform/getLayoutConfig';
 import { Box, useColorMode } from '@chakra-ui/react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import dayjs from 'dayjs';
@@ -262,9 +263,12 @@ export default function Home({ sealos_cloud_domain }: { sealos_cloud_domain: str
 }
 
 export async function getServerSideProps({ req, res, locales }: any) {
-  const local =
-    req?.cookies?.NEXT_LOCALE || compareFirstLanguages(req?.headers?.['accept-language'] || 'zh');
-  res.setHeader('Set-Cookie', `NEXT_LOCALE=${local}; Max-Age=2592000; Secure; SameSite=None`);
+  const layoutConfig = await getLayoutConfig();
+  const local = getRequestLocale(
+    req?.cookies?.NEXT_LOCALE,
+    getPlatformDefaultLocale(layoutConfig.version)
+  );
+  res.setHeader('Set-Cookie', getLocaleCookieHeader(local));
 
   const sealos_cloud_domain = global.AppConfig?.cloud.domain || 'cloud.sealos.io';
   return {

--- a/frontend/desktop/src/pages/phoneCheck.tsx
+++ b/frontend/desktop/src/pages/phoneCheck.tsx
@@ -1,6 +1,7 @@
 import { PhoneCheckForm } from '@/components/v2/PhoneCheckForm';
 import SignLayout from '@/components/v2/SignLayout';
-import { compareFirstLanguages } from '@/utils/tools';
+import { getLocaleCookieHeader, getPlatformDefaultLocale, getRequestLocale } from '@/utils/locale';
+import { getLayoutConfig } from './api/platform/getLayoutConfig';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 
@@ -12,9 +13,12 @@ export default function PersonalInfoPage() {
   );
 }
 export async function getServerSideProps({ req, res, locales }: any) {
-  const local =
-    req?.cookies?.NEXT_LOCALE || compareFirstLanguages(req?.headers?.['accept-language'] || 'en');
-  res.setHeader('Set-Cookie', `NEXT_LOCALE=${local}; Max-Age=2592000; Secure; SameSite=None`);
+  const layoutConfig = await getLayoutConfig();
+  const local = getRequestLocale(
+    req?.cookies?.NEXT_LOCALE,
+    getPlatformDefaultLocale(layoutConfig.version)
+  );
+  res.setHeader('Set-Cookie', getLocaleCookieHeader(local));
 
   const queryClient = new QueryClient();
   const props = {

--- a/frontend/desktop/src/pages/proxyOAuth.tsx
+++ b/frontend/desktop/src/pages/proxyOAuth.tsx
@@ -7,7 +7,8 @@ import { Flex, Spinner } from '@chakra-ui/react';
 import { isString } from 'lodash';
 import { useQuery } from '@tanstack/react-query';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
-import { compareFirstLanguages } from '@/utils/tools';
+import { getLocaleCookieHeader, getPlatformDefaultLocale, getRequestLocale } from '@/utils/locale';
+import { getLayoutConfig } from './api/platform/getLayoutConfig';
 import { OauthProvider } from '@/types/user';
 import { useConfigStore } from '@/stores/config';
 import { getAppConfig } from './api/platform/getAppConfig';
@@ -87,9 +88,12 @@ export default function Callback({ appConfig }: { appConfig: AppClientConfigType
 }
 
 export async function getServerSideProps({ req, res, locales }: any) {
-  const local =
-    req?.cookies?.NEXT_LOCALE || compareFirstLanguages(req?.headers?.['accept-language'] || 'zh');
-  res.setHeader('Set-Cookie', `NEXT_LOCALE=${local}; Max-Age=2592000; Secure; SameSite=None`);
+  const layoutConfig = await getLayoutConfig();
+  const local = getRequestLocale(
+    req?.cookies?.NEXT_LOCALE,
+    getPlatformDefaultLocale(layoutConfig.version)
+  );
+  res.setHeader('Set-Cookie', getLocaleCookieHeader(local));
   const sealos_cloud_domain = useConfigStore.getState().cloudConfig?.domain;
   const appConfig = await getAppConfig();
   return {

--- a/frontend/desktop/src/pages/signin.tsx
+++ b/frontend/desktop/src/pages/signin.tsx
@@ -1,6 +1,7 @@
 // import SigninComponent from '@/components/signin';
 import { useConfigStore } from '@/stores/config';
-import { compareFirstLanguages } from '@/utils/tools';
+import { getLocaleCookieHeader, getPlatformDefaultLocale, getRequestLocale } from '@/utils/locale';
+import { getLayoutConfig } from './api/platform/getLayoutConfig';
 import { Box, useToast } from '@chakra-ui/react';
 import { QueryClient, dehydrate } from '@tanstack/react-query';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
@@ -81,11 +82,14 @@ export default function SigninPage({ sessionExpired }: { sessionExpired?: boolea
 }
 
 export async function getServerSideProps({ req, res, locales }: any) {
-  const local =
-    req?.cookies?.NEXT_LOCALE || compareFirstLanguages(req?.headers?.['accept-language'] || 'zh');
+  const layoutConfig = await getLayoutConfig();
+  const local = getRequestLocale(
+    req?.cookies?.NEXT_LOCALE,
+    getPlatformDefaultLocale(layoutConfig.version)
+  );
 
   const sessionExpired = req?.cookies?.session_expired === '1';
-  const cookies = [`NEXT_LOCALE=${local}; Max-Age=2592000; Secure; SameSite=None`];
+  const cookies = [getLocaleCookieHeader(local)];
   if (sessionExpired) {
     cookies.push('session_expired=; Path=/; Max-Age=0');
   }

--- a/frontend/desktop/src/pages/workspace.tsx
+++ b/frontend/desktop/src/pages/workspace.tsx
@@ -1,6 +1,7 @@
 import WorkspaceComponent from '@/components/v2/Workspace';
 import SignLayout from '@/components/v2/SignLayout';
-import { compareFirstLanguages } from '@/utils/tools';
+import { getLocaleCookieHeader, getPlatformDefaultLocale, getRequestLocale } from '@/utils/locale';
+import { getLayoutConfig } from './api/platform/getLayoutConfig';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 
@@ -13,9 +14,12 @@ export default function WorkspacePage() {
 }
 
 export async function getServerSideProps({ req, res, locales }: any) {
-  const local =
-    req?.cookies?.NEXT_LOCALE || compareFirstLanguages(req?.headers?.['accept-language'] || 'en');
-  res.setHeader('Set-Cookie', `NEXT_LOCALE=${local}; Max-Age=2592000; Secure; SameSite=None`);
+  const layoutConfig = await getLayoutConfig();
+  const local = getRequestLocale(
+    req?.cookies?.NEXT_LOCALE,
+    getPlatformDefaultLocale(layoutConfig.version)
+  );
+  res.setHeader('Set-Cookie', getLocaleCookieHeader(local));
 
   const queryClient = new QueryClient();
   const props = {

--- a/frontend/desktop/src/types/system.ts
+++ b/frontend/desktop/src/types/system.ts
@@ -82,7 +82,6 @@ export type LayoutConfigType = {
   meta: MetaConfigType;
   customerServiceURL?: string;
   discordInviteLink?: string;
-  forcedLanguage?: string;
   currencySymbol?: 'shellCoin' | 'cny' | 'usd';
   protocol?: ProtocolConfigType;
   common: {

--- a/frontend/desktop/src/utils/locale.ts
+++ b/frontend/desktop/src/utils/locale.ts
@@ -1,0 +1,30 @@
+import type { CookieAttributes } from 'js-cookie';
+
+export const LOCALE_COOKIE_NAME = 'NEXT_LOCALE';
+export const LOCALE_COOKIE_MAX_AGE = 60 * 60 * 24 * 30;
+export type SupportedLocale = 'zh' | 'en';
+
+export const localeCookieOptions: CookieAttributes = {
+  expires: 30,
+  path: '/',
+  sameSite: 'None',
+  secure: true
+};
+
+export function normalizeLocale(locale?: string) {
+  if (locale?.toLowerCase().startsWith('zh')) return 'zh';
+  if (locale?.toLowerCase().startsWith('en')) return 'en';
+  return undefined;
+}
+
+export function getPlatformDefaultLocale(version?: string): SupportedLocale {
+  return version === 'cn' ? 'zh' : 'en';
+}
+
+export function getRequestLocale(localeCookie: string | undefined, defaultLocale: SupportedLocale) {
+  return normalizeLocale(localeCookie) || defaultLocale;
+}
+
+export function getLocaleCookieHeader(locale: string) {
+  return `${LOCALE_COOKIE_NAME}=${locale}; Path=/; Max-Age=${LOCALE_COOKIE_MAX_AGE}; Secure; SameSite=None`;
+}


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->

## Summary

- Persist the selected `zh` or `en` locale with a root-scoped cookie across Desktop SSR pages and client language selectors.
- Use the platform version as the default only when no valid user preference exists, and remove the forced-language configuration.
- Add unit coverage for locale normalization, cookie serialization, and client-side switching.

## Verification

- `helm lint frontend/desktop/deploy/charts/desktop-frontend`
- `helm template desktop-frontend frontend/desktop/deploy/charts/desktop-frontend --namespace desktop-frontend`
- `git diff --check origin/release-v5.1...`
- Jest was not run because this workspace does not have Desktop dependencies installed.

## Sequence Diagram

```mermaid
sequenceDiagram
    participant User
    participant Browser
    participant DesktopSSR as Desktop SSR
    participant Config as Layout Config

    User->>Browser: Open a Desktop page
    Browser->>DesktopSSR: Request with NEXT_LOCALE cookie
    DesktopSSR->>Config: Read platform version
    alt Valid locale cookie
        DesktopSSR->>DesktopSSR: Use persisted locale
    else Missing or invalid cookie
        DesktopSSR->>DesktopSSR: Derive platform default locale
    end
    DesktopSSR-->>Browser: Render locale and set root cookie
    User->>Browser: Switch language
    Browser->>Browser: Update NEXT_LOCALE at root path
```
