### PR TITLE
fix(account): expose startup and readiness probes

### DIFF
--- a/controllers/account/Makefile
+++ b/controllers/account/Makefile
@@ -63,7 +63,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 
 .PHONY: build
 build:  ## Build manager binary.
-	LD_FLAGS="-s -w" && CGO_ENABLED=0 GOOS=linux go build -ldflags "$${LD_FLAGS}" -trimpath -o bin/manager main.go
+	LD_FLAGS="-s -w" && CGO_ENABLED=0 GOOS=linux go build -ldflags "$${LD_FLAGS}" -trimpath -o bin/manager .
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.

--- a/controllers/account/config/manager/manager.yaml
+++ b/controllers/account/config/manager/manager.yaml
@@ -64,7 +64,7 @@ spec:
           periodSeconds: 10
         startupProbe:
           httpGet:
-            path: /healthz
+            path: /startupz
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/controllers/account/config/manager/manager.yaml
+++ b/controllers/account/config/manager/manager.yaml
@@ -62,6 +62,14 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 2
+          failureThreshold: 60
         # TODO(user): Configure the resources accordingly based on the project requirements.
         # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:

--- a/controllers/account/deploy/charts/account-controller/templates/deployment.yaml
+++ b/controllers/account/deploy/charts/account-controller/templates/deployment.yaml
@@ -84,6 +84,8 @@ spec:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/controllers/account/deploy/charts/account-controller/values.yaml
+++ b/controllers/account/deploy/charts/account-controller/values.yaml
@@ -93,7 +93,7 @@ readinessProbe:
 
 startupProbe:
   httpGet:
-    path: /healthz
+    path: /startupz
     port: 8081
   initialDelaySeconds: 5
   periodSeconds: 5

--- a/controllers/account/deploy/charts/account-controller/values.yaml
+++ b/controllers/account/deploy/charts/account-controller/values.yaml
@@ -91,6 +91,15 @@ readinessProbe:
   initialDelaySeconds: 5
   periodSeconds: 10
 
+startupProbe:
+  httpGet:
+    path: /healthz
+    port: 8081
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 2
+  failureThreshold: 60
+
 metrics:
   ## To enable this parameter, it needs to be enabled in the subsequent code; otherwise, it cannot be started
   enabled: false

--- a/controllers/account/main.go
+++ b/controllers/account/main.go
@@ -424,6 +424,9 @@ func main() {
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		if !mgr.GetCache().WaitForCacheSync(ctx) {
+			return nil
+		}
 		probeState.markReady()
 		<-ctx.Done()
 		return nil

--- a/controllers/account/main.go
+++ b/controllers/account/main.go
@@ -46,8 +46,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
@@ -136,6 +136,12 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	ctx := ctrl.SetupSignalHandler()
+	probeState := &probeState{}
+	if err := startProbeServer(ctx, probeAddr, probeState); err != nil {
+		setupLog.Error(err, "unable to start probe server")
+		os.Exit(1)
+	}
 	// local test env
 	// err := godotenv.Load()
 	// if err != nil {
@@ -149,7 +155,9 @@ func main() {
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
 		},
-		HealthProbeBindAddress: probeAddr,
+		// Probes are served by the standalone server started before the expensive
+		// dependency and controller initialization below.
+		HealthProbeBindAddress: "0",
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "a63686c3.sealos.io",
 		LeaseDuration:          &leaseDuration,
@@ -175,7 +183,7 @@ func main() {
 		MaxConcurrentReconciles: concurrent,
 		RateLimiter:             utils.GetRateLimiter(rateLimiterOptions),
 	}
-	dbCtx, ctx := context.Background(), context.Background()
+	dbCtx := context.Background()
 	dbClient, err := mongo.NewMongoInterface(dbCtx, os.Getenv(database.MongoURI))
 	if err != nil {
 		setupLog.Error(err, "unable to connect to mongo")
@@ -415,12 +423,12 @@ func main() {
 
 	//+kubebuilder:scaffold:builder
 
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up health check")
-		os.Exit(1)
-	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up ready check")
+	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		probeState.markReady()
+		<-ctx.Done()
+		return nil
+	})); err != nil {
+		setupLog.Error(err, "unable to set up readiness marker")
 		os.Exit(1)
 	}
 
@@ -451,8 +459,9 @@ func main() {
 	//	}
 	// }()
 
+	probeState.markStartupReady()
 	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "fail to run manager")
 		os.Exit(1)
 	}

