### PR TITLE
fix(account): prevent stale webhook balance cache from being renewed

### DIFF
--- a/controllers/pkg/utils/maps/ttl_map.go
+++ b/controllers/pkg/utils/maps/ttl_map.go
@@ -6,22 +6,26 @@ import (
 )
 
 type item[T any] struct {
-	value      T
-	lastAccess int64
+	value     T
+	expiresAt int64
 }
 
 type TTLMap[T any] struct {
-	m map[string]*item[T]
-	l sync.RWMutex
+	m   map[string]*item[T]
+	l   sync.RWMutex
+	ttl time.Duration
 }
 
 func New[T any](maxTTL int) (m *TTLMap[T]) {
-	m = &TTLMap[T]{m: make(map[string]*item[T])}
+	m = &TTLMap[T]{
+		m:   make(map[string]*item[T]),
+		ttl: time.Duration(maxTTL) * time.Second,
+	}
 	go func() {
 		for now := range time.Tick(2 * time.Second) {
 			m.l.Lock()
 			for k, v := range m.m {
-				if now.Unix()-v.lastAccess > int64(maxTTL) {
+				if now.UnixNano() >= v.expiresAt {
 					delete(m.m, k)
 				}
 			}
@@ -32,24 +36,26 @@ func New[T any](maxTTL int) (m *TTLMap[T]) {
 }
 
 func (m *TTLMap[T]) Len() int {
+	m.l.RLock()
+	defer m.l.RUnlock()
 	return len(m.m)
 }
 
 func (m *TTLMap[T]) Put(k string, v T) {
 	m.l.Lock()
 	defer m.l.Unlock()
-	it := &item[T]{value: v}
-	it.lastAccess = time.Now().Unix()
-	m.m[k] = it
+	m.m[k] = &item[T]{
+		value:     v,
+		expiresAt: time.Now().Add(m.ttl).UnixNano(),
+	}
 }
 
 func (m *TTLMap[T]) Get(k string) (v T, ok bool) {
 	m.l.RLock()
 	defer m.l.RUnlock()
 	it, ok := m.m[k]
-	if ok {
-		v = it.value
-		it.lastAccess = time.Now().Unix()
+	if !ok || time.Now().UnixNano() >= it.expiresAt {
+		return v, false
 	}
-	return v, ok
+	return it.value, true
 }

--- a/controllers/pkg/utils/maps/ttl_map_test.go
+++ b/controllers/pkg/utils/maps/ttl_map_test.go
@@ -93,11 +93,11 @@ func TestTTLExpiration(t *testing.T) {
 		}(i)
 	}
 
-	// Wait a bit less than TTL to ensure some reads keep items alive
+	// Wait less than TTL so entries remain available.
 	time.Sleep(500 * time.Millisecond)
 	wg.Wait()
 
-	// Verify length is still significant due to recent accesses
+	// Verify entries remain before their fixed expiration time.
 	if l := m.Len(); l < numOps/2 {
 		t.Errorf("Len() = %d; want at least %d after partial expiration", l, numOps/2)
 	}
@@ -163,25 +163,19 @@ func TestConcurrentAccess(t *testing.T) {
 	}
 }
 
-func TestLastAccessUpdate(t *testing.T) {
-	m := New[string](2) // 2 second TTL
+func TestGetDoesNotExtendTTL(t *testing.T) {
+	m := New[string](1)
+	m.Put("key1", "value1")
 
-	// Put a value
-	m.Put("key1", "TestLastAccessUpdatevalue1")
-
-	// Get it multiple times to update lastAccess
-	for i := range 3 {
-		time.Sleep(500 * time.Millisecond)
-		if v, _ := m.Get("key1"); v != "TestLastAccessUpdatevalue1" {
-			t.Errorf("Get(key1) = %v; want value1 at iteration %d", v, i)
+	for i := range 2 {
+		time.Sleep(400 * time.Millisecond)
+		if value, ok := m.Get("key1"); !ok || value != "value1" {
+			t.Fatalf("Get(key1) = (%q, %v), want (value1, true) at iteration %d", value, ok, i)
 		}
 	}
 
-	// Wait less than TTL
-	time.Sleep(1500 * time.Millisecond)
-
-	// Verify it's still there due to updated lastAccess
-	if v, _ := m.Get("key1"); v != "value1" {
-		t.Errorf("Get(key1) = %v; want value1 after access updates", v)
+	time.Sleep(400 * time.Millisecond)
+	if value, ok := m.Get("key1"); ok {
+		t.Fatalf("Get(key1) = (%q, true), want expired entry", value)
 	}
 }


### PR DESCRIPTION
## What changed

- expire cached account balances at a fixed deadline calculated when they are inserted
- stop extending an entry lifetime on every webhook cache hit
- avoid mutating cache entries under a read lock and protect `Len` with the read lock
- cover repeated reads across the expiration boundary

## Why

The debt admission webhook caches account balances. A negative balance cached before recharge was using sliding expiration, so repeated admission requests within the TTL continuously renewed the stale value. This could keep rejecting workloads after the account had been recharged.

## Testing

- `go test ./utils/maps -count=1`
- `go test -race ./utils/maps -count=1`
- `go test ./api/v1 -count=1`