### PR TITLE
fix(account): close payment watches and await worker shutdown

### DIFF
--- a/controllers/account/controllers/payment_controller.go
+++ b/controllers/account/controllers/payment_controller.go
@@ -106,8 +106,8 @@ func (r *PaymentReconciler) Start(ctx context.Context) error {
 	var wg sync.WaitGroup
 	defer wg.Wait()
 	fc := func(wg *sync.WaitGroup, t *time.Ticker, reconcileFunc func(ctx context.Context) []error) {
-		wg.Add(1)
 		defer wg.Done()
+		defer t.Stop()
 		for {
 			select {
 			case <-t.C:
@@ -123,14 +123,15 @@ func (r *PaymentReconciler) Start(ctx context.Context) error {
 	}
 	tickerReconcilePayment := time.NewTicker(r.reconcileDuration)
 	tickerNewPayment := time.NewTicker(r.createDuration)
+	wg.Add(2)
 	go fc(&wg, tickerReconcilePayment, r.reconcilePayments)
 	go fc(&wg, tickerNewPayment, r.reconcileCreatePayments)
 	return nil
 }
 
-func (r *PaymentReconciler) reconcilePayments(_ context.Context) (errs []error) {
+func (r *PaymentReconciler) reconcilePayments(ctx context.Context) (errs []error) {
 	paymentList := &accountv1.PaymentList{}
-	err := r.List(context.Background(), paymentList, &client.ListOptions{})
+	err := r.List(ctx, paymentList, &client.ListOptions{})
 	if err != nil {
 		errs = append(errs, fmt.Errorf("watch payment failed: %w", err))
 		return errs
@@ -153,7 +154,7 @@ func (r *PaymentReconciler) reconcilePayments(_ context.Context) (errs []error) 
 
 func (r *PaymentReconciler) reconcileCreatePayments(ctx context.Context) (errs []error) {
 	watcher, err := r.WatchClient.Watch(
-		context.Background(),
+		ctx,
 		&accountv1.PaymentList{},
 		&client.ListOptions{},
 	)
@@ -161,6 +162,7 @@ func (r *PaymentReconciler) reconcileCreatePayments(ctx context.Context) (errs [
 		errs = append(errs, fmt.Errorf("watch payment failed: %w", err))
 		return errs
 	}
+	defer watcher.Stop()
 	select {
 	case <-ctx.Done():
 		return errs

--- a/controllers/account/controllers/payment_controller.go
+++ b/controllers/account/controllers/payment_controller.go
@@ -133,7 +133,7 @@ func (r *PaymentReconciler) reconcilePayments(ctx context.Context) (errs []error
 	paymentList := &accountv1.PaymentList{}
 	err := r.List(ctx, paymentList, &client.ListOptions{})
 	if err != nil {
-		errs = append(errs, fmt.Errorf("watch payment failed: %w", err))
+		errs = append(errs, fmt.Errorf("list payments failed: %w", err))
 		return errs
 	}
 	for _, payment := range paymentList.Items {

--- a/controllers/account/controllers/payment_controller_lifecycle_test.go
+++ b/controllers/account/controllers/payment_controller_lifecycle_test.go
@@ -1,0 +1,186 @@
+// Copyright 2026 labring.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	accountv1 "github.com/labring/sealos/controllers/account/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type paymentLifecycleClient struct {
+	client.WithWatch
+	watchFunc func(context.Context) (watch.Interface, error)
+	listFunc  func(context.Context) error
+}
+
+func (c *paymentLifecycleClient) Watch(ctx context.Context, _ client.ObjectList, _ ...client.ListOption) (watch.Interface, error) {
+	return c.watchFunc(ctx)
+}
+
+func (c *paymentLifecycleClient) List(ctx context.Context, _ client.ObjectList, _ ...client.ListOption) error {
+	return c.listFunc(ctx)
+}
+
+func TestPaymentWatchClosesOnEveryReturn(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		event   *watch.Event
+		closed  bool
+		cancel  bool
+		wantErr bool
+	}{
+		{
+			name: "initialized payment",
+			event: &watch.Event{Type: watch.Modified, Object: &accountv1.Payment{
+				Status: accountv1.PaymentStatus{TradeNO: "existing-trade"},
+			}},
+		},
+		{name: "invalid object", event: &watch.Event{Type: watch.Added, Object: &corev1.Pod{}}, wantErr: true},
+		{name: "processing failure", event: &watch.Event{Type: watch.Added, Object: &accountv1.Payment{}}, wantErr: true},
+		{name: "nil object", event: &watch.Event{Type: watch.Error}},
+		{name: "closed stream", closed: true},
+		{name: "canceled context", cancel: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			stream := watch.NewRaceFreeFake()
+			if tt.event != nil {
+				stream.Action(tt.event.Type, tt.event.Object)
+			}
+			if tt.closed {
+				stream.Stop()
+			}
+			if tt.cancel {
+				cancel()
+			}
+			cl := &paymentLifecycleClient{watchFunc: func(got context.Context) (watch.Interface, error) {
+				if got != ctx {
+					t.Error("watch did not receive the caller context")
+				}
+				return stream, nil
+			}}
+			r := &PaymentReconciler{WatchClient: cl}
+			errs := r.reconcileCreatePayments(ctx)
+			if (len(errs) != 0) != tt.wantErr {
+				t.Fatalf("errors = %v, want error = %t", errs, tt.wantErr)
+			}
+			if !stream.IsStopped() {
+				t.Error("payment watch remains open after reconcile returns")
+			}
+		})
+	}
+}
+
+func TestPaymentWatchCreationError(t *testing.T) {
+	wantErr := errors.New("watch unavailable")
+	r := &PaymentReconciler{WatchClient: &paymentLifecycleClient{
+		watchFunc: func(context.Context) (watch.Interface, error) { return nil, wantErr },
+	}}
+	errs := r.reconcileCreatePayments(context.Background())
+	if len(errs) != 1 || !errors.Is(errs[0], wantErr) {
+		t.Fatalf("errors = %v, want wrapped watch error", errs)
+	}
+}
+
+func TestPaymentStartWaitsForWorkersAndCancelsAPIRequests(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	listStarted := make(chan struct{})
+	watchStarted := make(chan struct{})
+	listDone := make(chan struct{})
+	stream := watch.NewRaceFreeFake()
+	cl := &paymentLifecycleClient{
+		listFunc: func(got context.Context) error {
+			select {
+			case <-listStarted:
+			default:
+				close(listStarted)
+			}
+			// Bound the wait even when testing a broken context propagation.
+			select {
+			case <-got.Done():
+			case <-time.After(3 * time.Second):
+			}
+			if got != ctx {
+				t.Error("list did not receive the manager context")
+			}
+			select {
+			case <-listDone:
+			default:
+				close(listDone)
+			}
+			return got.Err()
+		},
+		watchFunc: func(got context.Context) (watch.Interface, error) {
+			if got != ctx {
+				t.Error("watch did not receive the manager context")
+			}
+			select {
+			case <-watchStarted:
+			default:
+				close(watchStarted)
+			}
+			return stream, nil
+		},
+	}
+	r := &PaymentReconciler{
+		Client: cl, WatchClient: cl, Logger: logr.Discard(),
+		reconcileDuration: time.Millisecond, createDuration: time.Millisecond,
+	}
+	returned := make(chan error, 1)
+	go func() { returned <- r.Start(ctx) }()
+	for _, started := range []chan struct{}{listStarted, watchStarted} {
+		select {
+		case <-started:
+		case err := <-returned:
+			cancel()
+			t.Fatalf("Start returned before cancellation: %v", err)
+		case <-time.After(5 * time.Second):
+			cancel()
+			t.Fatal("payment worker did not start")
+		}
+	}
+	select {
+	case err := <-returned:
+		t.Fatalf("Start returned while payment workers were running: %v", err)
+	default:
+	}
+	cancel()
+	select {
+	case err := <-returned:
+		if err != nil {
+			t.Fatalf("Start returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return after cancellation")
+	}
+	select {
+	case <-listDone:
+	default:
+		t.Error("Start returned before list worker exited")
+	}
+	if !stream.IsStopped() {
+		t.Error("Start left the payment watch open")
+	}
+}

--- a/controllers/account/controllers/payment_controller_lifecycle_test.go
+++ b/controllers/account/controllers/payment_controller_lifecycle_test.go
@@ -33,11 +33,19 @@ type paymentLifecycleClient struct {
 	listFunc  func(context.Context) error
 }
 
-func (c *paymentLifecycleClient) Watch(ctx context.Context, _ client.ObjectList, _ ...client.ListOption) (watch.Interface, error) {
+func (c *paymentLifecycleClient) Watch(
+	ctx context.Context,
+	_ client.ObjectList,
+	_ ...client.ListOption,
+) (watch.Interface, error) {
 	return c.watchFunc(ctx)
 }
 
-func (c *paymentLifecycleClient) List(ctx context.Context, _ client.ObjectList, _ ...client.ListOption) error {
+func (c *paymentLifecycleClient) List(
+	ctx context.Context,
+	_ client.ObjectList,
+	_ ...client.ListOption,
+) error {
 	return c.listFunc(ctx)
 }
 
@@ -74,12 +82,14 @@ func TestPaymentWatchClosesOnEveryReturn(t *testing.T) {
 			if tt.cancel {
 				cancel()
 			}
-			cl := &paymentLifecycleClient{watchFunc: func(got context.Context) (watch.Interface, error) {
-				if got != ctx {
-					t.Error("watch did not receive the caller context")
-				}
-				return stream, nil
-			}}
+			cl := &paymentLifecycleClient{
+				watchFunc: func(got context.Context) (watch.Interface, error) {
+					if got != ctx {
+						t.Error("watch did not receive the caller context")
+					}
+					return stream, nil
+				},
+			}
 			r := &PaymentReconciler{WatchClient: cl}
 			errs := r.reconcileCreatePayments(ctx)
 			if (len(errs) != 0) != tt.wantErr {


### PR DESCRIPTION
Payment reconciliation opens a watch on each creation-poll cycle but returns after one event without closing it, leaving streams and connections alive. Its workers also register with the WaitGroup after launch, allowing Start to return before they are registered.

Close each watch on every return path, propagate the runnable context to watch and list requests, register workers before launch, and stop their tickers on exit. Payment processing and polling intervals are unchanged.

Validation:
- Regression tests cover watch events, processing failures, stream closure, cancellation, watch creation errors, and worker shutdown. Restoring the original watch behavior makes the regression tests fail.
- Local module tests pass with the race detector.
- [GitHub Actions](https://github.com/zijiren233/sealos/actions/runs/34050053913): lint, race tests, and amd64/arm64 image builds passed.
- Deployed the Actions-built image by digest to the test cluster; rollout and leader takeover succeeded, with no new pod restarts during observation. No real payment transaction was performed.
