### PR TITLE
fix(logs): normalize VLogs query timestamps

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/utils/vlogsTime.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/vlogsTime.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { toVlogsQueryTime } from '@/utils/vlogsTime';
+
+describe('toVlogsQueryTime', () => {
+  it('serializes a browser timestamp as an unambiguous UTC query time', () => {
+    expect(toVlogsQueryTime(1787638417000)).toBe('2026-08-25T06:13:37.000Z');
+  });
+
+  it('rejects invalid log query timestamps', () => {
+    expect(() => toVlogsQueryTime('not-a-date')).toThrow('Invalid log query timestamp');
+  });
+});

--- a/frontend/providers/applaunchpad/src/components/DatePicker/index.tsx
+++ b/frontend/providers/applaunchpad/src/components/DatePicker/index.tsx
@@ -30,7 +30,6 @@ import { ChangeEventHandler, useMemo, useState } from 'react';
 import { DateRange, DayPicker, SelectRangeEventHandler } from 'react-day-picker';
 import useDateTimeStore from '@/store/date';
 import { formatTimeRange, parseTimeRange } from '@/utils/timeRange';
-import { MySelect } from '@sealos/ui';
 import MyIcon from '../Icon';
 
 interface DatePickerProps extends FlexProps {
@@ -48,8 +47,7 @@ const DatePicker = ({ isDisabled = false, ...props }: DatePickerProps) => {
   const currentLang = i18n.language;
   const { isOpen, onClose, onOpen } = useDisclosure();
 
-  const { startDateTime, endDateTime, setStartDateTime, setEndDateTime, timeZone, setTimeZone } =
-    useDateTimeStore();
+  const { startDateTime, endDateTime, setStartDateTime, setEndDateTime } = useDateTimeStore();
 
   const now = new Date();
   const sevenDaysAgo = subDays(now, 7);
@@ -462,21 +460,7 @@ const DatePicker = ({ isDisabled = false, ...props }: DatePickerProps) => {
             </Flex>
           </Flex>
           <Divider />
-          <Flex justify={'space-between'} pl={'12px'} alignItems={'center'} py={'8px'}>
-            <MySelect
-              height="32px"
-              width={'fit-content'}
-              border={'none'}
-              boxShadow={'none'}
-              backgroundColor={'transparent'}
-              color={'grayModern.600'}
-              value={timeZone}
-              list={[
-                { value: 'local', label: 'Local (Asia/Shanghai)' },
-                { value: 'utc', label: 'UTC' }
-              ]}
-              onchange={(val: any) => setTimeZone(val)}
-            />
+          <Flex justify={'flex-end'} alignItems={'center'} py={'8px'}>
             <ButtonGroup variant="outline" spacing="2" px={'10px'}>
               <Button
                 border={'1px solid'}

--- a/frontend/providers/applaunchpad/src/pages/api/log/queryLogs.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/log/queryLogs.ts
@@ -3,14 +3,15 @@ import { authSession } from '@/services/backend/auth';
 import { getK8s } from '@/services/backend/kubernetes';
 import { jsonRes } from '@/services/backend/response';
 import { ApiResp } from '@/services/kubernet';
+import { toVlogsQueryTime } from '@/utils/vlogsTime';
 
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 export interface LogQueryPayload {
   app?: string;
   time?: string;
-  startTime?: string;
-  endTime?: string;
+  startTime?: string | number;
+  endTime?: string | number;
   namespace?: string;
   limit?: string;
   jsonMode?: string;
@@ -72,7 +73,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     } = req.body as LogQueryPayload;
 
     const params: LogQueryPayload = {
-      ...(startTime && endTime ? { startTime, endTime } : { time }),
+      ...(startTime !== undefined && endTime !== undefined
+        ? {
+            startTime: toVlogsQueryTime(startTime),
+            endTime: toVlogsQueryTime(endTime)
+          }
+        : { time }),
       namespace: namespace,
       app: app,
       limit: limit,

--- a/frontend/providers/applaunchpad/src/pages/api/log/queryPodList.ts
+++ b/frontend/providers/applaunchpad/src/pages/api/log/queryPodList.ts
@@ -2,6 +2,7 @@ import { authSession } from '@/services/backend/auth';
 import { getK8s } from '@/services/backend/kubernetes';
 import { jsonRes } from '@/services/backend/response';
 import { ApiResp } from '@/services/kubernet';
+import { toVlogsQueryTime } from '@/utils/vlogsTime';
 
 import type { NextApiRequest, NextApiResponse } from 'next';
 
@@ -10,8 +11,8 @@ export interface PodListQueryPayload {
   time?: string;
   namespace?: string;
   podQuery?: string;
-  startTime?: string;
-  endTime?: string;
+  startTime?: string | number;
+  endTime?: string | number;
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
@@ -56,7 +57,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       namespace: namespace,
       app: app,
       podQuery: podQuery,
-      ...(startTime && endTime ? { startTime, endTime } : { time })
+      ...(startTime !== undefined && endTime !== undefined
+        ? {
+            startTime: toVlogsQueryTime(startTime),
+            endTime: toVlogsQueryTime(endTime)
+          }
+        : { time })
     };
 
     console.log(params, 'params');

--- a/frontend/providers/applaunchpad/src/pages/app/detail/logs.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/detail/logs.tsx
@@ -95,8 +95,8 @@ export default function LogsPage({ appName }: { appName: string }) {
     () =>
       getAppLogs({
         // time: timeRange,
-        startTime: startDateTime.toISOString(),
-        endTime: endDateTime.toISOString(),
+        startTime: startDateTime.getTime(),
+        endTime: endDateTime.getTime(),
         app: appName,
         stderrMode: formHook.watch('isOnlyStderr').toString(),
         limit: formHook.watch('limit').toString(),
@@ -146,8 +146,8 @@ export default function LogsPage({ appName }: { appName: string }) {
         numberMode: 'true',
         numberLevel: timeRange.slice(-1),
         jsonMode: formHook.watch('isJsonMode').toString(),
-        startTime: startDateTime.toISOString(),
-        endTime: endDateTime.toISOString(),
+        startTime: startDateTime.getTime(),
+        endTime: endDateTime.getTime(),
         stderrMode: formHook.watch('isOnlyStderr').toString(),
         pod:
           selectedPods.length === formHook.watch('pods').length
@@ -176,8 +176,8 @@ export default function LogsPage({ appName }: { appName: string }) {
       getLogPodList({
         // time: timeRange
         app: appName,
-        startTime: startDateTime.toISOString(),
-        endTime: endDateTime.toISOString()
+        startTime: startDateTime.getTime(),
+        endTime: endDateTime.getTime()
       }),
     {
       staleTime: 3000,

--- a/frontend/providers/applaunchpad/src/store/date.ts
+++ b/frontend/providers/applaunchpad/src/store/date.ts
@@ -5,11 +5,9 @@ import { immer } from 'zustand/middleware/immer';
 type DateTimeState = {
   startDateTime: Date;
   endDateTime: Date;
-  timeZone: 'local' | 'utc';
   refreshInterval: number;
   setStartDateTime: (time: Date) => void;
   setEndDateTime: (time: Date) => void;
-  setTimeZone: (timeZone: 'local' | 'utc') => void;
   setRefreshInterval: (val: number) => void;
 };
 
@@ -17,11 +15,9 @@ const useDateTimeStore = create<DateTimeState>()(
   immer((set, get) => ({
     startDateTime: subMinutes(new Date(), 30),
     endDateTime: new Date(),
-    timeZone: 'local',
     refreshInterval: 0,
     setStartDateTime: (datetime) => set({ startDateTime: datetime }),
     setEndDateTime: (datetime) => set({ endDateTime: datetime }),
-    setTimeZone: (timeZone) => set({ timeZone }),
     setRefreshInterval: (val) => set({ refreshInterval: val })
   }))
 );

--- a/frontend/providers/applaunchpad/src/utils/vlogsTime.ts
+++ b/frontend/providers/applaunchpad/src/utils/vlogsTime.ts
@@ -1,0 +1,9 @@
+export function toVlogsQueryTime(value: string | number | Date): string {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new Error('Invalid log query timestamp');
+  }
+
+  return date.toISOString();
+}

--- a/frontend/providers/dbprovider/__tests__/unit/utils/vlogsTime.test.ts
+++ b/frontend/providers/dbprovider/__tests__/unit/utils/vlogsTime.test.ts
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { toVlogsQueryTime } from '../../../src/utils/vlogsTime';
+
+test('serializes a browser timestamp as an unambiguous UTC query time', () => {
+  assert.equal(toVlogsQueryTime(1787638417000), '2026-08-25T06:13:37.000Z');
+});
+
+test('rejects invalid log query timestamps', () => {
+  assert.throws(() => toVlogsQueryTime('not-a-date'), /Invalid log query timestamp/);
+});

--- a/frontend/providers/dbprovider/src/api/db.ts
+++ b/frontend/providers/dbprovider/src/api/db.ts
@@ -163,7 +163,6 @@ export const getVlogsDatabaseLogs = (payload: {
   timeRange?: string;
   keyword?: string;
   pageSize?: number;
-  timeZone?: 'local' | 'utc';
 }) => POST<LogResult>(`/api/vlogs/database-logs`, payload);
 
 export const getVlogsDatabasePods = (payload: {
@@ -172,7 +171,6 @@ export const getVlogsDatabasePods = (payload: {
   startTime?: number;
   endTime?: number;
   timeRange?: string;
-  timeZone?: 'local' | 'utc';
 }) =>
   POST<{
     pods: { podName: string; alias: string; pvcUids: string[] }[];
@@ -188,5 +186,4 @@ export const getVlogsDatabaseLogCounts = (payload: {
   endTime?: number;
   timeRange?: string;
   keyword?: string;
-  timeZone?: 'local' | 'utc';
 }) => POST<{ logs_total: string; _time: string }[]>(`/api/vlogs/database-log-counts`, payload);

--- a/frontend/providers/dbprovider/src/components/DataPicker/index.tsx
+++ b/frontend/providers/dbprovider/src/components/DataPicker/index.tsx
@@ -21,7 +21,6 @@ import { DateRange, DayPicker, SelectRangeEventHandler } from 'react-day-picker'
 import 'react-day-picker/dist/style.css';
 import useDateTimeStore from '@/store/date';
 import { parseTimeRange, formatTimeRange } from '@/utils/timeRange';
-import { MySelect } from '@sealos/ui';
 import MyIcon from '../Icon';
 import { Calendar } from 'lucide-react';
 
@@ -40,8 +39,7 @@ const DatePicker = ({ isDisabled = false, ...props }: DatePickerProps) => {
   const currentLang = i18n.language;
   const { isOpen, onClose, onOpen } = useDisclosure();
   const isZh = i18n.language?.toLowerCase().startsWith('zh');
-  const { startDateTime, endDateTime, setStartDateTime, setEndDateTime, timeZone, setTimeZone } =
-    useDateTimeStore();
+  const { startDateTime, endDateTime, setStartDateTime, setEndDateTime } = useDateTimeStore();
 
   // 新的时间格式化函数
   const formatTimeRange = (start: Date, end: Date) => {
@@ -471,20 +469,6 @@ const DatePicker = ({ isDisabled = false, ...props }: DatePickerProps) => {
           </Flex>
           <Divider />
           <Flex justify={'flex-start'} pl={'12px'} pr={'12px'} alignItems={'center'} py={'8px'}>
-            <MySelect
-              height="32px"
-              width={'fit-content'}
-              border={'none'}
-              boxShadow={'none'}
-              backgroundColor={'transparent'}
-              color={'grayModern.600'}
-              value={timeZone}
-              list={[
-                { value: 'local', label: 'Local (Asia/Shanghai)' },
-                { value: 'utc', label: 'UTC' }
-              ]}
-              onchange={(val: any) => setTimeZone(val)}
-            />
             <ButtonGroup variant="outline" spacing="2" px={0} ml={'auto'}>
               <Button
                 border={'1px solid'}

--- a/frontend/providers/dbprovider/src/pages/api/vlogs/database-log-counts.ts
+++ b/frontend/providers/dbprovider/src/pages/api/vlogs/database-log-counts.ts
@@ -1,6 +1,7 @@
 import { jsonRes } from '@/services/backend/response';
 import { ApiResp } from '@/services/kubernet';
 import { VLOGS_CONFIG } from '@/config/vlogs';
+import { toVlogsQueryTime } from '@/utils/vlogsTime';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
@@ -13,8 +14,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       startTime,
       endTime,
       timeRange = '1h',
-      keyword = '',
-      timeZone = 'local'
+      keyword = ''
     } = req.body;
 
     if (!namespace || !pvc || !containers || !type) {
@@ -47,18 +47,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       app: ''
     };
 
-    if (startTime && endTime) {
-      // 如果选择的是本地时区，直接使用本地时间字符串而不是UTC时间
-      if (timeZone === 'local') {
-        const startDate = new Date(startTime);
-        const endDate = new Date(endTime);
-        // 格式化为本地时间字符串: YYYY-MM-DDTHH:mm:ss
-        vlogsParams.startTime = `${startDate.getFullYear()}-${String(startDate.getMonth() + 1).padStart(2, '0')}-${String(startDate.getDate()).padStart(2, '0')}T${String(startDate.getHours()).padStart(2, '0')}:${String(startDate.getMinutes()).padStart(2, '0')}:${String(startDate.getSeconds()).padStart(2, '0')}`;
-        vlogsParams.endTime = `${endDate.getFullYear()}-${String(endDate.getMonth() + 1).padStart(2, '0')}-${String(endDate.getDate()).padStart(2, '0')}T${String(endDate.getHours()).padStart(2, '0')}:${String(endDate.getMinutes()).padStart(2, '0')}:${String(endDate.getSeconds()).padStart(2, '0')}`;
-      } else {
-        vlogsParams.startTime = new Date(startTime).toISOString();
-        vlogsParams.endTime = new Date(endTime).toISOString();
-      }
+    if (startTime !== undefined && endTime !== undefined) {
+      vlogsParams.startTime = toVlogsQueryTime(startTime);
+      vlogsParams.endTime = toVlogsQueryTime(endTime);
     } else {
       vlogsParams.time = timeRange;
     }

--- a/frontend/providers/dbprovider/src/pages/api/vlogs/database-logs.ts
+++ b/frontend/providers/dbprovider/src/pages/api/vlogs/database-logs.ts
@@ -1,13 +1,8 @@
 import { jsonRes } from '@/services/backend/response';
 import { ApiResp } from '@/services/kubernet';
 import { VLOGS_CONFIG } from '@/config/vlogs';
+import { toVlogsQueryTime } from '@/utils/vlogsTime';
 import type { NextApiRequest, NextApiResponse } from 'next';
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
   try {
@@ -20,8 +15,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       endTime,
       timeRange = '1h',
       keyword = '',
-      pageSize = 100,
-      timeZone = 'local'
+      pageSize = 100
     } = req.body;
 
     if (!namespace || !pvc || !containers || !type) {
@@ -64,17 +58,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       app: ''
     };
 
-    if (startTime && endTime) {
-      if (timeZone === 'local') {
-        vlogsParams.startTime = dayjs(startTime).format('YYYY-MM-DDTHH:mm:ss');
-        vlogsParams.endTime = dayjs(endTime).format('YYYY-MM-DDTHH:mm:ss');
-      } else if (timeZone && timeZone !== 'utc') {
-        vlogsParams.startTime = dayjs(startTime).tz(timeZone).toISOString();
-        vlogsParams.endTime = dayjs(endTime).tz(timeZone).toISOString();
-      } else {
-        vlogsParams.startTime = dayjs(startTime).utc().toISOString();
-        vlogsParams.endTime = dayjs(endTime).utc().toISOString();
-      }
+    if (startTime !== undefined && endTime !== undefined) {
+      vlogsParams.startTime = toVlogsQueryTime(startTime);
+      vlogsParams.endTime = toVlogsQueryTime(endTime);
     } else {
       vlogsParams.time = timeRange;
     }

--- a/frontend/providers/dbprovider/src/pages/api/vlogs/database-pods.ts
+++ b/frontend/providers/dbprovider/src/pages/api/vlogs/database-pods.ts
@@ -4,6 +4,7 @@ import { authSession } from '@/services/backend/auth';
 import { getK8s } from '@/services/backend/kubernetes';
 import { SupportReconfigureDBType } from '@/types/db';
 import { VLOGS_CONFIG } from '@/config/vlogs';
+import { toVlogsQueryTime } from '@/utils/vlogsTime';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 interface VlogsPodQueryParams {
@@ -17,7 +18,7 @@ interface VlogsPodQueryParams {
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResp>) {
   try {
-    const { dbName, dbType, startTime, endTime, timeRange = '30d', timeZone = 'local' } = req.body;
+    const { dbName, dbType, startTime, endTime, timeRange = '30d' } = req.body;
 
     if (!dbName || !dbType) {
       throw new Error('Missing required parameters: dbName, dbType');
@@ -76,18 +77,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       podQuery: 'true'
     };
 
-    if (startTime && endTime) {
-      // 如果选择的是本地时区，直接使用本地时间字符串而不是UTC时间
-      if (timeZone === 'local') {
-        const startDate = new Date(startTime);
-        const endDate = new Date(endTime);
-        // 格式化为本地时间字符串: YYYY-MM-DDTHH:mm:ss
-        vlogsParams.startTime = `${startDate.getFullYear()}-${String(startDate.getMonth() + 1).padStart(2, '0')}-${String(startDate.getDate()).padStart(2, '0')}T${String(startDate.getHours()).padStart(2, '0')}:${String(startDate.getMinutes()).padStart(2, '0')}:${String(startDate.getSeconds()).padStart(2, '0')}`;
-        vlogsParams.endTime = `${endDate.getFullYear()}-${String(endDate.getMonth() + 1).padStart(2, '0')}-${String(endDate.getDate()).padStart(2, '0')}T${String(endDate.getHours()).padStart(2, '0')}:${String(endDate.getMinutes()).padStart(2, '0')}:${String(endDate.getSeconds()).padStart(2, '0')}`;
-      } else {
-        vlogsParams.startTime = new Date(startTime).toISOString();
-        vlogsParams.endTime = new Date(endTime).toISOString();
-      }
+    if (startTime !== undefined && endTime !== undefined) {
+      vlogsParams.startTime = toVlogsQueryTime(startTime);
+      vlogsParams.endTime = toVlogsQueryTime(endTime);
     } else {
       vlogsParams.time = timeRange;
     }

--- a/frontend/providers/dbprovider/src/pages/db/detail/components/ErrorLog/RunTimeLog.tsx
+++ b/frontend/providers/dbprovider/src/pages/db/detail/components/ErrorLog/RunTimeLog.tsx
@@ -65,7 +65,7 @@ export default function RunTimeLog({
   const theme = useTheme();
   const router = useRouter();
   const { intervalLoadPods, dbPods } = useDBStore();
-  const { startDateTime, endDateTime, timeZone } = useDateTimeStore();
+  const { startDateTime, endDateTime } = useDateTimeStore();
 
   const routeDbName = router.query.name as string;
 
@@ -125,8 +125,7 @@ export default function RunTimeLog({
         dbType: db.dbType as SupportReconfigureDBType,
         startTime: startDateTime.getTime(),
         endTime: endDateTime.getTime(),
-        timeRange: '30d',
-        timeZone
+        timeRange: '30d'
       };
 
       return await getVlogsDatabasePods(params);
@@ -153,8 +152,8 @@ export default function RunTimeLog({
         podName === ''
           ? dbPods[0]?.podName
           : Array.isArray(podName) && podName.length > 0
-          ? podName[0]
-          : undefined;
+            ? podName[0]
+            : undefined;
       if (!targetPodName) return [];
 
       return await getLogFiles({
@@ -243,8 +242,7 @@ export default function RunTimeLog({
         startTime: startDateTime.getTime(),
         endTime: endDateTime.getTime(),
         pageSize: logCount,
-        keyword: globalFilter || '',
-        timeZone
+        keyword: globalFilter || ''
       };
 
       console.log('RunTimeLog - getVlogsDatabaseLogs params:', {
@@ -375,8 +373,7 @@ export default function RunTimeLog({
         type: [logTypeStr],
         startTime: startDateTime.getTime(),
         endTime: endDateTime.getTime(),
-        keyword: globalFilter || '',
-        timeZone
+        keyword: globalFilter || ''
       };
 
       return await getVlogsDatabaseLogCounts(params);

--- a/frontend/providers/dbprovider/src/store/date.ts
+++ b/frontend/providers/dbprovider/src/store/date.ts
@@ -1,15 +1,13 @@
-import { subDays, subMinutes } from 'date-fns';
+import { subMinutes } from 'date-fns';
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 
 type DateTimeState = {
   startDateTime: Date;
   endDateTime: Date;
-  timeZone: 'local' | 'utc';
   refreshInterval: number;
   setStartDateTime: (time: Date) => void;
   setEndDateTime: (time: Date) => void;
-  setTimeZone: (timeZone: 'local' | 'utc') => void;
   setRefreshInterval: (val: number) => void;
 };
 
@@ -17,11 +15,9 @@ const useDateTimeStore = create<DateTimeState>()(
   immer((set, get) => ({
     startDateTime: subMinutes(new Date(), 30),
     endDateTime: new Date(),
-    timeZone: 'local',
     refreshInterval: 0,
     setStartDateTime: (datetime) => set({ startDateTime: datetime }),
     setEndDateTime: (datetime) => set({ endDateTime: datetime }),
-    setTimeZone: (timeZone) => set({ timeZone }),
     setRefreshInterval: (val) => set({ refreshInterval: val })
   }))
 );

--- a/frontend/providers/dbprovider/src/utils/vlogsTime.ts
+++ b/frontend/providers/dbprovider/src/utils/vlogsTime.ts
@@ -1,0 +1,9 @@
+export function toVlogsQueryTime(value: string | number | Date): string {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new Error('Invalid log query timestamp');
+  }
+
+  return date.toISOString();
+}


### PR DESCRIPTION
<!--
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR,
because it will be placed in the release note.
-->

## Summary

Normalize log query timestamps to RFC3339 UTC across AppLaunchpad and DBProvider, and remove the obsolete local/UTC selector. Add focused timestamp serialization tests.

## Sequence Diagram

```mermaid
sequenceDiagram
    participant User
    participant UI
    participant API
    participant VLogs

    User->>UI: Select a log time range
    UI->>API: Send start/end epoch milliseconds
    API->>API: Convert timestamps to RFC3339 UTC
    API->>VLogs: Query logs with normalized bounds
    VLogs-->>API: Return log data
    API-->>UI: Render logs
    UI-->>User: Display the selected range
```

## Verification

- `pnpm exec tsc --noEmit --pretty false -p providers/applaunchpad/tsconfig.json`
- `pnpm --filter dbprovider exec tsc --noEmit --pretty false`
- `go test ./...` in `service/vlogs`
