### PR TITLE
fix(resources): handle completed pods without a start time

### DIFF
--- a/controllers/resources/controllers/monitor_controller.go
+++ b/controllers/resources/controllers/monitor_controller.go
@@ -505,7 +505,7 @@ func (r *MonitorReconciler) monitorPodResourceUsage(
 		pod := &podList.Items[i]
 		if pod.Spec.NodeName == "" ||
 			pod.Status.Phase == corev1.PodSucceeded &&
-				time.Since(pod.Status.StartTime.Time) > 1*time.Minute {
+				(pod.Status.StartTime == nil || time.Since(pod.Status.StartTime.Time) > 1*time.Minute) {
 			continue
 		}
 		podResNamed := resources.NewResourceNamed(pod)

--- a/controllers/resources/controllers/monitor_controller_test.go
+++ b/controllers/resources/controllers/monitor_controller_test.go
@@ -51,11 +51,17 @@ func TestMonitorPodResourceUsageHandlesOptionalStartTime(t *testing.T) {
 			}
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "ns-a"},
-				Spec: corev1.PodSpec{NodeName: tt.node, Containers: []corev1.Container{{
-					Name: "app", Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
-						corev1.ResourceCPU: resource.MustParse("1"),
+				Spec: corev1.PodSpec{
+					NodeName: tt.node,
+					Containers: []corev1.Container{{
+						Name: "app",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("1"),
+							},
+						},
 					}},
-				}}},
+				},
 				Status: corev1.PodStatus{Phase: tt.phase, StartTime: tt.start},
 			}
 			r := &MonitorReconciler{

--- a/controllers/resources/controllers/monitor_controller_test.go
+++ b/controllers/resources/controllers/monitor_controller_test.go
@@ -13,3 +13,67 @@
 // limitations under the License.
 
 package controllers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/labring/sealos/controllers/pkg/resources"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestMonitorPodResourceUsageHandlesOptionalStartTime(t *testing.T) {
+	recent := metav1.NewTime(time.Now().Add(-10 * time.Second))
+	old := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+	for _, tt := range []struct {
+		name    string
+		phase   corev1.PodPhase
+		start   *metav1.Time
+		node    string
+		wantCPU string
+	}{
+		{name: "completed without start time", phase: corev1.PodSucceeded, node: "node-a", wantCPU: "0"},
+		{name: "recent completed", phase: corev1.PodSucceeded, start: &recent, node: "node-a", wantCPU: "1"},
+		{name: "old completed", phase: corev1.PodSucceeded, start: &old, node: "node-a", wantCPU: "0"},
+		{name: "running without start time", phase: corev1.PodRunning, node: "node-a", wantCPU: "1"},
+		{name: "pending without start time", phase: corev1.PodPending, node: "node-a", wantCPU: "0"},
+		{name: "unscheduled", phase: corev1.PodRunning, wantCPU: "0"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			if err := corev1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "ns-a"},
+				Spec: corev1.PodSpec{NodeName: tt.node, Containers: []corev1.Container{{
+					Name: "app", Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("1"),
+					}},
+				}}},
+				Status: corev1.PodStatus{Phase: tt.phase, StartTime: tt.start},
+			}
+			r := &MonitorReconciler{
+				cache:  fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build(),
+				Logger: logr.Discard(),
+			}
+			used := map[string]map[corev1.ResourceName]*quantity{}
+			named := map[string]*resources.ResourceNamed{}
+			if err := r.monitorPodResourceUsage("ns-a", used, named, nil); err != nil {
+				t.Fatal(err)
+			}
+			total := resource.MustParse("0")
+			for _, usage := range used {
+				total.Add(*usage[corev1.ResourceCPU].Quantity)
+			}
+			if want := resource.MustParse(tt.wantCPU); total.Cmp(want) != 0 {
+				t.Fatalf("CPU usage = %s, want %s", total.String(), want.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Resource monitoring dereferences status.startTime for scheduled, completed Pods even though the field is optional. A completed Pod without a start time therefore panics in the monitoring goroutine and terminates the controller process.

Skip completed Pods without a start time, matching the existing handling of non-running Pods with no usable start time. Preserve resource accounting for recently completed and running Pods.

Validation:
- Regression tests cover completed Pods with missing, recent, and old start times, running and pending Pods without start times, and unscheduled Pods. The missing-start-time case reproduces the panic with the original implementation.
- Local module tests pass with the race detector.
- [GitHub Actions](https://github.com/zijiren233/sealos/actions/runs/34050087480): lint, race tests, and amd64/arm64 image builds passed.
- Deployed the Actions-built image by digest to the test cluster; rollout and leader takeover succeeded, and one complete resource-monitoring cycle finished with no new pod restarts. The missing-start-time edge case was verified in regression tests.
