### PR TITLE
fix(template): show paused app status

### DIFF
--- a/frontend/providers/template/__tests__/unit/utils/adapt.test.ts
+++ b/frontend/providers/template/__tests__/unit/utils/adapt.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { pauseKey } from '@/constants/keys';
+import { StatusEnum } from '@/constants/status';
+import { adaptAppListItem } from '@/utils/adapt';
+
+const app = (annotations: Record<string, string> = {}) =>
+  ({
+    metadata: {
+      name: 'fastgpt',
+      annotations
+    },
+    spec: {
+      template: {
+        spec: {
+          containers: [{ resources: { limits: { cpu: '500m', memory: '1Gi' } } }]
+        }
+      }
+    },
+    status: {
+      replicas: 0,
+      readyReplicas: 0
+    }
+  }) as any;
+
+describe('adaptAppListItem', () => {
+  it('reports a paused application as stopped even when its replica counts are both zero', () => {
+    const item = adaptAppListItem(app({ [pauseKey]: '{"target":"cpu","value":"50"}' }));
+
+    expect(item.isPause).toBe(true);
+    expect(item.status.value).toBe(StatusEnum.Stopped);
+  });
+
+  it('keeps a non-paused application with matching replica counts running', () => {
+    const item = adaptAppListItem(app());
+
+    expect(item.isPause).toBe(false);
+    expect(item.status.value).toBe(StatusEnum.Running);
+  });
+});

--- a/frontend/providers/template/src/utils/adapt.ts
+++ b/frontend/providers/template/src/utils/adapt.ts
@@ -67,15 +67,18 @@ export const adaptAppListItem = (app: V1Deployment & V1StatefulSet): AppListItem
       )
     : 0;
 
+  const isPause = !!app?.metadata?.annotations?.[pauseKey];
+
   return {
     id: app.metadata?.uid || ``,
     name: app.metadata?.name || 'app name',
-    isPause: !!app?.metadata?.annotations?.[pauseKey],
+    isPause,
     status:
-      app.status?.readyReplicas === app.status?.replicas
+      isPause
+        ? StatusMap[StatusEnum.Stopped]
+        : app.status?.readyReplicas === app.status?.replicas
         ? StatusMap[StatusEnum.Running]
         : StatusMap[StatusEnum.Waiting],
-    // isPause: !!app?.metadata?.annotations?.[pauseKey],
     createTime: dayjs(app.metadata?.creationTimestamp).format('YYYY/MM/DD HH:mm'),
     cpu: cpuFormatToM(app.spec?.template?.spec?.containers?.[0]?.resources?.limits?.cpu),
     memory: memoryFormatToMi(app.spec?.template?.spec?.containers?.[0]?.resources?.limits?.memory),


### PR DESCRIPTION
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->

## Summary

Make the App Store report paused deployments as Stopped before evaluating replica equality, with regression coverage for zero replicas.

## Verification

`git diff --check` passed, and the equivalent isolated Template worktree passed Vitest, TypeScript, Prettier, and Helm lint; this workspace cannot start Vitest because `frontend/node_modules` is absent.

## Sequence Diagram

```mermaid
sequenceDiagram
    participant Store as App Store
    participant Adapter as adaptAppListItem
    participant Deployment as Deployment Metadata

    Store->>Adapter: Adapt application list item
    Adapter->>Deployment: Read pause annotation
    alt Pause annotation exists
        Adapter-->>Store: Stopped status
    else No pause annotation
        Adapter-->>Store: Derive status from replicas
    end
```
