### PR TITLE
fix(account): run workspace tasks only on the elected leader

### DIFF
--- a/controllers/account/controllers/workspace_lifecycle_test.go
+++ b/controllers/account/controllers/workspace_lifecycle_test.go
@@ -1,0 +1,48 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+func TestWorkspaceTasksRequireLeadershipAndWaitForShutdown(t *testing.T) {
+	account := &AccountReconciler{Logger: logr.Discard()}
+	tasks := map[string]interface {
+		manager.Runnable
+		manager.LeaderElectionRunnable
+	}{
+		"traffic": &WorkspaceTrafficController{AccountReconciler: account},
+		"subscription debt": &WorkspaceSubscriptionDebtProcessor{
+			AccountReconciler: account, pollInterval: time.Hour,
+		},
+	}
+	for name, task := range tasks {
+		t.Run(name, func(t *testing.T) {
+			if !task.NeedLeaderElection() {
+				t.Fatal("workspace mutations must require leadership")
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			done := make(chan error, 1)
+			go func() { done <- task.Start(ctx) }()
+			select {
+			case err := <-done:
+				t.Fatalf("Start returned before shutdown: %v", err)
+			case <-time.After(30 * time.Millisecond):
+			}
+			cancel()
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatal(err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("Start did not return after cancellation")
+			}
+		})
+	}
+}

--- a/controllers/account/controllers/workspace_subscription_debt.go
+++ b/controllers/account/controllers/workspace_subscription_debt.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -98,7 +97,7 @@ func (wdp *WorkspaceSubscriptionDebtProcessor) Start(ctx context.Context) error 
 			}
 			count, err := wdp.processExpiredWorkspaces(ctx)
 			if err != nil {
-				log.Printf("Failed to process expired workspace subscriptions: %v", err)
+				wdp.Logger.Error(err, "failed to process expired workspace subscriptions")
 			}
 
 			// 动态调整检查间隔

--- a/controllers/account/controllers/workspace_subscription_debt.go
+++ b/controllers/account/controllers/workspace_subscription_debt.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"sync"
 	"time"
 
 	notificationv1 "github.com/labring/sealos/controllers/pkg/notification/api/v1"
@@ -25,8 +24,6 @@ type WorkspaceSubscriptionDebtProcessor struct {
 	*AccountReconciler
 	db           *gorm.DB
 	pollInterval time.Duration
-	wg           sync.WaitGroup
-	stopChan     chan struct{}
 }
 
 // 债务状态定义
@@ -78,50 +75,44 @@ func NewWorkspaceSubscriptionDebtProcessor(
 		AccountReconciler: reconciler,
 		db:                reconciler.AccountV2.GetGlobalDB(),
 		pollInterval:      1 * time.Minute,
-		stopChan:          make(chan struct{}),
 	}
 }
 
+func (wdp *WorkspaceSubscriptionDebtProcessor) NeedLeaderElection() bool { return true }
+
 // Start 启动债务处理器
