### PR TITLE
fix(applaunchpad): keep ingress bound after protocol updates

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/utils/adapt.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/adapt.test.ts
@@ -210,6 +210,58 @@ describe('adaptAppDetail', () => {
     expect(app.networks.find((network) => network.port === 81)?.openPublicDomain).toBe(false);
   });
 
+  it('falls back from a missing ingress backend while preserving valid alternate services', async () => {
+    const ingress = createIngress() as any;
+    ingress.spec.rules[0].http.paths = [
+      {
+        path: '/',
+        pathType: 'Prefix',
+        backend: {
+          service: {
+            name: 'demo-old-service',
+            port: { number: 80 }
+          }
+        }
+      },
+      {
+        path: '/api',
+        pathType: 'Prefix',
+        backend: {
+          service: {
+            name: 'api-demo',
+            port: { number: 8080 }
+          }
+        }
+      }
+    ];
+
+    const app = await adaptAppDetail([createDeployment(), createService(), ingress], {
+      SEALOS_DOMAIN: '192.168.13.209.nip.io',
+      SEALOS_USER_DOMAINS: [
+        {
+          name: '192.168.13.209.nip.io',
+          secretName: 'wildcard-cert'
+        }
+      ],
+      backendServices: [createService() as any, createService('api-demo', [8080]) as any]
+    });
+
+    expect(app.networks[0].routes).toEqual([
+      {
+        path: '/',
+        pathType: 'Prefix',
+        serviceName: '',
+        servicePort: 80
+      },
+      {
+        path: '/api',
+        pathType: 'Prefix',
+        serviceName: 'api-demo',
+        servicePort: 8080
+      }
+    ]);
+  });
+
   it('can expose backend service candidates without treating them as current app ports', async () => {
     const app = await adaptAppDetail([createDeployment(), createService(), createIngress()], {
       SEALOS_DOMAIN: '192.168.13.209.nip.io',

--- a/frontend/providers/applaunchpad/__tests__/unit/utils/network-routes.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/network-routes.test.ts
@@ -1,5 +1,34 @@
 import { describe, expect, it } from 'vitest';
-import { rebindMainServiceRoutes, syncDefaultRouteServicePort } from '@/utils/network-routes';
+import {
+  rebindMainServiceRoutes,
+  serviceIdentityChanges,
+  syncDefaultRouteServicePort
+} from '@/utils/network-routes';
+
+describe('serviceIdentityChanges', () => {
+  it('does not rebind a Service when only the application protocol changes', () => {
+    expect(
+      serviceIdentityChanges({
+        currentNetwork: { openNodePort: false, protocol: 'TCP' },
+        nextOpenNodePort: false,
+        nextProtocol: 'TCP'
+      })
+    ).toBe(false);
+  });
+
+  it.each([
+    ['access mode', true, 'TCP'],
+    ['transport protocol', false, 'UDP']
+  ] as const)('rebinds a Service when %s changes', (_, nextOpenNodePort, nextProtocol) => {
+    expect(
+      serviceIdentityChanges({
+        currentNetwork: { openNodePort: false, protocol: 'TCP' },
+        nextOpenNodePort,
+        nextProtocol
+      })
+    ).toBe(true);
+  });
+});
 
 describe('rebindMainServiceRoutes', () => {
   it('removes a stale main service name while preserving explicit backends', () => {

--- a/frontend/providers/applaunchpad/src/components/app/detail/index/AppMainInfo.tsx
+++ b/frontend/providers/applaunchpad/src/components/app/detail/index/AppMainInfo.tsx
@@ -151,7 +151,8 @@ const AppMainInfo = ({ app = MOCK_APP_DETAIL }: { app: AppDetailType }) => {
       }
     },
     refetchIntervalInBackground: false,
-    staleTime: 1000 * 60 * 5
+    refetchOnMount: 'always',
+    staleTime: 0
   });
 
   const statusMap = useMemo(

--- a/frontend/providers/applaunchpad/src/pages/app/edit/components/NetworkSection.tsx
+++ b/frontend/providers/applaunchpad/src/pages/app/edit/components/NetworkSection.tsx
@@ -31,7 +31,11 @@ import type { AppEditType, ApplicationProtocolType } from '@/types/app';
 import RouteRulesModal from './RouteRulesModal';
 import { useCopyData } from '@/utils/tools';
 import { buildExternalUrl, getExternalProtocol } from '@/utils/network-url';
-import { rebindMainServiceRoutes, syncDefaultRouteServicePort } from '@/utils/network-routes';
+import {
+  rebindMainServiceRoutes,
+  serviceIdentityChanges,
+  syncDefaultRouteServicePort
+} from '@/utils/network-routes';
 import type { CustomAccessModalParams } from './CustomAccessModal';
 import type { CertificateCustomAccessModalParams } from './CertificateCustomAccessModal';
 import dynamic from 'next/dynamic';
@@ -277,6 +281,19 @@ const withoutMainServiceBinding = (
     previousServiceName: network.serviceName
   })
 });
+
+const getServiceBindingNetwork = (
+  network: AppEditType['networks'][0],
+  nextOpenNodePort: boolean,
+  nextProtocol: AppEditType['networks'][0]['protocol']
+) =>
+  serviceIdentityChanges({
+    currentNetwork: network,
+    nextOpenNodePort,
+    nextProtocol
+  })
+    ? withoutMainServiceBinding(network)
+    : network;
 
 const getNextAvailablePort = (networks: AppEditType['networks']) => {
   const usedPorts = new Set(networks.map((network) => Number(network.port)).filter(Boolean));
@@ -534,12 +551,19 @@ export function NetworkSection({
           const currentNetwork = currentNetworks[index];
 
           if (APPLICATION_PROTOCOLS.includes(protocol as any)) {
-            if (nodePortHost && currentNetwork.openNodePort) {
+            const openNodePort = Boolean(nodePortHost && currentNetwork.openNodePort);
+            const serviceBindingNetwork = getServiceBindingNetwork(
+              currentNetwork,
+              openNodePort,
+              'TCP'
+            );
+
+            if (openNodePort) {
               clearPublicDomainErrorByIndex(index);
               updateNetworks(
                 index,
                 withDefaultRoutes({
-                  ...withoutMainServiceBinding(currentNetwork),
+                  ...serviceBindingNetwork,
                   protocol: 'TCP',
                   appProtocol: protocol as any,
                   openNodePort: true,
@@ -555,7 +579,7 @@ export function NetworkSection({
               updateNetworks(
                 index,
                 withDefaultRoutes({
-                  ...withoutMainServiceBinding(currentNetwork),
+                  ...serviceBindingNetwork,
                   protocol: 'TCP',
                   appProtocol: protocol as any,
                   openNodePort: false,
@@ -569,10 +593,15 @@ export function NetworkSection({
             }
           } else {
             clearPublicDomainErrorByIndex(index);
+            const serviceBindingNetwork = getServiceBindingNetwork(
+              currentNetwork,
+              true,
+              protocol as any
+            );
             updateNetworks(
               index,
               withDefaultRoutes({
-                ...withoutMainServiceBinding(currentNetwork),
+                ...serviceBindingNetwork,
                 protocol: protocol as any,
                 appProtocol: undefined,
                 openNodePort: true,

--- a/frontend/providers/applaunchpad/src/utils/adapt.ts
+++ b/frontend/providers/applaunchpad/src/utils/adapt.ts
@@ -282,6 +282,9 @@ export const adaptAppDetail = async (
     .filter((item) => item.kind === YamlKindEnum.Service)
     .map((item) => item as V1Service);
   const backendServices = options?.backendServices || allServices;
+  const knownBackendServiceNames = new Set(
+    [...allServices, ...backendServices].map((service) => service.metadata?.name).filter(Boolean)
+  );
 
   const allServicePorts = allServices.flatMap((service) => service.spec?.ports || []);
 
@@ -603,12 +606,22 @@ export const adaptAppDetail = async (
             ? domain
             : domain.split('.').slice(1).join('.') || SEALOS_DOMAIN,
           routes: ingressPaths.length
-            ? ingressPaths.map((path) => ({
-                path: path.path || '/',
-                pathType: (path.pathType || 'Prefix') as NetworkRoutePathType,
-                serviceName: path.backend?.service?.name || service?.metadata?.name || '',
-                servicePort: path.backend?.service?.port?.number || item.port
-              }))
+            ? ingressPaths.map((path) => {
+                // An Ingress may outlive the Service it used to target. Keep valid
+                // alternate backends, but let an unknown backend fall back to the
+                // current main Service on the next edit.
+                const routeServiceName =
+                  path.backend?.service?.name || service?.metadata?.name || '';
+
+                return {
+                  path: path.path || '/',
+                  pathType: (path.pathType || 'Prefix') as NetworkRoutePathType,
+                  serviceName: knownBackendServiceNames.has(routeServiceName)
+                    ? routeServiceName
+                    : '',
+                  servicePort: path.backend?.service?.port?.number || item.port
+                };
+              })
             : [
                 {
                   path: '/',

--- a/frontend/providers/applaunchpad/src/utils/network-routes.ts
+++ b/frontend/providers/applaunchpad/src/utils/network-routes.ts
@@ -1,7 +1,17 @@
-import type { AppNetworkRouteType } from '@/types/app';
+import type { AppEditType, AppNetworkRouteType, TransportProtocolType } from '@/types/app';
 
 const targetsMainService = (route: AppNetworkRouteType, networkServiceName?: string) =>
   !route.serviceName || (!!networkServiceName && route.serviceName === networkServiceName);
+
+export const serviceIdentityChanges = ({
+  currentNetwork,
+  nextOpenNodePort,
+  nextProtocol
+}: {
+  currentNetwork: Pick<AppEditType['networks'][number], 'openNodePort' | 'protocol'>;
+  nextOpenNodePort: boolean;
+  nextProtocol: TransportProtocolType;
+}) => currentNetwork.openNodePort !== nextOpenNodePort || currentNetwork.protocol !== nextProtocol;
 
 export const rebindMainServiceRoutes = ({
   routes,


### PR DESCRIPTION
## Summary

Fixes BUG-86 by clearing main-route Service bindings only when a network edit changes the Kubernetes Service identity, while preserving bindings for application-protocol changes that remain TCP.
Treat orphaned Ingress backends as candidates for the current main Service and refetch public-access readiness when the overview remounts.

## Testing

- `vitest run --config providers/applaunchpad/vitest.config.ts providers/applaunchpad/__tests__/unit/utils/network-routes.test.ts providers/applaunchpad/__tests__/unit/utils/network-url.test.ts providers/applaunchpad/__tests__/unit/utils/adapt.test.ts`
- `git diff --check origin/release-v5.1...HEAD`

## Sequence Diagram

```mermaid
sequenceDiagram
    participant User
    participant NetworkEditor
    participant RouteBinding
    participant Ingress

    User->>NetworkEditor: Change access mode or transport protocol
    NetworkEditor->>RouteBinding: Check Service identity change
    alt Service identity changed
        RouteBinding->>Ingress: Clear stale main Service binding
        Ingress-->>NetworkEditor: Bind route to regenerated main Service
    else Application protocol remains TCP
        RouteBinding-->>NetworkEditor: Preserve existing Service binding
    end
```
