### PR TITLE
fix(desktop): block admin kubeconfig access

### DIFF
--- a/frontend/desktop/src/__tests__/unit/backend/auth/kubeconfig-access.test.ts
+++ b/frontend/desktop/src/__tests__/unit/backend/auth/kubeconfig-access.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getUserKubeconfig,
+  getUserKubeconfigNotPatch,
+  isAdminKubeconfigUser,
+  KubeconfigAccessDeniedError
+} from '@/services/backend/kubernetes/admin';
+
+describe('kubeconfig access policy', () => {
+  it('identifies only the admin User CR as restricted', () => {
+    expect(isAdminKubeconfigUser('admin')).toBe(true);
+    expect(isAdminKubeconfigUser('ns-admin')).toBe(false);
+    expect(isAdminKubeconfigUser('workspace-user')).toBe(false);
+  });
+
+  it('rejects admin before reading an existing kubeconfig', async () => {
+    await expect(getUserKubeconfigNotPatch('admin')).rejects.toBeInstanceOf(
+      KubeconfigAccessDeniedError
+    );
+  });
+
+  it('rejects admin before creating or updating a User CR', async () => {
+    await expect(getUserKubeconfig('uid', 'admin', 'payg')).rejects.toBeInstanceOf(
+      KubeconfigAccessDeniedError
+    );
+  });
+});