--- a/controllers/account/main.go
+++ b/controllers/account/main.go
@@ -57,6 +57,16 @@ var (
 	setupLog = ctrl.Log.WithName("setup")
 )
 
+type readinessRunnable struct {
+	manager.RunnableFunc
+}
+
+func (readinessRunnable) NeedLeaderElection() bool {
+	return false
+}
+
+var _ manager.LeaderElectionRunnable = readinessRunnable{}
+
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
@@ -423,14 +433,16 @@ func main() {
 
 	//+kubebuilder:scaffold:builder
 
-	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
-		if !mgr.GetCache().WaitForCacheSync(ctx) {
+	if err := mgr.Add(readinessRunnable{
+		RunnableFunc: manager.RunnableFunc(func(ctx context.Context) error {
+			if !mgr.GetCache().WaitForCacheSync(ctx) {
+				return nil
+			}
+			probeState.markReady()
+			<-ctx.Done()
 			return nil
-		}
-		probeState.markReady()
-		<-ctx.Done()
-		return nil
-	})); err != nil {
+		}),
+	}); err != nil {
 		setupLog.Error(err, "unable to set up readiness marker")
 		os.Exit(1)
 	}

--- a/controllers/account/probe.go
+++ b/controllers/account/probe.go
@@ -57,7 +57,7 @@ func startProbeServer(ctx context.Context, addr string, state *probeState) error
 		return nil
 	}
 
-	listener, err := net.Listen("tcp", addr)
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", addr)
 	if err != nil {
 		return err
 	}
@@ -69,7 +69,7 @@ func startProbeServer(ctx context.Context, addr string, state *probeState) error
 
 	go func() {
 		<-ctx.Done()
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 		defer cancel()
 		if err := server.Shutdown(shutdownCtx); err != nil {
 			setupLog.Error(err, "unable to shut down probe server")

--- a/controllers/account/probe.go
+++ b/controllers/account/probe.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	probeHealthPath  = "/healthz"
+	probeStartupPath = "/startupz"
+	probeReadyPath   = "/readyz"
+)
+
+type probeState struct {
+	startup atomic.Bool
+	ready   atomic.Bool
+}
+
+func (s *probeState) markStartupReady() {
+	s.startup.Store(true)
+}
+
+func (s *probeState) markReady() {
+	s.ready.Store(true)
+}
+
+func newProbeHandler(state *probeState) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc(probeHealthPath, func(w http.ResponseWriter, _ *http.Request) {
+		writeProbeResponse(w, true)
+	})
+	mux.HandleFunc(probeStartupPath, func(w http.ResponseWriter, _ *http.Request) {
+		writeProbeResponse(w, state.startup.Load())
+	})
+	mux.HandleFunc(probeReadyPath, func(w http.ResponseWriter, _ *http.Request) {
+		writeProbeResponse(w, state.ready.Load())
+	})
+	return mux
+}
+
+func writeProbeResponse(w http.ResponseWriter, ready bool) {
+	if !ready {
+		http.Error(w, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok\n"))
+}
+
+func startProbeServer(ctx context.Context, addr string, state *probeState) error {
+	if addr == "" || addr == "0" {
+		return nil
+	}
+
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+
+	server := &http.Server{
+		Handler:           newProbeHandler(state),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			setupLog.Error(err, "unable to shut down probe server")
+		}
+	}()
+
+	go func() {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			setupLog.Error(err, "probe server stopped unexpectedly")
+		}
+	}()
+
+	return nil
+}

--- a/controllers/account/probe_test.go
+++ b/controllers/account/probe_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -16,8 +17,16 @@ func TestProbeHandler(t *testing.T) {
 		want int
 	}{
 		{name: "health before initialization", path: probeHealthPath, want: http.StatusOK},
-		{name: "startup before initialization", path: probeStartupPath, want: http.StatusServiceUnavailable},
-		{name: "ready before cache sync", path: probeReadyPath, want: http.StatusServiceUnavailable},
+		{
+			name: "startup before initialization",
+			path: probeStartupPath,
+			want: http.StatusServiceUnavailable,
+		},
+		{
+			name: "ready before cache sync",
+			path: probeReadyPath,
+			want: http.StatusServiceUnavailable,
+		},
 	}
 	assertProbeStatuses(t, handler, tests)
 
