### PR TITLE
fix(applaunchpad): localize pod log time option

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -858,6 +858,9 @@ importers:
       svg-inline-loader:
         specifier: ^0.8.2
         version: 0.8.2
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@18.13.0)(sass@1.69.5)
       webpack-bundle-analyzer:
         specifier: ^4.9.1
         version: 4.10.1

--- a/frontend/providers/applaunchpad/__tests__/unit/i18n/logTimeTranslations.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/i18n/logTimeTranslations.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+
+import enCommon from '../../../public/locales/en/common.json';
+import zhCommon from '../../../public/locales/zh/common.json';
+
+describe('pod log time translations', () => {
+  it('defines the five-minute option used by LogsModal in both locales', () => {
+    expect(zhCommon.within_5_minutes).toBe('五分钟内');
+    expect(enCommon.within_5_minutes).toBe('Within 5 minutes');
+  });
+});

--- a/frontend/providers/applaunchpad/package.json
+++ b/frontend/providers/applaunchpad/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "vitest run",
     "link-sdk": "rm -rf node_modules/sealos-desktop-sdk && yalc link sealos-desktop-sdk",
     "unlink-sdk": "yalc remove --all && pnpm install sealos-desktop-sdk"
   },
@@ -79,6 +80,7 @@
     "eslint": "8.33.0",
     "eslint-config-next": "13.5.9",
     "svg-inline-loader": "^0.8.2",
+    "vitest": "^1.6.0",
     "webpack-bundle-analyzer": "^4.9.1"
   }
 }

--- a/frontend/providers/applaunchpad/public/locales/en/common.json
+++ b/frontend/providers/applaunchpad/public/locales/en/common.json
@@ -465,7 +465,7 @@
   "websocket": "WebSocket",
   "within_1_day": "Within 1 day",
   "within_1_hour": "Within 1 hour",
-  "within_5_minute": "Within 5 minute",
+  "within_5_minutes": "Within 5 minutes",
   "proxy_detected_title": "Proxy Detected",
   "proxy_detected_message": "Using the proxy will degrade the performance of Sealos. To disable the proxy, update your DNS provider."
 }

--- a/frontend/providers/applaunchpad/public/locales/zh/common.json
+++ b/frontend/providers/applaunchpad/public/locales/zh/common.json
@@ -465,7 +465,7 @@
   "websocket": "WebSocket",
   "within_1_day": "一天内",
   "within_1_hour": "一小时内",
-  "within_5_minute": "五分钟内",
+  "within_5_minutes": "五分钟内",
   "proxy_detected_title": "检测到代理",
   "proxy_detected_message": "使用代理会降低 Sealos 的性能。要禁用代理，请更新您的 DNS 提供商设置。"
 }


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->

## Summary

Fix the five-minute pod log time-range translation key so Chinese users see the localized label.
Correct the English copy to "Within 5 minutes" and add a regression test for both locale files.

## Sequence Diagram

```mermaid
sequenceDiagram
    participant User
    participant LogsModal
    participant I18n
    User->>LogsModal: Select five-minute log range
    LogsModal->>I18n: Resolve within_5_minutes
    I18n-->>LogsModal: Return localized label
    LogsModal-->>User: Display five-minute option
```