--- a/frontend/desktop/src/__tests__/unit/backend/auth/rotateKubeconfig.api.test.ts
+++ b/frontend/desktop/src/__tests__/unit/backend/auth/rotateKubeconfig.api.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { verifyAccessToken, K8sApiDefault, isAdminKubeconfigUser } = vi.hoisted(() => ({
+  verifyAccessToken: vi.fn(),
+  K8sApiDefault: vi.fn(),
+  isAdminKubeconfigUser: vi.fn()
+}));
+
+vi.mock('@/services/backend/auth', () => ({ verifyAccessToken }));
+vi.mock('@/services/backend/kubernetes/admin', () => ({
+  K8sApiDefault,
+  isAdminKubeconfigUser
+}));
+
+import handler from '@/pages/api/auth/rotateKubeconfig';
+
+const createMockRes = () => {
+  const res: any = {
+    body: undefined,
+    json: vi.fn((payload: unknown) => {
+      res.body = payload;
+      return res;
+    })
+  };
+  return res;
+};
+
+describe('rotate kubeconfig api', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 403 for admin without touching the cluster API', async () => {
+    verifyAccessToken.mockResolvedValue({
+      userCrName: 'admin',
+      workspaceId: 'other-workspace'
+    });
+    isAdminKubeconfigUser.mockReturnValue(true);
+
+    const res = createMockRes();
+    await handler({ headers: {} } as any, res);
+
+    expect(res.body).toEqual({
+      code: 403,
+      message: 'Kubeconfig rotation is forbidden for admin users',
+      data: null
+    });
+    expect(K8sApiDefault).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/desktop/src/pages/api/auth/getDefaultKubeconfig.ts
+++ b/frontend/desktop/src/pages/api/auth/getDefaultKubeconfig.ts
@@ -2,7 +2,10 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { HttpStatusCode } from 'axios';
 import { verifyGlobalToken, verifyRegionalJwt } from '@/services/backend/auth';
 import { getRegionToken } from '@/services/backend/regionAuth';
-import { getUserKubeconfigNotPatch } from '@/services/backend/kubernetes/admin';
+import {
+  getUserKubeconfigNotPatch,
+  KubeconfigAccessDeniedError
+} from '@/services/backend/kubernetes/admin';
 import { jsonRes } from '@/services/backend/response';
 import { switchKubeconfigNamespace } from '@/utils/switchKubeconfigNamespace';
 import { AccessTokenPayload } from '@/types/token';
@@ -49,6 +52,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     });
   } catch (err) {
     console.log(err);
+    if (err instanceof KubeconfigAccessDeniedError) {
+      return jsonRes(res, {
+        code: err.statusCode,
+        message: err.message
+      });
+    }
     return jsonRes(res, {
       message: 'Failed to get default kubeconfig',
       code: HttpStatusCode.InternalServerError

--- a/frontend/desktop/src/pages/api/auth/getKubeconfig.ts
+++ b/frontend/desktop/src/pages/api/auth/getKubeconfig.ts
@@ -1,6 +1,9 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { jsonRes } from '@/services/backend/response';
-import { getUserKubeconfigNotPatch } from '@/services/backend/kubernetes/admin';
+import {
+  getUserKubeconfigNotPatch,
+  KubeconfigAccessDeniedError
+} from '@/services/backend/kubernetes/admin';
 import { verifyAccessToken, verifyAppToken } from '@/services/backend/auth';
 
 import { switchKubeconfigNamespace } from '@/utils/switchKubeconfigNamespace';
@@ -26,6 +29,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     });
   } catch (err) {
     console.log(err);
+    if (err instanceof KubeconfigAccessDeniedError) {
+      return jsonRes(res, {
+        code: err.statusCode,
+        message: err.message
+      });
+    }
     return jsonRes(res, {
       message: 'Failed to get kubeconfig',
       code: 500

--- a/frontend/desktop/src/pages/api/auth/rotateKubeconfig.ts
+++ b/frontend/desktop/src/pages/api/auth/rotateKubeconfig.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { jsonRes } from '@/services/backend/response';
 import { verifyAccessToken } from '@/services/backend/auth';
-import { K8sApiDefault } from '@/services/backend/kubernetes/admin';
+import { isAdminKubeconfigUser, K8sApiDefault } from '@/services/backend/kubernetes/admin';
 import * as k8s from '@kubernetes/client-node';
 import { k8sRFC3339Time } from '@/utils/format';
 import { switchKubeconfigNamespace } from '@/utils/switchKubeconfigNamespace';
@@ -13,6 +13,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return jsonRes(res, {
         code: 401,
         message: 'invalid token'
+      });
+    }
+
+    if (isAdminKubeconfigUser(regionUser.userCrName)) {
+      return jsonRes(res, {
+        code: 403,
+        message: 'Kubeconfig rotation is forbidden for admin users'
       });
     }
 

--- a/frontend/desktop/src/services/backend/kubernetes/admin.ts
+++ b/frontend/desktop/src/services/backend/kubernetes/admin.ts
@@ -9,6 +9,25 @@ export function K8sApiDefault(): k8s.KubeConfig {
   return kc;
 }
 
+export const ADMIN_USER_CR_NAME = 'admin';
+
+export class KubeconfigAccessDeniedError extends Error {
+  readonly statusCode = 403;
+
+  constructor(userCrName: string) {
+    super('Kubeconfig access is forbidden for user ' + userCrName);
+    this.name = 'KubeconfigAccessDeniedError';
+  }
+}
+
+export const isAdminKubeconfigUser = (userCrName: string) => userCrName === ADMIN_USER_CR_NAME;
+
+const assertKubeconfigAccess = (userCrName: string) => {
+  if (isAdminKubeconfigUser(userCrName)) {
+    throw new KubeconfigAccessDeniedError(userCrName);
+  }
+};
+
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
@@ -287,6 +306,7 @@ export const getUserCr = async (kc: KubeConfig, name: string) => {
 };
 // for enter user state
 export const getUserKubeconfigNotPatch = async (name: string) => {
+  assertKubeconfigAccess(name);
   const kc = K8sApiDefault();
   try {
     const userCr = await getUserCr(kc, name);
@@ -302,6 +322,7 @@ export const getUserKubeconfig = async (
   k8s_username: string,
   userType: 'subscription' | 'payg'
 ) => {
+  assertKubeconfigAccess(k8s_username);
   const kc = K8sApiDefault();
   const group = 'user.sealos.io';
   const version = 'v1';

--- a/frontend/desktop/src/services/backend/middleware/error.ts
+++ b/frontend/desktop/src/services/backend/middleware/error.ts
@@ -9,9 +9,16 @@ export const ErrorHandler =
       await handler(req, res);
     } catch (error) {
       console.log(error);
+      const statusCode =
+        error &&
+        typeof error === 'object' &&
+        'statusCode' in error &&
+        typeof error.statusCode === 'number'
+          ? error.statusCode
+          : 500;
       jsonRes(res, {
         message,
-        code: 500
+        code: statusCode
       });
     }
   };


### PR DESCRIPTION
## Summary

- Block kubeconfig get and rotation for the privileged Kubernetes User CR named `admin`.
- Cover global JWT, regional/app token, login initialization, and rotate paths.
- Preserve HTTP 403 for this denied access and add regression tests.

## Validation

- Targeted Vitest: 4/4 passed.
- Full desktop test suite: 128 passed, 2 todo; one existing suite is blocked by missing unbuilt internal packages such as `@sealos/shared`.
- TypeScript and repository test scripts are likewise affected by pre-existing missing internal packages/errors.

## Risk

This prevents the cluster-level `admin` identity from obtaining or rotating kubeconfig through the desktop APIs, while `ns-admin` is not used as the identity check.