@@ -29,7 +38,11 @@ func TestProbeHandler(t *testing.T) {
 	}{
 		{name: "health after initialization", path: probeHealthPath, want: http.StatusOK},
 		{name: "startup after initialization", path: probeStartupPath, want: http.StatusOK},
-		{name: "ready before cache sync", path: probeReadyPath, want: http.StatusServiceUnavailable},
+		{
+			name: "ready before cache sync",
+			path: probeReadyPath,
+			want: http.StatusServiceUnavailable,
+		},
 	})
 
 	state.markReady()
@@ -48,12 +61,18 @@ func assertProbeStatuses(t *testing.T, handler http.Handler, tests []struct {
 	name string
 	path string
 	want int
-}) {
+},
+) {
 	t.Helper()
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			request := httptest.NewRequest(http.MethodGet, test.path, nil)
+			request := httptest.NewRequestWithContext(
+				context.Background(),
+				http.MethodGet,
+				test.path,
+				nil,
+			)
 			response := httptest.NewRecorder()
 			handler.ServeHTTP(response, request)
 

--- a/controllers/account/probe_test.go
+++ b/controllers/account/probe_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestProbeHandler(t *testing.T) {
+	state := &probeState{}
+	handler := newProbeHandler(state)
+
+	tests := []struct {
+		name string
+		path string
+		want int
+	}{
+		{name: "health before initialization", path: probeHealthPath, want: http.StatusOK},
+		{name: "startup before initialization", path: probeStartupPath, want: http.StatusServiceUnavailable},
+		{name: "ready before cache sync", path: probeReadyPath, want: http.StatusServiceUnavailable},
+	}
+	assertProbeStatuses(t, handler, tests)
+
+	state.markStartupReady()
+	assertProbeStatuses(t, handler, []struct {
+		name string
+		path string
+		want int
+	}{
+		{name: "health after initialization", path: probeHealthPath, want: http.StatusOK},
+		{name: "startup after initialization", path: probeStartupPath, want: http.StatusOK},
+		{name: "ready before cache sync", path: probeReadyPath, want: http.StatusServiceUnavailable},
+	})
+
+	state.markReady()
+	assertProbeStatuses(t, handler, []struct {
+		name string
+		path string
+		want int
+	}{
+		{name: "health when ready", path: probeHealthPath, want: http.StatusOK},
+		{name: "startup when ready", path: probeStartupPath, want: http.StatusOK},
+		{name: "ready after cache sync", path: probeReadyPath, want: http.StatusOK},
+	})
+}
+
+func assertProbeStatuses(t *testing.T, handler http.Handler, tests []struct {
+	name string
+	path string
+	want int
+}) {
+	t.Helper()
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, test.path, nil)
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+
+			if response.Code != test.want {
+				t.Fatalf("GET %s returned status %d, want %d", test.path, response.Code, test.want)
+			}
+		})
+	}
+}

--- a/controllers/account/probe_test.go
+++ b/controllers/account/probe_test.go
@@ -52,6 +52,7 @@ func assertProbeStatuses(t *testing.T, handler http.Handler, tests []struct {
 	t.Helper()
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			request := httptest.NewRequest(http.MethodGet, test.path, nil)
 			response := httptest.NewRecorder()

--- a/controllers/account/probe_test.go
+++ b/controllers/account/probe_test.go
@@ -52,7 +52,6 @@ func assertProbeStatuses(t *testing.T, handler http.Handler, tests []struct {
 	t.Helper()
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			request := httptest.NewRequest(http.MethodGet, test.path, nil)
 			response := httptest.NewRecorder()


### PR DESCRIPTION
## Background

The account controller can take a long time to initialize database clients, controllers, and background processors. Its health endpoints are currently registered only when the manager starts, so Kubernetes cannot distinguish slow startup from an unhealthy process and may repeatedly restart the pod.

## Changes

- Serve `/healthz`, `/startupz`, and `/readyz` from a standalone probe server before expensive initialization begins.
- Keep liveness available while startup is in progress.
- Report startup success after dependency and controller registration completes.
- Report readiness after the controller-runtime manager has started its cache and leader runnables.
- Configure the deployment manifests to use `/startupz` for the startup probe.
- Add endpoint state transition tests.

## Risks / Notes

The probe server binds the configured health-probe address, so the controller-runtime health probe listener is disabled to avoid a port conflict.
