### PR TITLE
fix(account): prevent consumption amount double counting

### DIFF
--- a/service/account/dao/consumption_test.go
+++ b/service/account/dao/consumption_test.go
@@ -23,12 +23,17 @@ func consumptionRequest() helper.ConsumptionRecordReq {
 
 func TestBuildConsumptionAmountPipeline(t *testing.T) {
 	tests := []struct {
-		name    string
-		request helper.ConsumptionRecordReq
+		name       string
+		request    helper.ConsumptionRecordReq
+		stageCount int
+		projectAt  int
+		groupAt    int
 	}{
 		{
-			name:    "all consumption",
-			request: consumptionRequest(),
+			name:       "all consumption",
+			request:    consumptionRequest(),
+			stageCount: 2,
+			groupAt:    1,
 		},
 		{
 			name: "namespace and app filters",
@@ -39,28 +44,31 @@ func TestBuildConsumptionAmountPipeline(t *testing.T) {
 				req.AppName = "app-test"
 				return req
 			}(),
+			stageCount: 4,
+			projectAt:  1,
+			groupAt:    3,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			pipeline := buildConsumptionAmountPipeline(test.request)
-			if len(pipeline) != 3 {
-				t.Fatalf("pipeline stage count = %d, want 3", len(pipeline))
+			if len(pipeline) != test.stageCount {
+				t.Fatalf("pipeline stage count = %d, want %d", len(pipeline), test.stageCount)
 			}
 			if !hasConsumptionStage(pipeline[0], "$match") {
 				t.Fatal("pipeline does not start with $match")
 			}
-			if !hasConsumptionStage(pipeline[1], "$project") {
-				t.Fatal("pipeline does not project one amount per billing record")
+			if test.projectAt > 0 {
+				if !hasConsumptionStage(pipeline[test.projectAt], "$project") {
+					t.Fatal("pipeline does not project one amount per billing record")
+				}
+				if hasConsumptionStage(pipeline[test.projectAt], "$facet") ||
+					hasConsumptionStage(pipeline[test.projectAt], "$unwind") {
+					t.Fatal("pipeline should not use $facet or $unwind")
+				}
 			}
-			if hasConsumptionStage(pipeline[1], "$facet") {
-				t.Fatal("pipeline should not use $facet")
-			}
-			if hasConsumptionStage(pipeline[1], "$unwind") {
-				t.Fatal("pipeline should not use $unwind")
-			}
-			if !hasConsumptionStage(pipeline[2], "$group") {
+			if !hasConsumptionStage(pipeline[test.groupAt], "$group") {
 				t.Fatal("pipeline does not end with $group")
 			}
 		})

--- a/service/account/dao/interface.go
+++ b/service/account/dao/interface.go
@@ -2213,6 +2213,47 @@ func (m *Account) Disconnect(ctx context.Context) error {
 }
 
 func buildConsumptionAmountPipeline(req helper.ConsumptionRecordReq) mongo.Pipeline {
+	// Example for a request with Owner="owner-123" and no AppName:
+	//
+	// db.billing.aggregate([
+	//   { $match: {
+	//     owner: "owner-123",
+	//     status: 1,
+	//     time: {
+	//       $gte: ISODate("2026-01-01T00:00:00Z"),
+	//       $lte: ISODate("2026-01-02T00:00:00Z")
+	//     }
+	//   } },
+	//   { $group: { _id: null, total: { $sum: "$amount" } } }
+	// ])
+	//
+	// Example for Owner="owner-123", AppType="APP" (app_type: 2),
+	// and AppName="app-a":
+	//
+	// db.billing.aggregate([
+	//   { $match: {
+	//     owner: "owner-123",
+	//     status: 1,
+	//     app_type: 2,
+	//     time: {
+	//       $gte: ISODate("2026-01-01T00:00:00Z"),
+	//       $lte: ISODate("2026-01-02T00:00:00Z")
+	//     }
+	//   } },
+	//   { $project: {
+	//     amount: { $sum: { $map: {
+	//       input: { $filter: {
+	//         input: { $ifNull: ["$app_costs", []] },
+	//         as: "appCost",
+	//         cond: { $eq: ["$$appCost.name", "app-a"] }
+	//       } },
+	//       as: "appCost",
+	//       in: "$$appCost.amount"
+	//     } } }
+	//   } },
+	//   { $match: { amount: { $gt: 0 } } },
+	//   { $group: { _id: null, total: { $sum: "$amount" } } }
+	// ])
 	appType := strings.ToUpper(strings.TrimSpace(req.AppType))
 	timeMatchValue := bson.D{
 		primitive.E{Key: "$gte", Value: req.StartTime},

--- a/service/account/dao/interface.go
+++ b/service/account/dao/interface.go
@@ -2234,6 +2234,7 @@ func buildConsumptionAmountPipeline(req helper.ConsumptionRecordReq) mongo.Pipel
 	}
 
 	pipeline := mongo.Pipeline{
+		// Owner is part of the match so the total never includes another workspace.
 		{{Key: "$match", Value: matchValue}},
 	}
 
@@ -2242,15 +2243,21 @@ func buildConsumptionAmountPipeline(req helper.ConsumptionRecordReq) mongo.Pipel
 		{Key: "total", Value: bson.D{{Key: "$sum", Value: "$amount"}}},
 	}}}
 	// Billing.Amount is the authoritative total for a billing record. Avoid
-	// inspecting app_costs unless the caller needs an app-level filter.
+	// inspecting app_costs unless the caller needs an app-level filter; this
+	// keeps the common all-app query to just match and group stages.
 	if req.AppName == "" {
 		return append(pipeline, groupStage)
 	}
 
+	// Direct types store their billable amount on the parent record. The
+	// app_costs array is only a breakdown for these records and must not be
+	// added to amount again.
 	directAppTypes := bson.A{
 		resources.AppType[resources.AppStore],
 		resources.AppType[resources.LLMToken],
 	}
+	// Ordinary resource types are billed through app_costs when an app name is
+	// requested, so only entries with the requested name contribute to the sum.
 	matchedNestedAmount := bson.M{
 		"$sum": bson.M{
 			"$map": bson.M{
@@ -2270,6 +2277,7 @@ func buildConsumptionAmountPipeline(req helper.ConsumptionRecordReq) mongo.Pipel
 	}
 	pipeline = append(
 		pipeline,
+		// Select exactly one amount source per billing record to avoid double counting.
 		bson.D{{Key: "$project", Value: bson.D{
 			{Key: "amount", Value: bson.D{{Key: "$cond", Value: bson.A{
 				bson.D{{Key: "$in", Value: bson.A{"$app_type", directAppTypes}}},
@@ -2281,6 +2289,8 @@ func buildConsumptionAmountPipeline(req helper.ConsumptionRecordReq) mongo.Pipel
 				matchedNestedAmount,
 			}}}},
 		}}},
+		// The projection emits zero for non-matching app records; discard them
+		// before the final total is calculated.
 		bson.D{{Key: "$match", Value: bson.D{
 			{Key: "amount", Value: bson.D{{Key: "$gt", Value: int64(0)}}},
 		}}},

--- a/service/account/dao/interface.go
+++ b/service/account/dao/interface.go
@@ -2233,83 +2233,60 @@ func buildConsumptionAmountPipeline(req helper.ConsumptionRecordReq) mongo.Pipel
 		)
 	}
 
-	appCostsInput := bson.M{"$ifNull": bson.A{"$app_costs", bson.A{}}}
-	appCostsAmount := bson.M{
-		"$reduce": bson.M{
-			"input":        appCostsInput,
-			"initialValue": int64(0),
-			"in": bson.M{"$add": bson.A{
-				"$$value",
-				bson.M{"$ifNull": bson.A{"$$this.amount", int64(0)}},
-			}},
-		},
-	}
-
-	// Preserve the legacy app_costs matching semantics while avoiding $unwind.
-	nestedAmount := any(appCostsAmount)
-	if appType != "" && req.AppName != "" {
-		if appType != resources.AppStore {
-			filteredAppCosts := bson.M{
-				"$filter": bson.M{
-					"input": appCostsInput,
-					"as":    "appCost",
-					"cond":  bson.M{"$eq": bson.A{"$$appCost.name", req.AppName}},
-				},
-			}
-			nestedAmount = bson.M{
-				"$reduce": bson.M{
-					"input":        filteredAppCosts,
-					"initialValue": int64(0),
-					"in": bson.M{"$add": bson.A{
-						"$$value",
-						bson.M{"$ifNull": bson.A{"$$this.amount", int64(0)}},
-					}},
-				},
-			}
-		} else {
-			nestedAmount = bson.M{
-				"$cond": bson.A{
-					bson.M{"$eq": bson.A{"$app_name", req.AppName}},
-					appCostsAmount,
-					int64(0),
-				},
-			}
-		}
-	}
-
-	directCondition := any(bson.M{
-		"$in": bson.A{"$app_type", bson.A{
-			resources.AppType[resources.AppStore],
-			resources.AppType[resources.LLMToken],
-		}},
-	})
-	if appType != "" {
-		directCondition = appType == resources.AppStore || appType == resources.LLMToken
-	}
-	if req.AppName != "" {
-		directCondition = bson.M{"$and": bson.A{
-			directCondition,
-			bson.M{"$eq": bson.A{"$app_name", req.AppName}},
-		}}
-	}
-	directAmount := bson.M{
-		"$cond": bson.A{
-			directCondition,
-			bson.M{"$ifNull": bson.A{"$amount", int64(0)}},
-			int64(0),
-		},
-	}
-
-	return mongo.Pipeline{
+	pipeline := mongo.Pipeline{
 		{{Key: "$match", Value: matchValue}},
-		{{Key: "$project", Value: bson.D{
-			{Key: "amount", Value: bson.M{"$add": bson.A{nestedAmount, directAmount}}},
-		}}},
-		{{Key: "$group", Value: bson.D{
-			{Key: "_id", Value: nil},
-			{Key: "total", Value: bson.D{{Key: "$sum", Value: "$amount"}}},
-		}}},
 	}
+
+	groupStage := bson.D{{Key: "$group", Value: bson.D{
+		{Key: "_id", Value: nil},
+		{Key: "total", Value: bson.D{{Key: "$sum", Value: "$amount"}}},
+	}}}
+	// Billing.Amount is the authoritative total for a billing record. Avoid
+	// inspecting app_costs unless the caller needs an app-level filter.
+	if req.AppName == "" {
+		return append(pipeline, groupStage)
+	}
+
+	directAppTypes := bson.A{
+		resources.AppType[resources.AppStore],
+		resources.AppType[resources.LLMToken],
+	}
+	matchedNestedAmount := bson.M{
+		"$sum": bson.M{
+			"$map": bson.M{
+				"input": bson.M{
+					"$filter": bson.M{
+						"input": bson.M{"$ifNull": bson.A{"$app_costs", bson.A{}}},
+						"as":    "appCost",
+						"cond": bson.M{
+							"$eq": bson.A{"$$appCost.name", req.AppName},
+						},
+					},
+				},
+				"as": "appCost",
+				"in": "$$appCost.amount",
+			},
+		},
+	}
+	pipeline = append(
+		pipeline,
+		bson.D{{Key: "$project", Value: bson.D{
+			{Key: "amount", Value: bson.D{{Key: "$cond", Value: bson.A{
+				bson.D{{Key: "$in", Value: bson.A{"$app_type", directAppTypes}}},
+				bson.D{{Key: "$cond", Value: bson.A{
+					bson.D{{Key: "$eq", Value: bson.A{"$app_name", req.AppName}}},
+					"$amount",
+					int64(0),
+				}}},
+				matchedNestedAmount,
+			}}}},
+		}}},
+		bson.D{{Key: "$match", Value: bson.D{
+			{Key: "amount", Value: bson.D{{Key: "$gt", Value: int64(0)}}},
+		}}},
+		groupStage,
+	)
+	return pipeline
 }
 
 func (m *MongoDB) GetConsumptionAmount(req helper.ConsumptionRecordReq) (int64, error) {

--- a/service/account/dao/workspace_consumption_runtime_test.go
+++ b/service/account/dao/workspace_consumption_runtime_test.go
@@ -267,6 +267,12 @@ func TestGetConsumptionAmountWithMongoRuntime(t *testing.T) {
 			Amount: 40, Owner: workspaceConsumptionTestOwner, Status: resources.Settled,
 		},
 		resources.Billing{
+			Time: endTime, OrderID: "app-store-with-app-costs", Type: resources.Consumption,
+			Namespace: "ns-d", AppName: "store-b", AppType: resources.AppType[resources.AppStore],
+			AppCosts: []resources.AppCost{{Name: "store-b", Amount: 25}},
+			Amount:   25, Owner: workspaceConsumptionTestOwner, Status: resources.Settled,
+		},
+		resources.Billing{
 			Time: endTime, OrderID: "unsettled-consumption", Type: resources.Consumption,
 			Namespace: "ns-ignored", AppCosts: []resources.AppCost{{Name: "app-a", Amount: 1000}},
 			AppType: resources.AppType[resources.APP], Amount: 1000,
@@ -299,7 +305,7 @@ func TestGetConsumptionAmountWithMongoRuntime(t *testing.T) {
 		req  helper.ConsumptionRecordReq
 		want int64
 	}{
-		{name: "all settled consumption", req: baseRequest, want: 95},
+		{name: "all settled consumption", req: baseRequest, want: 185},
 		{
 			name: "namespace filter",
 			req: withWorkspaceConsumptionRequest(
@@ -308,7 +314,7 @@ func TestGetConsumptionAmountWithMongoRuntime(t *testing.T) {
 					req.Namespace = "ns-a"
 				},
 			),
-			want: 35,
+			want: 100,
 		},
 		{
 			name: "nested app type filter",
@@ -318,7 +324,7 @@ func TestGetConsumptionAmountWithMongoRuntime(t *testing.T) {
 					req.AppType = " app "
 				},
 			),
-			want: 35,
+			want: 100,
 		},
 		{
 			name: "nested app name filter",
@@ -339,7 +345,7 @@ func TestGetConsumptionAmountWithMongoRuntime(t *testing.T) {
 					req.AppName = "store-a"
 				},
 			),
-			want: 75,
+			want: 40,
 		},
 		{
 			name: "direct app type and name filter",
@@ -351,6 +357,16 @@ func TestGetConsumptionAmountWithMongoRuntime(t *testing.T) {
 				},
 			),
 			want: 40,
+		},
+		{
+			name: "direct app name with nested costs",
+			req: withWorkspaceConsumptionRequest(
+				baseRequest,
+				func(req *helper.ConsumptionRecordReq) {
+					req.AppName = "store-b"
+				},
+			),
+			want: 25,
 		},
 	}
 

--- a/service/account/dao/workspace_consumption_runtime_test.go
+++ b/service/account/dao/workspace_consumption_runtime_test.go
@@ -436,11 +436,17 @@ func anonymizedConsumptionBillingFixtures(startTime, endTime time.Time) []any {
 			Amount:    10000, Owner: "other-owner", Status: resources.Settled,
 		},
 		resources.Billing{
-			Time: endTime.Add(time.Hour), OrderID: "billing-outside-range", Type: resources.Consumption,
+			Time: endTime.Add(
+				time.Hour,
+			),
+			OrderID:   "billing-outside-range",
+			Type:      resources.Consumption,
 			Namespace: "workspace-consumption-test-namespace",
 			AppType:   resources.AppType[resources.APP],
 			AppCosts:  []resources.AppCost{{Name: "ignored-outside-range", Amount: 11000}},
-			Amount:    11000, Owner: workspaceConsumptionTestOwner, Status: resources.Settled,
+			Amount:    11000,
+			Owner:     workspaceConsumptionTestOwner,
+			Status:    resources.Settled,
 		},
 	}
 }

--- a/service/account/dao/workspace_consumption_runtime_test.go
+++ b/service/account/dao/workspace_consumption_runtime_test.go
@@ -246,52 +246,7 @@ func TestGetConsumptionAmountWithMongoRuntime(t *testing.T) {
 	mongoDB, ctx := newWorkspaceConsumptionMongo(t)
 	startTime := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
 	endTime := time.Date(2026, time.January, 2, 0, 0, 0, 0, time.UTC)
-	documents := []any{
-		resources.Billing{
-			Time: startTime, OrderID: "nested-consumption", Type: resources.Consumption,
-			Namespace: "ns-a", AppCosts: []resources.AppCost{
-				{Name: "app-a", Amount: 30},
-				{Name: "app-b", Amount: 5},
-			},
-			AppType: resources.AppType[resources.APP], Amount: 100,
-			Owner: workspaceConsumptionTestOwner, Status: resources.Settled,
-		},
-		resources.Billing{
-			Time: endTime, OrderID: "llm-consumption", Type: resources.SubConsumption,
-			Namespace: "ns-b", AppName: "llm-a", AppType: resources.AppType[resources.LLMToken],
-			Amount: 20, Owner: workspaceConsumptionTestOwner, Status: resources.Settled,
-		},
-		resources.Billing{
-			Time: endTime, OrderID: "app-store-consumption", Type: resources.Consumption,
-			Namespace: "ns-c", AppName: "store-a", AppType: resources.AppType[resources.AppStore],
-			Amount: 40, Owner: workspaceConsumptionTestOwner, Status: resources.Settled,
-		},
-		resources.Billing{
-			Time: endTime, OrderID: "app-store-with-app-costs", Type: resources.Consumption,
-			Namespace: "ns-d", AppName: "store-b", AppType: resources.AppType[resources.AppStore],
-			AppCosts: []resources.AppCost{{Name: "store-b", Amount: 25}},
-			Amount:   25, Owner: workspaceConsumptionTestOwner, Status: resources.Settled,
-		},
-		resources.Billing{
-			Time: endTime, OrderID: "unsettled-consumption", Type: resources.Consumption,
-			Namespace: "ns-ignored", AppCosts: []resources.AppCost{{Name: "app-a", Amount: 1000}},
-			AppType: resources.AppType[resources.APP], Amount: 1000,
-			Owner: workspaceConsumptionTestOwner, Status: resources.Unsettled,
-		},
-		resources.Billing{
-			Time: endTime, OrderID: "other-owner-consumption", Type: resources.Consumption,
-			Namespace: "ns-ignored", AppCosts: []resources.AppCost{{Name: "app-a", Amount: 2000}},
-			AppType: resources.AppType[resources.APP], Amount: 2000,
-			Owner: "other-owner", Status: resources.Settled,
-		},
-		resources.Billing{
-			Time:    endTime.Add(time.Hour),
-			OrderID: "outside-consumption", Type: resources.Consumption,
-			Namespace: "ns-ignored", AppCosts: []resources.AppCost{{Name: "app-a", Amount: 3000}},
-			AppType: resources.AppType[resources.APP], Amount: 3000,
-			Owner: workspaceConsumptionTestOwner, Status: resources.Settled,
-		},
-	}
+	documents := anonymizedConsumptionBillingFixtures(startTime, endTime)
 	if _, err := mongoDB.getBillingCollection().InsertMany(ctx, documents); err != nil {
 		t.Fatalf("insert billing fixtures: %v", err)
 	}
@@ -305,16 +260,16 @@ func TestGetConsumptionAmountWithMongoRuntime(t *testing.T) {
 		req  helper.ConsumptionRecordReq
 		want int64
 	}{
-		{name: "all settled consumption", req: baseRequest, want: 185},
+		{name: "all settled consumption", req: baseRequest, want: 804},
 		{
 			name: "namespace filter",
 			req: withWorkspaceConsumptionRequest(
 				baseRequest,
 				func(req *helper.ConsumptionRecordReq) {
-					req.Namespace = "ns-a"
+					req.Namespace = "workspace-consumption-test-namespace"
 				},
 			),
-			want: 100,
+			want: 804,
 		},
 		{
 			name: "nested app type filter",
@@ -324,28 +279,28 @@ func TestGetConsumptionAmountWithMongoRuntime(t *testing.T) {
 					req.AppType = " app "
 				},
 			),
-			want: 100,
+			want: 69,
 		},
 		{
-			name: "nested app name filter",
+			name: "nested resource name filter",
 			req: withWorkspaceConsumptionRequest(
 				baseRequest,
 				func(req *helper.ConsumptionRecordReq) {
-					req.AppType = resources.APP
-					req.AppName = "app-a"
+					req.AppType = resources.DB
+					req.AppName = "resource-db-primary"
 				},
 			),
-			want: 30,
+			want: 11,
 		},
 		{
 			name: "direct app name filter",
 			req: withWorkspaceConsumptionRequest(
 				baseRequest,
 				func(req *helper.ConsumptionRecordReq) {
-					req.AppName = "store-a"
+					req.AppName = "app-store-a"
 				},
 			),
-			want: 40,
+			want: 451,
 		},
 		{
 			name: "direct app type and name filter",
@@ -353,20 +308,20 @@ func TestGetConsumptionAmountWithMongoRuntime(t *testing.T) {
 				baseRequest,
 				func(req *helper.ConsumptionRecordReq) {
 					req.AppType = resources.AppStore
-					req.AppName = "store-a"
+					req.AppName = "app-store-a"
 				},
 			),
-			want: 40,
+			want: 451,
 		},
 		{
-			name: "direct app name with nested costs",
+			name: "direct app name with one nested cost",
 			req: withWorkspaceConsumptionRequest(
 				baseRequest,
 				func(req *helper.ConsumptionRecordReq) {
-					req.AppName = "store-b"
+					req.AppName = "app-store-b"
 				},
 			),
-			want: 25,
+			want: 17,
 		},
 	}
 
@@ -380,6 +335,113 @@ func TestGetConsumptionAmountWithMongoRuntime(t *testing.T) {
 				t.Fatalf("consumption amount = %d, want %d", got, test.want)
 			}
 		})
