### PR TITLE
fix(account): load admin JWT secret in legacy deployment

### DIFF
--- a/controllers/account/config/default/manager_auth_proxy_patch.yaml
+++ b/controllers/account/config/default/manager_auth_proxy_patch.yaml
@@ -50,6 +50,8 @@ spec:
           - secretRef:
               name: payment-secret
               optional: true
+          - secretRef:
+              name: account-admin-jwt
           - configMapRef:
               name: account-manager-env
         securityContext:


### PR DESCRIPTION
## Background

The legacy Kustomize deployment does not expose the dedicated admin JWT Secret to the account controller manager. As a result, deployments using this manifest cannot provide the `ACCOUNT_ADMIN_JWT_SECRET` required by the admin API authentication configuration.

## Changes

- Inject the `account-admin-jwt` Secret into the manager container through `envFrom`.
- Keep the existing `payment-secret` and `account-manager-env` sources unchanged.

## Risks / Notes

- The `account-admin-jwt` Secret must exist in the deployment namespace and contain the `ACCOUNT_ADMIN_JWT_SECRET` key.
- This PR changes deployment wiring only; Secret generation and lifecycle remain handled by the existing account controller deployment flow.
