### PR TITLE
fix(desktop): preserve GitHub deployment through sign-in

### DIFF
--- a/frontend/desktop/src/__tests__/unit/oauth-github-deploy.test.ts
+++ b/frontend/desktop/src/__tests__/unit/oauth-github-deploy.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import OAuth from '@/pages/oauth';
+
+const mocks = vi.hoisted(() => ({
+  query: {} as Record<string, string | string[]>,
+  loggedIn: false,
+  replace: vi.fn(),
+  setAutoLaunch: vi.fn(),
+  cancelAutoDeployTemplate: vi.fn(),
+  setAutoDeployTemplate: vi.fn()
+}));
+
+// Run the route effect directly; authentication and navigation are external boundaries.
+vi.mock('react', () => ({
+  useEffect: (effect: () => void) => effect(),
+  useRef: (current: unknown) => ({ current })
+}));
+vi.mock('next/router', () => ({
+  useRouter: () => ({ isReady: true, query: mocks.query, replace: mocks.replace })
+}));
+vi.mock('@/stores/config', () => ({
+  useConfigStore: () => ({ authConfig: { idp: {} } })
+}));
+vi.mock('@/stores/session', () => ({
+  default: () => ({ isUserLogin: () => mocks.loggedIn })
+}));
+vi.mock('@/stores/app', () => ({
+  BRAIN_APP_KEY: 'system-brain',
+  default: () => ({
+    setAutoLaunch: mocks.setAutoLaunch,
+    cancelAutoDeployTemplate: mocks.cancelAutoDeployTemplate,
+    setAutoDeployTemplate: mocks.setAutoDeployTemplate
+  })
+}));
+vi.mock('@/stores/guideModal', () => ({ useGuideModalStore: () => ({}) }));
+vi.mock('@tanstack/react-query', () => ({ useMutation: () => ({}) }));
+vi.mock('@/hooks/useCustomToast', () => ({ useCustomToast: () => ({}) }));
+vi.mock('@/utils/gtm', () => ({ gtmLoginStart: vi.fn() }));
+vi.mock('@/utils/ssrLocale', () => ({ ensureLocaleCookie: vi.fn() }));
+vi.mock('@/api/platform', () => ({ createTemplateInstance: vi.fn() }));
+vi.mock('@/api/auth', () => ({ getRegionToken: vi.fn(), initRegionToken: vi.fn() }));
+vi.mock('@/api/namespace', () => ({ nsListRequest: vi.fn(), switchRequest: vi.fn() }));
+vi.mock('@/utils/sessionConfig', () => ({ sessionConfig: vi.fn() }));
+vi.mock('@/utils/switchKubeconfigNamespace', () => ({ switchKubeconfigNamespace: vi.fn() }));
+
+describe('GitHub deploy OAuth entry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.loggedIn = false;
+    mocks.query = {
+      openapp: 'system-brain',
+      githubRepo: 'https://github.com/example/repository',
+      autoDeploy: '1'
+    };
+  });
+
+  it('saves the complete deploy destination before redirecting to sign-in', () => {
+    OAuth();
+
+    expect(mocks.setAutoLaunch).toHaveBeenCalledExactlyOnceWith('system-brain', {
+      pathname: '/deploy',
+      raw: new URLSearchParams({
+        githubRepo: 'https://github.com/example/repository',
+        autoDeploy: '1'
+      }).toString()
+    });
+    expect(mocks.cancelAutoDeployTemplate).toHaveBeenCalledOnce();
+    expect(mocks.replace).toHaveBeenCalledWith('/signin');
+    expect(mocks.setAutoLaunch.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.replace.mock.invocationCallOrder[0]
+    );
+  });
+
+  it.each([undefined, '0'])('preserves manual deployment when autoDeploy is %s', (autoDeploy) => {
+    delete mocks.query.autoDeploy;
+    if (autoDeploy) mocks.query.autoDeploy = autoDeploy;
+    OAuth();
+    const destination = mocks.setAutoLaunch.mock.calls[0][1];
+    expect(destination.pathname).toBe('/deploy');
+    expect(new URLSearchParams(destination.raw).has('autoDeploy')).toBe(false);
+    expect(new URLSearchParams(destination.raw).get('githubRepo')).toBe(mocks.query.githubRepo);
+  });
+
+  it('retains marketing attribution with the deploy destination', () => {
+    mocks.query.sea_attr = 'campaign';
+    OAuth();
+    expect(new URLSearchParams(mocks.setAutoLaunch.mock.calls[0][1].raw).get('sea_attr')).toBe(
+      'campaign'
+    );
+    expect(mocks.replace).toHaveBeenCalledWith('/signin?sea_attr=campaign');
+  });
+
+  it('uses the same deploy destination for an already logged-in user', async () => {
+    mocks.loggedIn = true;
+    OAuth();
+    await vi.waitFor(() => expect(mocks.replace).toHaveBeenCalledWith('/'));
+    expect(mocks.setAutoLaunch.mock.calls[0][1].pathname).toBe('/deploy');
+    expect(new URLSearchParams(mocks.setAutoLaunch.mock.calls[0][1].raw).get('autoDeploy')).toBe(
+      '1'
+    );
+  });
+
+  it('keeps ordinary app launches unchanged', () => {
+    mocks.query = { openapp: 'system-brain' };
+    OAuth();
+    expect(mocks.setAutoLaunch).toHaveBeenCalledExactlyOnceWith('system-brain', {
+      pathname: '/',
+      raw: ''
+    });
+    expect(mocks.cancelAutoDeployTemplate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/desktop/src/pages/oauth.tsx
+++ b/frontend/desktop/src/pages/oauth.tsx
@@ -113,7 +113,7 @@ export default function OAuth() {
       return true;
     };
 
-    const openBrainGithubDeploy = async (activeMarketingQuery = marketingQuery) => {
+    const saveBrainGithubDeploy = (activeMarketingQuery = marketingQuery) => {
       if (openapp !== 'system-brain' || typeof githubRepo !== 'string') {
         return false;
       }
@@ -130,6 +130,13 @@ export default function OAuth() {
         pathname: '/deploy',
         raw: rawQuery
       });
+      // A new GitHub intent must not resume an older template deployment after login.
+      cancelAutoDeployTemplate();
+      return true;
+    };
+
+    const openBrainGithubDeploy = async (activeMarketingQuery = marketingQuery) => {
+      if (!saveBrainGithubDeploy(activeMarketingQuery)) return false;
       await router.replace(appendMarketingQuery('/', activeMarketingQuery));
 
       return true;
@@ -320,6 +327,9 @@ export default function OAuth() {
     };
 
     const handleSaveParams = () => {
+      // Persist the full destination before leaving for sign-in or an OAuth provider.
+      if (saveBrainGithubDeploy()) return;
+
       if (templateName && typeof templateName === 'string') {
         let parsedTemplateForm: Record<string, any> = {};
 


### PR DESCRIPTION
Clicking Deploy on Sealos from a GitHub repository while signed out lost the repository and auto-deploy flag when Desktop redirected to sign-in. After authentication, Brain opened its home page instead of continuing the deployment.

Persist the complete Brain `/deploy` destination before sign-in, sharing the destination-saving logic with the signed-in flow. Clear any previous template deployment intent so the login callback cannot resume an unrelated deployment. Manual deployment and marketing attribution are preserved.

Validation:
- 21 tests passed across the OAuth GitHub deployment, initial app target, and marketing attribution suites, including 6 new regression cases.
- ESLint passed for both changed files.
- No live authentication or deployment verification performed.