+	}
+}
+
+func anonymizedConsumptionBillingFixtures(startTime, endTime time.Time) []any {
+	// This reduced fixture keeps the shapes found in the exported records while
+	// replacing all identifiers, timestamps, and amounts with synthetic values.
+	// Ordinary resource records have no app_name and bill through app_costs;
+	// APP-STORE records have a parent app_name and a component breakdown.
+	return []any{
+		resources.Billing{
+			Time: startTime, OrderID: "billing-db", Type: resources.Consumption,
+			Namespace: "workspace-consumption-test-namespace",
+			AppType:   resources.AppType[resources.DB],
+			AppCosts: []resources.AppCost{
+				{Name: "resource-db-primary", Amount: 11},
+				{Name: "resource-db-secondary", Amount: 2},
+				{Name: "resource-db-cache", Amount: 2},
+				{Name: "resource-db-data", Amount: 36},
+				{Name: "resource-db-backup", Amount: 38},
+			},
+			Amount: 89, Owner: workspaceConsumptionTestOwner, Status: resources.Settled,
+		},
+		resources.Billing{
+			Time: startTime, OrderID: "billing-app", Type: resources.Consumption,
+			Namespace: "workspace-consumption-test-namespace",
+			AppType:   resources.AppType[resources.APP],
+			AppCosts: []resources.AppCost{
+				{Name: "resource-app-dashboard", Amount: 9},
+				{Name: "resource-app-runtime", Amount: 60},
+			},
+			Amount: 69, Owner: workspaceConsumptionTestOwner, Status: resources.Settled,
+		},
+		resources.Billing{
+			Time: startTime, OrderID: "billing-job", Type: resources.Consumption,
+			Namespace: "workspace-consumption-test-namespace",
+			AppType:   resources.AppType[resources.JOB],
+			AppCosts:  []resources.AppCost{{Name: "resource-job", Amount: 56}},
+			Amount:    56, Owner: workspaceConsumptionTestOwner, Status: resources.Settled,
+		},
+		resources.Billing{
+			Time: startTime, OrderID: "billing-object-storage", Type: resources.Consumption,
+			Namespace: "workspace-consumption-test-namespace",
+			AppType:   resources.AppType[resources.ObjectStorage],
+			AppCosts: []resources.AppCost{
+				{Name: "resource-object-a", Amount: 1},
+				{Name: "resource-object-b", Amount: 3},
+				{Name: "resource-object-c", Amount: 7},
+				{Name: "resource-object-d", Amount: 46},
+				{Name: "resource-object-e", Amount: 1},
+			},
+			Amount: 58, Owner: workspaceConsumptionTestOwner, Status: resources.Settled,
+		},
+		resources.Billing{
+			Time: startTime, OrderID: "billing-backup", Type: resources.Consumption,
+			Namespace: "workspace-consumption-test-namespace",
+			AppType:   resources.AppType[resources.DBBackup],
+			AppCosts: []resources.AppCost{
+				{Name: "resource-backup-a", Amount: 7},
+				{Name: "resource-backup-b", Amount: 57},
+			},
+			Amount: 64, Owner: workspaceConsumptionTestOwner, Status: resources.Settled,
+		},
+		resources.Billing{
+			Time: startTime, OrderID: "billing-app-store-a", Type: resources.Consumption,
+			Namespace: "workspace-consumption-test-namespace",
+			AppName:   "app-store-a", AppType: resources.AppType[resources.AppStore],
+			AppCosts: []resources.AppCost{
+				{Name: "app-store-a-db", Amount: 56},
+				{Name: "app-store-a-api", Amount: 9},
+				{Name: "app-store-a-cache", Amount: 78},
+				{Name: "app-store-a-proxy", Amount: 20},
+				{Name: "app-store-a-worker", Amount: 87},
+				{Name: "app-store-a-storage", Amount: 84},
+				{Name: "app-store-a-sandbox", Amount: 41},
+				{Name: "app-store-a", Amount: 56},
+				{Name: "app-store-a-plugin", Amount: 20},
+			},
+			Amount: 451, Owner: workspaceConsumptionTestOwner, Status: resources.Settled,
+		},
+		resources.Billing{
+			Time: startTime, OrderID: "billing-app-store-b", Type: resources.Consumption,
+			Namespace: "workspace-consumption-test-namespace",
+			AppName:   "app-store-b", AppType: resources.AppType[resources.AppStore],
+			AppCosts: []resources.AppCost{{Name: "app-store-b", Amount: 17}},
+			Amount:   17, Owner: workspaceConsumptionTestOwner, Status: resources.Settled,
+		},
+		resources.Billing{
+			Time: endTime, OrderID: "billing-unsettled", Type: resources.Consumption,
+			Namespace: "workspace-consumption-test-namespace",
+			AppType:   resources.AppType[resources.APP],
+			AppCosts:  []resources.AppCost{{Name: "ignored-unsettled", Amount: 9000}},
+			Amount:    9000, Owner: workspaceConsumptionTestOwner, Status: resources.Unsettled,
+		},
+		resources.Billing{
+			Time: startTime, OrderID: "billing-other-owner", Type: resources.Consumption,
+			Namespace: "workspace-consumption-test-namespace",
+			AppType:   resources.AppType[resources.APP],
+			AppCosts:  []resources.AppCost{{Name: "ignored-other-owner", Amount: 10000}},
+			Amount:    10000, Owner: "other-owner", Status: resources.Settled,
+		},
+		resources.Billing{
+			Time: endTime.Add(time.Hour), OrderID: "billing-outside-range", Type: resources.Consumption,
+			Namespace: "workspace-consumption-test-namespace",
+			AppType:   resources.AppType[resources.APP],
+			AppCosts:  []resources.AppCost{{Name: "ignored-outside-range", Amount: 11000}},
+			Amount:    11000, Owner: workspaceConsumptionTestOwner, Status: resources.Settled,
+		},
 	}
 }
 


