### PR TITLE
fix(applaunchpad): accept resolved public route responses

### DIFF
--- a/frontend/providers/applaunchpad/__tests__/unit/utils/publicAccess.test.ts
+++ b/frontend/providers/applaunchpad/__tests__/unit/utils/publicAccess.test.ts
@@ -66,16 +66,20 @@ describe('public access readiness', () => {
     });
   });
 
-  it('does not mark arbitrary non-success responses ready', async () => {
-    const result = await getPublicAddressReadyResult(
-      new Response('bad gateway', { status: 502 }),
-      'https://app.example.com'
+  it('treats application HTTP errors as accessible after the route resolves', async () => {
+    const url = 'https://app.example.com';
+    const results = await Promise.all(
+      [
+        new Response(null, { status: 404 }),
+        new Response('unauthorized', { status: 401 }),
+        new Response('internal server error', { status: 500 })
+      ].map((response) => getPublicAddressReadyResult(response, url))
     );
 
-    expect(result).toEqual({
-      ready: false,
-      url: 'https://app.example.com',
-      error: 'HTTP 502'
-    });
+    expect(results).toEqual([
+      { ready: true, url },
+      { ready: true, url },
+      { ready: true, url }
+    ]);
   });
 });

--- a/frontend/providers/applaunchpad/src/utils/publicAccess.ts
+++ b/frontend/providers/applaunchpad/src/utils/publicAccess.ts
@@ -34,16 +34,12 @@ export const isPublicAddressAccessible = ({
 export const getPublicAddressReadyResult = async (response: Response, url: string) => {
   const text = await response.text();
 
-  if (response.status === 404 && response.headers.get('content-length') === '0') {
-    return { ready: false, url, error: '404' };
-  }
-
-  if (response.status < 200 || response.status >= 400) {
-    const isUnhealthyUpstream = unhealthyUpstreamText.some((message) => text.includes(message));
+  const isUnhealthyUpstream = unhealthyUpstreamText.some((message) => text.includes(message));
+  if (isUnhealthyUpstream) {
     return {
       ready: false,
       url,
-      error: isUnhealthyUpstream ? 'Upstream not healthy' : `HTTP ${response.status}`
+      error: 'Upstream not healthy'
     };
   }
 


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->

## Summary

Treat resolved public-route HTTP errors as accessible unless the response indicates an unhealthy upstream.
Cover 404, 401, and 500 responses in the public-access readiness unit test.

## Sequence Diagram

```mermaid
sequenceDiagram
    participant Client
    participant PublicRoute
    participant ReadinessCheck
    Client->>PublicRoute: Probe public URL
    PublicRoute-->>ReadinessCheck: Return HTTP response
    alt Unhealthy upstream marker
        ReadinessCheck-->>Client: Keep route pending
    else Route resolved
        ReadinessCheck-->>Client: Mark route accessible
    end
```

## Verification

`git diff --check` passed.
The focused Vitest command could not run because Vitest is not installed in this workspace.
