### PR TITLE
fix(resources): bind monitor lifecycle to manager leadership

### DIFF
--- a/controllers/resources/controllers/monitor_controller.go
+++ b/controllers/resources/controllers/monitor_controller.go
@@ -62,7 +62,6 @@ type MonitorReconciler struct {
 	logr.Logger
 	Interval                 time.Duration
 	Scheme                   *runtime.Scheme
-	stopCh                   chan struct{}
 	wg                       sync.WaitGroup
 	periodicReconcile        time.Duration
 	gpuAliasCard             map[string]corev1.ResourceName
@@ -139,7 +138,6 @@ func NewMonitorReconciler(mgr ctrl.Manager) (*MonitorReconciler, error) {
 		Client:                mgr.GetClient(),
 		cache:                 mgr.GetCache(),
 		Logger:                ctrl.Log.WithName("controllers").WithName("Monitor"),
-		stopCh:                make(chan struct{}),
 		periodicReconcile:     1 * time.Minute,
 		PromURL:               os.Getenv(PrometheusURL),
 		ObjectStorageInstance: os.Getenv(ObjectStorageInstance),
@@ -197,30 +195,35 @@ func InitIndexField(mgr ctrl.Manager) error {
 }
 
 func (r *MonitorReconciler) StartReconciler(ctx context.Context) error {
-	r.startPeriodicReconcile()
+	r.startPeriodicReconcile(ctx)
 	if r.TrafficClient != nil || r.ObjStorageClient != nil {
-		r.startMonitorTraffic()
+		r.startMonitorTraffic(ctx)
 	}
 	<-ctx.Done()
-	r.stopPeriodicReconcile()
+	r.wg.Wait()
 	return nil
 }
 
-func (r *MonitorReconciler) startPeriodicReconcile() {
+func (r *MonitorReconciler) startPeriodicReconcile(ctx context.Context) {
 	r.wg.Add(1)
 	go func() {
 		defer r.wg.Done()
-		waitNextMinute()
+		if !waitForMonitorBoundary(ctx, time.Minute) {
+			return
+		}
 		ticker := time.NewTicker(r.periodicReconcile)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
+				if ctx.Err() != nil {
+					return
+				}
 				r.enqueueNamespacesForReconcile()
-				if err := r.refreshGPUConfig(context.Background()); err != nil {
+				if err := r.refreshGPUConfig(ctx); err != nil {
 					r.Error(err, "refresh gpu config failed")
 				}
-			case <-r.stopCh:
-				ticker.Stop()
+			case <-ctx.Done():
 				return
 			}
 		}
@@ -238,23 +241,20 @@ func (r *MonitorReconciler) getNamespaceList() (*corev1.NamespaceList, error) {
 	})
 }
 
-func waitNextMinute() {
-	waitTime := time.Until(time.Now().Truncate(time.Minute).Add(1 * time.Minute))
-	if waitTime > 0 {
-		logger.Info("wait for first reconcile", "waitTime", waitTime)
-		time.Sleep(waitTime)
+func waitForMonitorBoundary(ctx context.Context, interval time.Duration) bool {
+	waitTime := time.Until(time.Now().Truncate(interval).Add(interval))
+	logger.Info("wait for first reconcile", "waitTime", waitTime)
+	timer := time.NewTimer(waitTime)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return ctx.Err() == nil
 	}
 }
 
-func waitNextHour() {
-	waitTime := time.Until(time.Now().Truncate(time.Hour).Add(1 * time.Hour))
-	if waitTime > 0 {
-		logger.Info("wait for first reconcile", "waitTime", waitTime)
-		time.Sleep(waitTime)
-	}
-}
-
-func (r *MonitorReconciler) startMonitorTraffic() {
+func (r *MonitorReconciler) startMonitorTraffic(ctx context.Context) {
 	r.wg.Add(1)
 	go func() {
 		defer r.wg.Done()
@@ -264,30 +264,30 @@ func (r *MonitorReconciler) startMonitorTraffic() {
 				Truncate(time.Hour).
 				Add(1*time.Hour).
 				UTC()
-		waitNextHour()
+		if !waitForMonitorBoundary(ctx, time.Hour) {
+			return
+		}
 		ticker := time.NewTicker(1 * time.Hour)
+		defer ticker.Stop()
 		if err := r.MonitorTrafficUsed(startTime, endTime); err != nil {
 			r.Error(err, "failed to monitor pod traffic used")
 		}
 		for {
 			select {
 			case <-ticker.C:
+				if ctx.Err() != nil {
+					return
+				}
 				startTime, endTime = endTime, endTime.Add(1*time.Hour)
 				if err := r.MonitorTrafficUsed(startTime, endTime); err != nil {
 					r.Error(err, "failed to monitor pod traffic used")
 					break
 				}
-			case <-r.stopCh:
-				ticker.Stop()
+			case <-ctx.Done():
 				return
 			}
 		}
 	}()
-}
-
-func (r *MonitorReconciler) stopPeriodicReconcile() {
-	close(r.stopCh)
-	r.wg.Wait()
 }
 
 func (r *MonitorReconciler) enqueueNamespacesForReconcile() {

--- a/controllers/resources/controllers/monitor_lifecycle_test.go
+++ b/controllers/resources/controllers/monitor_lifecycle_test.go
@@ -1,0 +1,45 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/labring/sealos/controllers/pkg/database"
+)
+
+func TestMonitorStopsDuringInitialTrafficWait(t *testing.T) {
+	r := &MonitorReconciler{
+		Logger: logr.Discard(), periodicReconcile: time.Hour,
+		TrafficClient: &unusedTrafficDatabase{},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- r.StartReconciler(ctx) }()
+	select {
+	case err := <-done:
+		t.Fatalf("monitor returned before cancellation: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("monitor did not join its workers after cancellation")
+	}
+}
+
+type unusedTrafficDatabase struct{ database.Interface }
+
+func TestMonitorBoundaryAlreadyCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if waitForMonitorBoundary(ctx, time.Hour) {
+		t.Fatal("canceled monitor must not start a traffic query")
+	}
+}

--- a/controllers/resources/main.go
+++ b/controllers/resources/main.go
@@ -181,24 +181,20 @@ func runMonitor(ctx context.Context, mgr ctrl.Manager) error {
 		ctx,
 		os.Getenv(database.MongoURI),
 	)
-	if err != nil {
-		return fmt.Errorf("initialize monitor database: %w", err)
+	if reconciler.DBClient != nil {
+		defer disconnectMonitorDatabase(reconciler.DBClient)
 	}
-	defer func() {
-		if err := reconciler.DBClient.Disconnect(context.Background()); err != nil {
-			setupLog.Error(err, "failed to disconnect db client")
-		}
-	}()
+	if err != nil {
+		return monitorInitializationError(ctx, "initialize monitor database", err)
+	}
 	if trafficURI := os.Getenv(database.TrafficMongoURI); trafficURI != "" {
 		reconciler.TrafficClient, err = mongo.NewMongoInterface(ctx, trafficURI)
-		if err != nil {
-			return fmt.Errorf("initialize traffic database: %w", err)
+		if reconciler.TrafficClient != nil {
+			defer disconnectMonitorDatabase(reconciler.TrafficClient)
 		}
-		defer func() {
-			if err := reconciler.TrafficClient.Disconnect(context.Background()); err != nil {
-				setupLog.Error(err, "failed to disconnect traffic db client")
-			}
-		}()
+		if err != nil {
+			return monitorInitializationError(ctx, "initialize traffic database", err)
+		}
 	} else {
 		setupLog.Info("traffic mongo uri not found, please check env: TRAFFIC_MONGO_URI")
 	}
@@ -238,7 +234,7 @@ func runMonitor(ctx context.Context, mgr ctrl.Manager) error {
 		}
 		_, err := reconciler.ObjStorageClient.ListBuckets(ctx)
 		if err != nil {
-			return fmt.Errorf("list object storage buckets: %w", err)
+			return monitorInitializationError(ctx, "list object storage buckets", err)
 		}
 		if reconciler.PromURL = os.Getenv(PromURL); reconciler.PromURL == "" {
 			reconciler.Info("prometheus url not found, please check env: PROM_URL")
@@ -292,6 +288,25 @@ func runMonitor(ctx context.Context, mgr ctrl.Manager) error {
 		maintenance.Wait()
 	}()
 	return reconciler.StartReconciler(ctx)
+}
+
+func monitorInitializationError(ctx context.Context, stage string, err error) error {
+	if ctx.Err() != nil && errors.Is(err, ctx.Err()) {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", stage, err)
+}
+
+func disconnectMonitorDatabase(db interface {
+	Disconnect(ctx context.Context) error
+},
+) {
+	// Cleanup must remain usable after the leader context has been canceled.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := db.Disconnect(ctx); err != nil {
+		setupLog.Error(err, "failed to disconnect monitor database")
+	}
 }
 
 func runMonitorMaintenance(ctx context.Context, maintain func()) {

--- a/controllers/resources/main.go
+++ b/controllers/resources/main.go
@@ -160,7 +160,13 @@ func (monitorRunnable) NeedLeaderElection() bool { return true }
 func runMonitor(ctx context.Context, mgr ctrl.Manager) error {
 	// ReaderFailOnMissingInformer skips the per-read sync wait, so synchronize all
 	// explicitly registered informers before the monitor performs its first read.
-	if !mgr.GetCache().WaitForCacheSync(ctx) || ctx.Err() != nil {
+	if !mgr.GetCache().WaitForCacheSync(ctx) {
+		if ctx.Err() != nil {
+			return nil
+		}
+		return fmt.Errorf("resource cache sync did not complete")
+	}
+	if ctx.Err() != nil {
 		return nil
 	}
 	setupLog.Info("starting leader monitor")

--- a/controllers/resources/main.go
+++ b/controllers/resources/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -164,7 +165,7 @@ func runMonitor(ctx context.Context, mgr ctrl.Manager) error {
 		if ctx.Err() != nil {
 			return nil
 		}
-		return fmt.Errorf("resource cache sync did not complete")
+		return errors.New("resource cache sync did not complete")
 	}
 	if ctx.Err() != nil {
 		return nil

--- a/controllers/resources/main.go
+++ b/controllers/resources/main.go
@@ -18,10 +18,10 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
 
@@ -138,35 +139,43 @@ func main() {
 	//	os.Exit(1)
 	//}
 
-	managerCtx := ctrl.SetupSignalHandler()
-	go func() {
-		if err := mgr.Start(managerCtx); err != nil {
-			setupLog.Error(err, "problem running manager")
-			os.Exit(1)
-		}
-	}()
-	// ReaderFailOnMissingInformer skips the per-read sync wait, so synchronize all
-	// explicitly registered informers before the monitor performs its first read.
-	if !mgr.GetCache().WaitForCacheSync(managerCtx) {
-		setupLog.Error(
-			errors.New("resource cache sync did not complete"),
-			"unable to start monitor",
-		)
+	if err := mgr.Add(monitorRunnable{RunnableFunc: func(ctx context.Context) error {
+		return runMonitor(ctx, mgr)
+	}}); err != nil {
+		setupLog.Error(err, "unable to register monitor")
 		os.Exit(1)
 	}
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		setupLog.Error(err, "problem running manager")
+		os.Exit(1)
+	}
+}
+
+type monitorRunnable struct {
+	manager.RunnableFunc
+}
+
+func (monitorRunnable) NeedLeaderElection() bool { return true }
+
+func runMonitor(ctx context.Context, mgr ctrl.Manager) error {
+	// ReaderFailOnMissingInformer skips the per-read sync wait, so synchronize all
+	// explicitly registered informers before the monitor performs its first read.
+	if !mgr.GetCache().WaitForCacheSync(ctx) || ctx.Err() != nil {
+		return nil
+	}
+	setupLog.Info("starting leader monitor")
+	defer setupLog.Info("stopped leader monitor")
 
 	reconciler, err := controllers.NewMonitorReconciler(mgr)
 	if err != nil {
-		setupLog.Error(err, "failed to init monitor reconciler")
-		os.Exit(1)
+		return fmt.Errorf("initialize monitor reconciler: %w", err)
 	}
 	reconciler.DBClient, err = mongo.NewMongoInterface(
-		context.Background(),
+		ctx,
 		os.Getenv(database.MongoURI),
 	)
 	if err != nil {
-		setupLog.Error(err, "failed to init db client")
-		os.Exit(1)
+		return fmt.Errorf("initialize monitor database: %w", err)
 	}
 	defer func() {
 		if err := reconciler.DBClient.Disconnect(context.Background()); err != nil {
@@ -174,10 +183,9 @@ func main() {
 		}
 	}()
 	if trafficURI := os.Getenv(database.TrafficMongoURI); trafficURI != "" {
-		reconciler.TrafficClient, err = mongo.NewMongoInterface(context.Background(), trafficURI)
+		reconciler.TrafficClient, err = mongo.NewMongoInterface(ctx, trafficURI)
 		if err != nil {
-			setupLog.Error(err, "failed to init traffic db client")
-			os.Exit(1)
+			return fmt.Errorf("initialize traffic database: %w", err)
 		}
 		defer func() {
 			if err := reconciler.TrafficClient.Disconnect(context.Background()); err != nil {
@@ -190,8 +198,7 @@ func main() {
 
 	err = reconciler.DBClient.InitDefaultPropertyTypeLSWithDefaults()
 	if err != nil {
-		setupLog.Error(err, "failed to init property type with defaults")
-		os.Exit(1)
+		return fmt.Errorf("initialize property types: %w", err)
 	}
 	reconciler.Properties = resources.DefaultPropertyTypeLS
 	const (
@@ -220,13 +227,11 @@ func main() {
 			ak,
 			sk,
 		); err != nil {
-			reconciler.Error(err, "failed to new minio client")
-			os.Exit(1)
+			return fmt.Errorf("initialize object storage client: %w", err)
 		}
-		_, err := reconciler.ObjStorageClient.ListBuckets(context.Background())
+		_, err := reconciler.ObjStorageClient.ListBuckets(ctx)
 		if err != nil {
-			reconciler.Error(err, "failed to list minio buckets")
-			os.Exit(1)
+			return fmt.Errorf("list object storage buckets: %w", err)
 		}
 		if reconciler.PromURL = os.Getenv(PromURL); reconciler.PromURL == "" {
 			reconciler.Info("prometheus url not found, please check env: PROM_URL")
@@ -239,8 +244,7 @@ func main() {
 			secure,
 		)
 		if err != nil {
-			reconciler.Error(err, "failed to new minio metrics client")
-			os.Exit(1)
+			return fmt.Errorf("initialize object storage metrics client: %w", err)
 		}
 		reconciler.Info(
 			fmt.Sprintf(
@@ -259,12 +263,12 @@ func main() {
 	if err != nil {
 		reconciler.Error(err, "failed to create ttl traffic time series")
 	}
-	// timer creates tomorrow's timing table in advance to ensure that tomorrow's table exists
-	// Execute immediately and then every 24 hours.
-	time.AfterFunc(time.Until(getNextMidnight()), func() {
-		ticker := time.NewTicker(24 * time.Hour)
-		defer ticker.Stop()
-		for {
+	maintenanceCtx, cancelMaintenance := context.WithCancel(ctx)
+	var maintenance sync.WaitGroup
+	maintenance.Add(1)
+	go func() {
+		defer maintenance.Done()
+		runMonitorMaintenance(maintenanceCtx, func() {
 			err := reconciler.DBClient.CreateMonitorTimeSeriesIfNotExist(
 				time.Now().UTC().Add(24 * time.Hour),
 			)
@@ -274,16 +278,29 @@ func main() {
 			if err := reconciler.DropMonitorCollectionOlder(); err != nil {
 				reconciler.Error(err, "failed to drop monitor collection")
 			}
-			<-ticker.C
+		})
+	}()
+	defer func() {
+		cancelMaintenance()
+		maintenance.Wait()
+	}()
+	return reconciler.StartReconciler(ctx)
+}
+
+func runMonitorMaintenance(ctx context.Context, maintain func()) {
+	timer := time.NewTimer(time.Until(getNextMidnight()))
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			if ctx.Err() != nil {
+				return
+			}
+			maintain()
+			timer.Reset(24 * time.Hour)
 		}
-	})
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	if err := reconciler.StartReconciler(ctx); err != nil {
-		setupLog.Error(err, "failed to start monitor reconciler")
-		os.Exit(1)
 	}
 }
 

--- a/controllers/resources/main_test.go
+++ b/controllers/resources/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+var _ manager.LeaderElectionRunnable = monitorRunnable{}
+
+func TestMonitorRequiresLeaderElection(t *testing.T) {
+	if !(monitorRunnable{}).NeedLeaderElection() {
+		t.Fatal("monitor must run only on the elected leader")
+	}
+}
+
+func TestMonitorMaintenanceStopsBeforeFirstRun(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	done := make(chan struct{})
+	called := false
+	go func() {
+		defer close(done)
+		runMonitorMaintenance(ctx, func() { called = true })
+	}()
+	select {
+	case <-done:
+		if called {
+			t.Fatal("maintenance ran after cancellation")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("maintenance did not stop")
+	}
+}

--- a/controllers/resources/main_test.go
+++ b/controllers/resources/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -9,6 +11,48 @@ import (
 )
 
 var _ manager.LeaderElectionRunnable = monitorRunnable{}
+
+func TestMonitorInitializationCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := monitorInitializationError(
+		ctx,
+		"connect",
+		fmt.Errorf("ping: %w", ctx.Err()),
+	); err != nil {
+		t.Fatalf("cancellation should stop cleanly: %v", err)
+	}
+	failure := errors.New("authentication failed")
+	if err := monitorInitializationError(ctx, "connect", failure); !errors.Is(err, failure) {
+		t.Fatalf("unrelated initialization failure was lost: %v", err)
+	}
+	if err := monitorInitializationError(
+		context.Background(),
+		"connect",
+		context.Canceled,
+	); err == nil {
+		t.Fatal("an active manager must not silently lose its monitor")
+	}
+}
+
+type cleanupDatabase struct {
+	t *testing.T
+}
+
+func (db cleanupDatabase) Disconnect(ctx context.Context) error {
+	if ctx.Err() != nil {
+		db.t.Fatal("cleanup context is already canceled")
+	}
+	deadline, ok := ctx.Deadline()
+	if !ok || time.Until(deadline) > 5*time.Second {
+		db.t.Fatal("cleanup must have a bounded deadline")
+	}
+	return nil
+}
+
+func TestMonitorDatabaseCleanupHasDeadline(t *testing.T) {
+	disconnectMonitorDatabase(cleanupDatabase{t: t})
+}
 
 func TestMonitorRequiresLeaderElection(t *testing.T) {
 	if !(monitorRunnable{}).NeedLeaderElection() {


### PR DESCRIPTION
Resource monitoring currently starts after cache synchronization without waiting for leadership. Standby replicas can collect and persist the same usage, while the independent monitor context and collection-maintenance timer do not follow manager shutdown.

Run monitor initialization, monitoring, and collection maintenance inside a leader-election runnable. Propagate cancellation to periodic waits, join background workers, and return initialization errors through the manager. Preserve existing sampling schedules and billing/database behavior.

Validation:
- Full resources module tests with the race detector passed locally, including after rebasing onto main.
- Lint, race tests, and image builds passed in [GitHub Actions](https://github.com/zijiren233/sealos/actions/runs/34102423791).
- Deployed the Actions-built image to a test cluster with three replicas: only the Lease holder started the monitor and completed resource collection cycles.
- Terminated the leader normally: the monitor stopped promptly, including its initial hourly wait, and a standby acquired leadership.
- Injected Lease ownership loss: the former leader exited with code 1, restarted, and another replica acquired leadership and completed a subsequent collection cycle.
- Restored the original single-replica scale after testing.

Cluster validation used commit 6a803f914 before rebasing this isolated change onto main. Sample deduplication remains outside this fix.