### PR DESCRIPTION
## Background

Billing records store the authoritative total in `amount` and may also contain the per-application breakdown in `app_costs`. The regular consumption aggregation previously added both values, which could count the same billing record twice. This made `/account/v1alpha1/costs/consumption` inconsistent with the workspace consumption endpoint.

## Changes

- Keep filtering by owner, settlement status, time range, namespace, and application type.
- Use the top-level `amount` directly when no application name is requested.
- For application-name queries, use the top-level amount for `APP-STORE` and `LLM-TOKEN`, and sum only matching `app_costs` entries for ordinary resource types.
- Add MongoDB Testcontainers coverage for direct records that contain both `amount` and `app_costs`.

## Verification

- `go test ./dao -run '^TestBuildConsumptionAmountPipeline$' -count=1`
- `TESTCONTAINERS_REQUIRED=true go test ./dao -run '^TestGet(Workspace)?ConsumptionAmountWithMongoRuntime$' -count=1 -v`
- `golangci-lint run ./dao --path-mode=abs --config=.golangci.yml`
- Testcontainers benchmark with 10,000 records and MongoDB 4.4.29 (`-benchtime=1x`):

  | Query | all | namespace | app_type | app_name |
  | --- | ---: | ---: | ---: | ---: |
  | workspace consumption | 23.1 ms | 19.1 ms | 24.9 ms | 39.4 ms |
  | regular consumption | 23.4 ms | 19.2 ms | 24.0 ms | 31.2 ms |