-func (wdp *WorkspaceSubscriptionDebtProcessor) Start(ctx context.Context) {
-	wdp.wg.Add(1)
-	go func() {
-		defer wdp.wg.Done()
-		ticker := time.NewTicker(wdp.pollInterval)
-		defer ticker.Stop()
+func (wdp *WorkspaceSubscriptionDebtProcessor) Start(ctx context.Context) error {
+	wdp.Logger.Info("start workspace subscription debt controller")
+	defer wdp.Logger.Info("stop workspace subscription debt controller")
+	ticker := time.NewTicker(wdp.pollInterval)
+	defer ticker.Stop()
 
-		idleCount := 0
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-wdp.stopChan:
-				return
-			case <-ticker.C:
-				count, err := wdp.processExpiredWorkspaces(ctx)
-				if err != nil {
-					log.Printf("Failed to process expired workspace subscriptions: %v", err)
-				}
+	idleCount := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if ctx.Err() != nil {
+				return nil
+			}
+			count, err := wdp.processExpiredWorkspaces(ctx)
+			if err != nil {
+				log.Printf("Failed to process expired workspace subscriptions: %v", err)
+			}
 
-				// 动态调整检查间隔
-				if count == 0 {
-					idleCount++
-					if idleCount > 10 { // 10次空闲后增加间隔
-						ticker.Reset(wdp.pollInterval * 2)
-					}
-				} else {
-					idleCount = 0
-					ticker.Reset(wdp.pollInterval)
+			// 动态调整检查间隔
+			if count == 0 {
+				idleCount++
+				if idleCount > 10 { // 10次空闲后增加间隔
+					ticker.Reset(wdp.pollInterval * 2)
 				}
+			} else {
+				idleCount = 0
+				ticker.Reset(wdp.pollInterval)
 			}
 		}
-	}()
-}
-
-// Stop 停止债务处理器
-func (wdp *WorkspaceSubscriptionDebtProcessor) Stop() {
-	close(wdp.stopChan)
-	wdp.wg.Wait()
+	}
 }
 
 func (wdp *WorkspaceSubscriptionDebtProcessor) determineCurrentStatus(
@@ -374,7 +365,8 @@ func (wdp *WorkspaceSubscriptionDebtProcessor) syncWorkspaceDebtStatus(
 	if err := wdp.readWorkspaceNotices(
 		ctx,
 		namespaces,
-		wdp.getWorkspaceStatusesGreaterThan(currentDebtStatus)...); err != nil {
+		wdp.getWorkspaceStatusesGreaterThan(currentDebtStatus)...,
+	); err != nil {
 		return fmt.Errorf("read workspace notices error: %w", err)
 	}
 

--- a/controllers/account/controllers/workspace_traffic_controller.go
+++ b/controllers/account/controllers/workspace_traffic_controller.go
@@ -356,15 +356,28 @@ func (c *WorkspaceTrafficController) updateWorkspaceTrafficStatus(
 	return nil
 }
 
-// ProcessTrafficWithTimeRange processes workspace traffic within time ranges
-func (c *WorkspaceTrafficController) ProcessTrafficWithTimeRange() {
-	c.Logger.Info("start workspace traffic controller")
-	startTime := time.Now().Add(-1 * time.Minute)
+func (c *WorkspaceTrafficController) NeedLeaderElection() bool { return true }
 
-	for range time.NewTicker(time.Minute).C {
+// Start processes workspace traffic until the manager stops this leader.
+func (c *WorkspaceTrafficController) Start(ctx context.Context) error {
+	c.Logger.Info("start workspace traffic controller")
+	defer c.Logger.Info("stop workspace traffic controller")
+	startTime := time.Now().Add(-1 * time.Minute)
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+		if ctx.Err() != nil {
+			return nil
+		}
 		c.Logger.Info("time to process workspace traffic", "startTime", startTime)
 		endTime := time.Now()
-		result, err := c.TrafficDB.GetNamespaceTraffic(context.Background(), startTime, endTime)
+		result, err := c.TrafficDB.GetNamespaceTraffic(ctx, startTime, endTime)
 		if err != nil {
 			c.Logger.Error(err, "failed to get namespace traffic")
 			endTime = startTime

--- a/controllers/account/main.go
+++ b/controllers/account/main.go
@@ -523,9 +523,13 @@ func main() {
 	workspaceSubDebtProcessor := controllers.NewWorkspaceSubscriptionDebtProcessor(
 		accountReconciler,
 	)
-	go workspaceTrafficProcessor.ProcessTrafficWithTimeRange()
+	if err := mgr.Add(workspaceTrafficProcessor); err != nil {
+		setupManagerError(err, "WorkspaceTraffic")
+	}
 	// workspaceSubscriptionProcessor.Start(ctx)
-	workspaceSubDebtProcessor.Start(ctx)
+	if err := mgr.Add(workspaceSubDebtProcessor); err != nil {
+		setupManagerError(err, "WorkspaceSubscriptionDebt")
+	}
 
 	//+kubebuilder:scaffold:builder
 


### PR DESCRIPTION
Workspace traffic and subscription debt processing currently start before the manager acquires leadership. Standby replicas therefore run these mutations too, and the manager does not wait for their shutdown.

Register both tasks as leader-election runnables. Keep Start blocked until cancellation, stop timers on exit, and pass the manager context to traffic queries. Traffic windows, deduction algorithms, and database deduplication remain unchanged.

Validation:
- Full account module tests with the race detector passed locally, including after rebasing onto main.
- Lint, race tests, and image builds passed in [GitHub Actions](https://github.com/zijiren233/sealos/actions/runs/34102422175).
- Deployed the Actions-built image to a test cluster with three replicas: only the Lease holder started workspace tasks and processed traffic.
- Terminated the leader normally: both tasks stopped, and a standby acquired leadership and started them.
- Injected Lease ownership loss: the former leader exited with code 1, restarted, and a different replica acquired leadership and processed the next traffic window.
- Restored the original single-replica scale after testing.

Cluster validation used commit 880cbd141 before rebasing this isolated change onto main. Database consumption idempotency remains outside this fix.
